### PR TITLE
feat(preview): internalize tar archive listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -313,6 +313,7 @@ dependencies = [
  "base64",
  "cfb",
  "crossterm",
+ "flate2",
  "image",
  "json5",
  "notify",
@@ -321,6 +322,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "tar",
  "toml",
  "toml_edit",
  "trash",
@@ -660,6 +662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,8 +1000,21 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1178,6 +1199,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1642,6 +1674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 base64 = "0.22"
 cfb = "0.10"
 crossterm = "0.28"
+flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }
 image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 notify = "7.0"
 json5 = "0.4"
@@ -17,6 +18,7 @@ quick-xml = "0.38"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tar = "0.4"
 yaml_serde = "0.10"
 toml = "0.8"
 toml_edit = "0.22"

--- a/src/preview/container/archive.rs
+++ b/src/preview/container/archive.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{file_info, fs::natural_cmp, ui::theme};
+use flate2::read::GzDecoder;
 use ratatui::text::Line;
 use std::{
     collections::{BTreeMap, HashMap, VecDeque, hash_map::DefaultHasher},
@@ -12,6 +13,7 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
     time::SystemTime,
 };
+use tar::Archive as TarArchive;
 use zip::ZipArchive;
 
 const COMIC_ARCHIVE_IMAGE_ENTRY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
@@ -64,6 +66,9 @@ pub(in crate::preview) fn build_archive_preview(
         return Some(preview);
     }
     if let Some(preview) = build_zip_archive_preview(path, format, type_detail) {
+        return Some(preview);
+    }
+    if let Some(preview) = build_tar_archive_preview(path, format, type_detail) {
         return Some(preview);
     }
     build_external_archive_preview(path, format, type_detail)
@@ -241,6 +246,27 @@ fn build_zip_archive_preview(
         scan_truncated,
     });
     Some(preview)
+}
+
+fn build_tar_archive_preview(
+    path: &Path,
+    format: ArchiveFormat,
+    type_detail: Option<&'static str>,
+) -> Option<PreviewContent> {
+    let (metadata, entries, total_entries, scan_truncated) =
+        collect_internal_tar_listing(path, format)?;
+    let detail = type_detail.unwrap_or(archive_default_label(format));
+
+    Some(render_archive_preview(ArchiveRenderConfig {
+        detail: detail.to_string(),
+        metadata,
+        entries: Some(entries),
+        total_entries_hint: Some(total_entries),
+        empty_label: archive_is_empty_label(format),
+        unavailable_label: "Unable to read archive contents",
+        extra_sections: Vec::new(),
+        scan_truncated,
+    }))
 }
 
 fn build_comic_archive_preview(
@@ -493,12 +519,73 @@ fn build_external_archive_preview(
     }))
 }
 
