### PR TITLE
feat(preview): prefer resvg for svg previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ elio
 |---|---|
 | `pdfinfo` + `pdftocairo` | Rendered PDF page previews |
 | `gio open` or `xdg-open` | Open files externally with `o` |
-| `ffmpeg` or `magick` | Broader image format rendering |
+| `ffmpeg` | Broader raster image format rendering |
+| `resvg` | Preferred SVG rasterization for image previews |
+| `magick` | SVG rasterization fallback and broader image format rendering |
 
 ---
 

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -221,6 +221,7 @@ pub(super) struct ImagePrepareRequest {
     pub target_width_px: u32,
     pub target_height_px: u32,
     pub ffmpeg_available: bool,
+    pub resvg_available: bool,
     pub magick_available: bool,
     pub force_render_to_cache: bool,
     pub prepare_inline_payload: bool,

--- a/src/app/jobs/tests.rs
+++ b/src/app/jobs/tests.rs
@@ -10,6 +10,7 @@ fn image_prepare_request(name: &str) -> ImagePrepareRequest {
         target_width_px: 640,
         target_height_px: 480,
         ffmpeg_available: true,
+        resvg_available: true,
         magick_available: true,
         force_render_to_cache: false,
         prepare_inline_payload: false,

--- a/src/app/overlays/images.rs
+++ b/src/app/overlays/images.rs
@@ -43,6 +43,7 @@ pub(in crate::app) struct ImagePreviewState {
     activation_ready_at: Option<Instant>,
     pub(in crate::app) selection_activation_delay: Duration,
     ffmpeg_available: Option<bool>,
+    resvg_available: Option<bool>,
     magick_available: Option<bool>,
     preload_viewport: Option<StaticImagePreloadViewport>,
 }
@@ -477,6 +478,13 @@ impl App {
             .get_or_insert_with(|| command_exists("magick"))
     }
 
+    fn resvg_available(&mut self) -> bool {
+        *self
+            .image_preview
+            .resvg_available
+            .get_or_insert_with(|| command_exists("resvg"))
+    }
+
     fn ffmpeg_available(&mut self) -> bool {
         *self
             .image_preview
@@ -820,8 +828,7 @@ impl App {
         let key = StaticImageKey::from_request(request);
         if self.image_preview.failed_images.contains(&key)
             || self.image_preview.pending_prepares.contains(&key)
-            || self.cached_prepared_static_image_for_overlay(&key, request)
-                .is_some()
+            || self.cached_prepared_static_image_for_overlay(&key, request).is_some()
         {
             return;
         }
@@ -847,6 +854,7 @@ impl App {
             target_width_px: request.target_width_px,
             target_height_px: request.target_height_px,
             ffmpeg_available: self.ffmpeg_available(),
+            resvg_available: self.resvg_available(),
             magick_available: self.magick_available(),
             force_render_to_cache: request.force_render_to_cache,
             prepare_inline_payload: request.prepare_inline_payload,
@@ -1103,15 +1111,24 @@ where
             });
         }
         let temp_path = static_image_render_temp_path(&cache_path)?;
-        if request.magick_available
-            && render_svg_to_png(
+        let rendered = (request.resvg_available
+            && render_svg_to_png_with_resvg(
                 &request.path,
                 &temp_path,
+                source_dimensions,
                 target_width_px,
                 target_height_px,
                 &canceled,
-            )
-        {
+            ))
+            || (request.magick_available
+                && render_svg_to_png_with_magick(
+                    &request.path,
+                    &temp_path,
+                    target_width_px,
+                    target_height_px,
+                    &canceled,
+                ));
+        if rendered {
             finalize_static_image_render(&temp_path, &cache_path)?;
             let payload = inline_payload(&cache_path)?;
             return Some(PreparedStaticImageAsset {
@@ -1262,9 +1279,7 @@ fn static_image_can_prepare_inline(
     }
 }
 
-fn static_image_supports_iterm_source_passthrough(
-    request: &StaticImageOverlayRequest,
-) -> bool {
+fn static_image_supports_iterm_source_passthrough(request: &StaticImageOverlayRequest) -> bool {
     static_image_format_for_overlay_request(request)
         .is_some_and(|format| static_image_supports_iterm_source_format(&request.path, format))
         && !request.force_render_to_cache
@@ -1332,7 +1347,40 @@ fn static_image_format_for_path(path: &Path) -> Option<StaticImageFormat> {
         .and_then(StaticImageFormat::from_label)
 }
 
-fn render_svg_to_png(
+fn render_svg_to_png_with_resvg(
+    input_path: &Path,
+    output_path: &Path,
+    source_dimensions: RenderedImageDimensions,
+    target_width_px: u32,
+    target_height_px: u32,
+    canceled: &impl Fn() -> bool,
+) -> bool {
+    if let Some(parent) = output_path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        return false;
+    }
+
+    let (width_arg, height_arg) =
+        fit_svg_render_dimensions(source_dimensions, target_width_px, target_height_px);
+    let mut command = Command::new("resvg");
+    if let Some(width_px) = width_arg {
+        command.arg("--width").arg(width_px.to_string());
+    }
+    if let Some(height_px) = height_arg {
+        command.arg("--height").arg(height_px.to_string());
+    }
+    command
+        .arg(input_path)
+        .arg(output_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    run_cancelable_command(&mut command, canceled)
+        .is_some_and(|status| status.success() && output_path.exists())
+}
+
+fn render_svg_to_png_with_magick(
     input_path: &Path,
     output_path: &Path,
     target_width_px: u32,
@@ -1360,6 +1408,31 @@ fn render_svg_to_png(
         canceled,
     )
     .is_some_and(|status| status.success() && output_path.exists())
+}
+
+fn fit_svg_render_dimensions(
+    source_dimensions: RenderedImageDimensions,
+    target_width_px: u32,
+    target_height_px: u32,
+) -> (Option<u32>, Option<u32>) {
+    let source_width = source_dimensions.width_px.max(1) as f32;
+    let source_height = source_dimensions.height_px.max(1) as f32;
+    let scale = (target_width_px.max(1) as f32 / source_width)
+        .min(target_height_px.max(1) as f32 / source_height)
+        .min(1.0);
+    if scale >= 1.0 {
+        return (None, None);
+    }
+
+    let fitted_width = (source_width * scale).round().max(1.0) as u32;
+    let fitted_height = (source_height * scale).round().max(1.0) as u32;
+    let width_ratio = target_width_px.max(1) as f32 / source_width;
+    let height_ratio = target_height_px.max(1) as f32 / source_height;
+    if width_ratio <= height_ratio {
+        (Some(fitted_width), None)
+    } else {
+        (None, Some(fitted_height))
+    }
 }
 
 fn render_raster_to_png_with_ffmpeg(

--- a/src/app/overlays/pdf/tests.rs
+++ b/src/app/overlays/pdf/tests.rs
@@ -590,6 +590,7 @@ fn oriented_jpeg_fallback_preview_uses_exif_corrected_dimensions() {
             target_width_px: 60,
             target_height_px: 60,
             ffmpeg_available: false,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: false,
             prepare_inline_payload: false,
@@ -638,6 +639,7 @@ fn oriented_jpeg_ffmpeg_preview_uses_exif_corrected_dimensions() {
             target_width_px: 60,
             target_height_px: 60,
             ffmpeg_available: true,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: false,
             prepare_inline_payload: false,
@@ -679,6 +681,7 @@ fn extensionless_png_static_image_preparation_succeeds() {
             target_width_px: 768,
             target_height_px: 540,
             ffmpeg_available: true,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: false,
             prepare_inline_payload: false,
@@ -742,6 +745,7 @@ fn raster_static_images_use_png_display_paths() {
                 target_width_px: 768,
                 target_height_px: 540,
                 ffmpeg_available: true,
+                resvg_available: false,
                 magick_available: true,
                 force_render_to_cache: false,
                 prepare_inline_payload: false,
@@ -768,7 +772,11 @@ fn raster_static_images_use_png_display_paths() {
 }
 
 #[test]
-fn svg_static_images_are_normalized_to_cached_png_overlays() {
+fn svg_static_images_prefer_resvg_when_available() {
+    if !crate::app::overlays::inline_image::command_exists("resvg") {
+        return;
+    }
+
     let (_app, root) = build_selected_static_image_app("svg-cache", "demo.svg");
     let path = root.join("demo.svg");
     let metadata = fs::metadata(&path).expect("svg metadata should exist");
@@ -780,7 +788,8 @@ fn svg_static_images_are_normalized_to_cached_png_overlays() {
             target_width_px: 768,
             target_height_px: 540,
             ffmpeg_available: true,
-            magick_available: true,
+            resvg_available: true,
+            magick_available: false,
             force_render_to_cache: false,
             prepare_inline_payload: false,
         },
@@ -808,7 +817,56 @@ fn svg_static_images_are_normalized_to_cached_png_overlays() {
 }
 
 #[test]
+fn svg_static_images_fall_back_to_magick_when_resvg_is_unavailable() {
+    if !crate::app::overlays::inline_image::command_exists("magick") {
+        return;
+    }
+
+    let (_app, root) = build_selected_static_image_app("svg-magick-fallback", "demo.svg");
+    let path = root.join("demo.svg");
+    let metadata = fs::metadata(&path).expect("svg metadata should exist");
+    let prepared = crate::app::overlays::images::prepare_static_image_asset(
+        &jobs::ImagePrepareRequest {
+            path: path.clone(),
+            size: metadata.len(),
+            modified: None,
+            target_width_px: 768,
+            target_height_px: 540,
+            ffmpeg_available: true,
+            resvg_available: false,
+            magick_available: true,
+            force_render_to_cache: false,
+            prepare_inline_payload: false,
+        },
+        || false,
+    )
+    .expect("svg image should prepare successfully via magick fallback");
+
+    assert_eq!(
+        prepared
+            .display_path
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("png")
+    );
+    assert_eq!(
+        prepared.dimensions,
+        RenderedImageDimensions {
+            width_px: 600,
+            height_px: 300,
+        }
+    );
+    assert_ne!(prepared.display_path, path);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn extensionless_svg_static_image_preparation_succeeds() {
+    if !crate::app::overlays::inline_image::command_exists("resvg") {
+        return;
+    }
+
     let root = temp_root("svg-noext-cache");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let path = root.join("logo");
@@ -823,7 +881,8 @@ fn extensionless_svg_static_image_preparation_succeeds() {
             target_width_px: 768,
             target_height_px: 540,
             ffmpeg_available: true,
-            magick_available: true,
+            resvg_available: true,
+            magick_available: false,
             force_render_to_cache: false,
             prepare_inline_payload: false,
         },
@@ -866,6 +925,7 @@ fn oversized_png_static_images_are_normalized_to_cached_overlays() {
             target_width_px: 768,
             target_height_px: 540,
             ffmpeg_available: true,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: false,
             prepare_inline_payload: false,
@@ -918,6 +978,7 @@ fn forced_png_preview_renders_a_cached_overlay_asset() {
             target_width_px: 768,
             target_height_px: 540,
             ffmpeg_available: true,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: true,
             prepare_inline_payload: false,
@@ -970,6 +1031,7 @@ fn oversized_extensionless_png_static_images_are_normalized_to_cached_overlays()
             target_width_px: 768,
             target_height_px: 540,
             ffmpeg_available: true,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: false,
             prepare_inline_payload: false,
@@ -1226,6 +1288,7 @@ fn png_static_image_preparation_preserves_alpha_channel() {
             target_width_px: 8,
             target_height_px: 8,
             ffmpeg_available: true,
+            resvg_available: false,
             magick_available: true,
             force_render_to_cache: false,
             prepare_inline_payload: false,
@@ -1268,6 +1331,7 @@ fn iterm_png_and_jpeg_static_images_use_direct_source_payloads() {
                 target_width_px: 768,
                 target_height_px: 540,
                 ffmpeg_available: true,
+                resvg_available: false,
                 magick_available: true,
                 force_render_to_cache: false,
                 prepare_inline_payload: true,

--- a/src/app/overlays/preview_visual/tests.rs
+++ b/src/app/overlays/preview_visual/tests.rs
@@ -506,6 +506,7 @@ fn concurrent_inline_raster_prepares_keep_shared_render_cache_readable() {
         target_width_px: 384,
         target_height_px: 640,
         ffmpeg_available: false,
+        resvg_available: false,
         magick_available: false,
         force_render_to_cache: false,
         prepare_inline_payload: false,


### PR DESCRIPTION
## Summary

  This PR makes SVG previews prefer resvg when it is installed, while keeping magick as the fallback.