### PR TITLE
feat(clipboard): queue consecutive paste operations

### DIFF
--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -3,7 +3,7 @@ mod copy;
 use super::{
     App,
     jobs::PasteRequest,
-    state::{Clipboard, PasteProgress},
+    state::{Clipboard, PasteProgress, QueuedPaste},
     types::ClipOp,
 };
 use anyhow::Result;
@@ -20,6 +20,10 @@ impl App {
         self.paste_progress
             .as_ref()
             .map(|p| (p.completed, p.total, p.op))
+    }
+
+    pub fn queued_paste_count(&self) -> usize {
+        self.queued_pastes.len()
     }
 
     /// Returns the clipboard operation for a specific path, if it is in the
@@ -72,38 +76,74 @@ impl App {
     /// Paste the clipboard contents into the current directory (async with
     /// progress reporting).
     pub(in crate::app) fn paste(&mut self) -> Result<()> {
-        if self.paste_progress.is_some() {
-            self.status = "Paste in progress — press Esc to cancel".to_string();
+        if self.paste_progress.is_some() && self.clipboard.is_none() {
+            self.status = "Paste in progress — yank or cut another item to queue it".to_string();
             return Ok(());
         }
 
-        let Some(clipboard) = self.clipboard.take() else {
+        let Some(request) = self.take_clipboard_paste() else {
             self.status = "Nothing to paste".to_string();
             return Ok(());
         };
 
-        if clipboard.paths.is_empty() {
+        if self.paste_progress.is_some() {
+            self.queued_pastes.push_back(request);
+            let pending = self.queued_pastes.len();
+            self.status = if pending == 1 {
+                "Queued paste (1 pending)".to_string()
+            } else {
+                format!("Queued paste ({pending} pending)")
+            };
             return Ok(());
         }
 
+        self.start_paste_request(request);
+
+        Ok(())
+    }
+
+    pub(super) fn clear_queued_pastes(&mut self) -> usize {
+        let queued = self.queued_pastes.len();
+        self.queued_pastes.clear();
+        queued
+    }
+
+    pub(super) fn start_next_queued_paste(&mut self) -> bool {
+        let Some(request) = self.queued_pastes.pop_front() else {
+            return false;
+        };
+        self.start_paste_request(request);
+        true
+    }
+
+    fn take_clipboard_paste(&mut self) -> Option<QueuedPaste> {
+        let clipboard = self.clipboard.take()?;
+        if clipboard.paths.is_empty() {
+            return None;
+        }
+        Some(QueuedPaste {
+            dest_dir: self.cwd.clone(),
+            paths: clipboard.paths,
+            op: clipboard.op,
+        })
+    }
+
+    fn start_paste_request(&mut self, request: QueuedPaste) {
         let token = self.paste_token.wrapping_add(1);
         self.paste_token = token;
-        let dest_dir = self.cwd.clone();
         self.paste_progress = Some(PasteProgress {
             completed: 0,
-            total: clipboard.paths.len(),
-            op: clipboard.op,
+            total: request.paths.len(),
+            op: request.op,
         });
-        self.paste_dest_dir = Some(dest_dir.clone());
+        self.paste_dest_dir = Some(request.dest_dir.clone());
 
         self.scheduler.submit_paste(PasteRequest {
             token,
-            dest_dir,
-            paths: clipboard.paths,
-            op: clipboard.op,
+            dest_dir: request.dest_dir,
+            paths: request.paths,
+            op: request.op,
         });
-
-        Ok(())
     }
 
     /// Collect the paths that y/x should act on: all space-selected paths if

--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -22,18 +22,31 @@ fn temp_path(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!("elio-clipboard-{label}-{unique}"))
 }
 
-/// Poll `process_background_jobs` until `paste_progress` is `None` (meaning
-/// the worker sent its final `done=true` result and the directory reload was
-/// queued) or the timeout expires.
+/// Poll `process_background_jobs` until there is no active paste and no queued
+/// follow-up paste left to start, or the timeout expires.
 fn wait_for_paste(app: &mut App) {
     for _ in 0..500 {
         let _ = app.process_background_jobs();
-        if app.paste_progress().is_none() {
+        if app.paste_progress().is_none() && app.queued_pastes.is_empty() {
             return;
         }
         std::thread::sleep(Duration::from_millis(10));
     }
     panic!("timed out waiting for paste to complete");
+}
+
+fn wait_for_paste_and_reload(app: &mut App) {
+    for _ in 0..500 {
+        let _ = app.process_background_jobs();
+        if app.paste_progress().is_none()
+            && app.queued_pastes.is_empty()
+            && app.directory_runtime.pending_load.is_none()
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for paste and directory reload to complete");
 }
 
 fn clipboard_env_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -398,12 +411,113 @@ fn new_paste_after_cancel_is_not_affected_by_old_cancel_token() {
     fs::remove_dir_all(&dst2).unwrap();
 }
 
-// ── second paste blocked while one is running ────────────────────────────────
+// ── queued pastes ────────────────────────────────────────────────────────────
 
 #[test]
-fn second_paste_is_blocked_while_one_is_in_progress() {
-    let src_dir = temp_path("block-src");
-    let dst_dir = temp_path("block-dst");
+fn yank_paste_then_yank_paste_queues_the_second_snapshot() {
+    let src_dir = temp_path("queue-src");
+    let dst1 = temp_path("queue-dst-1");
+    let dst2 = temp_path("queue-dst-2");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst1).unwrap();
+    fs::create_dir_all(&dst2).unwrap();
+    fs::write(src_dir.join("a.txt"), "a").unwrap();
+    fs::write(src_dir.join("b.txt"), "b").unwrap();
+
+    let mut app = App::new_at(src_dir.clone()).unwrap();
+
+    app.yank();
+    app.cwd = dst1.clone();
+    app.paste().unwrap();
+
+    let token_after_first = app.paste_token;
+    assert!(app.paste_progress().is_some());
+
+    // Queue a second paste after changing both the source selection and the
+    // destination directory.  The queued snapshot must preserve both.
+    app.cwd = src_dir.clone();
+    app.select_index(1);
+    app.yank();
+    app.cwd = dst2.clone();
+    app.paste().unwrap();
+
+    assert_eq!(
+        app.paste_token, token_after_first,
+        "paste_token must not change until the queued paste actually starts"
+    );
+    assert_eq!(app.queued_pastes.len(), 1, "second paste should be queued");
+    assert!(
+        app.status.contains("Queued paste"),
+        "status should indicate that the second paste was queued"
+    );
+    assert_eq!(app.queued_pastes[0].dest_dir, dst2);
+    assert_eq!(app.queued_pastes[0].paths, vec![src_dir.join("b.txt")]);
+
+    wait_for_paste(&mut app);
+
+    assert!(dst1.join("a.txt").exists());
+    assert!(dst2.join("b.txt").exists());
+
+    fs::remove_dir_all(&src_dir).unwrap();
+    fs::remove_dir_all(&dst1).unwrap();
+    fs::remove_dir_all(&dst2).unwrap();
+}
+
+#[test]
+fn queued_paste_with_missing_destination_fails_and_later_queue_continues() {
+    let src_dir = temp_path("queue-missing-src");
+    let dst1 = temp_path("queue-missing-dst-1");
+    let missing_dst = temp_path("queue-missing-dst-2");
+    let dst3 = temp_path("queue-missing-dst-3");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst1).unwrap();
+    fs::create_dir_all(&dst3).unwrap();
+    fs::write(src_dir.join("a.txt"), "a").unwrap();
+    fs::write(src_dir.join("b.txt"), "b").unwrap();
+    fs::write(src_dir.join("c.txt"), "c").unwrap();
+
+    let mut app = App::new_at(src_dir.clone()).unwrap();
+    app.yank();
+    app.cwd = dst1.clone();
+    app.paste().unwrap();
+
+    app.clipboard = Some(super::super::state::Clipboard {
+        paths: vec![src_dir.join("b.txt")],
+        op: ClipOp::Yank,
+    });
+    app.cwd = missing_dst.clone();
+    app.paste().unwrap();
+
+    app.clipboard = Some(super::super::state::Clipboard {
+        paths: vec![src_dir.join("c.txt")],
+        op: ClipOp::Yank,
+    });
+    app.cwd = dst3.clone();
+    app.paste().unwrap();
+
+    assert_eq!(app.queued_pastes.len(), 2);
+
+    wait_for_paste(&mut app);
+
+    assert!(dst1.join("a.txt").exists());
+    assert!(
+        !missing_dst.join("b.txt").exists(),
+        "paste into a missing destination should fail"
+    );
+    assert!(
+        dst3.join("c.txt").exists(),
+        "a later queued paste should still run after an earlier queued failure"
+    );
+
+    fs::remove_dir_all(&src_dir).unwrap();
+    fs::remove_dir_all(&dst1).unwrap();
+    fs::remove_dir_all(&dst3).unwrap();
+}
+
+#[test]
+fn queued_same_destination_pastes_defer_reload_until_queue_drains() {
+    let src_dir = temp_path("queue-same-dst-src");
+    let dst_dir = temp_path("queue-same-dst-dst");
     fs::create_dir_all(&src_dir).unwrap();
     fs::create_dir_all(&dst_dir).unwrap();
     fs::write(src_dir.join("a.txt"), "a").unwrap();
@@ -413,32 +527,96 @@ fn second_paste_is_blocked_while_one_is_in_progress() {
     app.yank();
     app.cwd = dst_dir.clone();
     app.paste().unwrap();
+    let first_token = app.paste_token;
 
-    let token_after_first = app.paste_token;
-    assert!(app.paste_progress().is_some());
-
-    // Attempt a second paste while the first is still in flight.
-    // clipboard is None (consumed), so set it directly.
     app.clipboard = Some(super::super::state::Clipboard {
         paths: vec![src_dir.join("b.txt")],
         op: ClipOp::Yank,
     });
+    app.cwd = dst_dir.clone();
     app.paste().unwrap();
 
-    // Token must not have changed — the second paste was rejected.
-    assert_eq!(
-        app.paste_token, token_after_first,
-        "paste_token must not change when second paste is blocked"
-    );
+    let mut queued_started = false;
+    for _ in 0..500 {
+        let _ = app.process_background_jobs();
+        if app.paste_token != first_token {
+            queued_started = true;
+            assert!(
+                app.directory_runtime.pending_load.is_none(),
+                "reload should stay deferred while a queued paste to the same destination starts"
+            );
+            assert!(
+                app.paste_progress().is_some(),
+                "second paste should be active once its token becomes current"
+            );
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
     assert!(
-        app.status.contains("in progress"),
-        "status should indicate a paste is already running"
+        queued_started,
+        "queued paste should start after the first one finishes"
     );
 
-    wait_for_paste(&mut app);
+    wait_for_paste_and_reload(&mut app);
+
+    assert!(dst_dir.join("a.txt").exists());
+    assert!(dst_dir.join("b.txt").exists());
+    assert_eq!(app.status_message(), "Copied 1 item");
 
     fs::remove_dir_all(&src_dir).unwrap();
     fs::remove_dir_all(&dst_dir).unwrap();
+}
+
+#[test]
+fn esc_cancels_active_paste_and_clears_queued_pastes() {
+    let src_dir = temp_path("queue-cancel-src");
+    let dst1 = temp_path("queue-cancel-dst-1");
+    let dst2 = temp_path("queue-cancel-dst-2");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst1).unwrap();
+    fs::create_dir_all(&dst2).unwrap();
+    fs::write(src_dir.join("a.txt"), "a").unwrap();
+    fs::write(src_dir.join("b.txt"), "b").unwrap();
+
+    let mut app = App::new_at(src_dir.clone()).unwrap();
+    app.yank();
+    app.cwd = dst1.clone();
+    app.paste().unwrap();
+
+    app.clipboard = Some(super::super::state::Clipboard {
+        paths: vec![src_dir.join("b.txt")],
+        op: ClipOp::Yank,
+    });
+    app.cwd = dst2.clone();
+    app.paste().unwrap();
+    assert_eq!(app.queued_pastes.len(), 1);
+
+    app.handle_event(crossterm::event::Event::Key(
+        crossterm::event::KeyEvent::from(crossterm::event::KeyCode::Esc),
+    ))
+    .unwrap();
+
+    assert!(app.paste_progress().is_none());
+    assert!(
+        app.queued_pastes.is_empty(),
+        "Esc should clear queued pastes as well as the active paste"
+    );
+
+    for _ in 0..300 {
+        let _ = app.process_background_jobs();
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(
+        !dst2.join("b.txt").exists(),
+        "queued paste should not run after Esc cancels the queue"
+    );
+
+    fs::remove_dir_all(&src_dir).unwrap();
+    fs::remove_dir_all(&dst1).unwrap();
+    fs::remove_dir_all(&dst2).unwrap();
 }
 
 // ── nothing-to-paste ─────────────────────────────────────────────────────────
@@ -455,6 +633,34 @@ fn paste_with_empty_clipboard_sets_status_and_leaves_no_progress() {
     assert!(app.paste_progress().is_none());
 
     fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn paste_during_active_paste_without_clipboard_explains_how_to_queue() {
+    let src_dir = temp_path("queue-hint-src");
+    let dst_dir = temp_path("queue-hint-dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+    fs::write(src_dir.join("a.txt"), "a").unwrap();
+
+    let mut app = App::new_at(src_dir.clone()).unwrap();
+    app.yank();
+    app.cwd = dst_dir.clone();
+    app.paste().unwrap();
+
+    let token = app.paste_token;
+    app.paste().unwrap();
+
+    assert_eq!(app.paste_token, token);
+    assert_eq!(
+        app.status,
+        "Paste in progress — yank or cut another item to queue it"
+    );
+
+    wait_for_paste(&mut app);
+
+    fs::remove_dir_all(&src_dir).unwrap();
+    fs::remove_dir_all(&dst_dir).unwrap();
 }
 
 #[test]

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -83,6 +83,7 @@ impl App {
             } else if self.paste_progress.is_some() {
                 self.scheduler.cancel_paste(self.paste_token);
                 self.paste_progress = None;
+                self.clear_queued_pastes();
             } else {
                 self.clear_selection();
                 self.clipboard = None;
@@ -174,6 +175,7 @@ impl App {
                 } else if self.paste_progress.is_some() {
                     self.scheduler.cancel_paste(self.paste_token);
                     self.paste_progress = None;
+                    self.clear_queued_pastes();
                 } else {
                     self.clear_selection();
                     self.clipboard = None;

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -191,6 +191,12 @@ impl App {
                             .take()
                             .unwrap_or_else(|| self.cwd.clone());
                         let status = build.status.unwrap_or_default();
+                        let next_queued_dest = self
+                            .queued_pastes
+                            .front()
+                            .map(|queued| queued.dest_dir.as_path());
+                        let defer_reload_for_same_dest =
+                            next_queued_dest == Some(dest_dir.as_path());
                         // Only reload in-place when the user is still in the
                         // destination directory and not mid-navigation to
                         // somewhere else (which would cancel their navigation).
@@ -200,7 +206,10 @@ impl App {
                             .as_ref()
                             .map(|l| l.target_cwd.as_path());
                         let nav_to_dest = nav_target == Some(dest_dir.as_path());
-                        if dest_dir == self.cwd && (nav_target.is_none() || nav_to_dest) {
+                        if dest_dir == self.cwd
+                            && (nav_target.is_none() || nav_to_dest)
+                            && !defer_reload_for_same_dest
+                        {
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,
                                 target_cwd: dest_dir,
@@ -215,8 +224,13 @@ impl App {
                         } else {
                             // User navigated away — just surface the status.
                             // Navigation will load dest_dir fresh if they return.
+                            // If another queued paste targets this same
+                            // directory, defer the reload until that queued
+                            // paste finishes to avoid showing a mid-queue
+                            // snapshot.
                             self.status = status;
                         }
+                        self.start_next_queued_paste();
                     } else if let Some(prog) = &mut self.paste_progress {
                         prog.completed = build.completed;
                     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -92,6 +92,13 @@ pub(super) struct PasteProgress {
 }
 
 #[derive(Clone, Debug)]
+pub(super) struct QueuedPaste {
+    pub(super) dest_dir: PathBuf,
+    pub(super) paths: Vec<PathBuf>,
+    pub(super) op: ClipOp,
+}
+
+#[derive(Clone, Debug)]
 pub(super) struct TrashProgress {
     pub(super) completed: usize,
     pub(super) total: usize,
@@ -430,6 +437,7 @@ pub struct App {
     pub(super) clipboard: Option<Clipboard>,
     pub(super) paste_token: u64,
     pub(super) paste_progress: Option<PasteProgress>,
+    pub(super) queued_pastes: VecDeque<QueuedPaste>,
     /// Destination directory of the in-flight paste.  Kept separately from
     /// `paste_progress` so that cancelling the chip does not lose the context
     /// needed by the completion handler to reload the right directory.
@@ -536,6 +544,7 @@ impl App {
             clipboard: None,
             paste_token: 0,
             paste_progress: None,
+            queued_pastes: VecDeque::new(),
             paste_dest_dir: None,
             trash_token: 0,
             trash_progress: None,

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -126,6 +126,7 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
     let clip = app.clipboard_info();
     let sel_count = app.selection_count();
     let paste_prog = app.paste_progress();
+    let queued_pastes = app.queued_paste_count();
     let trash_prog = app.trash_progress();
     let restore_prog = app.restore_progress();
 
@@ -175,7 +176,11 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
                 ClipOp::Yank => palette.yank_bar,
                 ClipOp::Cut => palette.cut_bar,
             };
-            let label = format!(" {verb} {completed}/{total} ");
+            let label = if queued_pastes == 0 {
+                format!(" {verb} {completed}/{total} ")
+            } else {
+                format!(" {verb} {completed}/{total} (+{queued_pastes} queued) ")
+            };
             chips_width += label.len() as u16 + 2;
             spans.push(Span::styled(
                 label,
@@ -255,8 +260,32 @@ fn status_idle_hint() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{status_idle_hint, status_section_width};
-    use crate::ui::helpers;
+    use super::{render_status, status_idle_hint, status_section_width};
+    use crate::{
+        app::{App, FrameState},
+        ui::{helpers, theme},
+    };
+    use crossterm::event::{Event, KeyCode, KeyEvent};
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-chrome-{label}-{unique}"))
+    }
+
+    fn row_text(buffer: &Buffer, y: u16) -> String {
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect::<String>()
+    }
 
     #[test]
     fn idle_status_keeps_the_compact_help_width() {
@@ -277,5 +306,45 @@ mod tests {
     #[test]
     fn idle_hint_stays_unchanged() {
         assert_eq!(status_idle_hint(), "f folders  ^F files  ? help");
+    }
+
+    #[test]
+    fn paste_status_chip_shows_queued_count() {
+        let src_dir = temp_path("paste-chip-src");
+        let dst_dir = temp_path("paste-chip-dst");
+        fs::create_dir_all(&src_dir).expect("failed to create source dir");
+        fs::create_dir_all(&dst_dir).expect("failed to create destination dir");
+        fs::write(src_dir.join("a.txt"), "a").expect("failed to write first file");
+        fs::write(src_dir.join("b.txt"), "b").expect("failed to write second file");
+
+        let mut app = App::new_at(src_dir.clone()).expect("failed to create app");
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('y'))))
+            .expect("yank shortcut should succeed");
+        app.cwd = dst_dir.clone();
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('p'))))
+            .expect("paste shortcut should succeed");
+        app.cwd = src_dir.clone();
+        app.selected = 1;
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('y'))))
+            .expect("second yank shortcut should succeed");
+        app.cwd = dst_dir.clone();
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('p'))))
+            .expect("second paste should be queued");
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 1)).expect("terminal should init");
+        terminal
+            .draw(|frame| render_status(frame, frame.area(), &app, theme::palette()))
+            .expect("status should render");
+
+        let rendered = row_text(terminal.backend().buffer(), 0);
+        assert!(
+            rendered.contains("(+1 queued)"),
+            "status row should show queued paste count, got: {rendered:?}"
+        );
+
+        app.set_frame_state(FrameState::default());
+        drop(app);
+        fs::remove_dir_all(src_dir).expect("failed to remove source dir");
+        fs::remove_dir_all(dst_dir).expect("failed to remove destination dir");
     }
 }


### PR DESCRIPTION
## Summary

This PR adds queued paste operations to the file manager, ensuring that consecutive paste requests are successfully staged instead of being blocked by an active operation.

### Key Features:
- **Serial Paste Queue:** Implementation of an app-level queue to handle multiple paste requests in sequence.
- **Snapshotting:** Captures clipboard contents and destination directories at the moment of the request to ensure data integrity.
- **Status Integration:** Enhanced the status chip to display real-time progress for both active and queued tasks.
- **Unified Cancellation:** `Esc` or `Ctrl+C` now provides a clean break by cancelling the active operation and clearing the remaining queue.

## Behavior

- **Immediate Execution:** If the queue is empty, the paste starts immediately.
- **Serial Processing:** New requests are added to the queue and processed one by one to prevent IO congestion.
- **Persistence:** Each queued item maintains its own source paths, operation type (Yank vs. Cut), and specific destination.
- **Reload Deferral:** To prevent UI flickering, directory reloads are deferred until the entire queue for that destination has drained.
- **Error Handling:** If a queued destination is deleted before its turn, that specific task fails gracefully while the rest of the queue continues.

## UI

- **Status Chip:** Now provides clear feedback on the queue depth:
    - `Copying 1/3 (+2 queued)`
    - `Moving 4/7 (+1 queued)`
- **User Guidance:** Attempting to paste identical content while a task is active now triggers a helpful hint on how to queue additional work.

## Testing

**Verified with:**
- [x] `cargo test app::clipboard::tests` (Queue ordering and snapshots)
- [x] `cargo test ui::chrome::tests` (Status chip and UI feedback)
- [x] `cargo test --all-targets`

**Result:**
- **677 passed; 0 failed**