+fn collect_internal_tar_listing(
+    path: &Path,
+    format: ArchiveFormat,
+) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>, usize, bool)> {
+    match format {
+        ArchiveFormat::Tar => {
+            let file = File::open(path).ok()?;
+            collect_tar_listing_from_reader(file, path, format)
+        }
+        ArchiveFormat::TarGzip => {
+            let file = File::open(path).ok()?;
+            collect_tar_listing_from_reader(GzDecoder::new(file), path, format)
+        }
+        _ => None,
+    }
+}
+
+fn collect_tar_listing_from_reader<R: Read>(
+    reader: R,
+    path: &Path,
+    format: ArchiveFormat,
+) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>, usize, bool)> {
+    let mut archive = TarArchive::new(reader);
+    let entries = archive.entries().ok()?;
+    let mut normalized_entries = Vec::new();
+    let mut metadata = ArchiveMetadata {
+        format_label: Some(archive_format_name(format).to_string()),
+        physical_size: fs::metadata(path).ok().map(|metadata| metadata.len()),
+        ..ArchiveMetadata::default()
+    };
+    let mut total_entries = 0usize;
+    let mut scan_truncated = false;
+
+    for entry in entries {
+        let entry = entry.ok()?;
+        total_entries = total_entries.saturating_add(1);
+        if total_entries > ARCHIVE_ENTRY_SCAN_LIMIT {
+            scan_truncated = true;
+            break;
+        }
+
+        let is_dir = entry.header().entry_type().is_dir();
+        metadata.unpacked_size = Some(
+            metadata
+                .unpacked_size
+                .unwrap_or(0)
+                .saturating_add(entry.header().size().ok().unwrap_or(0)),
+        );
+
+        let path = entry.path().ok()?;
+        let path = path.to_string_lossy();
+        if let Some(path) = normalize_archive_path(&path, false) {
+            normalized_entries.push(ArchiveEntry { path, is_dir });
+        }
+    }
+
+    Some((metadata, normalized_entries, total_entries, scan_truncated))
+}
+
 fn collect_preferred_archive_entries(
     path: &Path,
     format: ArchiveFormat,
 ) -> Option<Vec<ArchiveEntry>> {
     if prefers_tar_listing(format) {
-        return collect_archive_entries_with_bsdtar(path)
+        return collect_internal_tar_listing(path, format)
+            .map(|(_, entries, _, _)| entries)
+            .or_else(|| collect_archive_entries_with_bsdtar(path))
             .or_else(|| collect_archive_entries_with_tar(path));
     }
 

--- a/src/preview/tests.rs
+++ b/src/preview/tests.rs
@@ -3,6 +3,7 @@ use crate::{
     app::{Entry, EntryKind},
     ui::theme,
 };
+use flate2::{Compression, write::GzEncoder};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use ratatui::style::{Color, Modifier};
 use ratatui::text::Line;
@@ -18,6 +19,7 @@ use std::{
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
+use tar::{Builder as TarBuilder, Header as TarHeader};
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 fn temp_path(label: &str) -> PathBuf {
@@ -190,28 +192,49 @@ fn write_test_raster_image(path: &Path, format: ImageFormat, width_px: u32, heig
         .expect("failed to write raster test image");
 }
 
-fn write_tar_gz_entries(path: &Path, entries: &[(&str, &str)]) -> bool {
-    let root = temp_path("tar-gz-root");
-    fs::create_dir_all(&root).expect("failed to create tar staging root");
+fn write_tar_entries(path: &Path, entries: &[(&str, &str)]) {
+    let file = File::create(path).expect("failed to create tar");
+    let mut builder = TarBuilder::new(file);
+    append_tar_entries(&mut builder, entries);
+    builder.finish().expect("failed to finish tar");
+}
 
+fn write_tar_gz_entries(path: &Path, entries: &[(&str, &str)]) {
+    let file = File::create(path).expect("failed to create tar.gz");
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = TarBuilder::new(encoder);
+    append_tar_entries(&mut builder, entries);
+    builder.finish().expect("failed to finish tar.gz");
+}
+
+fn append_tar_entries<W: Write>(builder: &mut TarBuilder<W>, entries: &[(&str, &str)]) {
     for (name, contents) in entries {
-        let entry_path = root.join(name);
-        if let Some(parent) = entry_path.parent() {
-            fs::create_dir_all(parent).expect("failed to create tar staging directory");
+        if let Some(parent) = Path::new(name).parent() {
+            append_tar_directories(builder, parent);
         }
-        fs::write(&entry_path, contents).expect("failed to write tar staging file");
+
+        let mut header = TarHeader::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o644);
+        header.set_size(contents.len() as u64);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, *name, contents.as_bytes())
+            .expect("failed to append tar entry");
     }
+}
 
-    let created = Command::new("tar")
-        .arg("-czf")
-        .arg(path)
-        .arg("-C")
-        .arg(&root)
-        .arg(".")
-        .status();
-
-    fs::remove_dir_all(root).expect("failed to remove tar staging root");
-    created.as_ref().is_ok_and(|status| status.success())
+fn append_tar_directories<W: Write>(builder: &mut TarBuilder<W>, path: &Path) {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component);
+        let mut header = TarHeader::new_gnu();
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_mode(0o755);
+        header.set_size(0);
+        header.set_cksum();
+        let _ = builder.append_data(&mut header, &current, std::io::empty());
+    }
 }
 
 fn write_xz_compressed_file(path: &Path, contents: &[u8]) -> bool {
@@ -2722,20 +2745,44 @@ fn comic_rar_preview_renders_first_page_without_summary() {
 }
 
 #[test]
-fn tar_gz_preview_lists_inner_archive_contents() {
-    let root = temp_path("tar-gz-preview");
+fn tar_preview_lists_inner_archive_contents() {
+    let root = temp_path("tar-preview");
     fs::create_dir_all(&root).expect("failed to create temp root");
-    let path = root.join("bundle.tar.gz");
-    if !write_tar_gz_entries(
+    let path = root.join("bundle.tar");
+    write_tar_entries(
         &path,
         &[
             ("docs/readme.txt", "hello"),
             ("src/main.rs", "fn main() {}\n"),
         ],
-    ) {
-        fs::remove_dir_all(root).expect("failed to remove temp root");
-        return;
-    }
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("TAR archive"));
+    assert!(line_texts.iter().any(|text| text.contains("docs/")));
+    assert!(line_texts.iter().any(|text| text.contains("src/")));
+    assert!(line_texts.iter().any(|text| text.contains("readme.txt")));
+    assert!(line_texts.iter().any(|text| text.contains("main.rs")));
+    assert!(!line_texts.iter().any(|text| text.contains("bundle.tar")));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn tar_gz_preview_lists_inner_archive_contents() {
+    let root = temp_path("tar-gz-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("bundle.tar.gz");
+    write_tar_gz_entries(
+        &path,
+        &[
+            ("docs/readme.txt", "hello"),
+            ("src/main.rs", "fn main() {}\n"),
+        ],
+    );
 
     let preview = build_preview(&file_entry(path));
     let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
@@ -2756,13 +2803,10 @@ fn tgz_preview_keeps_tar_gz_label_and_contents_tree() {
     let root = temp_path("tgz-preview");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let path = root.join("bundle.tgz");
-    if !write_tar_gz_entries(
+    write_tar_gz_entries(
         &path,
         &[("assets/logo.txt", "logo"), ("bin/elio", "#!/bin/sh\n")],
-    ) {
-        fs::remove_dir_all(root).expect("failed to remove temp root");
-        return;
-    }
+    );
 
     let preview = build_preview(&file_entry(path));
     let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();


### PR DESCRIPTION

• ## Summary

  This PR internalizes preview listing for .tar, .tar.gz, and .tgz using an in-process path, while keeping the existing external fallbacks for unsupported or unreadable cases.

  It reduces normal-path dependence on tar/bsdtar with a small binary increase and no change to heavier archive formats.

  ## What changed

  - Added internal tar listing for .tar, .tar.gz, and .tgz
  - Prefer the internal tar path in archive preview before external fallbacks
  - Kept existing fallback behavior intact as a safety net
  - Updated tar-related tests to generate fixtures in-process instead of relying on an external tar binary

  ## Scope not included

  This PR does not internalize:

  - .tar.xz
  - .tar.bz2
  - .tar.zst
  - ISO listing
  - 7z handling
  - fallback removal

  ## Verification

  - cargo test
  - cargo build --release

  Results:

  - 414 tests passed
  - release build succeeded

  ## Binary impact

  - before: 5,322,352
  - after: 5,367,408
  - delta: +45,056 bytes