### PR TITLE
Quality/toolchain and ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,66 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: -D warnings
+
+jobs:
+  quality:
+    name: fmt, clippy, test, docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install preview test tooling
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            ffmpeg \
+            genisoimage \
+            imagemagick \
+            libarchive-tools \
+            poppler-utils \
+            xz-utils
+
+          if ! command -v 7z >/dev/null 2>&1; then
+            if sudo apt-get install -y p7zip-full; then
+              :
+            else
+              sudo apt-get install -y 7zip
+              if command -v 7zz >/dev/null 2>&1 && ! command -v 7z >/dev/null 2>&1; then
+                sudo ln -s "$(command -v 7zz)" /usr/local/bin/7z
+              fi
+            fi
+          fi
+
+      - name: Install Rust 1.93.0
+        uses: dtolnay/rust-toolchain@1.93.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --check
+
+      - name: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test
+
+      - name: cargo doc --no-deps
+        run: cargo doc --no-deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Toolchain
+
+`rust-toolchain.toml` pins the project to Rust 1.93.0 and installs the required `rustfmt` and `clippy` components automatically when you work in the repository.
+
+## Local Quality Checks
+
+Before opening a PR, run the same checks enforced in CI:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+```
+
+## Optional Preview Tooling
+
+For the broadest local preview-test coverage, install the optional archive and PDF tools used by the test suite, especially `7z`, `bsdtar`, `isoinfo`, `pdfinfo`, `pdftocairo`, and `xz`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.93.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

This branch adds the project guardrails after the refactor series settled.

### Changes:
- **Toolchain Pinning:** Pinned the Rust toolchain to `1.93.0`.
- **CI/CD Pipeline:** Added a GitHub Actions workflow for formatting, clippy, tests, and docs.
- **Contributor Docs:** Documented the local quality checks for contributors.

## Structure

**Added:**
- `rust-toolchain.toml`
- `.github/workflows/rust.yml`
- `CONTRIBUTING.md`

## Notes

- **`rust-toolchain.toml`:** Pins the repo to Rust `1.93.0` and ensures `rustfmt` and `clippy` are installed.
- **Workflow Steps:** The CI runs:
  - `cargo fmt --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo test`
  - `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- **Dependencies:** The GitHub Actions job installs the external archive/PDF tooling required for broad preview-test coverage.
- **Documentation:** Local contributor guidance is now in `CONTRIBUTING.md` to keep the `README` focused on the end-user.

## Verification

**Ran locally:**
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`