### PR TITLE
Improve preview cancellation and line budgeting

### DIFF
--- a/src/app/actions/preview.rs
+++ b/src/app/actions/preview.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::preview::{
-    PreviewContent, PreviewKind, PreviewLineCoverage, PreviewRequestOptions, PreviewWorkClass,
-    loading_preview_for, preview_work_class, should_build_preview_in_background,
+    MIN_DYNAMIC_CODE_PREVIEW_LINE_LIMIT, PreviewContent, PreviewKind, PreviewLineCoverage,
+    PreviewRequestOptions, PreviewWorkClass, default_code_preview_line_limit, loading_preview_for,
+    preview_work_class, should_build_preview_in_background,
 };
 use std::sync::Arc;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -187,10 +188,12 @@ impl App {
                     self.preview_state.metrics.cache_misses += 1;
                     let loading_path = entry.path.clone();
                     let work_class = preview_work_class(&entry, &preview_options);
+                    let code_line_limit = self.preview_code_line_limit_for_entry(&entry);
                     let request = PreviewRequest {
                         token: self.preview_state.token,
                         entry,
                         variant: preview_options.clone(),
+                        code_line_limit,
                         priority: PreviewPriority::High,
                         work_class,
                     };
@@ -212,10 +215,12 @@ impl App {
                     );
                     let loading_path = entry.path.clone();
                     let work_class = preview_work_class(&entry, &preview_options);
+                    let code_line_limit = self.preview_code_line_limit_for_entry(&entry);
                     let request = PreviewRequest {
                         token: self.preview_state.token,
                         entry,
                         variant: preview_options.clone(),
+                        code_line_limit,
                         priority: PreviewPriority::High,
                         work_class,
                     };
@@ -293,6 +298,7 @@ impl App {
         let cached = self.preview_state.result_cache.get(&PreviewCacheKey {
             path: entry.path.clone(),
             variant: variant.clone(),
+            code_line_limit: self.preview_code_line_limit_for_entry(entry),
         })?;
         if cached.size == entry.size && cached.modified == entry.modified {
             Some(cached.preview.clone())
@@ -311,19 +317,33 @@ impl App {
             .get(&PreviewCacheKey {
                 path: entry.path.clone(),
                 variant: variant.clone(),
+                code_line_limit: self.preview_code_line_limit_for_entry(entry),
             })
             .map(|cached| cached.preview.clone())
     }
 
+    #[cfg(test)]
     pub(in crate::app) fn cache_preview_result(
         &mut self,
         entry: &Entry,
         variant: &PreviewRequestOptions,
         preview: &PreviewContent,
     ) {
+        let code_line_limit = self.preview_code_line_limit_for_entry(entry);
+        self.cache_preview_result_with_code_line_limit(entry, variant, code_line_limit, preview);
+    }
+
+    pub(in crate::app) fn cache_preview_result_with_code_line_limit(
+        &mut self,
+        entry: &Entry,
+        variant: &PreviewRequestOptions,
+        code_line_limit: usize,
+        preview: &PreviewContent,
+    ) {
         let key = PreviewCacheKey {
             path: entry.path.clone(),
             variant: variant.clone(),
+            code_line_limit,
         };
         self.preview_state.result_cache.insert(
             key.clone(),
@@ -434,10 +454,12 @@ impl App {
                 continue;
             }
 
+            let code_line_limit = self.preview_code_line_limit_for_entry(&entry);
             let request = PreviewRequest {
                 token: self.preview_state.token,
                 entry,
                 variant,
+                code_line_limit,
                 priority: PreviewPriority::Low,
                 work_class: PreviewWorkClass::Light,
             };
@@ -457,6 +479,32 @@ impl App {
         self.comic_preview_request_options_for_entry(entry)
             .or_else(|| self.epub_preview_request_options_for_entry(entry))
             .unwrap_or_default()
+    }
+
+    pub(in crate::app) fn preview_code_line_limit_for_entry(&self, entry: &Entry) -> usize {
+        self.preview_code_line_limit_for_entry_with_rows(
+            entry,
+            self.frame_state.preview_rows_visible,
+        )
+    }
+
+    pub(in crate::app) fn preview_code_line_limit_for_entry_with_rows(
+        &self,
+        entry: &Entry,
+        preview_rows_visible: usize,
+    ) -> usize {
+        let facts = crate::file_info::inspect_path_cached(
+            &entry.path,
+            entry.kind,
+            entry.size,
+            entry.modified,
+        );
+        if facts.preview.kind == crate::file_info::PreviewKind::Source
+            && facts.preview.structured_format.is_none()
+        {
+            return preview_code_line_limit(preview_rows_visible);
+        }
+        default_code_preview_line_limit()
     }
 
     #[cfg(test)]
@@ -506,6 +554,16 @@ impl App {
             .content
             .set_total_line_count_pending(pending);
     }
+}
+
+fn preview_code_line_limit(preview_rows_visible: usize) -> usize {
+    if preview_rows_visible == 0 {
+        return default_code_preview_line_limit();
+    }
+    preview_rows_visible.saturating_mul(3).clamp(
+        MIN_DYNAMIC_CODE_PREVIEW_LINE_LIMIT,
+        default_code_preview_line_limit(),
+    )
 }
 
 impl App {

--- a/src/app/actions/tests.rs
+++ b/src/app/actions/tests.rs
@@ -19,7 +19,7 @@ fn make_auto_reload_ready(app: &mut App) {
 }
 
 fn wait_for_directory_load(app: &mut App) {
-    for _ in 0..100 {
+    for _ in 0..300 {
         let _ = app.process_background_jobs();
         if app.directory_runtime.pending_load.is_none() {
             return;
@@ -30,7 +30,7 @@ fn wait_for_directory_load(app: &mut App) {
 }
 
 fn wait_for_directory_reload_to_queue(app: &mut App) {
-    for _ in 0..100 {
+    for _ in 0..300 {
         let _ = app.process_background_jobs();
         if app.directory_runtime.pending_load.is_some() {
             return;
@@ -194,6 +194,46 @@ fn selection_summary_marks_directories_with_trailing_slash() {
 
     let app = App::new_at(root.clone()).expect("failed to create app");
     assert_eq!(app.selection_summary(), "1/1  child/");
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn set_frame_state_refreshes_code_preview_when_visible_rows_change() {
+    let root = temp_path("code-preview-resize");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("main.rs"), "fn main() {}\n").expect("failed to write code file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    let initial_preview_token = app.preview_state.token;
+
+    app.set_frame_state(FrameState {
+        preview_rows_visible: 12,
+        preview_cols_visible: 80,
+        ..FrameState::default()
+    });
+
+    assert!(app.preview_state.token > initial_preview_token);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn set_frame_state_does_not_refresh_plain_text_preview_when_visible_rows_change() {
+    let root = temp_path("text-preview-resize");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("notes.txt"), "plain text\n").expect("failed to write text file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    let initial_preview_token = app.preview_state.token;
+
+    app.set_frame_state(FrameState {
+        preview_rows_visible: 12,
+        preview_cols_visible: 80,
+        ..FrameState::default()
+    });
+
+    assert_eq!(app.preview_state.token, initial_preview_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/create/mod.rs
+++ b/src/app/create/mod.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::text_edit::*;
+use super::*;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use std::{env, fs, path::Path};
 
@@ -36,22 +36,32 @@ impl App {
         let Some(c) = &self.create else {
             return "Create".to_string();
         };
-        let files = c.lines.iter().filter(|l| {
-            let t = l.trim();
-            !t.is_empty() && !t.starts_with('/') && !t.ends_with('/')
-        }).count();
-        let dirs = c.lines.iter().filter(|l| {
-            let t = l.trim();
-            !t.is_empty() && (t.starts_with('/') || t.ends_with('/'))
-        }).count();
+        let files = c
+            .lines
+            .iter()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty() && !t.starts_with('/') && !t.ends_with('/')
+            })
+            .count();
+        let dirs = c
+            .lines
+            .iter()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty() && (t.starts_with('/') || t.ends_with('/'))
+            })
+            .count();
         match (files, dirs) {
             (0, 0) => "Create".to_string(),
             (f, 0) => format!("Create {} file{}", f, if f == 1 { "" } else { "s" }),
             (0, d) => format!("Create {} folder{}", d, if d == 1 { "" } else { "s" }),
             (f, d) => format!(
                 "Create {} file{} and {} folder{}",
-                f, if f == 1 { "" } else { "s" },
-                d, if d == 1 { "" } else { "s" },
+                f,
+                if f == 1 { "" } else { "s" },
+                d,
+                if d == 1 { "" } else { "s" },
             ),
         }
     }
@@ -62,8 +72,6 @@ impl App {
             .and_then(|c| c.line_errors.get(index))
             .and_then(Option::as_deref)
     }
-
-
 }
 
 // ---------------------------------------------------------------------------
@@ -90,9 +98,7 @@ impl App {
 
 impl App {
     pub(in crate::app) fn handle_create_key(&mut self, key: KeyEvent) -> Result<()> {
-        if key.modifiers.contains(KeyModifiers::CONTROL)
-            && matches!(key.code, KeyCode::Char('c'))
-        {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             self.create = None;
             return Ok(());
         }
@@ -243,22 +249,22 @@ impl App {
                     return Ok(());
                 }
                 // Click inside list area — move cursor to clicked line and column.
-                if let Some(list_area) = self.frame_state.create_list_area {
-                    if rect_contains(list_area, mouse.column, mouse.row) {
-                        let scroll_top = self.frame_state.create_scroll_top;
-                        let row_offset = (mouse.row - list_area.y) as usize;
-                        let line_idx = scroll_top + row_offset;
-                        let line_count = self.create_line_count();
-                        if line_idx < line_count {
-                            let line_len = self.create_line(line_idx).chars().count();
-                            // Text starts after icon (3 cells).
-                            let char_col = (mouse.column.saturating_sub(list_area.x + 3)) as usize;
-                            let cursor_col = char_col.min(line_len);
-                            if let Some(c) = &mut self.create {
-                                c.cursor_line = line_idx;
-                                c.cursor_col = cursor_col;
-                                c.preferred_col = cursor_col;
-                            }
+                if let Some(list_area) = self.frame_state.create_list_area
+                    && rect_contains(list_area, mouse.column, mouse.row)
+                {
+                    let scroll_top = self.frame_state.create_scroll_top;
+                    let row_offset = (mouse.row - list_area.y) as usize;
+                    let line_idx = scroll_top + row_offset;
+                    let line_count = self.create_line_count();
+                    if line_idx < line_count {
+                        let line_len = self.create_line(line_idx).chars().count();
+                        // Text starts after icon (3 cells).
+                        let char_col = (mouse.column.saturating_sub(list_area.x + 3)) as usize;
+                        let cursor_col = char_col.min(line_len);
+                        if let Some(c) = &mut self.create {
+                            c.cursor_line = line_idx;
+                            c.cursor_col = cursor_col;
+                            c.preferred_col = cursor_col;
                         }
                     }
                 }
@@ -328,8 +334,8 @@ impl App {
 
     fn create_move_vertical(&mut self, delta: isize) {
         let Some(c) = &mut self.create else { return };
-        let new_line = (c.cursor_line as isize + delta)
-            .clamp(0, c.lines.len() as isize - 1) as usize;
+        let new_line =
+            (c.cursor_line as isize + delta).clamp(0, c.lines.len() as isize - 1) as usize;
         if new_line == c.cursor_line {
             return;
         }
@@ -531,8 +537,14 @@ impl App {
         let files = items.iter().filter(|(_, i)| !i.is_dir).count();
         let dirs = items.iter().filter(|(_, i)| i.is_dir).count();
         let status = match (files, dirs) {
-            (1, 0) => format!("Created \"{}\"", items.iter().find(|(_, i)| !i.is_dir).unwrap().1.name),
-            (0, 1) => format!("Created \"{}\"", items.iter().find(|(_, i)| i.is_dir).unwrap().1.name),
+            (1, 0) => format!(
+                "Created \"{}\"",
+                items.iter().find(|(_, i)| !i.is_dir).unwrap().1.name
+            ),
+            (0, 1) => format!(
+                "Created \"{}\"",
+                items.iter().find(|(_, i)| i.is_dir).unwrap().1.name
+            ),
             (f, 0) => format!("Created {f} files"),
             (0, d) => format!("Created {d} folders"),
             (f, d) => format!(
@@ -617,7 +629,12 @@ impl App {
         self.help_open = false;
         self.search = None;
         self.create = None;
-        self.trash = Some(TrashOverlay { targets, scroll: 0, confirmed: true, permanent });
+        self.trash = Some(TrashOverlay {
+            targets,
+            scroll: 0,
+            confirmed: true,
+            permanent,
+        });
     }
 
     pub fn trash_is_open(&self) -> bool {
@@ -628,11 +645,19 @@ impl App {
         let Some(t) = &self.trash else {
             return String::new();
         };
-        let verb = if t.permanent { "Delete permanently" } else { "Trash" };
+        let verb = if t.permanent {
+            "Delete permanently"
+        } else {
+            "Trash"
+        };
         match t.targets.len() {
             0 => String::new(),
             1 => {
-                let kind = if t.targets[0].is_dir { "folder" } else { "file" };
+                let kind = if t.targets[0].is_dir {
+                    "folder"
+                } else {
+                    "file"
+                };
                 format!("{verb} 1 selected {kind}?")
             }
             _ => {
@@ -682,7 +707,7 @@ impl App {
         self.trash
             .as_ref()
             .and_then(|t| t.targets.get(index))
-            .map_or(false, |t| t.is_dir)
+            .is_some_and(|t| t.is_dir)
     }
 
     pub fn trash_confirmed(&self) -> bool {
@@ -690,9 +715,7 @@ impl App {
     }
 
     pub(in crate::app) fn handle_trash_key(&mut self, key: KeyEvent) -> Result<()> {
-        if key.modifiers.contains(KeyModifiers::CONTROL)
-            && matches!(key.code, KeyCode::Char('c'))
-        {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             self.trash = None;
             return Ok(());
         }
@@ -750,11 +773,15 @@ impl App {
                     self.trash = None;
                     return Ok(());
                 }
-                if self.frame_state.trash_confirm_btn
+                if self
+                    .frame_state
+                    .trash_confirm_btn
                     .is_some_and(|r| rect_contains(r, mouse.column, mouse.row))
                 {
                     self.confirm_trash()?;
-                } else if self.frame_state.trash_cancel_btn
+                } else if self
+                    .frame_state
+                    .trash_cancel_btn
                     .is_some_and(|r| rect_contains(r, mouse.column, mouse.row))
                 {
                     self.trash = None;
@@ -784,11 +811,13 @@ impl App {
         for target in &t.targets {
             if t.permanent {
                 if target.is_dir {
-                    fs::remove_dir_all(&target.path)
-                        .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))?;
+                    fs::remove_dir_all(&target.path).map_err(|e| {
+                        anyhow::anyhow!("Could not delete \"{}\": {e}", target.name)
+                    })?;
                 } else {
-                    fs::remove_file(&target.path)
-                        .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))?;
+                    fs::remove_file(&target.path).map_err(|e| {
+                        anyhow::anyhow!("Could not delete \"{}\": {e}", target.name)
+                    })?;
                 }
             } else {
                 trash::delete(&target.path)
@@ -796,7 +825,11 @@ impl App {
             }
         }
         self.selected_paths.clear();
-        let verb = if t.permanent { "Permanently deleted" } else { "Trashed" };
+        let verb = if t.permanent {
+            "Permanently deleted"
+        } else {
+            "Trashed"
+        };
         let status = match t.targets.len() {
             0 => String::new(),
             1 => format!("{verb} \"{}\"", t.targets[0].name),
@@ -900,7 +933,7 @@ impl App {
         self.bulk_rename
             .as_ref()
             .and_then(|r| r.items.get(index))
-            .map_or(false, |i| i.is_dir)
+            .is_some_and(|i| i.is_dir)
     }
 
     pub fn bulk_rename_line_error(&self, index: usize) -> Option<&str> {
@@ -919,9 +952,7 @@ impl App {
     }
 
     pub(in crate::app) fn handle_bulk_rename_key(&mut self, key: KeyEvent) -> Result<()> {
-        if key.modifiers.contains(KeyModifiers::CONTROL)
-            && matches!(key.code, KeyCode::Char('c'))
-        {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             self.bulk_rename = None;
             return Ok(());
         }
@@ -997,30 +1028,28 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
-                    if r.cursor_col > 0 {
-                        let start =
-                            previous_delete_start(&r.new_names[r.cursor_line], r.cursor_col);
-                        remove_char_range(&mut r.new_names[r.cursor_line], start, r.cursor_col);
-                        r.cursor_col = start;
-                        r.preferred_col = start;
-                        r.line_errors[r.cursor_line] = None;
-                    }
+                if let Some(r) = &mut self.bulk_rename
+                    && r.cursor_col > 0
+                {
+                    let start = previous_delete_start(&r.new_names[r.cursor_line], r.cursor_col);
+                    remove_char_range(&mut r.new_names[r.cursor_line], start, r.cursor_col);
+                    r.cursor_col = start;
+                    r.preferred_col = start;
+                    r.line_errors[r.cursor_line] = None;
                 }
             }
             KeyCode::Char('h' | 'w')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
-                    if r.cursor_col > 0 {
-                        let start =
-                            previous_delete_start(&r.new_names[r.cursor_line], r.cursor_col);
-                        remove_char_range(&mut r.new_names[r.cursor_line], start, r.cursor_col);
-                        r.cursor_col = start;
-                        r.preferred_col = start;
-                        r.line_errors[r.cursor_line] = None;
-                    }
+                if let Some(r) = &mut self.bulk_rename
+                    && r.cursor_col > 0
+                {
+                    let start = previous_delete_start(&r.new_names[r.cursor_line], r.cursor_col);
+                    remove_char_range(&mut r.new_names[r.cursor_line], start, r.cursor_col);
+                    r.cursor_col = start;
+                    r.preferred_col = start;
+                    r.line_errors[r.cursor_line] = None;
                 }
             }
             KeyCode::Delete
@@ -1044,16 +1073,15 @@ impl App {
                 }
             }
             KeyCode::Backspace if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename {
-                    if r.cursor_col > 0 {
-                        let start =
-                            char_to_byte(&r.new_names[r.cursor_line], r.cursor_col - 1);
-                        let end = char_to_byte(&r.new_names[r.cursor_line], r.cursor_col);
-                        r.new_names[r.cursor_line].replace_range(start..end, "");
-                        r.cursor_col -= 1;
-                        r.preferred_col = r.cursor_col;
-                        r.line_errors[r.cursor_line] = None;
-                    }
+                if let Some(r) = &mut self.bulk_rename
+                    && r.cursor_col > 0
+                {
+                    let start = char_to_byte(&r.new_names[r.cursor_line], r.cursor_col - 1);
+                    let end = char_to_byte(&r.new_names[r.cursor_line], r.cursor_col);
+                    r.new_names[r.cursor_line].replace_range(start..end, "");
+                    r.cursor_col -= 1;
+                    r.preferred_col = r.cursor_col;
+                    r.line_errors[r.cursor_line] = None;
                 }
             }
             KeyCode::Delete if key.modifiers == KeyModifiers::NONE => {
@@ -1092,8 +1120,8 @@ impl App {
         let Some(r) = &mut self.bulk_rename else {
             return;
         };
-        let new_line = (r.cursor_line as isize + delta)
-            .clamp(0, r.items.len() as isize - 1) as usize;
+        let new_line =
+            (r.cursor_line as isize + delta).clamp(0, r.items.len() as isize - 1) as usize;
         if new_line == r.cursor_line {
             return;
         }
@@ -1113,24 +1141,22 @@ impl App {
                     self.bulk_rename = None;
                     return Ok(());
                 }
-                if let Some(list_area) = self.frame_state.bulk_rename_list_area {
-                    if rect_contains(list_area, mouse.column, mouse.row) {
-                        let scroll_top = self.frame_state.bulk_rename_scroll_top;
-                        let row_offset = (mouse.row - list_area.y) as usize;
-                        let line_idx = scroll_top + row_offset;
-                        let count = self.bulk_rename_item_count();
-                        if line_idx < count {
-                            let line_len =
-                                self.bulk_rename_new_name(line_idx).chars().count();
-                            // Text starts after icon (3 cells).
-                            let char_col =
-                                (mouse.column.saturating_sub(list_area.x + 3)) as usize;
-                            let cursor_col = char_col.min(line_len);
-                            if let Some(r) = &mut self.bulk_rename {
-                                r.cursor_line = line_idx;
-                                r.cursor_col = cursor_col;
-                                r.preferred_col = cursor_col;
-                            }
+                if let Some(list_area) = self.frame_state.bulk_rename_list_area
+                    && rect_contains(list_area, mouse.column, mouse.row)
+                {
+                    let scroll_top = self.frame_state.bulk_rename_scroll_top;
+                    let row_offset = (mouse.row - list_area.y) as usize;
+                    let line_idx = scroll_top + row_offset;
+                    let count = self.bulk_rename_item_count();
+                    if line_idx < count {
+                        let line_len = self.bulk_rename_new_name(line_idx).chars().count();
+                        // Text starts after icon (3 cells).
+                        let char_col = (mouse.column.saturating_sub(list_area.x + 3)) as usize;
+                        let cursor_col = char_col.min(line_len);
+                        if let Some(r) = &mut self.bulk_rename {
+                            r.cursor_line = line_idx;
+                            r.cursor_col = cursor_col;
+                            r.preferred_col = cursor_col;
                         }
                     }
                 }
@@ -1195,8 +1221,7 @@ impl App {
             if let Some(r) = &mut self.bulk_rename {
                 r.line_errors = errors;
                 r.cursor_line = err_line;
-                r.cursor_col =
-                    r.cursor_col.min(r.new_names[err_line].chars().count());
+                r.cursor_col = r.cursor_col.min(r.new_names[err_line].chars().count());
                 r.preferred_col = r.cursor_col;
             }
             return Ok(());
@@ -1256,8 +1281,7 @@ impl App {
         let status = match renamed {
             0 => "No files renamed".to_string(),
             1 => {
-                let (_, orig, new_name) =
-                    ops.iter().find(|(_, o, n)| o != n).unwrap();
+                let (_, orig, new_name) = ops.iter().find(|(_, o, n)| o != n).unwrap();
                 format!("Renamed \"{}\" → \"{}\"", orig, new_name)
             }
             n => format!("Renamed {} items", n),
@@ -1325,7 +1349,7 @@ impl App {
     }
 
     pub fn rename_item_is_dir(&self) -> bool {
-        self.rename.as_ref().map_or(false, |r| r.is_dir)
+        self.rename.as_ref().is_some_and(|r| r.is_dir)
     }
 
     pub fn rename_error(&self) -> Option<&str> {
@@ -1333,9 +1357,7 @@ impl App {
     }
 
     pub(in crate::app) fn handle_rename_key(&mut self, key: KeyEvent) -> Result<()> {
-        if key.modifiers.contains(KeyModifiers::CONTROL)
-            && matches!(key.code, KeyCode::Char('c'))
-        {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             self.rename = None;
             return Ok(());
         }
@@ -1397,26 +1419,26 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename {
-                    if r.cursor_col > 0 {
-                        let start = previous_delete_start(&r.input, r.cursor_col);
-                        remove_char_range(&mut r.input, start, r.cursor_col);
-                        r.cursor_col = start;
-                        r.error = None;
-                    }
+                if let Some(r) = &mut self.rename
+                    && r.cursor_col > 0
+                {
+                    let start = previous_delete_start(&r.input, r.cursor_col);
+                    remove_char_range(&mut r.input, start, r.cursor_col);
+                    r.cursor_col = start;
+                    r.error = None;
                 }
             }
             KeyCode::Char('h' | 'w')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename {
-                    if r.cursor_col > 0 {
-                        let start = previous_delete_start(&r.input, r.cursor_col);
-                        remove_char_range(&mut r.input, start, r.cursor_col);
-                        r.cursor_col = start;
-                        r.error = None;
-                    }
+                if let Some(r) = &mut self.rename
+                    && r.cursor_col > 0
+                {
+                    let start = previous_delete_start(&r.input, r.cursor_col);
+                    remove_char_range(&mut r.input, start, r.cursor_col);
+                    r.cursor_col = start;
+                    r.error = None;
                 }
             }
             KeyCode::Delete
@@ -1440,14 +1462,14 @@ impl App {
                 }
             }
             KeyCode::Backspace if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename {
-                    if r.cursor_col > 0 {
-                        let start = char_to_byte(&r.input, r.cursor_col - 1);
-                        let end = char_to_byte(&r.input, r.cursor_col);
-                        r.input.replace_range(start..end, "");
-                        r.cursor_col -= 1;
-                        r.error = None;
-                    }
+                if let Some(r) = &mut self.rename
+                    && r.cursor_col > 0
+                {
+                    let start = char_to_byte(&r.input, r.cursor_col - 1);
+                    let end = char_to_byte(&r.input, r.cursor_col);
+                    r.input.replace_range(start..end, "");
+                    r.cursor_col -= 1;
+                    r.error = None;
                 }
             }
             KeyCode::Delete if key.modifiers == KeyModifiers::NONE => {
@@ -1482,17 +1504,14 @@ impl App {
     }
 
     pub(in crate::app) fn handle_rename_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
-        match mouse.kind {
-            MouseEventKind::Down(MouseButton::Left) => {
-                let inside = self
-                    .frame_state
-                    .rename_panel
-                    .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
-                if !inside {
-                    self.rename = None;
-                }
+        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
+            let inside = self
+                .frame_state
+                .rename_panel
+                .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
+            if !inside {
+                self.rename = None;
             }
-            _ => {}
         }
         Ok(())
     }
@@ -1616,7 +1635,11 @@ impl App {
         self.search = None;
         self.create = None;
         self.trash = None;
-        self.restore = Some(RestoreOverlay { targets, scroll: 0, confirmed: true });
+        self.restore = Some(RestoreOverlay {
+            targets,
+            scroll: 0,
+            confirmed: true,
+        });
     }
 
     pub fn restore_is_open(&self) -> bool {
@@ -1630,7 +1653,11 @@ impl App {
         match r.targets.len() {
             0 => String::new(),
             1 => {
-                let kind = if r.targets[0].is_dir { "folder" } else { "file" };
+                let kind = if r.targets[0].is_dir {
+                    "folder"
+                } else {
+                    "file"
+                };
                 format!("Restore 1 selected {kind}?")
             }
             _ => {
@@ -1680,7 +1707,7 @@ impl App {
         self.restore
             .as_ref()
             .and_then(|r| r.targets.get(index))
-            .map_or(false, |t| t.is_dir)
+            .is_some_and(|t| t.is_dir)
     }
 
     pub fn restore_confirmed(&self) -> bool {
@@ -1688,9 +1715,7 @@ impl App {
     }
 
     pub(in crate::app) fn handle_restore_key(&mut self, key: KeyEvent) -> Result<()> {
-        if key.modifiers.contains(KeyModifiers::CONTROL)
-            && matches!(key.code, KeyCode::Char('c'))
-        {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             self.restore = None;
             return Ok(());
         }
@@ -1748,11 +1773,15 @@ impl App {
                     self.restore = None;
                     return Ok(());
                 }
-                if self.frame_state.restore_confirm_btn
+                if self
+                    .frame_state
+                    .restore_confirm_btn
                     .is_some_and(|r| rect_contains(r, mouse.column, mouse.row))
                 {
                     self.confirm_restore()?;
-                } else if self.frame_state.restore_cancel_btn
+                } else if self
+                    .frame_state
+                    .restore_cancel_btn
                     .is_some_and(|r| rect_contains(r, mouse.column, mouse.row))
                 {
                     self.restore = None;

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -51,9 +51,8 @@ impl App {
                 self.help_open = false;
                 return Ok(());
             }
-            match key.code {
-                KeyCode::Esc => self.help_open = false,
-                _ => {}
+            if key.code == KeyCode::Esc {
+                self.help_open = false;
             }
             if is_help_shortcut(key) {
                 self.help_open = false;
@@ -132,9 +131,7 @@ impl App {
                     }
                 }
                 KeyCode::Char(']') => {
-                    if self.step_epub_section(1)
-                        || self.step_comic_page(1)
-                        || self.step_pdf_page(1)
+                    if self.step_epub_section(1) || self.step_comic_page(1) || self.step_pdf_page(1)
                     {
                         return Ok(());
                     }

--- a/src/app/input/tests.rs
+++ b/src/app/input/tests.rs
@@ -708,7 +708,10 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
         fs::write(root.join(name), name).expect("failed to write temp file");
     }
     let long_file = root.join("long.txt");
-    let contents = (0..60).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    let contents = (0..60)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     fs::write(&long_file, &contents).expect("failed to write long file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
@@ -725,11 +728,24 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
 
     // Side-by-side layout: entries on the left, preview on the right
     app.set_frame_state(FrameState {
-        entries_panel: Some(Rect { x: 0, y: 0, width: 40, height: 20 }),
-        preview_panel: Some(Rect { x: 40, y: 0, width: 40, height: 20 }),
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
+        preview_panel: Some(Rect {
+            x: 40,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
         preview_rows_visible: 16,
         preview_cols_visible: 38,
-        metrics: ViewMetrics { cols: 1, rows_visible: 8 },
+        metrics: ViewMetrics {
+            cols: 1,
+            rows_visible: 8,
+        },
         ..FrameState::default()
     });
     wait_for_background_preview(&mut app);
@@ -765,8 +781,14 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
     }))
     .expect("preview scroll should be handled");
 
-    assert_eq!(app.selected, before_selected, "entry selection must not change when scrolling preview");
-    assert!(app.preview_state.scroll > before_scroll, "preview must have scrolled");
+    assert_eq!(
+        app.selected, before_selected,
+        "entry selection must not change when scrolling preview"
+    );
+    assert!(
+        app.preview_state.scroll > before_scroll,
+        "preview must have scrolled"
+    );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -778,7 +800,10 @@ fn high_frequency_preview_wheel_scrolls_preview_without_prior_moved_event() {
     let root = temp_path("wheel-hf-preview-no-moved");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let long_file = root.join("long.txt");
-    let contents = (0..60).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    let contents = (0..60)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     fs::write(&long_file, &contents).expect("failed to write long file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
@@ -796,11 +821,24 @@ fn high_frequency_preview_wheel_scrolls_preview_without_prior_moved_event() {
     app.select_index(long_index);
 
     app.set_frame_state(FrameState {
-        entries_panel: Some(Rect { x: 0, y: 0, width: 40, height: 20 }),
-        preview_panel: Some(Rect { x: 40, y: 0, width: 40, height: 20 }),
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
+        preview_panel: Some(Rect {
+            x: 40,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
         preview_rows_visible: 16,
         preview_cols_visible: 38,
-        metrics: ViewMetrics { cols: 1, rows_visible: 8 },
+        metrics: ViewMetrics {
+            cols: 1,
+            rows_visible: 8,
+        },
         ..FrameState::default()
     });
     wait_for_background_preview(&mut app);
@@ -817,8 +855,14 @@ fn high_frequency_preview_wheel_scrolls_preview_without_prior_moved_event() {
     }))
     .expect("preview scroll should be handled");
 
-    assert_eq!(app.selected, before_selected, "entry selection must not change when scrolling preview");
-    assert!(app.preview_state.scroll > before_scroll, "preview must have scrolled without a prior Moved event");
+    assert_eq!(
+        app.selected, before_selected,
+        "entry selection must not change when scrolling preview"
+    );
+    assert!(
+        app.preview_state.scroll > before_scroll,
+        "preview must have scrolled without a prior Moved event"
+    );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -831,7 +875,10 @@ fn hover_panel_routes_scroll_when_event_coords_are_outside_panels() {
     let root = temp_path("wheel-hover-panel-routing");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let long_file = root.join("long.txt");
-    let contents = (0..60).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    let contents = (0..60)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     fs::write(&long_file, &contents).expect("failed to write long file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
@@ -848,11 +895,24 @@ fn hover_panel_routes_scroll_when_event_coords_are_outside_panels() {
     app.select_index(long_index);
 
     app.set_frame_state(FrameState {
-        entries_panel: Some(Rect { x: 0, y: 0, width: 40, height: 20 }),
-        preview_panel: Some(Rect { x: 40, y: 0, width: 40, height: 20 }),
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
+        preview_panel: Some(Rect {
+            x: 40,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
         preview_rows_visible: 16,
         preview_cols_visible: 38,
-        metrics: ViewMetrics { cols: 1, rows_visible: 8 },
+        metrics: ViewMetrics {
+            cols: 1,
+            rows_visible: 8,
+        },
         ..FrameState::default()
     });
     wait_for_background_preview(&mut app);
@@ -879,7 +939,10 @@ fn hover_panel_routes_scroll_when_event_coords_are_outside_panels() {
     }))
     .expect("scroll should be handled");
 
-    assert_eq!(app.selected, before_selected, "entry selection must not change");
+    assert_eq!(
+        app.selected, before_selected,
+        "entry selection must not change"
+    );
     assert!(
         app.preview_state.scroll > before_scroll,
         "hover_panel should have routed scroll to preview despite wrong coords"

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -18,8 +18,8 @@ use self::{
 use super::overlays::images::PreparedStaticImageAsset;
 use super::overlays::pdf::PdfProbeResult;
 use super::*;
-use crate::preview::PreviewWorkClass;
 use crate::fs::search::SearchCandidate;
+use crate::preview::PreviewWorkClass;
 use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
@@ -270,6 +270,7 @@ pub(super) struct PreviewBuild {
     pub token: u64,
     pub entry: Entry,
     pub variant: preview::PreviewRequestOptions,
+    pub code_line_limit: usize,
     pub result: preview::PreviewContent,
 }
 
@@ -278,6 +279,7 @@ pub(super) struct PreviewRequest {
     pub token: u64,
     pub entry: Entry,
     pub variant: preview::PreviewRequestOptions,
+    pub code_line_limit: usize,
     pub priority: PreviewPriority,
     pub work_class: PreviewWorkClass,
 }

--- a/src/app/jobs/pool/preview.rs
+++ b/src/app/jobs/pool/preview.rs
@@ -3,7 +3,11 @@ use crate::preview::{PreviewRequestOptions, PreviewWorkClass};
 use std::{
     collections::{HashSet, VecDeque},
     path::PathBuf,
-    sync::{Arc, Condvar, Mutex, mpsc},
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     thread,
     time::{Instant, SystemTime},
 };
@@ -32,11 +36,12 @@ struct PreviewState {
     capacity: usize,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 struct ActivePreviewJob {
     key: PreviewJobKey,
     priority: PreviewPriority,
     work_class: PreviewWorkClass,
+    canceled: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -45,6 +50,7 @@ pub(in crate::app::jobs) struct PreviewJobKey {
     pub(in crate::app::jobs) size: u64,
     pub(in crate::app::jobs) modified: Option<SystemTime>,
     pub(in crate::app::jobs) variant: PreviewRequestOptions,
+    pub(in crate::app::jobs) code_line_limit: usize,
 }
 
 impl PreviewPool {
@@ -73,20 +79,26 @@ impl PreviewPool {
             let result_tx = result_tx.clone();
             let metrics = Arc::clone(&metrics);
             workers.push(thread::spawn(move || {
-                while let Some(request) = PreviewShared::pop(&shared) {
-                    let key = PreviewJobKey::from_entry(&request.entry, &request.variant);
+                while let Some((request, canceled)) = PreviewShared::pop(&shared) {
+                    let key = PreviewJobKey::from_request(&request);
                     let started_at = Instant::now();
-                    let result = crate::preview::build_preview_with_options(
+                    let result = crate::preview::build_preview_with_options_and_code_line_limit(
                         &request.entry,
                         &request.variant,
+                        request.code_line_limit,
+                        &|| canceled.load(Ordering::Relaxed),
                     );
                     PreviewShared::finish(&shared, &key);
                     lock_unpoison(&metrics).record_preview_completed(started_at.elapsed());
+                    if canceled.load(Ordering::Relaxed) {
+                        continue;
+                    }
                     if result_tx
                         .send(JobResult::Preview(Box::new(PreviewBuild {
                             token: request.token,
                             entry: request.entry,
                             variant: request.variant,
+                            code_line_limit: request.code_line_limit,
                             result,
                         })))
                         .is_err()
@@ -104,7 +116,7 @@ impl PreviewPool {
     }
 
     pub(in crate::app::jobs) fn submit(&self, request: PreviewRequest) -> bool {
-        let key = PreviewJobKey::from_entry(&request.entry, &request.variant);
+        let key = PreviewJobKey::from_request(&request);
         let mut state = lock_unpoison(&self.shared.state);
         if state.closed {
             return false;
@@ -120,6 +132,7 @@ impl PreviewPool {
                     lock_unpoison(&self.metrics).preview_promotions += 1;
                 }
                 let evicted = trim_preview_queue_for_high(&mut state);
+                cancel_stale_active_previews(&state, &key);
                 state.queued_high_keys.insert(key);
                 state.pending_high.push_back(request);
                 let mut metrics = lock_unpoison(&self.metrics);
@@ -138,6 +151,9 @@ impl PreviewPool {
                 }
                 if state.queued_low_keys.contains(&key) {
                     replace_preview_request(&mut state.pending_low, request, &key);
+                    return true;
+                }
+                if preview_active_contains(&state, &key) {
                     return true;
                 }
                 let evicted = if preview_pending_len(&state) >= state.capacity {
@@ -176,10 +192,7 @@ impl PreviewPool {
             PreviewPriority::High => &state.pending_high,
             PreviewPriority::Low => &state.pending_low,
         };
-        queue
-            .iter()
-            .map(|request| PreviewJobKey::from_entry(&request.entry, &request.variant))
-            .collect()
+        queue.iter().map(PreviewJobKey::from_request).collect()
     }
 
     #[cfg(test)]
@@ -208,15 +221,27 @@ impl PreviewPool {
     }
 
     #[cfg(test)]
+    pub(in crate::app::jobs) fn canceled_active_keys(&self) -> Vec<PreviewJobKey> {
+        let mut keys = lock_unpoison(&self.shared.state)
+            .active_jobs
+            .iter()
+            .filter(|job| job.canceled.load(Ordering::Relaxed))
+            .map(|job| job.key.clone())
+            .collect::<Vec<_>>();
+        keys.sort_by(|left, right| left.path.cmp(&right.path));
+        keys
+    }
+
+    #[cfg(test)]
     pub(in crate::app::jobs) fn pop_next_pending_for_tests(&self) -> Option<PreviewRequest> {
         let mut state = lock_unpoison(&self.shared.state);
         if let Some(request) = state.pending_high.pop_front() {
-            let key = PreviewJobKey::from_entry(&request.entry, &request.variant);
+            let key = PreviewJobKey::from_request(&request);
             state.queued_high_keys.remove(&key);
-            start_preview_request(&mut state, key, &request);
+            let _ = start_preview_request(&mut state, key, &request);
             return Some(request);
         }
-        pop_low_priority_request(&mut state)
+        pop_low_priority_request(&mut state).map(|(request, _)| request)
     }
 }
 
@@ -229,6 +254,9 @@ impl Drop for PreviewPool {
             state.pending_low.clear();
             state.queued_high_keys.clear();
             state.queued_low_keys.clear();
+            for job in &state.active_jobs {
+                job.canceled.store(true, Ordering::Relaxed);
+            }
         }
         self.shared.available.notify_all();
         for worker in self.workers.drain(..) {
@@ -238,17 +266,17 @@ impl Drop for PreviewPool {
 }
 
 impl PreviewShared {
-    fn pop(shared: &Arc<Self>) -> Option<PreviewRequest> {
+    fn pop(shared: &Arc<Self>) -> Option<(PreviewRequest, Arc<AtomicBool>)> {
         let mut state = lock_unpoison(&shared.state);
         loop {
             if state.closed {
                 return None;
             }
             if let Some(request) = state.pending_high.pop_front() {
-                let key = PreviewJobKey::from_entry(&request.entry, &request.variant);
+                let key = PreviewJobKey::from_request(&request);
                 state.queued_high_keys.remove(&key);
-                start_preview_request(&mut state, key, &request);
-                return Some(request);
+                let canceled = start_preview_request(&mut state, key, &request);
+                return Some((request, canceled));
             }
             if let Some(request) = pop_low_priority_request(&mut state) {
                 return Some(request);
@@ -266,12 +294,13 @@ impl PreviewShared {
 }
 
 impl PreviewJobKey {
-    fn from_entry(entry: &Entry, variant: &PreviewRequestOptions) -> Self {
+    fn from_request(request: &PreviewRequest) -> Self {
         Self {
-            path: entry.path.clone(),
-            size: entry.size,
-            modified: entry.modified,
-            variant: variant.clone(),
+            path: request.entry.path.clone(),
+            size: request.entry.size,
+            modified: request.entry.modified,
+            variant: request.variant.clone(),
+            code_line_limit: request.code_line_limit,
         }
     }
 }
@@ -279,7 +308,7 @@ impl PreviewJobKey {
 fn remove_preview_request(queue: &mut VecDeque<PreviewRequest>, key: &PreviewJobKey) {
     if let Some(index) = queue
         .iter()
-        .position(|request| PreviewJobKey::from_entry(&request.entry, &request.variant) == *key)
+        .position(|request| PreviewJobKey::from_request(request) == *key)
     {
         queue.remove(index);
     }
@@ -289,16 +318,19 @@ fn start_preview_request(
     state: &mut PreviewState,
     key: PreviewJobKey,
     request: &PreviewRequest,
-) {
+) -> Arc<AtomicBool> {
+    let canceled = Arc::new(AtomicBool::new(false));
     state.active_keys.insert(key.clone());
     state.active_jobs.push(ActivePreviewJob {
         key,
         priority: request.priority,
         work_class: request.work_class,
+        canceled: Arc::clone(&canceled),
     });
+    canceled
 }
 
-fn pop_low_priority_request(state: &mut PreviewState) -> Option<PreviewRequest> {
+fn pop_low_priority_request(state: &mut PreviewState) -> Option<(PreviewRequest, Arc<AtomicBool>)> {
     let heavy_limit_reached =
         active_low_priority_heavy_count(state) >= MAX_CONCURRENT_LOW_PRIORITY_HEAVY_PREVIEWS;
     let index = if heavy_limit_reached {
@@ -310,10 +342,10 @@ fn pop_low_priority_request(state: &mut PreviewState) -> Option<PreviewRequest> 
         0
     };
     let request = state.pending_low.remove(index)?;
-    let key = PreviewJobKey::from_entry(&request.entry, &request.variant);
+    let key = PreviewJobKey::from_request(&request);
     state.queued_low_keys.remove(&key);
-    start_preview_request(state, key, &request);
-    Some(request)
+    let canceled = start_preview_request(state, key, &request);
+    Some((request, canceled))
 }
 
 fn active_low_priority_heavy_count(state: &PreviewState) -> usize {
@@ -321,8 +353,7 @@ fn active_low_priority_heavy_count(state: &PreviewState) -> usize {
         .active_jobs
         .iter()
         .filter(|job| {
-            job.priority == PreviewPriority::Low
-                && job.work_class == PreviewWorkClass::Heavy
+            job.priority == PreviewPriority::Low && job.work_class == PreviewWorkClass::Heavy
         })
         .count()
 }
@@ -345,7 +376,7 @@ fn replace_preview_request_with_priority(
     request.priority = priority;
     if let Some(index) = queue
         .iter()
-        .position(|queued| PreviewJobKey::from_entry(&queued.entry, &queued.variant) == *key)
+        .position(|queued| PreviewJobKey::from_request(queued) == *key)
     {
         queue[index] = request;
     }
@@ -355,13 +386,25 @@ fn preview_pending_len(state: &PreviewState) -> usize {
     state.pending_high.len() + state.pending_low.len()
 }
 
+fn preview_active_contains(state: &PreviewState, key: &PreviewJobKey) -> bool {
+    state.active_jobs.iter().any(|job| job.key == *key)
+}
+
+fn cancel_stale_active_previews(state: &PreviewState, keep: &PreviewJobKey) {
+    for job in &state.active_jobs {
+        if &job.key != keep {
+            job.canceled.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
 fn evict_oldest_low_priority_preview(state: &mut PreviewState) -> bool {
     let Some(stale) = state.pending_low.pop_front() else {
         return false;
     };
     state
         .queued_low_keys
-        .remove(&PreviewJobKey::from_entry(&stale.entry, &stale.variant));
+        .remove(&PreviewJobKey::from_request(&stale));
     true
 }
 
@@ -378,7 +421,7 @@ fn trim_preview_queue_for_high(state: &mut PreviewState) -> u64 {
         };
         state
             .queued_high_keys
-            .remove(&PreviewJobKey::from_entry(&stale.entry, &stale.variant));
+            .remove(&PreviewJobKey::from_request(&stale));
     }
     evicted
 }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -1,5 +1,9 @@
 use super::*;
-use std::{collections::HashMap, sync::Arc, time::{Duration, Instant}};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 const JOB_RESULT_APPLY_MAX_PER_TICK: usize = 12;
 const JOB_RESULT_APPLY_TIME_BUDGET: Duration = Duration::from_millis(2);
@@ -155,7 +159,12 @@ impl App {
                     }
                 }
                 JobResult::Preview(build) => {
-                    self.cache_preview_result(&build.entry, &build.variant, &build.result);
+                    self.cache_preview_result_with_code_line_limit(
+                        &build.entry,
+                        &build.variant,
+                        build.code_line_limit,
+                        &build.result,
+                    );
                     let build_is_comic = build.result.kind == preview::PreviewKind::Comic;
                     let build_is_epub_section = matches!(
                         build.variant,
@@ -178,6 +187,8 @@ impl App {
                     if build.token != self.preview_state.token
                         || !is_current_entry
                         || !is_current_variant
+                        || build.code_line_limit
+                            != self.preview_code_line_limit_for_entry(&build.entry)
                     {
                         self.refresh_static_image_preloads_for_cached_selected_page_preview(
                             build_has_page_image,
@@ -207,12 +218,11 @@ impl App {
             }
         }
 
-        if processed == JOB_RESULT_APPLY_MAX_PER_TICK
-            || (processed > 0 && started_at.elapsed() >= JOB_RESULT_APPLY_TIME_BUDGET)
+        if (processed == JOB_RESULT_APPLY_MAX_PER_TICK
+            || (processed > 0 && started_at.elapsed() >= JOB_RESULT_APPLY_TIME_BUDGET))
+            && let Ok(job) = self.scheduler.try_recv()
         {
-            if let Ok(job) = self.scheduler.try_recv() {
-                self.scheduler.defer_result(job);
-            }
+            self.scheduler.defer_result(job);
         }
 
         dirty

--- a/src/app/jobs/tasks/directory_fingerprint.rs
+++ b/src/app/jobs/tasks/directory_fingerprint.rs
@@ -49,17 +49,15 @@ impl DirectoryFingerprintPool {
             workers.push(thread::spawn(move || {
                 while let Some(request) = DirectoryFingerprintShared::pop(&shared) {
                     let key = DirectoryFingerprintJobKey::from_request(&request);
-                    let result = crate::fs::scan_directory_fingerprint(
-                        &request.cwd,
-                        request.show_hidden,
-                    )
-                    .map_err(|error| {
-                        error
-                            .downcast_ref::<std::io::Error>()
-                            .map(crate::fs::describe_io_error)
-                            .unwrap_or("Read error")
-                            .to_string()
-                    });
+                    let result =
+                        crate::fs::scan_directory_fingerprint(&request.cwd, request.show_hidden)
+                            .map_err(|error| {
+                                error
+                                    .downcast_ref::<std::io::Error>()
+                                    .map(crate::fs::describe_io_error)
+                                    .unwrap_or("Read error")
+                                    .to_string()
+                            });
                     DirectoryFingerprintShared::finish(&shared, &key);
                     if result_tx
                         .send(JobResult::DirectoryFingerprint(DirectoryFingerprintBuild {

--- a/src/app/jobs/tests.rs
+++ b/src/app/jobs/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::preview::{PreviewRequestOptions, PreviewWorkClass};
+use crate::preview::{PreviewRequestOptions, PreviewWorkClass, default_code_preview_line_limit};
 use std::sync::Arc;
 
 fn image_prepare_request(name: &str) -> ImagePrepareRequest {
@@ -22,8 +22,19 @@ fn preview_request(entry: Entry, token: u64, priority: PreviewPriority) -> Previ
         token,
         entry,
         variant: PreviewRequestOptions::Default,
+        code_line_limit: default_code_preview_line_limit(),
         priority,
         work_class: PreviewWorkClass::Light,
+    }
+}
+
+fn preview_job_key(path: &str, size: u64) -> PreviewJobKey {
+    PreviewJobKey {
+        path: PathBuf::from(path),
+        size,
+        modified: None,
+        variant: PreviewRequestOptions::Default,
+        code_line_limit: default_code_preview_line_limit(),
     }
 }
 
@@ -40,26 +51,13 @@ fn preview_pool_deduplicates_identical_active_or_queued_requests() {
         readonly: false,
     };
 
-    assert!(scheduler.submit_preview(preview_request(
-        entry.clone(),
-        1,
-        PreviewPriority::Low,
-    )));
-    assert!(scheduler.submit_preview(preview_request(
-        entry,
-        2,
-        PreviewPriority::Low,
-    )));
+    assert!(scheduler.submit_preview(preview_request(entry.clone(), 1, PreviewPriority::Low,)));
+    assert!(scheduler.submit_preview(preview_request(entry, 2, PreviewPriority::Low,)));
     let snapshot = scheduler.snapshot();
     assert!(snapshot.preview_pending_high.is_empty());
     assert_eq!(
         snapshot.preview_pending_low,
-        vec![PreviewJobKey {
-            path: PathBuf::from("archive.zip"),
-            size: 42,
-            modified: None,
-            variant: PreviewRequestOptions::Default,
-        }]
+        vec![preview_job_key("archive.zip", 42)]
     );
     assert!(snapshot.preview_active.is_empty());
 }
@@ -113,20 +111,7 @@ fn preview_pool_discards_oldest_queued_request_when_full() {
     assert!(scheduler.snapshot().preview_pending_high.is_empty());
     assert_eq!(
         scheduler.snapshot().preview_pending_low,
-        vec![
-            PreviewJobKey {
-                path: PathBuf::from("b.zip"),
-                size: 1,
-                modified: None,
-                variant: PreviewRequestOptions::Default,
-            },
-            PreviewJobKey {
-                path: PathBuf::from("c.zip"),
-                size: 1,
-                modified: None,
-                variant: PreviewRequestOptions::Default,
-            },
-        ]
+        vec![preview_job_key("b.zip", 1), preview_job_key("c.zip", 1)]
     );
 }
 
@@ -143,27 +128,14 @@ fn high_priority_preview_promotes_over_low_priority_duplicate() {
         readonly: false,
     };
 
-    assert!(scheduler.submit_preview(preview_request(
-        entry.clone(),
-        1,
-        PreviewPriority::Low,
-    )));
-    assert!(scheduler.submit_preview(preview_request(
-        entry,
-        2,
-        PreviewPriority::High,
-    )));
+    assert!(scheduler.submit_preview(preview_request(entry.clone(), 1, PreviewPriority::Low,)));
+    assert!(scheduler.submit_preview(preview_request(entry, 2, PreviewPriority::High,)));
 
     let snapshot = scheduler.snapshot();
     assert!(snapshot.preview_pending_low.is_empty());
     assert_eq!(
         snapshot.preview_pending_high,
-        vec![PreviewJobKey {
-            path: PathBuf::from("archive.zip"),
-            size: 42,
-            modified: None,
-            variant: PreviewRequestOptions::Default,
-        }]
+        vec![preview_job_key("archive.zip", 42)]
     );
     assert_eq!(scheduler.metrics_snapshot().preview_promotions, 1);
 }
@@ -202,12 +174,7 @@ fn low_priority_preview_does_not_displace_full_high_priority_queue() {
     let snapshot = scheduler.snapshot();
     assert_eq!(
         snapshot.preview_pending_high,
-        vec![PreviewJobKey {
-            path: PathBuf::from("a.zip"),
-            size: 1,
-            modified: None,
-            variant: PreviewRequestOptions::Default,
-        }]
+        vec![preview_job_key("a.zip", 1)]
     );
     assert!(snapshot.preview_pending_low.is_empty());
     assert_eq!(
@@ -267,6 +234,7 @@ fn low_priority_heavy_preview_does_not_start_a_second_heavy_job() {
         token: 1,
         entry: first.clone(),
         variant: PreviewRequestOptions::Default,
+        code_line_limit: default_code_preview_line_limit(),
         priority: PreviewPriority::Low,
         work_class: PreviewWorkClass::Heavy,
     }));
@@ -274,6 +242,7 @@ fn low_priority_heavy_preview_does_not_start_a_second_heavy_job() {
         token: 2,
         entry: second.clone(),
         variant: PreviewRequestOptions::Default,
+        code_line_limit: default_code_preview_line_limit(),
         priority: PreviewPriority::Low,
         work_class: PreviewWorkClass::Heavy,
     }));
@@ -291,6 +260,7 @@ fn low_priority_heavy_preview_does_not_start_a_second_heavy_job() {
             size: 1,
             modified: None,
             variant: PreviewRequestOptions::Default,
+            code_line_limit: default_code_preview_line_limit(),
         }]
     );
 }
@@ -321,6 +291,7 @@ fn low_priority_light_preview_can_start_while_heavy_preview_is_active() {
         token: 1,
         entry: heavy.clone(),
         variant: PreviewRequestOptions::Default,
+        code_line_limit: default_code_preview_line_limit(),
         priority: PreviewPriority::Low,
         work_class: PreviewWorkClass::Heavy,
     }));
@@ -328,6 +299,7 @@ fn low_priority_light_preview_can_start_while_heavy_preview_is_active() {
         token: 2,
         entry: light.clone(),
         variant: PreviewRequestOptions::Default,
+        code_line_limit: default_code_preview_line_limit(),
         priority: PreviewPriority::Low,
         work_class: PreviewWorkClass::Light,
     }));
@@ -342,6 +314,47 @@ fn low_priority_light_preview_can_start_while_heavy_preview_is_active() {
         .pop_next_pending_for_tests()
         .expect("light preview should still start");
     assert_eq!(started_light.entry.path, light.path);
+}
+
+#[test]
+fn high_priority_preview_cancels_active_stale_preview_work() {
+    let scheduler = JobScheduler::new_for_tests(0, 0, 4);
+    let active = Entry {
+        path: PathBuf::from("active.rs"),
+        name: "active.rs".to_string(),
+        name_key: "active.rs".to_string(),
+        kind: EntryKind::File,
+        size: 1,
+        modified: None,
+        readonly: false,
+    };
+    let current = Entry {
+        path: PathBuf::from("current.rs"),
+        name: "current.rs".to_string(),
+        name_key: "current.rs".to_string(),
+        kind: EntryKind::File,
+        size: 1,
+        modified: None,
+        readonly: false,
+    };
+
+    assert!(scheduler.submit_preview(preview_request(active.clone(), 1, PreviewPriority::Low,)));
+    let started = scheduler
+        .preview
+        .pop_next_pending_for_tests()
+        .expect("stale preview should start");
+    assert_eq!(started.entry.path, active.path);
+
+    assert!(scheduler.submit_preview(preview_request(current.clone(), 2, PreviewPriority::High,)));
+
+    assert_eq!(
+        scheduler.preview.canceled_active_keys(),
+        vec![preview_job_key("active.rs", 1)]
+    );
+    assert_eq!(
+        scheduler.snapshot().preview_pending_high,
+        vec![preview_job_key("current.rs", 1)]
+    );
 }
 
 #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -40,8 +40,24 @@ pub use self::types::{
 
 impl App {
     pub fn set_frame_state(&mut self, frame_state: FrameState) -> bool {
+        let previous_code_line_limit = self.selected_entry().map(|entry| {
+            self.preview_code_line_limit_for_entry_with_rows(
+                entry,
+                self.frame_state.preview_rows_visible,
+            )
+        });
         self.frame_state = frame_state;
-        let dirty = self.sync_scroll() | self.sync_search_scroll() | self.sync_preview_scroll();
+        let mut dirty = self.sync_scroll() | self.sync_search_scroll() | self.sync_preview_scroll();
+        let next_code_line_limit = self.selected_entry().map(|entry| {
+            self.preview_code_line_limit_for_entry_with_rows(
+                entry,
+                self.frame_state.preview_rows_visible,
+            )
+        });
+        if previous_code_line_limit != next_code_line_limit {
+            self.refresh_preview();
+            dirty = true;
+        }
         if !self.browser_wheel_burst_active() {
             self.queue_visible_directory_item_counts();
         }

--- a/src/app/overlays/comic.rs
+++ b/src/app/overlays/comic.rs
@@ -223,6 +223,7 @@ impl App {
                 entry: entry.clone(),
                 work_class: preview_work_class(&entry, &variant),
                 variant,
+                code_line_limit: self.preview_code_line_limit_for_entry(&entry),
                 priority: PreviewPriority::Low,
             });
         }
@@ -264,7 +265,7 @@ impl App {
                 (key.path == entry.path
                     && cached.size == entry.size
                     && cached.modified == entry.modified)
-                    .then(|| cached.preview.navigation_position.as_ref())
+                    .then_some(cached.preview.navigation_position.as_ref())
                     .flatten()
                     .filter(|position| position.label == "Page")
                     .map(|position| position.count)
@@ -282,6 +283,7 @@ impl App {
             .contains_key(&PreviewCacheKey {
                 path: path.to_path_buf(),
                 variant: preview::PreviewRequestOptions::ComicPage(page),
+                code_line_limit: preview::default_code_preview_line_limit(),
             })
     }
 }

--- a/src/app/overlays/epub.rs
+++ b/src/app/overlays/epub.rs
@@ -1,6 +1,6 @@
 use super::super::*;
-use crate::preview::preview_work_class;
 use crate::file_info::{self, DocumentFormat};
+use crate::preview::preview_work_class;
 use std::{
     path::PathBuf,
     time::{Instant, SystemTime},
@@ -182,6 +182,7 @@ impl App {
                 entry: entry.clone(),
                 work_class: preview_work_class(&entry, &variant),
                 variant,
+                code_line_limit: self.preview_code_line_limit_for_entry(&entry),
                 priority: PreviewPriority::Low,
             });
         }
@@ -239,6 +240,7 @@ impl App {
             .contains_key(&PreviewCacheKey {
                 path: path.to_path_buf(),
                 variant: preview::PreviewRequestOptions::EpubSection(section),
+                code_line_limit: preview::default_code_preview_line_limit(),
             })
     }
 }

--- a/src/app/overlays/images.rs
+++ b/src/app/overlays/images.rs
@@ -714,7 +714,9 @@ impl App {
     }
 
     fn remember_static_image_inline_payload(&mut self, key: StaticImageKey, payload: Arc<str>) {
-        self.image_preview.inline_payloads.insert(key.clone(), payload);
+        self.image_preview
+            .inline_payloads
+            .insert(key.clone(), payload);
         self.image_preview
             .payload_order
             .retain(|queued| queued != &key);
@@ -828,7 +830,9 @@ impl App {
         let key = StaticImageKey::from_request(request);
         if self.image_preview.failed_images.contains(&key)
             || self.image_preview.pending_prepares.contains(&key)
-            || self.cached_prepared_static_image_for_overlay(&key, request).is_some()
+            || self
+                .cached_prepared_static_image_for_overlay(&key, request)
+                .is_some()
         {
             return;
         }
@@ -1010,7 +1014,9 @@ fn union_rect(a: Rect, b: Rect) -> Rect {
     let left = a.x.min(b.x);
     let top = a.y.min(b.y);
     let right = a.x.saturating_add(a.width).max(b.x.saturating_add(b.width));
-    let bottom = a.y.saturating_add(a.height).max(b.y.saturating_add(b.height));
+    let bottom =
+        a.y.saturating_add(a.height)
+            .max(b.y.saturating_add(b.height));
     Rect {
         x: left,
         y: top,
@@ -1089,7 +1095,9 @@ where
         if !request.prepare_inline_payload {
             return Some(None);
         }
-        Some(Some(super::inline_image::encode_iterm_inline_payload(path)?))
+        Some(Some(super::inline_image::encode_iterm_inline_payload(
+            path,
+        )?))
     };
 
     if static_image_supports_iterm_source_passthrough_for_prepare(request, format) {

--- a/src/app/overlays/pdf/tests.rs
+++ b/src/app/overlays/pdf/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::app::overlays::images::StaticImageKey;
-use crate::app::overlays::inline_image::{command_exists, ImageProtocol, TerminalWindowSize};
+use crate::app::overlays::inline_image::{ImageProtocol, TerminalWindowSize, command_exists};
 use crate::preview::PreviewKind;
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use std::{

--- a/src/app/overlays/preview_visual.rs
+++ b/src/app/overlays/preview_visual.rs
@@ -1,6 +1,6 @@
 use super::super::*;
-use super::inline_image::ImageProtocol;
 use super::images;
+use super::inline_image::ImageProtocol;
 use ratatui::layout::Rect;
 
 const PREVIEW_INLINE_COVER_MIN_HEIGHT: u16 = 6;

--- a/src/app/overlays/preview_visual/tests.rs
+++ b/src/app/overlays/preview_visual/tests.rs
@@ -89,8 +89,10 @@ fn write_binary_zip_entries(path: &Path, entries: &[(&str, &[u8])]) {
 }
 
 fn wait_for_displayed_preview_overlay(app: &mut App) {
-    for _ in 0..200 {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
         let _ = app.process_background_jobs();
+        let _ = app.process_image_preview_timers();
         app.present_preview_overlay()
             .expect("presenting preview overlay should not fail");
         if app.static_image_overlay_displayed() {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -172,6 +172,7 @@ pub(super) struct CachedPreview {
 pub(super) struct PreviewCacheKey {
     pub(super) path: PathBuf,
     pub(super) variant: preview::PreviewRequestOptions,
+    pub(super) code_line_limit: usize,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/app/text_edit.rs
+++ b/src/app/text_edit.rs
@@ -1,5 +1,4 @@
-/// Shared text editing primitives used by the create and search overlays.
-
+//! Shared text editing primitives used by the create and search overlays.
 pub(super) fn is_word_char(ch: char) -> bool {
     ch.is_alphanumeric() || ch == '_'
 }

--- a/src/file_info/license.rs
+++ b/src/file_info/license.rs
@@ -275,7 +275,7 @@ fn detect_spdx_identifier(text: &str) -> Option<LicenseDetection> {
         };
         let value = cleaned[index + "spdx-license-identifier:".len()..]
             .trim()
-            .trim_end_matches(|ch: char| matches!(ch, '*' | '/' | ';' | '-' | '>'))
+            .trim_end_matches(['*', '/', ';', '-', '>'])
             .trim();
         if value.is_empty() {
             return Some(LicenseDetection::Generic);

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -255,12 +255,12 @@ pub(crate) fn load_directory_snapshot(
     // sibling `info/` directory), replace each entry's modification time with the deletion
     // date stored in the corresponding `.trashinfo` file so the listing shows "trashed X ago"
     // rather than the file's own last-modified timestamp.
-    if dir.file_name().is_some_and(|n| n == "files") {
-        if let Some(info_dir) = dir.parent().map(|p| p.join("info")).filter(|p| p.is_dir()) {
-            for entry in &mut entries {
-                if let Some(date) = read_trash_deletion_date(&info_dir, &entry.name) {
-                    entry.modified = Some(date);
-                }
+    if dir.file_name().is_some_and(|n| n == "files")
+        && let Some(info_dir) = dir.parent().map(|p| p.join("info")).filter(|p| p.is_dir())
+    {
+        for entry in &mut entries {
+            if let Some(date) = read_trash_deletion_date(&info_dir, &entry.name) {
+                entry.modified = Some(date);
             }
         }
     }
@@ -404,6 +404,91 @@ fn fingerprint_time(time: Option<SystemTime>) -> Option<(u64, u32)> {
     })
 }
 
+// ---------------------------------------------------------------------------
+// Restore from trash
+// ---------------------------------------------------------------------------
+
+/// Restores a trashed item to its original location.
+///
+/// `entry_path` must be a file inside a FreeDesktop `Trash/files/` directory.
+/// The corresponding `.trashinfo` is used to find the original path. Returns
+/// the restored destination path on success.
+pub(crate) fn restore_trash_item(entry_path: &Path) -> anyhow::Result<PathBuf> {
+    let name = entry_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow::anyhow!("cannot determine file name for {:?}", entry_path))?;
+
+    // Derive the `info/` dir: Trash/files/../info == Trash/info
+    let info_dir = entry_path
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|trash_root| trash_root.join("info"))
+        .ok_or_else(|| anyhow::anyhow!("cannot determine trash info dir for {:?}", entry_path))?;
+
+    let info_path = info_dir.join(format!("{name}.trashinfo"));
+    let content =
+        fs::read_to_string(&info_path).with_context(|| format!("cannot read {:?}", info_path))?;
+
+    let original = parse_trashinfo_original_path(&content)
+        .ok_or_else(|| anyhow::anyhow!("cannot parse original path from {:?}", info_path))?;
+
+    if original.exists() {
+        anyhow::bail!("destination already exists: {:?}", original);
+    }
+
+    if let Some(parent) = original.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create parent dir {:?}", parent))?;
+    }
+
+    fs::rename(entry_path, &original)
+        .with_context(|| format!("cannot move {:?} to {:?}", entry_path, original))?;
+
+    let _ = fs::remove_file(&info_path);
+
+    Ok(original)
+}
+
+fn parse_trashinfo_original_path(content: &str) -> Option<PathBuf> {
+    for line in content.lines() {
+        if let Some(encoded) = line.trim().strip_prefix("Path=") {
+            return Some(PathBuf::from(percent_decode(encoded)));
+        }
+    }
+    None
+}
+
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2]))
+        {
+            out.push(hi << 4 | lo);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -478,8 +563,14 @@ mod tests {
         ];
 
         sort_entries(&mut entries, SortMode::Name);
-        let names = entries.iter().map(|entry| entry.name.as_str()).collect::<Vec<_>>();
-        assert_eq!(names, vec!["episode 1.mkv", "episode 2.mkv", "episode 10.mkv"]);
+        let names = entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec!["episode 1.mkv", "episode 2.mkv", "episode 10.mkv"]
+        );
     }
 
     #[test]
@@ -515,7 +606,10 @@ mod tests {
         ];
 
         sort_entries(&mut entries, SortMode::Name);
-        let names = entries.iter().map(|entry| entry.name.as_str()).collect::<Vec<_>>();
+        let names = entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
         assert_eq!(
             names,
             vec![
@@ -636,92 +730,5 @@ mod tests {
         assert_eq!(secs, 1_710_498_600);
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Restore from trash
-// ---------------------------------------------------------------------------
-
-/// Restores a trashed item to its original location.
-///
-/// `entry_path` must be a file inside a FreeDesktop `Trash/files/` directory.
-/// The corresponding `.trashinfo` is used to find the original path. Returns
-/// the restored destination path on success.
-pub(crate) fn restore_trash_item(entry_path: &Path) -> anyhow::Result<PathBuf> {
-    let name = entry_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| anyhow::anyhow!("cannot determine file name for {:?}", entry_path))?;
-
-    // Derive the `info/` dir: Trash/files/../info == Trash/info
-    let info_dir = entry_path
-        .parent()
-        .and_then(|p| p.parent())
-        .map(|trash_root| trash_root.join("info"))
-        .ok_or_else(|| anyhow::anyhow!("cannot determine trash info dir for {:?}", entry_path))?;
-
-    let info_path = info_dir.join(format!("{name}.trashinfo"));
-    let content = fs::read_to_string(&info_path)
-        .with_context(|| format!("cannot read {:?}", info_path))?;
-
-    let original = parse_trashinfo_original_path(&content)
-        .ok_or_else(|| anyhow::anyhow!("cannot parse original path from {:?}", info_path))?;
-
-    if original.exists() {
-        anyhow::bail!(
-            "destination already exists: {:?}",
-            original
-        );
-    }
-
-    if let Some(parent) = original.parent() {
-        if !parent.exists() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("cannot create parent dir {:?}", parent))?;
-        }
-    }
-
-    fs::rename(entry_path, &original)
-        .with_context(|| format!("cannot move {:?} to {:?}", entry_path, original))?;
-
-    let _ = fs::remove_file(&info_path);
-
-    Ok(original)
-}
-
-fn parse_trashinfo_original_path(content: &str) -> Option<PathBuf> {
-    for line in content.lines() {
-        if let Some(encoded) = line.trim().strip_prefix("Path=") {
-            return Some(PathBuf::from(percent_decode(encoded)));
-        }
-    }
-    None
-}
-
-fn percent_decode(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let (Some(hi), Some(lo)) = (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2])) {
-                out.push(hi << 4 | lo);
-                i += 3;
-                continue;
-            }
-        }
-        out.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
-}
-
-fn hex_nibble(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
     }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod watch;
 mod directory;
 mod sort;
 
-pub(self) fn is_hidden(file_name: &std::ffi::OsStr) -> bool {
+fn is_hidden(file_name: &std::ffi::OsStr) -> bool {
     file_name.to_string_lossy().starts_with('.')
 }
 

--- a/src/fs/search.rs
+++ b/src/fs/search.rs
@@ -198,7 +198,11 @@ fn compare_scored(
                 &candidates[left.0].relative_key,
                 &candidates[right.0].relative_key,
             )
-            .then_with(|| candidates[left.0].relative.cmp(&candidates[right.0].relative))
+            .then_with(|| {
+                candidates[left.0]
+                    .relative
+                    .cmp(&candidates[right.0].relative)
+            })
         })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,16 +231,16 @@ fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
             // event we accumulate all queued events first and render the final state once.
             loop {
                 let event = event::read()?;
-                if std::env::var_os("ELIO_LOG_MOUSE").is_some() {
-                    if let Event::Mouse(m) = &event {
-                        let _ = std::fs::OpenOptions::new()
-                            .create(true)
-                            .append(true)
-                            .open("/tmp/elio-mouse.log")
-                            .and_then(|mut f| {
-                                writeln!(f, "{:?} col={} row={}", m.kind, m.column, m.row)
-                            });
-                    }
+                if std::env::var_os("ELIO_LOG_MOUSE").is_some()
+                    && let Event::Mouse(m) = &event
+                {
+                    let _ = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open("/tmp/elio-mouse.log")
+                        .and_then(|mut f| {
+                            writeln!(f, "{:?} col={} row={}", m.kind, m.column, m.row)
+                        });
                 }
                 if matches!(event, Event::Resize(_, _)) {
                     app.handle_terminal_image_resize();

--- a/src/preview/container/archive.rs
+++ b/src/preview/container/archive.rs
@@ -3,7 +3,7 @@ use crate::{file_info, fs::natural_cmp, ui::theme};
 use flate2::read::GzDecoder;
 use ratatui::text::Line;
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque, hash_map::DefaultHasher},
     env,
     fs::{self, File},
     hash::{Hash, Hasher},

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -66,9 +66,7 @@ pub(crate) fn loading_preview_for(
     } else {
         loading_preview_kind(&facts)
     };
-    let lines = if is_comic_page_preview {
-        Vec::new()
-    } else if is_epub_section_preview {
+    let lines = if is_comic_page_preview || is_epub_section_preview {
         Vec::new()
     } else if facts.builtin_class == FileClass::Archive {
         vec![
@@ -115,10 +113,28 @@ pub(crate) fn build_preview(entry: &Entry) -> PreviewContent {
     build_preview_with_options(entry, &PreviewRequestOptions::Default)
 }
 
+#[cfg(test)]
 pub(crate) fn build_preview_with_options(
     entry: &Entry,
     options: &PreviewRequestOptions,
 ) -> PreviewContent {
+    build_preview_with_options_and_code_line_limit(
+        entry,
+        options,
+        default_code_preview_line_limit(),
+        &|| false,
+    )
+}
+
+pub(crate) fn build_preview_with_options_and_code_line_limit<F>(
+    entry: &Entry,
+    options: &PreviewRequestOptions,
+    code_line_limit: usize,
+    canceled: &F,
+) -> PreviewContent
+where
+    F: Fn() -> bool,
+{
     if entry.is_dir() {
         return directory::build_directory_preview(entry);
     }
@@ -170,6 +186,7 @@ pub(crate) fn build_preview_with_options(
         }
     };
     let source_line_count = count_source_lines(&text_preview.text);
+    let effective_code_line_limit = clamp_code_preview_line_limit(code_line_limit);
     let line_truncated = source_line_count > PREVIEW_RENDER_LINE_LIMIT;
     let mut preview_truncation_note = truncation_note(text_preview.bytes_truncated, line_truncated);
 
@@ -213,23 +230,34 @@ pub(crate) fn build_preview_with_options(
             }
         }
 
+        let code_line_truncated = source_line_count > effective_code_line_limit;
+        let code_truncation_note = truncation_note_with_line_limit(
+            text_preview.bytes_truncated,
+            code_line_truncated,
+            effective_code_line_limit,
+        );
+        preview_truncation_note =
+            combine_preview_notes(preview_truncation_note, code_truncation_note.as_deref());
         let mut preview = PreviewContent::new(
             PreviewKind::Code,
-            highlighting::render_code_preview(
+            highlighting::render_code_preview_with(
                 &text_preview.text,
                 preview_spec.highlight_language,
                 true,
+                effective_code_line_limit,
+                canceled,
             ),
         );
         if let Some(detail) = source_preview_detail(type_detail, preview_spec) {
             preview = preview.with_detail(detail);
         }
-        return finalize_text_preview(
+        return finalize_text_preview_with_line_limit(
             preview,
             source_line_count,
             text_preview.bytes_truncated,
-            line_truncated,
+            code_line_truncated,
             preview_truncation_note,
+            effective_code_line_limit,
         );
     }
 

--- a/src/preview/document.rs
+++ b/src/preview/document.rs
@@ -1327,7 +1327,7 @@ fn build_preview_visual(
     }
 }
 
-fn resolve_epub_cover_item<'a>(package: &'a EpubPackageDocument) -> Option<&'a EpubManifestItem> {
+fn resolve_epub_cover_item(package: &EpubPackageDocument) -> Option<&EpubManifestItem> {
     package
         .manifest
         .values()

--- a/src/preview/highlighting/mod.rs
+++ b/src/preview/highlighting/mod.rs
@@ -25,9 +25,30 @@ pub(super) fn render_code_preview(
     language: Option<HighlightLanguage>,
     line_numbers: bool,
 ) -> Vec<Line<'static>> {
+    render_code_preview_with(
+        text,
+        language,
+        line_numbers,
+        super::default_code_preview_line_limit(),
+        &|| false,
+    )
+}
+
+pub(super) fn render_code_preview_with<F>(
+    text: &str,
+    language: Option<HighlightLanguage>,
+    line_numbers: bool,
+    code_line_limit: usize,
+    canceled: &F,
+) -> Vec<Line<'static>>
+where
+    F: Fn() -> bool,
+{
     match language {
-        Some(language) => render_highlighted_code_preview(text, language, line_numbers),
-        None => render_plain_code_preview(text, line_numbers),
+        Some(language) => {
+            render_highlighted_code_preview(text, language, line_numbers, code_line_limit, canceled)
+        }
+        None => render_plain_code_preview(text, line_numbers, code_line_limit, canceled),
     }
 }
 
@@ -56,9 +77,14 @@ fn render_highlighted_code_preview(
     text: &str,
     language: HighlightLanguage,
     line_numbers: bool,
+    code_line_limit: usize,
+    canceled: &impl Fn() -> bool,
 ) -> Vec<Line<'static>> {
     let code_palette = theme::code_preview_palette();
-    let source_lines = super::collect_preview_lines(text);
+    let source_lines = super::collect_preview_lines_with_limit(
+        text,
+        super::clamp_code_preview_line_limit(code_line_limit),
+    );
     let number_width = super::line_number_width(source_lines.len());
     let mut rendered = Vec::new();
     let mut jsonc_block_comment = false;
@@ -70,6 +96,9 @@ fn render_highlighted_code_preview(
     let mut shell_state = shell::ShellState::default();
 
     for (index, line) in source_lines.iter().enumerate() {
+        if canceled() {
+            break;
+        }
         let mut spans = Vec::new();
         if line_numbers {
             spans.push(super::line_number_span(index + 1, number_width));
@@ -123,19 +152,30 @@ fn render_highlighted_code_preview(
         rendered.push(Line::from(spans));
     }
 
-    if rendered.is_empty() {
+    if rendered.is_empty() && !canceled() {
         rendered.push(Line::from("File is empty"));
     }
     rendered
 }
 
-fn render_plain_code_preview(text: &str, line_numbers: bool) -> Vec<Line<'static>> {
+fn render_plain_code_preview(
+    text: &str,
+    line_numbers: bool,
+    code_line_limit: usize,
+    canceled: &impl Fn() -> bool,
+) -> Vec<Line<'static>> {
     let code_palette = theme::code_preview_palette();
-    let source_lines = super::collect_preview_lines(text);
+    let source_lines = super::collect_preview_lines_with_limit(
+        text,
+        super::clamp_code_preview_line_limit(code_line_limit),
+    );
     let number_width = super::line_number_width(source_lines.len());
     let mut rendered = Vec::new();
 
     for (index, line) in source_lines.iter().enumerate() {
+        if canceled() {
+            break;
+        }
         let mut spans = Vec::new();
         if line_numbers {
             spans.push(super::line_number_span(index + 1, number_width));
@@ -152,7 +192,7 @@ fn render_plain_code_preview(text: &str, line_numbers: bool) -> Vec<Line<'static
         rendered.push(Line::from(spans));
     }
 
-    if rendered.is_empty() {
+    if rendered.is_empty() && !canceled() {
         rendered.push(Line::from("File is empty"));
     }
     rendered

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -11,20 +11,24 @@ mod types;
 
 #[cfg(test)]
 pub(crate) use self::dispatch::build_preview;
+#[cfg(test)]
+pub(crate) use self::dispatch::build_preview_with_options;
 pub(crate) use self::dispatch::{
-    build_preview_with_options, loading_preview_for, preview_work_class,
+    build_preview_with_options_and_code_line_limit, loading_preview_for, preview_work_class,
     should_build_preview_in_background,
 };
 pub(crate) use self::text::count_total_text_lines;
 use self::text::{
-    collect_preview_lines, combine_preview_notes, count_source_lines, finalize_text_preview,
-    read_text_preview, render_plain_text_preview, render_reflowed_text_preview,
-    trim_trailing_line_endings, truncation_note,
+    collect_preview_lines_with_limit, combine_preview_notes, count_source_lines,
+    finalize_text_preview, finalize_text_preview_with_line_limit, read_text_preview,
+    render_plain_text_preview, render_reflowed_text_preview, trim_trailing_line_endings,
+    truncation_note, truncation_note_with_line_limit,
 };
 use self::types::*;
 pub(crate) use self::types::{
-    PreviewContent, PreviewKind, PreviewLineCoverage, PreviewRequestOptions, PreviewVisual,
-    PreviewVisualKind, PreviewVisualLayout, PreviewWorkClass,
+    MIN_DYNAMIC_CODE_PREVIEW_LINE_LIMIT, PreviewContent, PreviewKind, PreviewLineCoverage,
+    PreviewRequestOptions, PreviewVisual, PreviewVisualKind, PreviewVisualLayout, PreviewWorkClass,
+    clamp_code_preview_line_limit, default_code_preview_line_limit,
 };
 
 #[cfg(test)]

--- a/src/preview/tests.rs
+++ b/src/preview/tests.rs
@@ -3584,6 +3584,41 @@ fn line_truncated_preview_reports_visible_limit() {
 }
 
 #[test]
+fn code_preview_respects_custom_line_limit() {
+    let root = temp_path("code-line-limit");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("main.rs");
+    let text = (1..=12)
+        .map(|index| format!("let value_{index} = {index};"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&path, text).expect("failed to write code");
+
+    let preview = build_preview_with_options_and_code_line_limit(
+        &file_entry(path),
+        &PreviewRequestOptions::Default,
+        4,
+        &|| false,
+    );
+    let header = preview
+        .header_detail(0, 20)
+        .expect("header detail should be present");
+
+    assert_eq!(preview.kind, PreviewKind::Code);
+    assert_eq!(preview.lines.len(), 4);
+    assert_eq!(
+        preview.line_coverage.map(|coverage| coverage.shown_lines),
+        Some(4)
+    );
+    assert!(
+        header.contains("showing first 4 lines"),
+        "unexpected header: {header}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 #[cfg(unix)]
 fn protected_directory_preview_reports_permission_denied() {
     let root = temp_path("protected-dir-preview");

--- a/src/preview/text.rs
+++ b/src/preview/text.rs
@@ -104,6 +104,33 @@ pub(super) fn finalize_text_preview(
     preview
 }
 
+pub(super) fn finalize_text_preview_with_line_limit(
+    mut preview: PreviewContent,
+    source_line_count: usize,
+    bytes_truncated: bool,
+    line_truncated: bool,
+    truncation_note: Option<String>,
+    shown_line_limit: usize,
+) -> PreviewContent {
+    let shown_lines = if line_truncated {
+        shown_line_limit
+    } else {
+        source_line_count
+    };
+    preview = preview.with_line_coverage(
+        shown_lines,
+        (!bytes_truncated).then_some(source_line_count),
+        bytes_truncated || line_truncated,
+    );
+    if !bytes_truncated {
+        preview = preview.with_source_lines(source_line_count);
+    }
+    if let Some(note) = truncation_note {
+        preview = preview.with_truncation(note);
+    }
+    preview
+}
+
 pub(super) fn truncation_note(bytes_truncated: bool, line_truncated: bool) -> Option<String> {
     let mut parts = Vec::new();
     if bytes_truncated {
@@ -111,6 +138,25 @@ pub(super) fn truncation_note(bytes_truncated: bool, line_truncated: bool) -> Op
     }
     if line_truncated {
         parts.push(format!("showing first {PREVIEW_RENDER_LINE_LIMIT} lines"));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("  •  "))
+    }
+}
+
+pub(super) fn truncation_note_with_line_limit(
+    bytes_truncated: bool,
+    line_truncated: bool,
+    shown_line_limit: usize,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    if bytes_truncated {
+        parts.push("truncated to 64 KiB".to_string());
+    }
+    if line_truncated {
+        parts.push(format!("showing first {shown_line_limit} lines"));
     }
     if parts.is_empty() {
         None
@@ -191,8 +237,12 @@ pub(crate) fn count_total_text_lines(path: &Path) -> anyhow::Result<usize> {
 }
 
 pub(super) fn collect_preview_lines(text: &str) -> Vec<String> {
+    collect_preview_lines_with_limit(text, PREVIEW_RENDER_LINE_LIMIT)
+}
+
+pub(super) fn collect_preview_lines_with_limit(text: &str, line_limit: usize) -> Vec<String> {
     text.lines()
-        .take(PREVIEW_RENDER_LINE_LIMIT)
+        .take(line_limit)
         .map(trim_trailing_line_endings)
         .collect()
 }
@@ -241,7 +291,11 @@ fn count_utf8_lines(mut reader: BufReader<File>, prefix: &[u8]) -> anyhow::Resul
         last_byte = chunk.last().copied();
     }
 
-    Ok(finalize_counted_lines(saw_bytes, newline_count, last_byte == Some(b'\n')))
+    Ok(finalize_counted_lines(
+        saw_bytes,
+        newline_count,
+        last_byte == Some(b'\n'),
+    ))
 }
 
 fn count_utf16_lines(mut reader: BufReader<File>, endian: Utf16Endian) -> anyhow::Result<usize> {
@@ -282,7 +336,11 @@ fn count_utf16_lines(mut reader: BufReader<File>, endian: Utf16Endian) -> anyhow
     ))
 }
 
-fn finalize_counted_lines(saw_content: bool, newline_count: usize, ends_with_newline: bool) -> usize {
+fn finalize_counted_lines(
+    saw_content: bool,
+    newline_count: usize,
+    ends_with_newline: bool,
+) -> usize {
     if !saw_content {
         return 1;
     }

--- a/src/preview/types.rs
+++ b/src/preview/types.rs
@@ -15,6 +15,7 @@ use unicode_width::UnicodeWidthStr;
 
 pub(super) const PREVIEW_LIMIT_BYTES: usize = 64 * 1024;
 pub(super) const PREVIEW_RENDER_LINE_LIMIT: usize = 240;
+pub(crate) const MIN_DYNAMIC_CODE_PREVIEW_LINE_LIMIT: usize = 80;
 pub(super) const ARCHIVE_ENTRY_SCAN_LIMIT: usize = 50_000;
 pub(super) const ZIP_MANIFEST_LIMIT_BYTES: u64 = 64 * 1024;
 pub(super) const ISO_METADATA_SCAN_BYTES: u64 = 128 * 1024;
@@ -114,6 +115,14 @@ pub(crate) enum PreviewVisualKind {
 pub(crate) enum PreviewVisualLayout {
     Inline,
     FullHeight,
+}
+
+pub(crate) fn default_code_preview_line_limit() -> usize {
+    PREVIEW_RENDER_LINE_LIMIT
+}
+
+pub(crate) fn clamp_code_preview_line_limit(line_limit: usize) -> usize {
+    line_limit.clamp(1, PREVIEW_RENDER_LINE_LIMIT)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -733,10 +742,12 @@ fn wrap_preview_line<'a>(
         non_whitespace_previous = !is_whitespace;
     }
 
-    if pending_line.is_empty() && pending_word.is_empty() && !pending_whitespace.is_empty() {
-        if !push_wrapped_line(wrapped, empty_wrapped_preview_line(alignment), line_limit) {
-            return false;
-        }
+    if pending_line.is_empty()
+        && pending_word.is_empty()
+        && !pending_whitespace.is_empty()
+        && !push_wrapped_line(wrapped, empty_wrapped_preview_line(alignment), line_limit)
+    {
+        return false;
     }
     if !pending_line.is_empty() || !trim {
         pending_line.extend(pending_whitespace.drain(..));
@@ -771,15 +782,18 @@ fn push_wrapped_preview_line(
     alignment: Option<Alignment>,
     line_limit: usize,
 ) -> bool {
-    let mut line = line_from_graphemes(graphemes);
-    line.alignment = alignment;
+    let line = Line {
+        alignment,
+        ..line_from_graphemes(graphemes)
+    };
     push_wrapped_line(wrapped, line, line_limit)
 }
 
 fn empty_wrapped_preview_line(alignment: Option<Alignment>) -> Line<'static> {
-    let mut line = Line::default();
-    line.alignment = alignment;
-    line
+    Line {
+        alignment,
+        ..Line::default()
+    }
 }
 
 fn line_from_graphemes(graphemes: &[StyledGrapheme<'_>]) -> Line<'static> {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -397,9 +397,13 @@ fn render_list(
                 .constraints([Constraint::Length(1), Constraint::Min(1)])
                 .split(row);
             frame.render_widget(
-                Paragraph::new(if selected || multi_selected { "▌" } else { " " })
-                    .alignment(Alignment::Left)
-                    .style(Style::default().bg(bg).fg(bar_color)),
+                Paragraph::new(if selected || multi_selected {
+                    "▌"
+                } else {
+                    " "
+                })
+                .alignment(Alignment::Left)
+                .style(Style::default().bg(bg).fg(bar_color)),
                 columns[0],
             );
             let secondary = if entry.is_dir() {
@@ -542,8 +546,7 @@ fn render_preview_body(
     let body_area = body[0];
     let scrollbar_area = body.get(1).copied();
     state.preview_body_area = Some(sections[1]);
-    let (media_area, text_area) = if let Some(media_rows) = app.preview_visual_rows(body_area)
-    {
+    let (media_area, text_area) = if let Some(media_rows) = app.preview_visual_rows(body_area) {
         let split = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(media_rows), Constraint::Min(0)])
@@ -905,7 +908,11 @@ fn render_compact_list_row(
 
     Line::from(vec![
         Span::styled(
-            if selected || multi_selected { "▌" } else { " " },
+            if selected || multi_selected {
+                "▌"
+            } else {
+                " "
+            },
             Style::default().fg(marker_color),
         ),
         Span::raw(" "),

--- a/src/ui/overlay_manager.rs
+++ b/src/ui/overlay_manager.rs
@@ -480,11 +480,7 @@ pub(super) fn render_create_overlay(
         } else {
             0
         };
-        let h_start = if col > text_width {
-            col - text_width
-        } else {
-            0
-        };
+        let h_start = col.saturating_sub(text_width);
 
         let mut visible_text: String = chars.iter().skip(h_start).take(text_width).collect();
         if h_start > 0 && !visible_text.is_empty() {
@@ -683,11 +679,7 @@ pub(super) fn render_bulk_rename_overlay(
         } else {
             0
         };
-        let h_start = if col > text_width {
-            col - text_width
-        } else {
-            0
-        };
+        let h_start = col.saturating_sub(text_width);
         let mut visible_text: String = chars.iter().skip(h_start).take(text_width).collect();
         if h_start > 0 && !visible_text.is_empty() {
             visible_text.remove(0);
@@ -811,7 +803,7 @@ pub(super) fn render_rename_overlay(
     let chars: Vec<char> = input.chars().collect();
     let col = cursor_col.min(chars.len());
     let available = input_area.width.saturating_sub(3) as usize; // 3 for icon prefix
-    let h_start = if col > available { col - available } else { 0 };
+    let h_start = col.saturating_sub(available);
 
     let mut visible_text: String = chars.iter().skip(h_start).take(available).collect();
     if h_start > 0 && !visible_text.is_empty() {

--- a/src/ui/theme/appearance.rs
+++ b/src/ui/theme/appearance.rs
@@ -1337,9 +1337,10 @@ macro = "#fedcba"
 
     #[test]
     fn blush_light_example_theme_parses_and_applies_custom_icon_and_code_colors() {
-        let theme =
-            Theme::from_config_str(include_str!("../../../examples/themes/blush-light/theme.toml"))
-                .expect("blush-light theme should parse");
+        let theme = Theme::from_config_str(include_str!(
+            "../../../examples/themes/blush-light/theme.toml"
+        ))
+        .expect("blush-light theme should parse");
 
         assert_eq!(theme.preview.code.keyword, rgb(0xd8, 0x63, 0x92));
         assert_eq!(theme.preview.code.function, rgb(0x8f, 0x71, 0xbf));
@@ -1362,9 +1363,10 @@ macro = "#fedcba"
 
     #[test]
     fn default_light_example_theme_parses_and_preserves_default_icon_mappings() {
-        let theme =
-            Theme::from_config_str(include_str!("../../../examples/themes/default-light/theme.toml"))
-                .expect("default-light theme should parse");
+        let theme = Theme::from_config_str(include_str!(
+            "../../../examples/themes/default-light/theme.toml"
+        ))
+        .expect("default-light theme should parse");
 
         assert_eq!(theme.palette.bg, rgb(0xef, 0xf2, 0xf5));
         assert_eq!(theme.preview.code.keyword, rgb(0x7a, 0xae, 0xff));
@@ -1425,9 +1427,10 @@ macro = "#fedcba"
 
     #[test]
     fn amber_dusk_example_theme_parses_and_applies_warm_dark_palette() {
-        let theme =
-            Theme::from_config_str(include_str!("../../../examples/themes/amber-dusk/theme.toml"))
-                .expect("amber-dusk theme should parse");
+        let theme = Theme::from_config_str(include_str!(
+            "../../../examples/themes/amber-dusk/theme.toml"
+        ))
+        .expect("amber-dusk theme should parse");
 
         assert_eq!(theme.palette.bg, rgb(0x12, 0x0f, 0x0d));
         assert_eq!(theme.preview.code.keyword, rgb(0xcf, 0x98, 0x51));
@@ -1515,9 +1518,10 @@ macro = "#fedcba"
 
     #[test]
     fn tokyo_night_example_theme_parses_and_applies_palette_consistently() {
-        let theme =
-            Theme::from_config_str(include_str!("../../../examples/themes/tokyo-night/theme.toml"))
-                .expect("tokyo-night theme should parse");
+        let theme = Theme::from_config_str(include_str!(
+            "../../../examples/themes/tokyo-night/theme.toml"
+        ))
+        .expect("tokyo-night theme should parse");
 
         assert_eq!(theme.palette.bg, rgb(0x1a, 0x1b, 0x26));
         assert_eq!(theme.preview.code.keyword, rgb(0xbb, 0x9a, 0xf7));
@@ -1594,7 +1598,10 @@ macro = "#fedcba"
             "docs",
         ];
         let themes = [
-            ("default", include_str!("../../../examples/themes/default/theme.toml")),
+            (
+                "default",
+                include_str!("../../../examples/themes/default/theme.toml"),
+            ),
             (
                 "default-light",
                 include_str!("../../../examples/themes/default-light/theme.toml"),
@@ -1611,8 +1618,14 @@ macro = "#fedcba"
                 "catppuccin-mocha",
                 include_str!("../../../examples/themes/catppuccin-mocha/theme.toml"),
             ),
-            ("tokyo-night", include_str!("../../../examples/themes/tokyo-night/theme.toml")),
-            ("navi", include_str!("../../../examples/themes/navi/theme.toml")),
+            (
+                "tokyo-night",
+                include_str!("../../../examples/themes/tokyo-night/theme.toml"),
+            ),
+            (
+                "navi",
+                include_str!("../../../examples/themes/navi/theme.toml"),
+            ),
             (
                 "neon-cherry",
                 include_str!("../../../examples/themes/neon-cherry/theme.toml"),
@@ -1622,7 +1635,9 @@ macro = "#fedcba"
         for (label, config) in themes {
             let theme = Theme::from_config_str(config)
                 .unwrap_or_else(|error| panic!("{label} theme should parse: {error}"));
-            let normal_folder_color = theme.resolve(Path::new("projects"), EntryKind::Directory).color;
+            let normal_folder_color = theme
+                .resolve(Path::new("projects"), EntryKind::Directory)
+                .color;
 
             for directory in generic_dirs {
                 let resolved = theme.resolve(Path::new(directory), EntryKind::Directory);
@@ -1632,8 +1647,7 @@ macro = "#fedcba"
                     "{label}: {directory} should resolve as a directory",
                 );
                 assert_eq!(
-                    resolved.color,
-                    normal_folder_color,
+                    resolved.color, normal_folder_color,
                     "{label}: {directory} should use the normal folder color",
                 );
             }


### PR DESCRIPTION
## Summary

This PR improves preview efficiency and correctness without changing Elio’s preview architecture. It adds cooperative cancellation for stale in-flight preview jobs, makes syntax-style code previews use a conservative viewport-aware line budget, and updates preview cache/result handling so resize-driven code preview changes stay correct. Structured previews are unchanged.

## What changed

- **Cooperative Cancellation**: Cancel stale preview work earlier instead of finishing and discarding it.
- **Viewport-Aware Limits**: Make code preview line limits depend on visible preview height, capped by the existing max.
- **Cache & Validation**: Include `code_line_limit` in preview job keys, cache keys, and result validation.
- **UI Responsiveness**: Refresh code previews when preview height changes.
- **Maintenance**: Cleaned up warnings and kept the branch fully green.

## Verification

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`

**Result:** `419 passed, 0 failed`