### PR TITLE
fix(files): make trash and delete async, cancelable, and more responsive

### DIFF
--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -86,15 +86,17 @@ impl App {
 
         let token = self.paste_token.wrapping_add(1);
         self.paste_token = token;
+        let dest_dir = self.cwd.clone();
         self.paste_progress = Some(PasteProgress {
             completed: 0,
             total: clipboard.paths.len(),
             op: clipboard.op,
         });
+        self.paste_dest_dir = Some(dest_dir.clone());
 
         self.scheduler.submit_paste(PasteRequest {
             token,
-            dest_dir: self.cwd.clone(),
+            dest_dir,
             paths: clipboard.paths,
             op: clipboard.op,
         });

--- a/src/app/create/mod.rs
+++ b/src/app/create/mod.rs
@@ -292,6 +292,195 @@ mod tests {
     }
 
     #[test]
+    fn confirm_trash_batch_trashes_multiple_files_and_reports_count() {
+        let root = temp_path("trash-batch-multi");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("alpha.txt"), "a").expect("failed to write alpha");
+        fs::write(root.join("beta.txt"), "b").expect("failed to write beta");
+        fs::write(root.join("gamma.txt"), "c").expect("failed to write gamma");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        // in_trash = false → non-permanent batch trash
+        app.selected_paths.insert(root.join("alpha.txt"));
+        app.selected_paths.insert(root.join("beta.txt"));
+        app.selected_paths.insert(root.join("gamma.txt"));
+        app.open_trash_prompt();
+
+        assert_eq!(app.trash_title(), "Trash 3 files?");
+        app.confirm_trash().expect("trash should succeed");
+
+        assert!(app.trash.is_none());
+        assert!(app.selected_paths.is_empty());
+
+        wait_for_trash_and_reload(&mut app);
+
+        assert!(!root.join("alpha.txt").exists());
+        assert!(!root.join("beta.txt").exists());
+        assert!(!root.join("gamma.txt").exists());
+        assert_eq!(app.status_message(), "Trashed 3 items");
+
+        // Purge the items we just trashed from the OS trash so the test
+        // leaves no permanent side-effects.
+        {
+            use trash::os_limited::{list, purge_all};
+            if let Ok(items) = list() {
+                let ours: Vec<_> = items
+                    .into_iter()
+                    .filter(|item| item.original_parent == root)
+                    .collect();
+                let _ = purge_all(ours);
+            }
+        }
+
+        app.directory_runtime.watch = None;
+        drop(app);
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn confirm_trash_batch_single_file_shows_quoted_name() {
+        let root = temp_path("trash-batch-single");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("notes.txt"), "hello").expect("failed to write file");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        // in_trash = false → non-permanent batch trash
+        app.selected_paths.insert(root.join("notes.txt"));
+        app.open_trash_prompt();
+
+        assert_eq!(app.trash_title(), "Trash 1 selected file?");
+        app.confirm_trash().expect("trash should succeed");
+
+        assert!(app.trash.is_none());
+        assert!(app.selected_paths.is_empty());
+
+        wait_for_trash_and_reload(&mut app);
+
+        assert!(!root.join("notes.txt").exists());
+        assert_eq!(app.status_message(), "Trashed \"notes.txt\"");
+
+        // Purge from OS trash to avoid side-effects.
+        {
+            use trash::os_limited::{list, purge_all};
+            if let Ok(items) = list() {
+                let ours: Vec<_> = items
+                    .into_iter()
+                    .filter(|item| item.original_parent == root)
+                    .collect();
+                let _ = purge_all(ours);
+            }
+        }
+
+        app.directory_runtime.watch = None;
+        drop(app);
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn esc_during_batched_trash_keeps_chip_visible_until_done() {
+        // Non-permanent (batched) trash is a single atomic OS call that may
+        // already be in flight when the user presses Esc.  The chip must
+        // remain visible until the worker sends done=true so the user can
+        // see the operation is still running, not silently cancelled.
+        let root = temp_path("trash-cancel-batched");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("canary.txt"), "x").expect("failed to write file");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        app.selected_paths.insert(root.join("canary.txt"));
+        app.open_trash_prompt();
+        app.confirm_trash().expect("trash should succeed");
+
+        // Chip is showing immediately after submit.
+        assert!(
+            app.trash_progress().is_some(),
+            "chip should be visible after submit"
+        );
+
+        // Simulate Esc: cancel_trash is called but chip must NOT be cleared.
+        app.scheduler.cancel_trash(app.trash_token);
+        // trash_progress is still Some — chip stays visible.
+        assert!(
+            app.trash_progress().is_some(),
+            "chip must remain visible after Esc for batched trash"
+        );
+
+        // Wait for the worker to finish (cancelled before start or completed).
+        wait_for_trash_and_reload(&mut app);
+
+        // Chip is gone once done=true is processed.
+        assert!(
+            app.trash_progress().is_none(),
+            "chip should be gone after completion"
+        );
+
+        // Status is either "Trash cancelled" (cancel won the race) or "Trashed
+        // \"canary.txt\"" (batch was already in flight).  Either is correct.
+        let status = app.status_message();
+        let valid = status.starts_with("Trash cancelled")
+            || status.starts_with("Trashed")
+            || status.starts_with("Nothing was deleted");
+        assert!(valid, "unexpected status: {status:?}");
+
+        // Purge from OS trash if the file actually got trashed.
+        if !root.join("canary.txt").exists() {
+            use trash::os_limited::{list, purge_all};
+            if let Ok(items) = list() {
+                let ours: Vec<_> = items
+                    .into_iter()
+                    .filter(|item| item.original_parent == root)
+                    .collect();
+                let _ = purge_all(ours);
+            }
+        }
+
+        app.directory_runtime.watch = None;
+        drop(app);
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn esc_during_permanent_delete_clears_chip_immediately() {
+        // Permanent delete can be interrupted between items, so pressing Esc
+        // should clear the chip right away (not wait for done=true).
+        let root = temp_path("trash-cancel-permanent");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("gone.txt"), "x").expect("failed to write file");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        app.in_trash = true;
+        app.selected_paths.insert(root.join("gone.txt"));
+        app.open_trash_prompt();
+        app.confirm_trash().expect("trash should succeed");
+
+        assert!(
+            app.trash_progress().is_some(),
+            "chip should be visible after submit"
+        );
+
+        // Simulate Esc for permanent delete: chip clears immediately.
+        let token = app.trash_token;
+        app.scheduler.cancel_trash(token);
+        app.trash_progress = None;
+
+        assert!(
+            app.trash_progress().is_none(),
+            "chip should clear immediately for permanent delete"
+        );
+
+        // Drive to completion so background thread shuts down cleanly.
+        for _ in 0..200 {
+            let _ = app.process_background_jobs();
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        app.directory_runtime.watch = None;
+        drop(app);
+        // root may or may not still contain gone.txt depending on the race.
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn confirm_restore_restores_file_from_trashinfo_and_queues_reload() {
         let (root, trash_files, original_path, trashed_path) = create_fake_trash_file("restore");
 

--- a/src/app/create/mod.rs
+++ b/src/app/create/mod.rs
@@ -27,7 +27,7 @@ mod tests {
     fn wait_for_trash_and_reload(app: &mut App) {
         for _ in 0..500 {
             let _ = app.process_background_jobs();
-            if app.trash_progress.is_none() && app.directory_runtime.pending_load.is_none() {
+            if app.trash_progress().is_none() && app.directory_runtime.pending_load.is_none() {
                 return;
             }
             std::thread::sleep(Duration::from_millis(10));

--- a/src/app/create/mod.rs
+++ b/src/app/create/mod.rs
@@ -13,8 +13,27 @@ mod tests {
     use std::{
         fs,
         path::{Path, PathBuf},
-        time::{SystemTime, UNIX_EPOCH},
+        time::{Duration, SystemTime, UNIX_EPOCH},
     };
+
+    /// Drive background jobs until both the trash worker and the subsequent
+    /// directory reload have both completed.  Checking only `trash_progress`
+    /// is not enough: a single `process_background_jobs` call can consume
+    /// the `Trash(done=true)` result *and* the immediately-queued
+    /// `Directory` reload in the same batch (a tiny directory scan completes
+    /// before the loop's next `try_recv`).  Driving until `pending_load` is
+    /// also gone guarantees that `app.status_message()` holds the final
+    /// status in all cases.
+    fn wait_for_trash_and_reload(app: &mut App) {
+        for _ in 0..500 {
+            let _ = app.process_background_jobs();
+            if app.trash_progress.is_none() && app.directory_runtime.pending_load.is_none() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("timed out waiting for trash and directory reload to complete");
+    }
 
     fn temp_path(label: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -257,12 +276,15 @@ mod tests {
         app.confirm_trash().expect("trash should succeed");
 
         assert!(app.trash.is_none());
-        assert!(!root.join("gone.txt").exists());
         assert!(app.selected_paths.is_empty());
 
-        let (status, reselect_path) = take_pending_status(&mut app);
-        assert_eq!(status, "Permanently deleted \"gone.txt\"");
-        assert_eq!(reselect_path, None);
+        // Deletion is async — wait for the background worker *and* the
+        // subsequent directory reload to both finish.
+        wait_for_trash_and_reload(&mut app);
+
+        assert!(!root.join("gone.txt").exists());
+        // Status is set by apply_directory_snapshot once the reload completes.
+        assert_eq!(app.status_message(), "Permanently deleted \"gone.txt\"");
 
         app.directory_runtime.watch = None;
         drop(app);

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -249,8 +249,14 @@ impl App {
     }
 
     pub(in crate::app::create) fn confirm_trash(&mut self) -> Result<()> {
-        if self.trash_progress.is_some() {
-            self.status = "Trash in progress — press Esc to cancel".to_string();
+        if let Some(prog) = &self.trash_progress {
+            self.status = if prog.permanent {
+                "Delete in progress — press Esc to cancel".to_string()
+            } else {
+                // Batched trash is a single atomic OS call that cannot be
+                // reliably interrupted once started.
+                "Trash in progress".to_string()
+            };
             self.trash = None;
             return Ok(());
         }

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -1,15 +1,12 @@
 use super::super::{
     App,
-    state::{
-        DirectoryHistoryMode, DirectoryLoadCompletion, PendingDirectoryLoad, TrashOverlay,
-        TrashTarget,
-    },
+    jobs::TrashRequest,
+    state::{TrashOverlay, TrashProgress, TrashTarget},
 };
 use crate::fs::rect_contains;
-use ::trash::delete;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use std::{env, fs, path::Path};
+use std::{env, path::Path};
 
 impl App {
     pub(in crate::app) fn cwd_is_trash(&self) -> bool {
@@ -244,48 +241,29 @@ impl App {
     }
 
     pub(in crate::app::create) fn confirm_trash(&mut self) -> Result<()> {
+        if self.trash_progress.is_some() {
+            self.status = "Trash in progress".to_string();
+            self.trash = None;
+            return Ok(());
+        }
         let Some(t) = self.trash.take() else {
             return Ok(());
         };
-        for target in &t.targets {
-            if t.permanent {
-                if target.is_dir {
-                    fs::remove_dir_all(&target.path).map_err(|error| {
-                        anyhow::anyhow!("Could not delete \"{}\": {error}", target.name)
-                    })?;
-                } else {
-                    fs::remove_file(&target.path).map_err(|error| {
-                        anyhow::anyhow!("Could not delete \"{}\": {error}", target.name)
-                    })?;
-                }
-            } else {
-                delete(&target.path).map_err(|error| {
-                    anyhow::anyhow!("Could not trash \"{}\": {error}", target.name)
-                })?;
-            }
+        if t.targets.is_empty() {
+            return Ok(());
         }
         self.selected_paths.clear();
-        let verb = if t.permanent {
-            "Permanently deleted"
-        } else {
-            "Trashed"
-        };
-        let status = match t.targets.len() {
-            0 => String::new(),
-            1 => format!("{verb} \"{}\"", t.targets[0].name),
-            n => format!("{verb} {n} items"),
-        };
-        self.queue_directory_load(PendingDirectoryLoad {
-            token: 0,
-            target_cwd: self.cwd.clone(),
-            previous_cwd: self.cwd.clone(),
-            previous_selected_path: None,
-            previous_selection_name: None,
-            reselect_path: None,
-            history_mode: DirectoryHistoryMode::None,
-            refresh_search: false,
-            completion: DirectoryLoadCompletion::Status(status),
-        })?;
+
+        let token = self.trash_token.wrapping_add(1);
+        self.trash_token = token;
+        self.trash_progress = Some(TrashProgress { completed: 0 });
+
+        self.scheduler.submit_trash(TrashRequest {
+            token,
+            targets: t.targets,
+            permanent: t.permanent,
+        });
+
         Ok(())
     }
 }

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -77,6 +77,14 @@ impl App {
         self.trash.is_some()
     }
 
+    /// Returns `(completed, total, permanent)` for an in-progress
+    /// trash/delete, or `None` when idle.
+    pub fn trash_progress(&self) -> Option<(usize, usize, bool)> {
+        self.trash_progress
+            .as_ref()
+            .map(|p| (p.completed, p.total, p.permanent))
+    }
+
     pub fn trash_title(&self) -> String {
         let Some(t) = &self.trash else {
             return String::new();
@@ -256,7 +264,11 @@ impl App {
 
         let token = self.trash_token.wrapping_add(1);
         self.trash_token = token;
-        self.trash_progress = Some(TrashProgress { completed: 0 });
+        self.trash_progress = Some(TrashProgress {
+            completed: 0,
+            total: t.targets.len(),
+            permanent: t.permanent,
+        });
 
         self.scheduler.submit_trash(TrashRequest {
             token,

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -250,7 +250,7 @@ impl App {
 
     pub(in crate::app::create) fn confirm_trash(&mut self) -> Result<()> {
         if self.trash_progress.is_some() {
-            self.status = "Trash in progress".to_string();
+            self.status = "Trash in progress — press Esc to cancel".to_string();
             self.trash = None;
             return Ok(());
         }
@@ -269,6 +269,7 @@ impl App {
             total: t.targets.len(),
             permanent: t.permanent,
         });
+        self.trash_source_cwd = Some(self.cwd.clone());
 
         self.scheduler.submit_trash(TrashRequest {
             token,

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -61,7 +61,10 @@ impl App {
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            if self.paste_progress.is_some() {
+            if self.trash_progress.is_some() {
+                self.scheduler.cancel_trash(self.trash_token);
+                self.trash_progress = None;
+            } else if self.paste_progress.is_some() {
                 self.scheduler.cancel_paste(self.paste_token);
                 self.paste_progress = None;
             } else {
@@ -149,7 +152,10 @@ impl App {
         match key.code {
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Esc => {
-                if self.paste_progress.is_some() {
+                if self.trash_progress.is_some() {
+                    self.scheduler.cancel_trash(self.trash_token);
+                    self.trash_progress = None;
+                } else if self.paste_progress.is_some() {
                     self.scheduler.cancel_paste(self.paste_token);
                     self.paste_progress = None;
                 } else {

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -61,9 +61,14 @@ impl App {
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            if self.trash_progress.is_some() {
+            if let Some(prog) = &self.trash_progress {
                 self.scheduler.cancel_trash(self.trash_token);
-                self.trash_progress = None;
+                if prog.permanent {
+                    // Permanent delete can be stopped between items; clear chip immediately.
+                    self.trash_progress = None;
+                }
+                // Non-permanent: the batch OS call is atomic and may already be
+                // in flight.  Keep the chip visible; done=true will clear it.
             } else if self.paste_progress.is_some() {
                 self.scheduler.cancel_paste(self.paste_token);
                 self.paste_progress = None;
@@ -152,9 +157,11 @@ impl App {
         match key.code {
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Esc => {
-                if self.trash_progress.is_some() {
+                if let Some(prog) = &self.trash_progress {
                     self.scheduler.cancel_trash(self.trash_token);
-                    self.trash_progress = None;
+                    if prog.permanent {
+                        self.trash_progress = None;
+                    }
                 } else if self.paste_progress.is_some() {
                     self.scheduler.cancel_paste(self.paste_token);
                     self.paste_progress = None;

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -524,6 +524,10 @@ impl JobScheduler {
         self.trash.submit(request)
     }
 
+    pub(super) fn cancel_trash(&self, token: u64) {
+        self.trash.cancel_trash(token);
+    }
+
     pub(super) fn submit_search(&self, request: SearchRequest) -> bool {
         self.search.submit(request)
     }

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -13,7 +13,7 @@ use self::{
         directory::DirectoryPool, directory_fingerprint::DirectoryFingerprintPool,
         image::ImagePreparePool, item_count::DirectoryItemCountPool,
         line_count::PreviewLineCountPool, paste::PastePool, pdf_probe::PdfProbePool,
-        pdf_render::PdfRenderPool,
+        pdf_render::PdfRenderPool, trash::TrashPool,
     },
 };
 use super::overlays::images::PreparedStaticImageAsset;
@@ -305,6 +305,23 @@ pub(super) struct PasteBuild {
     pub status: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct TrashRequest {
+    pub token: u64,
+    pub targets: Vec<crate::app::state::TrashTarget>,
+    pub permanent: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct TrashBuild {
+    pub token: u64,
+    pub completed: usize,
+    /// `true` on the final result; `false` on intermediate progress updates.
+    pub done: bool,
+    /// Populated only when `done = true`.
+    pub status: Option<String>,
+}
+
 #[derive(Debug)]
 pub(super) enum JobResult {
     Directory(DirectoryBuild),
@@ -317,6 +334,7 @@ pub(super) enum JobResult {
     Search(SearchBuild),
     Preview(Box<PreviewBuild>),
     Paste(PasteBuild),
+    Trash(TrashBuild),
 }
 
 #[cfg(test)]
@@ -342,6 +360,7 @@ pub(super) struct JobScheduler {
     directory: DirectoryPool,
     directory_fingerprint: DirectoryFingerprintPool,
     paste: PastePool,
+    trash: TrashPool,
     directory_item_count: DirectoryItemCountPool,
     preview_line_count: PreviewLineCountPool,
     image_prepare: ImagePreparePool,
@@ -366,6 +385,7 @@ impl JobScheduler {
         Self {
             directory: DirectoryPool::new(1, result_tx.clone(), Arc::clone(&metrics)),
             paste: PastePool::new(result_tx.clone()),
+            trash: TrashPool::new(result_tx.clone()),
             directory_fingerprint: DirectoryFingerprintPool::new(
                 config.directory_fingerprint_worker_count,
                 result_tx.clone(),
@@ -500,6 +520,10 @@ impl JobScheduler {
         self.paste.cancel_paste(token);
     }
 
+    pub(super) fn submit_trash(&self, request: TrashRequest) -> bool {
+        self.trash.submit(request)
+    }
+
     pub(super) fn submit_search(&self, request: SearchRequest) -> bool {
         self.search.submit(request)
     }
@@ -524,6 +548,7 @@ impl JobScheduler {
             || self.directory.has_pending_work()
             || self.directory_fingerprint.has_pending_work()
             || self.paste.has_pending_work()
+            || self.trash.has_pending_work()
             || self.directory_item_count.has_pending_work()
             || self.preview_line_count.has_pending_work()
             || self.image_prepare.has_pending_work()

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -203,6 +203,29 @@ impl App {
                     }
                     dirty = true;
                 }
+                JobResult::Trash(build) => {
+                    if build.token != self.trash_token {
+                        continue;
+                    }
+                    if build.done {
+                        self.trash_progress = None;
+                        let status = build.status.unwrap_or_default();
+                        let _ = self.queue_directory_load(PendingDirectoryLoad {
+                            token: 0,
+                            target_cwd: self.cwd.clone(),
+                            previous_cwd: self.cwd.clone(),
+                            previous_selected_path: None,
+                            previous_selection_name: None,
+                            reselect_path: None,
+                            history_mode: DirectoryHistoryMode::None,
+                            refresh_search: false,
+                            completion: DirectoryLoadCompletion::Status(status),
+                        });
+                    } else if let Some(prog) = &mut self.trash_progress {
+                        prog.completed = build.completed;
+                    }
+                    dirty = true;
+                }
                 JobResult::Preview(build) => {
                     self.cache_preview_result_with_code_line_limit(
                         &build.entry,

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -186,18 +186,37 @@ impl App {
                     }
                     if build.done {
                         self.paste_progress = None;
+                        let dest_dir = self
+                            .paste_dest_dir
+                            .take()
+                            .unwrap_or_else(|| self.cwd.clone());
                         let status = build.status.unwrap_or_default();
-                        let _ = self.queue_directory_load(PendingDirectoryLoad {
-                            token: 0,
-                            target_cwd: self.cwd.clone(),
-                            previous_cwd: self.cwd.clone(),
-                            previous_selected_path: None,
-                            previous_selection_name: None,
-                            reselect_path: None,
-                            history_mode: DirectoryHistoryMode::None,
-                            refresh_search: false,
-                            completion: DirectoryLoadCompletion::Status(status),
-                        });
+                        // Only reload in-place when the user is still in the
+                        // destination directory and not mid-navigation to
+                        // somewhere else (which would cancel their navigation).
+                        let nav_target = self
+                            .directory_runtime
+                            .pending_load
+                            .as_ref()
+                            .map(|l| l.target_cwd.as_path());
+                        let nav_to_dest = nav_target == Some(dest_dir.as_path());
+                        if dest_dir == self.cwd && (nav_target.is_none() || nav_to_dest) {
+                            let _ = self.queue_directory_load(PendingDirectoryLoad {
+                                token: 0,
+                                target_cwd: dest_dir,
+                                previous_cwd: self.cwd.clone(),
+                                previous_selected_path: None,
+                                previous_selection_name: None,
+                                reselect_path: None,
+                                history_mode: DirectoryHistoryMode::None,
+                                refresh_search: false,
+                                completion: DirectoryLoadCompletion::Status(status),
+                            });
+                        } else {
+                            // User navigated away — just surface the status.
+                            // Navigation will load dest_dir fresh if they return.
+                            self.status = status;
+                        }
                     } else if let Some(prog) = &mut self.paste_progress {
                         prog.completed = build.completed;
                     }
@@ -209,18 +228,37 @@ impl App {
                     }
                     if build.done {
                         self.trash_progress = None;
+                        let source_cwd = self
+                            .trash_source_cwd
+                            .take()
+                            .unwrap_or_else(|| self.cwd.clone());
                         let status = build.status.unwrap_or_default();
-                        let _ = self.queue_directory_load(PendingDirectoryLoad {
-                            token: 0,
-                            target_cwd: self.cwd.clone(),
-                            previous_cwd: self.cwd.clone(),
-                            previous_selected_path: None,
-                            previous_selection_name: None,
-                            reselect_path: None,
-                            history_mode: DirectoryHistoryMode::None,
-                            refresh_search: false,
-                            completion: DirectoryLoadCompletion::Status(status),
-                        });
+                        // Only reload in-place when the user is still in the
+                        // source directory and not mid-navigation to somewhere
+                        // else (which would cancel their navigation).
+                        let nav_target = self
+                            .directory_runtime
+                            .pending_load
+                            .as_ref()
+                            .map(|l| l.target_cwd.as_path());
+                        let nav_to_source = nav_target == Some(source_cwd.as_path());
+                        if source_cwd == self.cwd && (nav_target.is_none() || nav_to_source) {
+                            let _ = self.queue_directory_load(PendingDirectoryLoad {
+                                token: 0,
+                                target_cwd: source_cwd,
+                                previous_cwd: self.cwd.clone(),
+                                previous_selected_path: None,
+                                previous_selection_name: None,
+                                reselect_path: None,
+                                history_mode: DirectoryHistoryMode::None,
+                                refresh_search: false,
+                                completion: DirectoryLoadCompletion::Status(status),
+                            });
+                        } else {
+                            // User navigated away — just surface the status.
+                            // Navigation will load source_cwd fresh if they return.
+                            self.status = status;
+                        }
                     } else if let Some(prog) = &mut self.trash_progress {
                         prog.completed = build.completed;
                     }

--- a/src/app/jobs/tasks/mod.rs
+++ b/src/app/jobs/tasks/mod.rs
@@ -8,3 +8,4 @@ pub(super) mod line_count;
 pub(super) mod paste;
 pub(super) mod pdf_probe;
 pub(super) mod pdf_render;
+pub(super) mod trash;

--- a/src/app/jobs/tasks/paste.rs
+++ b/src/app/jobs/tasks/paste.rs
@@ -8,7 +8,13 @@ use std::{
         mpsc,
     },
     thread,
+    time::{Duration, Instant},
 };
+
+/// Minimum time between intermediate progress results sent to the UI.
+/// Prevents a per-file result flood from turning into a constant redraw storm
+/// when pasting or trashing large numbers of small files.
+const PROGRESS_SEND_INTERVAL: Duration = Duration::from_millis(80);
 
 pub(in crate::app::jobs) struct PastePool {
     shared: Arc<PasteShared>,
@@ -163,8 +169,8 @@ impl PasteShared {
     }
 }
 
-/// Execute the paste operation, sending intermediate progress results through
-/// `result_tx` after each item.  Returns `(completed, errors, stopped_early)`.
+/// Execute the paste operation, sending throttled intermediate progress
+/// results through `result_tx`.  Returns `(completed, errors, stopped_early)`.
 ///
 /// `stopped_early` is `true` if the loop was cut short by a cancel flag rather
 /// than running to completion.
@@ -177,6 +183,9 @@ fn run_paste(
     let mut completed = 0usize;
     let mut errors: Vec<String> = Vec::new();
     let mut stopped_early = false;
+    // Tracks when we last sent a progress result.  None = never sent, which
+    // causes the first update to go through immediately.
+    let mut last_progress_at: Option<Instant> = None;
 
     for src in &request.paths {
         if cancelled.load(Ordering::Relaxed)
@@ -187,24 +196,17 @@ fn run_paste(
         }
         let Some(file_name) = src.file_name().and_then(|n| n.to_str()) else {
             errors.push(format!("Cannot determine name for {}", src.display()));
-            // Still send progress so the chip stays fresh.
-            let _ = result_tx.send(JobResult::Paste(PasteBuild {
-                token: request.token,
-                completed,
-                done: false,
-                status: None,
-            }));
+            if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at) {
+                break;
+            }
             continue;
         };
 
         if !src.exists() {
             errors.push(format!("\"{}\" no longer exists", file_name));
-            let _ = result_tx.send(JobResult::Paste(PasteBuild {
-                token: request.token,
-                completed,
-                done: false,
-                status: None,
-            }));
+            if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at) {
+                break;
+            }
             continue;
         }
 
@@ -213,12 +215,10 @@ fn run_paste(
             let natural = request.dest_dir.join(file_name);
             if natural == *src {
                 completed += 1;
-                let _ = result_tx.send(JobResult::Paste(PasteBuild {
-                    token: request.token,
-                    completed,
-                    done: false,
-                    status: None,
-                }));
+                if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at)
+                {
+                    break;
+                }
                 continue;
             }
         }
@@ -273,21 +273,36 @@ fn run_paste(
             completed += 1;
         }
 
-        // Send intermediate progress after each item.
-        if result_tx
-            .send(JobResult::Paste(PasteBuild {
-                token: request.token,
-                completed,
-                done: false,
-                status: None,
-            }))
-            .is_err()
-        {
+        if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at) {
             break;
         }
     }
 
     (completed, errors, stopped_early)
+}
+
+/// Send a throttled intermediate progress result for the paste worker.
+/// Returns `false` if the receiver has been dropped (loop should break).
+fn send_paste_progress(
+    result_tx: &mpsc::Sender<JobResult>,
+    token: u64,
+    completed: usize,
+    last_progress_at: &mut Option<Instant>,
+) -> bool {
+    let now = Instant::now();
+    let due = last_progress_at.is_none_or(|t| now.duration_since(t) >= PROGRESS_SEND_INTERVAL);
+    if due {
+        *last_progress_at = Some(now);
+        return result_tx
+            .send(JobResult::Paste(PasteBuild {
+                token,
+                completed,
+                done: false,
+                status: None,
+            }))
+            .is_ok();
+    }
+    true
 }
 
 /// Return a destination path inside `dir` for an item named `name` that does

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -11,8 +11,9 @@ use std::{
 };
 
 /// Minimum time between intermediate progress results sent to the UI.
-/// Prevents a per-file result flood from turning into a constant redraw storm
-/// when pasting or trashing large numbers of small files.
+/// Only applies to permanent delete, which processes files one at a time.
+/// Non-permanent trash is a single batched OS call with no intermediate
+/// progress.
 const PROGRESS_SEND_INTERVAL: Duration = Duration::from_millis(80);
 
 pub(in crate::app::jobs) struct TrashPool {
@@ -177,11 +178,27 @@ fn run_trash(
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
 ) -> (usize, Vec<String>, bool) {
+    if request.permanent {
+        run_permanent_delete(request, result_tx, cancelled, cancel_token)
+    } else {
+        run_trash_batch(request, cancelled, cancel_token)
+    }
+}
+
+/// Delete each target permanently using per-item `fs` calls.
+///
+/// Sends throttled intermediate progress results so the UI chip updates
+/// during long operations, and supports mid-batch cancellation between
+/// items.
+fn run_permanent_delete(
+    request: &TrashRequest,
+    result_tx: &mpsc::Sender<JobResult>,
+    cancelled: &AtomicBool,
+    cancel_token: &AtomicU64,
+) -> (usize, Vec<String>, bool) {
     let mut completed = 0usize;
     let mut errors: Vec<String> = Vec::new();
     let mut stopped_early = false;
-    // Tracks when we last sent a progress result.  None = never sent, which
-    // causes the first update to go through immediately.
     let mut last_progress_at: Option<Instant> = None;
 
     for target in &request.targets {
@@ -192,35 +209,17 @@ fn run_trash(
             break;
         }
 
-        let ok = if request.permanent {
-            let result = if target.is_dir {
-                fs::remove_dir_all(&target.path)
-                    .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))
-            } else {
-                fs::remove_file(&target.path)
-                    .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))
-            };
-            match result {
-                Ok(()) => true,
-                Err(e) => {
-                    errors.push(e.to_string());
-                    false
-                }
-            }
+        let result = if target.is_dir {
+            fs::remove_dir_all(&target.path)
+                .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))
         } else {
-            match ::trash::delete(&target.path)
-                .map_err(|e| anyhow::anyhow!("Could not trash \"{}\": {e}", target.name))
-            {
-                Ok(()) => true,
-                Err(e) => {
-                    errors.push(e.to_string());
-                    false
-                }
-            }
+            fs::remove_file(&target.path)
+                .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))
         };
 
-        if ok {
-            completed += 1;
+        match result {
+            Ok(()) => completed += 1,
+            Err(e) => errors.push(e.to_string()),
         }
 
         if !send_trash_progress(result_tx, request.token, completed, &mut last_progress_at) {
@@ -231,8 +230,39 @@ fn run_trash(
     (completed, errors, stopped_early)
 }
 
-/// Send a throttled intermediate progress result for the trash worker.
-/// Returns `false` if the receiver has been dropped (loop should break).
+/// Move all targets to the OS trash in a single batched call to
+/// `trash::delete_all`.
+///
+/// This is significantly faster than per-item trashing because the `trash`
+/// crate amortizes expensive setup work — reading `/proc/mounts`, resolving
+/// the trash directory, checking for name collisions — across the whole
+/// batch instead of repeating it for every file.
+///
+/// Cancellation is checked once before the batch starts.  The batch itself
+/// is treated as atomic from Elio's perspective: once the OS call is in
+/// flight it cannot be interrupted mid-way.  No intermediate progress
+/// results are sent; the UI chip stays at 0/N until the call returns.
+fn run_trash_batch(
+    request: &TrashRequest,
+    cancelled: &AtomicBool,
+    cancel_token: &AtomicU64,
+) -> (usize, Vec<String>, bool) {
+    if cancelled.load(Ordering::Relaxed) || cancel_token.load(Ordering::Relaxed) == request.token {
+        return (0, Vec::new(), true);
+    }
+
+    let paths: Vec<_> = request.targets.iter().map(|t| &t.path).collect();
+    let total = paths.len();
+
+    match ::trash::delete_all(paths) {
+        Ok(()) => (total, Vec::new(), false),
+        Err(e) => (0, vec![e.to_string()], false),
+    }
+}
+
+/// Send a throttled intermediate progress result for the permanent-delete
+/// worker.  Returns `false` if the receiver has been dropped (loop should
+/// break).
 fn send_trash_progress(
     result_tx: &mpsc::Sender<JobResult>,
     token: u64,

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -7,7 +7,13 @@ use std::{
         mpsc,
     },
     thread,
+    time::{Duration, Instant},
 };
+
+/// Minimum time between intermediate progress results sent to the UI.
+/// Prevents a per-file result flood from turning into a constant redraw storm
+/// when pasting or trashing large numbers of small files.
+const PROGRESS_SEND_INTERVAL: Duration = Duration::from_millis(80);
 
 pub(in crate::app::jobs) struct TrashPool {
     shared: Arc<TrashShared>,
@@ -113,6 +119,13 @@ impl TrashPool {
         true
     }
 
+    /// Signal the worker to stop after the current item if it is processing
+    /// the trash request with the given token.  A concurrent or future request
+    /// with a different token is unaffected.
+    pub(in crate::app::jobs) fn cancel_trash(&self, token: u64) {
+        self.shared.cancel_token.store(token, Ordering::Relaxed);
+    }
+
     pub(in crate::app::jobs) fn has_pending_work(&self) -> bool {
         let state = lock_unpoison(&self.shared.state);
         state.pending.is_some() || state.active
@@ -167,6 +180,9 @@ fn run_trash(
     let mut completed = 0usize;
     let mut errors: Vec<String> = Vec::new();
     let mut stopped_early = false;
+    // Tracks when we last sent a progress result.  None = never sent, which
+    // causes the first update to go through immediately.
+    let mut last_progress_at: Option<Instant> = None;
 
     for target in &request.targets {
         if cancelled.load(Ordering::Relaxed)
@@ -207,18 +223,34 @@ fn run_trash(
             completed += 1;
         }
 
-        if result_tx
-            .send(JobResult::Trash(TrashBuild {
-                token: request.token,
-                completed,
-                done: false,
-                status: None,
-            }))
-            .is_err()
-        {
+        if !send_trash_progress(result_tx, request.token, completed, &mut last_progress_at) {
             break;
         }
     }
 
     (completed, errors, stopped_early)
+}
+
+/// Send a throttled intermediate progress result for the trash worker.
+/// Returns `false` if the receiver has been dropped (loop should break).
+fn send_trash_progress(
+    result_tx: &mpsc::Sender<JobResult>,
+    token: u64,
+    completed: usize,
+    last_progress_at: &mut Option<Instant>,
+) -> bool {
+    let now = Instant::now();
+    let due = last_progress_at.is_none_or(|t| now.duration_since(t) >= PROGRESS_SEND_INTERVAL);
+    if due {
+        *last_progress_at = Some(now);
+        return result_tx
+            .send(JobResult::Trash(TrashBuild {
+                token,
+                completed,
+                done: false,
+                status: None,
+            }))
+            .is_ok();
+    }
+    true
 }

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -1,0 +1,224 @@
+use super::*;
+use std::{
+    fs,
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc,
+    },
+    thread,
+};
+
+pub(in crate::app::jobs) struct TrashPool {
+    shared: Arc<TrashShared>,
+    workers: Vec<thread::JoinHandle<()>>,
+}
+
+struct TrashShared {
+    state: Mutex<TrashState>,
+    available: Condvar,
+    cancelled: AtomicBool,
+    cancel_token: AtomicU64,
+}
+
+struct TrashState {
+    pending: Option<TrashRequest>,
+    active: bool,
+    closed: bool,
+}
+
+impl TrashPool {
+    pub(in crate::app::jobs) fn new(result_tx: mpsc::Sender<JobResult>) -> Self {
+        let shared = Arc::new(TrashShared {
+            state: Mutex::new(TrashState {
+                pending: None,
+                active: false,
+                closed: false,
+            }),
+            available: Condvar::new(),
+            cancelled: AtomicBool::new(false),
+            cancel_token: AtomicU64::new(0),
+        });
+        let shared_worker = Arc::clone(&shared);
+        let worker = thread::spawn(move || {
+            while let Some(request) = TrashShared::pop(&shared_worker) {
+                TrashShared::set_active(&shared_worker, true);
+                let (completed, errors, stopped_early) = run_trash(
+                    &request,
+                    &result_tx,
+                    &shared_worker.cancelled,
+                    &shared_worker.cancel_token,
+                );
+                TrashShared::set_active(&shared_worker, false);
+
+                let verb = if request.permanent {
+                    "Permanently deleted"
+                } else {
+                    "Trashed"
+                };
+                let total = request.targets.len();
+                let single_name = (total == 1).then(|| request.targets[0].name.as_str());
+                let status = if stopped_early {
+                    match completed {
+                        0 => "Trash cancelled".to_string(),
+                        1 => format!("Trash cancelled — {verb} 1 item"),
+                        n => format!("Trash cancelled — {verb} {n} items"),
+                    }
+                } else if errors.is_empty() {
+                    match (completed, single_name) {
+                        (0, _) => "Nothing was deleted".to_string(),
+                        (1, Some(name)) => format!("{verb} \"{name}\""),
+                        (n, _) => format!("{verb} {n} items"),
+                    }
+                } else if completed == 0 {
+                    if errors.len() == 1 {
+                        errors[0].clone()
+                    } else {
+                        format!("{} errors — first: {}", errors.len(), errors[0])
+                    }
+                } else {
+                    format!(
+                        "{verb} {completed} item(s); {} error(s) — first: {}",
+                        errors.len(),
+                        errors[0]
+                    )
+                };
+
+                if result_tx
+                    .send(JobResult::Trash(TrashBuild {
+                        token: request.token,
+                        completed,
+                        done: true,
+                        status: Some(status),
+                    }))
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+        Self {
+            shared,
+            workers: vec![worker],
+        }
+    }
+
+    pub(in crate::app::jobs) fn submit(&self, request: TrashRequest) -> bool {
+        let mut state = lock_unpoison(&self.shared.state);
+        if state.closed {
+            return false;
+        }
+        state.pending = Some(request);
+        self.shared.available.notify_one();
+        true
+    }
+
+    pub(in crate::app::jobs) fn has_pending_work(&self) -> bool {
+        let state = lock_unpoison(&self.shared.state);
+        state.pending.is_some() || state.active
+    }
+}
+
+impl Drop for TrashPool {
+    fn drop(&mut self) {
+        {
+            let mut state = lock_unpoison(&self.shared.state);
+            state.closed = true;
+            // Do NOT clear `pending` and do NOT set `cancelled`: the worker must
+            // finish any in-flight and queued requests completely before exiting.
+            // Setting `cancelled` here (as PastePool does) would abandon targets
+            // mid-batch and leave them neither deleted nor untouched, which is
+            // worse than a momentary delay on exit.
+        }
+        self.shared.available.notify_all();
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl TrashShared {
+    fn pop(shared: &Arc<Self>) -> Option<TrashRequest> {
+        let mut state = lock_unpoison(&shared.state);
+        loop {
+            // Drain any queued request before honoring the close signal so
+            // that a pending job submitted just before shutdown is not lost.
+            if let Some(request) = state.pending.take() {
+                return Some(request);
+            }
+            if state.closed {
+                return None;
+            }
+            state = wait_unpoison(&shared.available, state);
+        }
+    }
+
+    fn set_active(shared: &Arc<Self>, active: bool) {
+        lock_unpoison(&shared.state).active = active;
+    }
+}
+
+fn run_trash(
+    request: &TrashRequest,
+    result_tx: &mpsc::Sender<JobResult>,
+    cancelled: &AtomicBool,
+    cancel_token: &AtomicU64,
+) -> (usize, Vec<String>, bool) {
+    let mut completed = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    let mut stopped_early = false;
+
+    for target in &request.targets {
+        if cancelled.load(Ordering::Relaxed)
+            || cancel_token.load(Ordering::Relaxed) == request.token
+        {
+            stopped_early = true;
+            break;
+        }
+
+        let ok = if request.permanent {
+            let result = if target.is_dir {
+                fs::remove_dir_all(&target.path)
+                    .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))
+            } else {
+                fs::remove_file(&target.path)
+                    .map_err(|e| anyhow::anyhow!("Could not delete \"{}\": {e}", target.name))
+            };
+            match result {
+                Ok(()) => true,
+                Err(e) => {
+                    errors.push(e.to_string());
+                    false
+                }
+            }
+        } else {
+            match ::trash::delete(&target.path)
+                .map_err(|e| anyhow::anyhow!("Could not trash \"{}\": {e}", target.name))
+            {
+                Ok(()) => true,
+                Err(e) => {
+                    errors.push(e.to_string());
+                    false
+                }
+            }
+        };
+
+        if ok {
+            completed += 1;
+        }
+
+        if result_tx
+            .send(JobResult::Trash(TrashBuild {
+                token: request.token,
+                completed,
+                done: false,
+                status: None,
+            }))
+            .is_err()
+        {
+            break;
+        }
+    }
+
+    (completed, errors, stopped_early)
+}

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -92,6 +92,11 @@ pub(super) struct PasteProgress {
 }
 
 #[derive(Clone, Debug)]
+pub(super) struct TrashProgress {
+    pub(super) completed: usize,
+}
+
+#[derive(Clone, Debug)]
 pub(super) struct TrashTarget {
     pub(super) path: std::path::PathBuf,
     pub(super) name: String,
@@ -368,6 +373,8 @@ pub struct App {
     pub(super) clipboard: Option<Clipboard>,
     pub(super) paste_token: u64,
     pub(super) paste_progress: Option<PasteProgress>,
+    pub(super) trash_token: u64,
+    pub(super) trash_progress: Option<TrashProgress>,
     pub(super) trash: Option<TrashOverlay>,
     pub(super) restore: Option<RestoreOverlay>,
     pub(super) create: Option<CreateOverlay>,
@@ -449,6 +456,8 @@ impl App {
             clipboard: None,
             paste_token: 0,
             paste_progress: None,
+            trash_token: 0,
+            trash_progress: None,
             trash: None,
             restore: None,
             create: None,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -94,6 +94,8 @@ pub(super) struct PasteProgress {
 #[derive(Clone, Debug)]
 pub(super) struct TrashProgress {
     pub(super) completed: usize,
+    pub(super) total: usize,
+    pub(super) permanent: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -375,8 +375,15 @@ pub struct App {
     pub(super) clipboard: Option<Clipboard>,
     pub(super) paste_token: u64,
     pub(super) paste_progress: Option<PasteProgress>,
+    /// Destination directory of the in-flight paste.  Kept separately from
+    /// `paste_progress` so that cancelling the chip does not lose the context
+    /// needed by the completion handler to reload the right directory.
+    pub(super) paste_dest_dir: Option<PathBuf>,
     pub(super) trash_token: u64,
     pub(super) trash_progress: Option<TrashProgress>,
+    /// Source directory of the in-flight trash.  Kept separately from
+    /// `trash_progress` for the same reason as `paste_dest_dir`.
+    pub(super) trash_source_cwd: Option<PathBuf>,
     pub(super) trash: Option<TrashOverlay>,
     pub(super) restore: Option<RestoreOverlay>,
     pub(super) create: Option<CreateOverlay>,
@@ -458,8 +465,10 @@ impl App {
             clipboard: None,
             paste_token: 0,
             paste_progress: None,
+            paste_dest_dir: None,
             trash_token: 0,
             trash_progress: None,
+            trash_source_cwd: None,
             trash: None,
             restore: None,
             create: None,

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -127,8 +127,14 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
         let mut chips_width: u16 = 0;
 
         if let Some((completed, total, permanent)) = trash_prog {
-            let verb = if permanent { "Deleting" } else { "Trashing" };
-            let label = format!(" {verb} {completed}/{total} ");
+            let label = if permanent {
+                format!(" Deleting {completed}/{total} ")
+            } else {
+                // Batched trash has no per-item progress; show an
+                // indeterminate indicator rather than a misleading 0/N.
+                let noun = if total == 1 { "item" } else { "items" };
+                format!(" Trashing {total} {noun}… ")
+            };
             chips_width += label.len() as u16 + 2;
             spans.push(Span::styled(
                 label,

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -117,15 +117,28 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
     let clip = app.clipboard_info();
     let sel_count = app.selection_count();
     let paste_prog = app.paste_progress();
+    let trash_prog = app.trash_progress();
 
-    // Build the left line: optional paste-progress chip (takes over the
-    // clipboard slot during an active paste), optional selection chip, then
-    // the path/position summary truncated to whatever space remains.
+    // Build the left line: optional progress chips (trash takes priority,
+    // then paste; both take over the clipboard slot), optional selection
+    // chip, then the path/position summary.
     let left_line = {
         let mut spans: Vec<Span<'_>> = Vec::new();
         let mut chips_width: u16 = 0;
 
-        if let Some((completed, total, op)) = paste_prog {
+        if let Some((completed, total, permanent)) = trash_prog {
+            let verb = if permanent { "Deleting" } else { "Trashing" };
+            let label = format!(" {verb} {completed}/{total} ");
+            chips_width += label.len() as u16 + 2;
+            spans.push(Span::styled(
+                label,
+                Style::default()
+                    .bg(palette.trash_bar)
+                    .fg(palette.chrome)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw("  "));
+        } else if let Some((completed, total, op)) = paste_prog {
             let verb = match op {
                 ClipOp::Yank => "Copying",
                 ClipOp::Cut => "Moving",

--- a/src/ui/theme/appearance/parsing.rs
+++ b/src/ui/theme/appearance/parsing.rs
@@ -37,6 +37,7 @@ struct PaletteOverride {
     selection_bar: Option<String>,
     yank_bar: Option<String>,
     cut_bar: Option<String>,
+    trash_bar: Option<String>,
     sidebar_active: Option<String>,
     button_bg: Option<String>,
     button_disabled_bg: Option<String>,
@@ -159,6 +160,7 @@ fn apply_palette_overrides(
     apply_palette_color(&mut palette.selection_bar, overrides.selection_bar)?;
     apply_palette_color(&mut palette.yank_bar, overrides.yank_bar)?;
     apply_palette_color(&mut palette.cut_bar, overrides.cut_bar)?;
+    apply_palette_color(&mut palette.trash_bar, overrides.trash_bar)?;
     apply_palette_color(&mut palette.sidebar_active, overrides.sidebar_active)?;
     apply_palette_color(&mut palette.button_bg, overrides.button_bg)?;
     apply_palette_color(

--- a/src/ui/theme/appearance/rules.rs
+++ b/src/ui/theme/appearance/rules.rs
@@ -1024,6 +1024,7 @@ impl Theme {
                 selection_bar: rgb(255, 178, 86),
                 yank_bar: rgb(87, 201, 87),
                 cut_bar: rgb(224, 90, 90),
+                trash_bar: rgb(210, 65, 95),
                 sidebar_active: rgb(27, 56, 88),
                 button_bg: rgb(14, 23, 38),
                 button_disabled_bg: rgb(8, 16, 27),

--- a/src/ui/theme/appearance/types.rs
+++ b/src/ui/theme/appearance/types.rs
@@ -22,6 +22,7 @@ pub(crate) struct Palette {
     pub selection_bar: Color,
     pub yank_bar: Color,
     pub cut_bar: Color,
+    pub trash_bar: Color,
     pub sidebar_active: Color,
     pub button_bg: Color,
     pub button_disabled_bg: Color,


### PR DESCRIPTION
## Summary

Improve trash and permanent delete so large operations do not block the UI, while keeping progress and status behavior aligned with what the backend can actually report.

## What changed

- **Async Operations**: Moved trash and permanent delete into background jobs to prevent UI blocking.
- **Progress Tracking**: 
    - Added progress indicators in the status bar.
    - Permanent delete shows real-time `Deleting x/y` progress.
    - Normal trash shows `Trashing N items…` to remain honest to the batched OS call.
- **Cancellation & Safety**: 
    - Allowed canceling permanent delete with `Esc` / `Ctrl+C`.
    - Normal trash remains non-cancelable once the batched OS call is in flight.
    - Prevented overlapping trash jobs from overwriting each other.
- **Efficiency**: Batched non-permanent trash with `trash::delete_all(...)` to avoid per-file overhead.
- **Context Awareness**: Preserved source-directory context so completion reloads and status updates apply correctly.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --quiet`

**Result:** All checks and tests passed.