### PR TITLE
feat(config): add configurable browser key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ show_top_bar = false
 # places  = 10
 # files   = 45
 # preview = 45
+
+# [keys]
+# yank = "y"   # and so on for any action you want to rebind
 ```
 
 | Key | Default | Description |
@@ -111,7 +114,33 @@ show_top_bar = false
 | `layout.panes.files` | unset | Relative width weight for the Files pane |
 | `layout.panes.preview` | unset | Relative width weight for the Preview pane; `0` hides it |
 
-Pane weights are relative — `10/45/45` and `20/90/90` produce the same split. If `[layout.panes]` is omitted, elio uses a built-in responsive layout. See [examples/config.toml](examples/config.toml) for an annotated reference.
+Pane weights are relative — `10/45/45` and `20/90/90` produce the same split. If `[layout.panes]` is omitted, elio uses a built-in responsive layout.
+
+### Key bindings
+
+Any browser action key can be rebound in the `[keys]` section. Each value must be a **single character**. Duplicate bindings and reserved characters are rejected at startup with an error to stderr; the affected key falls back to its default.
+
+| Key | Default | Action |
+|---|---|---|
+| `keys.quit` | `q` | Quit |
+| `keys.yank` | `y` | Yank (copy) |
+| `keys.cut` | `x` | Cut |
+| `keys.paste` | `p` | Paste |
+| `keys.trash` | `d` | Trash / permanent delete in trash |
+| `keys.create` | `a` | Create file or folder |
+| `keys.rename` | `r` | Rename / bulk rename / restore from trash |
+| `keys.copy_path` | `c` | Copy path details to clipboard |
+| `keys.search_folders` | `f` | Fuzzy-find folders |
+| `keys.open` | `o` | Open externally |
+| `keys.sort` | `s` | Cycle sort mode |
+| `keys.toggle_view` | `v` | Toggle grid / list view |
+| `keys.toggle_hidden` | `.` | Toggle dotfiles visibility |
+| `keys.scroll_preview_left` | `<` | Scroll preview left |
+| `keys.scroll_preview_right` | `>` | Scroll preview right |
+
+**Reserved** (cannot be rebound): `h` `j` `k` `l` `g` `G` `?` `[` `]` `+` `=` `-` `_` `Space`
+
+See [examples/config.toml](examples/config.toml) for an annotated reference.
 
 ---
 
@@ -162,6 +191,8 @@ The full default theme is at [`assets/themes/default/theme.toml`](assets/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
+Keys marked with `*` are rebindable via `[keys]` in `config.toml` — the defaults are shown. See the [Key bindings](#key-bindings) section for the full list of configurable actions.
+
 ### Navigation
 
 | Key | Action |
@@ -179,11 +210,11 @@ The full default theme is at [`assets/themes/default/theme.toml`](assets/themes/
 
 | Key | Action |
 |---|---|
-| `v` | Toggle grid / list view |
+| `v` `*` | Toggle grid / list view |
 | `+` / `-` | Grid zoom in / out |
-| `.` | Show / hide dotfiles |
-| `s` | Cycle sort (Name → Modified → Size) |
-| `<` / `>` | Scroll preview left / right |
+| `.` `*` | Show / hide dotfiles |
+| `s` `*` | Cycle sort (Name → Modified → Size) |
+| `<` / `>` `*` | Scroll preview left / right |
 
 ### Files and Clipboard
 
@@ -191,21 +222,21 @@ The full default theme is at [`assets/themes/default/theme.toml`](assets/themes/
 |---|---|
 | `Space` | Toggle selection |
 | `Ctrl+A` | Select all |
-| `y` | Yank (copy) |
-| `x` | Cut |
-| `p` | Paste |
-| `a` | Create file or folder |
-| `d` | Trash; permanently delete if already in trash |
-| `r` | Rename / bulk rename / restore from trash |
+| `y` `*` | Yank (copy) |
+| `x` `*` | Cut |
+| `p` `*` | Paste |
+| `a` `*` | Create file or folder |
+| `d` `*` | Trash; permanently delete if already in trash |
+| `r` `*` | Rename / bulk rename / restore from trash |
 | `F2` | Rename / bulk rename |
-| `o` | Open externally |
-| `c` | Copy path details to clipboard |
+| `o` `*` | Open externally |
+| `c` `*` | Copy path details to clipboard |
 
 ### Search
 
 | Key | Action |
 |---|---|
-| `f` | Fuzzy-find folders in the current tree |
+| `f` `*` | Fuzzy-find folders in the current tree |
 | `Ctrl+F` | Fuzzy-find files in the current tree |
 
 ### Mouse
@@ -223,7 +254,7 @@ The full default theme is at [`assets/themes/default/theme.toml`](assets/themes/
 |---|---|
 | `?` | Open help overlay |
 | `Esc` | Cancel / clear selection / close overlay |
-| `q` | Quit |
+| `q` `*` | Quit |
 
 </details>
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -22,3 +22,24 @@ show_top_bar = false
 # places = 10
 # files = 45
 # preview = 45
+
+# Rebind browser action keys. Each value must be a single character.
+# Reserved (never rebindable): h j k l g G ? [ ] + = - _ Space
+# Omit any key to keep the built-in default shown in the comment.
+#
+# [keys]
+# quit              = "q"
+# yank              = "y"
+# cut               = "x"
+# paste             = "p"
+# trash             = "d"
+# create            = "a"
+# rename            = "r"
+# copy_path         = "c"
+# search_folders    = "f"
+# open              = "o"
+# sort              = "s"
+# toggle_view       = "v"
+# toggle_hidden     = "."
+# scroll_preview_left  = "<"
+# scroll_preview_right = ">"

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -162,7 +162,6 @@ impl App {
         }
 
         match key.code {
-            KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Esc => {
                 if let Some(prog) = &self.trash_progress {
                     self.scheduler.cancel_trash(self.trash_token);
@@ -212,29 +211,12 @@ impl App {
             KeyCode::Char('G') => self.select_last(),
             KeyCode::Enter => self.open_selected()?,
             KeyCode::Backspace => self.go_parent()?,
-            KeyCode::Char('v') => {
-                self.toggle_view_mode();
-            }
-            KeyCode::Char('s') => self.cycle_sort_mode()?,
-            KeyCode::Char('.') => self.toggle_hidden_files()?,
             KeyCode::Char(' ') => self.toggle_selection(),
             KeyCode::Char('+') | KeyCode::Char('=') if self.view_mode == ViewMode::Grid => {
                 self.adjust_zoom(1);
             }
             KeyCode::Char('-') | KeyCode::Char('_') if self.view_mode == ViewMode::Grid => {
                 self.adjust_zoom(-1);
-            }
-            KeyCode::Char('a') => self.open_create_prompt(),
-            KeyCode::Char('c') => self.open_copy_overlay(),
-            KeyCode::Char('d') => self.open_trash_prompt(),
-            KeyCode::Char('r') => {
-                if self.in_trash {
-                    self.open_restore_prompt();
-                } else if !self.selected_paths.is_empty() {
-                    self.open_bulk_rename_prompt();
-                } else {
-                    self.open_rename_prompt();
-                }
             }
             KeyCode::F(2) => {
                 if !self.in_trash {
@@ -245,18 +227,46 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('<') => {
+            KeyCode::Char(c) => {
+                if let Some(action) = crate::config::keys().action_for(c) {
+                    self.dispatch_action(action)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(in crate::app) fn dispatch_action(&mut self, action: crate::config::Action) -> Result<()> {
+        use crate::config::Action;
+        match action {
+            Action::Quit => self.should_quit = true,
+            Action::Yank => self.yank(),
+            Action::Cut => self.cut(),
+            Action::Paste => self.paste()?,
+            Action::Trash => self.open_trash_prompt(),
+            Action::Create => self.open_create_prompt(),
+            Action::Rename => {
+                if self.in_trash {
+                    self.open_restore_prompt();
+                } else if !self.selected_paths.is_empty() {
+                    self.open_bulk_rename_prompt();
+                } else {
+                    self.open_rename_prompt();
+                }
+            }
+            Action::CopyPath => self.open_copy_overlay(),
+            Action::SearchFolders => self.open_search_with_status(SearchScope::Folders),
+            Action::Open => self.open_in_system()?,
+            Action::Sort => self.cycle_sort_mode()?,
+            Action::ToggleView => self.toggle_view_mode(),
+            Action::ToggleHidden => self.toggle_hidden_files()?,
+            Action::ScrollPreviewLeft => {
                 let _ = self.scroll_preview_columns(-1);
             }
-            KeyCode::Char('>') => {
+            Action::ScrollPreviewRight => {
                 let _ = self.scroll_preview_columns(1);
             }
-            KeyCode::Char('f') => self.open_search_with_status(SearchScope::Folders),
-            KeyCode::Char('o') => self.open_in_system()?,
-            KeyCode::Char('y') => self.yank(),
-            KeyCode::Char('x') => self.cut(),
-            KeyCode::Char('p') => self.paste()?,
-            _ => {}
         }
         Ok(())
     }

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::helpers::{temp_path, wait_for_directory_load};
+use crate::config::Action;
 use std::{
     fs, thread,
     time::{Duration, Instant},
@@ -421,6 +422,75 @@ fn high_frequency_alt_right_does_not_trigger_history_navigation() {
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(child.as_path())
     );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+// --- keybindings integration tests ---
+
+/// Parses a [keys] override, derives an action via KeyBindings::action_for,
+/// dispatches it through App::dispatch_action, and checks the resulting state.
+/// This covers the full config-to-runtime pipeline:
+///   TOML string → KeyBindings → action_for → dispatch_action → app state
+///
+/// Note: App::handle_event reads from the process-wide config singleton, so we
+/// cannot inject per-test overrides there.  The dispatch_action path (which
+/// handle_event delegates to for every configurable key) is tested here
+/// directly with a parsed KeyBindings, giving equivalent coverage.
+#[test]
+fn rebound_yank_key_dispatches_yank_action() {
+    use crate::config::KeyBindings;
+
+    // Parse a config that rebinds yank from "y" to "Y".
+    let kb = KeyBindings::from_toml_str("[keys]\nyank = \"Y\"");
+    assert_eq!(
+        kb.action_for('Y'),
+        Some(Action::Yank),
+        "new key should map to Yank"
+    );
+    assert_eq!(
+        kb.action_for('y'),
+        None,
+        "old key should no longer map to Yank"
+    );
+
+    // Create an app with a file so yank has something to act on.
+    let root = temp_path("rebind-yank-e2e");
+    fs::write(root.join("file.txt"), "hello").expect("failed to write file");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.select_index(0);
+
+    assert!(app.clipboard.is_none(), "clipboard should start empty");
+
+    // Dispatch the action the rebound key would trigger.
+    let action = kb.action_for('Y').expect("Y should be bound");
+    app.dispatch_action(action)
+        .expect("dispatch should succeed");
+
+    assert!(
+        app.clipboard.is_some(),
+        "yank should have populated the clipboard"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn rebound_quit_key_sets_should_quit() {
+    use crate::config::KeyBindings;
+
+    let kb = KeyBindings::from_toml_str("[keys]\nquit = \"Q\"");
+    assert_eq!(kb.action_for('Q'), Some(Action::Quit));
+    assert_eq!(kb.action_for('q'), None);
+
+    let root = temp_path("rebind-quit-e2e");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    assert!(!app.should_quit);
+
+    app.dispatch_action(kb.action_for('Q').unwrap())
+        .expect("dispatch should succeed");
+    assert!(app.should_quit);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,16 +22,251 @@ pub(crate) struct PaneWeights {
     pub preview: u16,
 }
 
-#[derive(Clone, Copy)]
+/// A browser action that can be triggered by a configurable key binding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Action {
+    Quit,
+    Yank,
+    Cut,
+    Paste,
+    Trash,
+    Create,
+    Rename,
+    CopyPath,
+    SearchFolders,
+    Open,
+    Sort,
+    ToggleView,
+    ToggleHidden,
+    ScrollPreviewLeft,
+    ScrollPreviewRight,
+}
+
+/// Single-character key bindings for browser actions.
+/// All fields default to the built-in keys; set any field in `[keys]` in
+/// `config.toml` to override that binding.
+pub(crate) struct KeyBindings {
+    pub quit: char,
+    pub yank: char,
+    pub cut: char,
+    pub paste: char,
+    pub trash: char,
+    pub create: char,
+    pub rename: char,
+    pub copy_path: char,
+    pub search_folders: char,
+    pub open: char,
+    pub sort: char,
+    pub toggle_view: char,
+    pub toggle_hidden: char,
+    pub scroll_preview_left: char,
+    pub scroll_preview_right: char,
+}
+
+/// Characters that are hard-wired to non-configurable actions and may not be
+/// used as key binding values.
+const RESERVED_CHARS: &[char] = &[
+    'h', 'j', 'k', 'l', // navigation (vim keys)
+    'g', 'G', // go-to overlay / jump to last
+    '?', // help
+    '[', ']', // page stepping (epub / comic / pdf)
+    '+', '=', '-', '_', // grid zoom
+    ' ', // toggle selection
+];
+
+impl KeyBindings {
+    fn default_bindings() -> Self {
+        Self {
+            quit: 'q',
+            yank: 'y',
+            cut: 'x',
+            paste: 'p',
+            trash: 'd',
+            create: 'a',
+            rename: 'r',
+            copy_path: 'c',
+            search_folders: 'f',
+            open: 'o',
+            sort: 's',
+            toggle_view: 'v',
+            toggle_hidden: '.',
+            scroll_preview_left: '<',
+            scroll_preview_right: '>',
+        }
+    }
+
+    /// Returns the action bound to `c`, if any.
+    pub(crate) fn action_for(&self, c: char) -> Option<Action> {
+        match c {
+            _ if c == self.quit => Some(Action::Quit),
+            _ if c == self.yank => Some(Action::Yank),
+            _ if c == self.cut => Some(Action::Cut),
+            _ if c == self.paste => Some(Action::Paste),
+            _ if c == self.trash => Some(Action::Trash),
+            _ if c == self.create => Some(Action::Create),
+            _ if c == self.rename => Some(Action::Rename),
+            _ if c == self.copy_path => Some(Action::CopyPath),
+            _ if c == self.search_folders => Some(Action::SearchFolders),
+            _ if c == self.open => Some(Action::Open),
+            _ if c == self.sort => Some(Action::Sort),
+            _ if c == self.toggle_view => Some(Action::ToggleView),
+            _ if c == self.toggle_hidden => Some(Action::ToggleHidden),
+            _ if c == self.scroll_preview_left => Some(Action::ScrollPreviewLeft),
+            _ if c == self.scroll_preview_right => Some(Action::ScrollPreviewRight),
+            _ => None,
+        }
+    }
+
+    /// Parse a full config TOML string and return only the resolved key
+    /// bindings.  Falls back to defaults on parse error.
+    /// Used by integration tests that need a `KeyBindings` from an override
+    /// string without going through the process-wide `OnceLock`.
+    #[cfg(test)]
+    pub(crate) fn from_toml_str(s: &str) -> Self {
+        Config::from_str(s)
+            .map(|c| c.keys)
+            .unwrap_or_else(|_| Self::default_bindings())
+    }
+
+    fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
+        // Each entry: (field_name, user_override_string, default_char)
+        let raw: [(&str, Option<String>, char); 15] = [
+            ("quit", overrides.quit, defaults.quit),
+            ("yank", overrides.yank, defaults.yank),
+            ("cut", overrides.cut, defaults.cut),
+            ("paste", overrides.paste, defaults.paste),
+            ("trash", overrides.trash, defaults.trash),
+            ("create", overrides.create, defaults.create),
+            ("rename", overrides.rename, defaults.rename),
+            ("copy_path", overrides.copy_path, defaults.copy_path),
+            (
+                "search_folders",
+                overrides.search_folders,
+                defaults.search_folders,
+            ),
+            ("open", overrides.open, defaults.open),
+            ("sort", overrides.sort, defaults.sort),
+            ("toggle_view", overrides.toggle_view, defaults.toggle_view),
+            (
+                "toggle_hidden",
+                overrides.toggle_hidden,
+                defaults.toggle_hidden,
+            ),
+            (
+                "scroll_preview_left",
+                overrides.scroll_preview_left,
+                defaults.scroll_preview_left,
+            ),
+            (
+                "scroll_preview_right",
+                overrides.scroll_preview_right,
+                defaults.scroll_preview_right,
+            ),
+        ];
+
+        // Step 1: parse each override string independently, falling back to
+        //         default on any format or reserved-char error.
+        // (resolved_char, is_user_set)
+        let mut candidates: [(char, bool); 15] = [(' ', false); 15];
+        for (i, (name, override_str, default)) in raw.iter().enumerate() {
+            candidates[i] = match override_str {
+                None => (*default, false),
+                Some(s) => {
+                    let mut chars = s.chars();
+                    match (chars.next(), chars.next()) {
+                        (Some(c), None) if RESERVED_CHARS.contains(&c) => {
+                            eprintln!(
+                                "elio: keys.{name}: '{c}' is reserved and cannot be rebound; \
+                                 using default '{default}'"
+                            );
+                            (*default, false)
+                        }
+                        (Some(c), None) if c.is_control() => {
+                            eprintln!(
+                                "elio: keys.{name}: control characters cannot be used as key \
+                                 bindings; using default '{default}'"
+                            );
+                            (*default, false)
+                        }
+                        (Some(c), None) => (c, true),
+                        _ => {
+                            eprintln!(
+                                "elio: keys.{name}: {s:?} is not a single character; \
+                                 using default '{default}'"
+                            );
+                            (*default, false)
+                        }
+                    }
+                }
+            };
+        }
+
+        // Step 2: reject user-set bindings that collide with any other binding
+        //         (user-set or default).  Loop until stable so that reverting one
+        //         binding does not silently leave a conflict with another.
+        loop {
+            let mut changed = false;
+            for i in 0..15 {
+                if !candidates[i].1 {
+                    continue;
+                }
+                let c = candidates[i].0;
+                let collision = (0..15).filter(|&j| j != i).any(|j| candidates[j].0 == c);
+                if collision {
+                    let (name, _, default) = &raw[i];
+                    let other = raw
+                        .iter()
+                        .enumerate()
+                        .filter(|&(j, _)| j != i && candidates[j].0 == c)
+                        .map(|(_, (n, _, _))| *n)
+                        .next()
+                        .unwrap_or("another key");
+                    eprintln!(
+                        "elio: keys.{name}: '{c}' is already bound to {other}; \
+                         using default '{default}'"
+                    );
+                    candidates[i] = (*default, false);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        // Step 3: build from the resolved candidates (order matches `raw`).
+        let c = |i: usize| candidates[i].0;
+        Self {
+            quit: c(0),
+            yank: c(1),
+            cut: c(2),
+            paste: c(3),
+            trash: c(4),
+            create: c(5),
+            rename: c(6),
+            copy_path: c(7),
+            search_folders: c(8),
+            open: c(9),
+            sort: c(10),
+            toggle_view: c(11),
+            toggle_hidden: c(12),
+            scroll_preview_left: c(13),
+            scroll_preview_right: c(14),
+        }
+    }
+}
+
 struct Config {
     ui: UiConfig,
     layout: LayoutConfig,
+    keys: KeyBindings,
 }
 
 #[derive(Deserialize, Default)]
 struct ConfigFile {
     ui: Option<UiConfigOverride>,
     layout: Option<LayoutConfigOverride>,
+    keys: Option<KeysConfigOverride>,
 }
 
 #[derive(Deserialize, Default)]
@@ -39,6 +274,25 @@ struct UiConfigOverride {
     show_top_bar: Option<bool>,
     grid_zoom: Option<i64>,
     show_hidden: Option<bool>,
+}
+
+#[derive(Deserialize, Default)]
+struct KeysConfigOverride {
+    quit: Option<String>,
+    yank: Option<String>,
+    cut: Option<String>,
+    paste: Option<String>,
+    trash: Option<String>,
+    create: Option<String>,
+    rename: Option<String>,
+    copy_path: Option<String>,
+    search_folders: Option<String>,
+    open: Option<String>,
+    sort: Option<String>,
+    toggle_view: Option<String>,
+    toggle_hidden: Option<String>,
+    scroll_preview_left: Option<String>,
+    scroll_preview_right: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -63,6 +317,10 @@ pub(crate) fn ui() -> UiConfig {
 
 pub(crate) fn layout() -> LayoutConfig {
     active_config().layout
+}
+
+pub(crate) fn keys() -> &'static KeyBindings {
+    &active_config().keys
 }
 
 pub(crate) fn config_dir() -> Option<PathBuf> {
@@ -124,6 +382,7 @@ impl Config {
                 show_hidden: false,
             },
             layout: LayoutConfig { panes: None },
+            keys: KeyBindings::default_bindings(),
         }
     }
 
@@ -146,6 +405,9 @@ impl Config {
                 Ok(layout) => resolved.layout = layout,
                 Err(error) => eprintln!("elio: invalid [layout.panes] config: {error}"),
             }
+        }
+        if let Some(keys) = parsed.keys {
+            resolved.keys = KeyBindings::from_override(keys, &KeyBindings::default_bindings());
         }
         Ok(resolved)
     }
@@ -298,5 +560,148 @@ preview = 90
 
         assert!(config.ui.show_top_bar);
         assert_eq!(config.layout.panes, None);
+    }
+
+    // --- [keys] tests ---
+
+    #[test]
+    fn keys_default_bindings_are_sane() {
+        let config = Config::default_config();
+        assert_eq!(config.keys.yank, 'y');
+        assert_eq!(config.keys.cut, 'x');
+        assert_eq!(config.keys.paste, 'p');
+        assert_eq!(config.keys.quit, 'q');
+    }
+
+    #[test]
+    fn keys_can_be_overridden() {
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "Y"
+cut = "X"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'Y');
+        assert_eq!(config.keys.cut, 'X');
+        // unset keys stay at default
+        assert_eq!(config.keys.paste, 'p');
+    }
+
+    #[test]
+    fn keys_rejects_multi_char_string_and_uses_default() {
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "yy"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'y'); // falls back to default
+    }
+
+    #[test]
+    fn keys_rejects_empty_string_and_uses_default() {
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = ""
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'y');
+    }
+
+    #[test]
+    fn keys_rejects_reserved_char_and_uses_default() {
+        // 'j' is a reserved navigation key
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "j"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'y');
+    }
+
+    #[test]
+    fn keys_rejects_control_characters_and_uses_default() {
+        // \t and \n are dispatched as dedicated KeyCode variants (Tab, Enter),
+        // not as KeyCode::Char, so they can never fire the action dispatch path.
+        let config = Config::from_str("[keys]\nquit = \"\\t\"").expect("config should parse");
+        assert_eq!(config.keys.quit, 'q');
+
+        let config = Config::from_str("[keys]\nquit = \"\\n\"").expect("config should parse");
+        assert_eq!(config.keys.quit, 'q');
+    }
+
+    #[test]
+    fn keys_rejects_user_user_duplicate_and_uses_defaults() {
+        // Both yank and paste set to "p" — conflict, both revert to defaults
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "p"
+paste = "p"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'y');
+        assert_eq!(config.keys.paste, 'p');
+    }
+
+    #[test]
+    fn keys_rejects_user_default_collision_and_uses_default() {
+        // yank set to "d" which is trash's default — conflict, yank reverts
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "d"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'y');
+        assert_eq!(config.keys.trash, 'd');
+    }
+
+    #[test]
+    fn keys_allows_swapping_two_defaults() {
+        // yank = "x", cut = "y" — each takes the other's default, no conflict
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "x"
+cut = "y"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.yank, 'x');
+        assert_eq!(config.keys.cut, 'y');
+    }
+
+    #[test]
+    fn action_for_returns_correct_action_for_default_bindings() {
+        let kb = KeyBindings::default_bindings();
+        assert_eq!(kb.action_for('y'), Some(Action::Yank));
+        assert_eq!(kb.action_for('x'), Some(Action::Cut));
+        assert_eq!(kb.action_for('p'), Some(Action::Paste));
+        assert_eq!(kb.action_for('q'), Some(Action::Quit));
+        assert_eq!(kb.action_for('j'), None); // reserved, never bindable
+        assert_eq!(kb.action_for('z'), None); // unbound
+    }
+
+    #[test]
+    fn action_for_reflects_overridden_binding() {
+        let config = Config::from_str(
+            r#"
+[keys]
+yank = "Y"
+"#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.keys.action_for('Y'), Some(Action::Yank));
+        assert_eq!(config.keys.action_for('y'), None);
     }
 }

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -15,188 +15,85 @@ pub(super) fn render_help(
     state: &mut FrameState,
     palette: Palette,
 ) {
-    const NAVIGATION_ENTRIES: &[HelpEntry<'_>] = &[
-        HelpEntry {
-            key: "↑↓ / jk",
-            action: "move selection",
-        },
-        HelpEntry {
-            key: "← / h / Backspace",
-            action: "parent folder",
-        },
-        HelpEntry {
-            key: "→ / l / Enter",
-            action: "enter folder / open",
-        },
-        HelpEntry {
-            key: "g",
-            action: "go-to menu",
-        },
-        HelpEntry {
-            key: "G",
-            action: "last item",
-        },
-        HelpEntry {
-            key: "PageUp / PageDown",
-            action: "page up / down",
-        },
-        HelpEntry {
-            key: "Tab / Shift+Tab",
-            action: "cycle places",
-        },
-        HelpEntry {
-            key: "Alt+← / →",
-            action: "back / forward",
-        },
+    let kb = crate::config::keys();
+
+    let navigation_entries = vec![
+        e("↑↓ / jk", "move selection"),
+        e("← / h / Backspace", "parent folder"),
+        e("→ / l / Enter", "enter folder / open"),
+        e("g", "go-to menu"),
+        e("G", "last item"),
+        e("PageUp / PageDown", "page up / down"),
+        e("Tab / Shift+Tab", "cycle places"),
+        e("Alt+← / →", "back / forward"),
     ];
-    const SEARCH_ENTRIES: &[HelpEntry<'_>] = &[
-        HelpEntry {
-            key: "f",
-            action: "search folders",
-        },
-        HelpEntry {
-            key: "Ctrl+F",
-            action: "search files",
-        },
-        HelpEntry {
-            key: "Ctrl+←→",
-            action: "move by word",
-        },
-        HelpEntry {
-            key: "Ctrl+Backspace",
-            action: "delete previous word",
-        },
-        HelpEntry {
-            key: "Ctrl+Del",
-            action: "delete next word",
-        },
-        HelpEntry {
-            key: "Ctrl+W / Alt+D",
-            action: "fallback word delete",
-        },
+    let search_entries = vec![
+        e(&kb.search_folders.to_string(), "search folders"),
+        e("Ctrl+F", "search files"),
+        e("Ctrl+←→", "move by word"),
+        e("Ctrl+Backspace", "delete previous word"),
+        e("Ctrl+Del", "delete next word"),
+        e("Ctrl+W / Alt+D", "fallback word delete"),
     ];
-    const CLIPBOARD_ENTRIES: &[HelpEntry<'_>] = &[
-        HelpEntry {
-            key: "Space",
-            action: "toggle selection",
-        },
-        HelpEntry {
-            key: "Ctrl+A",
-            action: "select all",
-        },
-        HelpEntry {
-            key: "Esc",
-            action: "clear selection",
-        },
-        HelpEntry {
-            key: "y",
-            action: "yank (copy)",
-        },
-        HelpEntry {
-            key: "c",
-            action: "copy path details",
-        },
-        HelpEntry {
-            key: "x",
-            action: "cut",
-        },
-        HelpEntry {
-            key: "p",
-            action: "paste",
-        },
+    let clipboard_entries = vec![
+        e("Space", "toggle selection"),
+        e("Ctrl+A", "select all"),
+        e("Esc", "clear selection"),
+        e(&kb.yank.to_string(), "yank (copy)"),
+        e(&kb.copy_path.to_string(), "copy path details"),
+        e(&kb.cut.to_string(), "cut"),
+        e(&kb.paste.to_string(), "paste"),
     ];
-    const FILES_ENTRIES: &[HelpEntry<'_>] = &[
-        HelpEntry {
-            key: "a",
-            action: "create file or folder",
-        },
-        HelpEntry {
-            key: "Alt/Shift+Enter",
-            action: "add line in create prompt",
-        },
-        HelpEntry {
-            key: "d",
-            action: "trash (delete if in trash)",
-        },
-        HelpEntry {
-            key: "r / F2",
-            action: "rename (bulk if selection)",
-        },
-        HelpEntry {
-            key: "r (in trash)",
-            action: "restore from trash",
-        },
-        HelpEntry {
-            key: "o",
-            action: "open externally",
-        },
+    let rename_key = format!("{} / F2", kb.rename);
+    let rename_trash_key = format!("{} (in trash)", kb.rename);
+    let files_entries = vec![
+        e(&kb.create.to_string(), "create file or folder"),
+        e("Alt/Shift+Enter", "add line in create prompt"),
+        e(&kb.trash.to_string(), "trash (delete if in trash)"),
+        e(&rename_key, "rename (bulk if selection)"),
+        e(&rename_trash_key, "restore from trash"),
+        e(&kb.open.to_string(), "open externally"),
     ];
-    const VIEW_ENTRIES: &[HelpEntry<'_>] = &[
-        HelpEntry {
-            key: "v",
-            action: "toggle grid / list",
-        },
-        HelpEntry {
-            key: "+ / -",
-            action: "grid zoom in / out",
-        },
-        HelpEntry {
-            key: ".",
-            action: "toggle dotfiles",
-        },
-        HelpEntry {
-            key: "s",
-            action: "cycle sort",
-        },
-        HelpEntry {
-            key: "< / >",
-            action: "scroll preview left / right",
-        },
+    let scroll_key = format!("{} / {}", kb.scroll_preview_left, kb.scroll_preview_right);
+    let view_entries = vec![
+        e(&kb.toggle_view.to_string(), "toggle grid / list"),
+        e("+ / -", "grid zoom in / out"),
+        e(&kb.toggle_hidden.to_string(), "toggle dotfiles"),
+        e(&kb.sort.to_string(), "cycle sort"),
+        e(&scroll_key, "scroll preview left / right"),
     ];
-    const MOUSE_ENTRIES: &[HelpEntry<'_>] = &[
-        HelpEntry {
-            key: "Click",
-            action: "select item",
-        },
-        HelpEntry {
-            key: "Double-click",
-            action: "open item",
-        },
-        HelpEntry {
-            key: "Wheel",
-            action: "move selection",
-        },
-        HelpEntry {
-            key: "Shift+Wheel",
-            action: "scroll preview",
-        },
+    let mouse_entries = vec![
+        e("Click", "select item"),
+        e("Double-click", "open item"),
+        e("Wheel", "move selection"),
+        e("Shift+Wheel", "scroll preview"),
     ];
-    const LEFT_SECTIONS: &[HelpSection<'_>] = &[
+    let left_sections = vec![
         HelpSection {
             title: "Navigate",
-            entries: NAVIGATION_ENTRIES,
+            entries: navigation_entries,
         },
         HelpSection {
             title: "Search",
-            entries: SEARCH_ENTRIES,
+            entries: search_entries,
         },
         HelpSection {
             title: "Mouse",
-            entries: MOUSE_ENTRIES,
+            entries: mouse_entries,
         },
     ];
-    const RIGHT_SECTIONS: &[HelpSection<'_>] = &[
+    let right_sections = vec![
         HelpSection {
             title: "Files",
-            entries: FILES_ENTRIES,
+            entries: files_entries,
         },
         HelpSection {
             title: "Selection & Clipboard",
-            entries: CLIPBOARD_ENTRIES,
+            entries: clipboard_entries,
         },
         HelpSection {
             title: "View",
-            entries: VIEW_ENTRIES,
+            entries: view_entries,
         },
     ];
 
@@ -264,7 +161,7 @@ pub(super) fn render_help(
         .split(rows[1]);
 
     frame.render_widget(
-        Paragraph::new(help_column_lines(cols[0].width, LEFT_SECTIONS, palette))
+        Paragraph::new(help_column_lines(cols[0].width, &left_sections, palette))
             .style(Style::default().bg(palette.chrome_alt).fg(palette.text))
             .wrap(Wrap { trim: false }),
         cols[0],
@@ -281,7 +178,7 @@ pub(super) fn render_help(
     );
 
     frame.render_widget(
-        Paragraph::new(help_column_lines(cols[2].width, RIGHT_SECTIONS, palette))
+        Paragraph::new(help_column_lines(cols[2].width, &right_sections, palette))
             .style(Style::default().bg(palette.chrome_alt).fg(palette.text))
             .wrap(Wrap { trim: false }),
         cols[2],
@@ -304,28 +201,31 @@ pub(super) fn render_help(
     );
 }
 
-#[derive(Clone, Copy)]
-struct HelpEntry<'a> {
-    key: &'a str,
-    action: &'a str,
+struct HelpEntry {
+    key: String,
+    action: &'static str,
 }
 
-#[derive(Clone, Copy)]
-struct HelpSection<'a> {
-    title: &'a str,
-    entries: &'a [HelpEntry<'a>],
+/// Convenience constructor — accepts anything that converts to a `String` for
+/// the key so call sites can pass `&str`, `String`, or `&String` uniformly.
+fn e(key: &str, action: &'static str) -> HelpEntry {
+    HelpEntry {
+        key: key.to_string(),
+        action,
+    }
 }
 
-fn help_column_lines(
-    width: u16,
-    sections: &[HelpSection<'_>],
-    palette: Palette,
-) -> Vec<Line<'static>> {
+struct HelpSection {
+    title: &'static str,
+    entries: Vec<HelpEntry>,
+}
+
+fn help_column_lines(width: u16, sections: &[HelpSection], palette: Palette) -> Vec<Line<'static>> {
     let content_width = width.max(1) as usize;
     let max_key_width = sections
         .iter()
         .flat_map(|section| section.entries.iter())
-        .map(|entry| UnicodeWidthStr::width(entry.key))
+        .map(|entry| UnicodeWidthStr::width(entry.key.as_str()))
         .max()
         .unwrap_or(0);
     let gap_width = 2usize;
@@ -345,8 +245,8 @@ fn help_column_lines(
             lines.push(Line::default());
         }
         lines.push(help_section_title(section.title, palette));
-        for entry in section.entries {
-            lines.extend(help_entry_lines(*entry, key_width, action_width, palette));
+        for entry in &section.entries {
+            lines.extend(help_entry_lines(entry, key_width, action_width, palette));
         }
     }
     lines
@@ -362,7 +262,7 @@ fn help_section_title(title: &str, palette: Palette) -> Line<'static> {
 }
 
 fn help_entry_lines(
-    entry: HelpEntry<'_>,
+    entry: &HelpEntry,
     key_width: usize,
     action_width: usize,
     palette: Palette,
@@ -372,13 +272,14 @@ fn help_entry_lines(
         wrapped_action.push(String::new());
     }
 
-    let key_padding = " ".repeat(key_width.saturating_sub(UnicodeWidthStr::width(entry.key)));
+    let key_padding =
+        " ".repeat(key_width.saturating_sub(UnicodeWidthStr::width(entry.key.as_str())));
     let continuation = " ".repeat(key_width + 2);
     let mut lines = Vec::with_capacity(wrapped_action.len());
 
     lines.push(Line::from(vec![
         Span::styled(
-            entry.key.to_string(),
+            entry.key.clone(),
             Style::default()
                 .fg(palette.accent_text)
                 .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary

This PR adds configurable browser key bindings via `config.toml`, allowing users to customize common browser actions while maintaining system stability through strict validation and fallback behavior.

### Key Features:
- **`[keys]` config section:** A dedicated section for remapping browser action keys.
- **Strict validation:** Startup checks for invalid, duplicate, reserved, and control-character bindings.
- **Dynamic help UI:** The help overlay now reflects configured shortcuts.
- **Fallback behavior:** Invalid bindings revert to built-in defaults with a warning to `stderr`.

## Bindable Actions

Users can now remap keys for:
*   **File operations:** Yank, Cut, Paste, Trash, Create, Rename, Restore.
*   **Browser actions:** Search, Open Externally, Sort, Toggle View, Toggle Hidden.
*   **Metadata:** Copy path details.
*   **Preview:** Horizontal scrolling controls.

*Note: Navigation keys (arrows/HJKL), overlay-specific controls, and `Ctrl`/`Alt` shortcuts remain hardcoded for core stability.*

## Behavior & Constraints
*   **Format:** Each binding must be a single character.
*   **Rejections:** Reserved keys and control characters are rejected to prevent hijacking core terminal functions.
*   **Conflict resolution:** Duplicate bindings are rejected at startup to avoid ambiguous action dispatch.

## Testing

**Verified with:**
- [x] `cargo test config::tests -- --nocapture` (Validation logic)
- [x] `cargo test app::input::tests::keyboard -- --nocapture` (End-to-end dispatch)
- [x] `cargo test -- --nocapture`

**Result:**
- **661 passed; 0 failed**