### PR TITLE
refactor: replace shell-based command detection with native PATH lookup

### DIFF
--- a/src/app/overlays/inline_image.rs
+++ b/src/app/overlays/inline_image.rs
@@ -8,7 +8,6 @@ use std::{
     fs::{self, File},
     io::{Read, Write as _},
     path::Path,
-    process::Command,
     sync::Arc,
 };
 
@@ -631,11 +630,38 @@ pub(in crate::app) fn build_kitty_clear_sequence() -> &'static str {
 }
 
 pub(in crate::app) fn command_exists(program: &str) -> bool {
-    Command::new("sh")
-        .arg("-lc")
-        .arg(format!("command -v {program} >/dev/null 2>&1"))
-        .status()
-        .is_ok_and(|status| status.success())
+    if program.is_empty() {
+        return false;
+    }
+
+    let program_path = Path::new(program);
+    if program_path.components().count() > 1 {
+        return executable_file_exists(program_path);
+    }
+
+    env::var_os("PATH").is_some_and(|paths| {
+        env::split_paths(&paths).any(|dir| executable_file_exists(&dir.join(program)))
+    })
+}
+
+fn executable_file_exists(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 fn place_terminal_image_with_kitty_protocol(
@@ -703,7 +729,9 @@ fn intersect_rect(a: Rect, b: Rect) -> Option<Rect> {
     let left = a.x.max(b.x);
     let top = a.y.max(b.y);
     let right = a.x.saturating_add(a.width).min(b.x.saturating_add(b.width));
-    let bottom = a.y.saturating_add(a.height).min(b.y.saturating_add(b.height));
+    let bottom =
+        a.y.saturating_add(a.height)
+            .min(b.y.saturating_add(b.height));
     (right > left && bottom > top).then_some(Rect {
         x: left,
         y: top,

--- a/src/app/overlays/pdf/tests.rs
+++ b/src/app/overlays/pdf/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::app::overlays::images::StaticImageKey;
-use crate::app::overlays::inline_image::{ImageProtocol, TerminalWindowSize};
+use crate::app::overlays::inline_image::{command_exists, ImageProtocol, TerminalWindowSize};
 use crate::preview::PreviewKind;
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use std::{
@@ -1134,6 +1134,34 @@ fn select_image_protocol_alacritty_disabled_and_other_override_enabled() {
 fn fallback_window_size_pixels_uses_reasonable_cell_defaults() {
     assert_eq!(fallback_window_size_pixels(100, 40), (800, 640));
     assert_eq!(fallback_window_size_pixels(0, 0), (8, 16));
+}
+
+#[cfg(unix)]
+#[test]
+fn command_exists_checks_direct_executable_paths_without_shelling_out() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = temp_root("command-exists-direct-path");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let executable = root.join("demo-tool");
+    fs::write(&executable, b"#!/bin/sh\nexit 0\n").expect("failed to write test executable");
+
+    let mut permissions = fs::metadata(&executable)
+        .expect("test executable metadata should exist")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).expect("failed to mark test executable");
+
+    assert!(command_exists(
+        executable.to_str().expect("path should be valid utf-8")
+    ));
+
+    let not_executable = root.join("demo-data");
+    fs::write(&not_executable, b"plain data").expect("failed to write plain file");
+    assert!(!command_exists(
+        not_executable.to_str().expect("path should be valid utf-8")
+    ));
 }
 
 #[test]


### PR DESCRIPTION

  ## Summary
  - replace shell-based `command -v` detection with native PATH lookup
  - support direct executable paths without spawning `sh`
  - add a regression test for executable-path detection

  ## Why
  This is the first step in reducing runtime external dependencies and making `elio` more self-contained. It removes the app's dependency on `sh` for tool detection without changing feature
  behavior.

  ## Scope
  - no feature changes
  - no PDF/image/archive behavior changes beyond how tool presence is detected
  - Unix-targeted executable-bit check, which matches the current target environment

  ## Verification
  - `cargo test`
  - result: `413 passed; 0 failed`