### PR TITLE
feat(config): add configurable Places entries and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ show_top_bar = false
 # show_hidden = false # show dotfiles on startup (toggle at runtime with .)
 # start_in_grid = false # open in grid view on startup (toggle at runtime with v)
 
+# [places]
+# show_devices = true
+# entries = [
+#   "home",
+#   "desktop",
+#   "documents",
+#   { builtin = "downloads", icon = "" },
+#   "pictures",
+#   "music",
+#   "videos",
+#   "root",
+#   { title = "Projects", path = "~/workspace", icon = "󰚝" },
+#   "trash",
+# ]
+
 # [layout.panes]
 # places  = 10
 # files   = 45
@@ -112,11 +127,23 @@ show_top_bar = false
 | `ui.grid_zoom` | `1` | Starting grid zoom level (`0`, `1`, or `2`; values outside range are clamped) |
 | `ui.show_hidden` | `false` | Show dotfiles and hidden files on startup; can still be toggled at runtime with `.` |
 | `ui.start_in_grid` | `false` | Start the file browser in grid view; can still be toggled at runtime with `v` |
+| `places.show_devices` | `true` | Show the auto-detected `Devices` section at the bottom of Places |
+| `places.entries` | built-in pinned list | Ordered list of pinned Places entries; accepts built-in names, `{ builtin, icon? }`, or custom `{ title, path, icon? }` objects |
 | `layout.panes.places` | unset | Relative width weight for the Places pane; `0` hides it |
 | `layout.panes.files` | unset | Relative width weight for the Files pane |
 | `layout.panes.preview` | unset | Relative width weight for the Preview pane; `0` hides it |
 
 Pane weights are relative — `10/45/45` and `20/90/90` produce the same split. If `[layout.panes]` is omitted, elio uses a built-in responsive layout.
+
+Omit `[places]` entirely to keep the exact default sidebar.
+
+`places.entries` supports three forms:
+
+- `"downloads"`: use the built-in entry with its default icon
+- `{ builtin = "downloads", icon = "" }`: use a built-in entry with a custom icon
+- `{ title = "Projects", path = "~/workspace", icon = "󰚝" }`: add a custom entry
+
+Built-in names are: `home`, `desktop`, `documents`, `downloads`, `pictures`, `music`, `videos`, `root`, and `trash`. These are stable config ids, not localized display names: for example, use `"downloads"` even if your actual folder is named `Descargas`. In the UI, built-in user folders are shown using the resolved folder name when available. Missing built-ins are skipped automatically; custom entries stay visible even if the target path does not exist yet. Entries are deduped by resolved path, so the first matching path wins. `icon` accepts any non-empty string, but a single Nerd Font glyph usually looks best.
 
 ### Key bindings
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -6,6 +6,35 @@ show_top_bar = false
 # show_hidden = false  # show dotfiles and hidden files on startup (toggle with .)
 # start_in_grid = false  # open in grid view on startup (toggle with v)
 
+# Customize the Places pane. `entries` controls the pinned items in order;
+# `show_devices` keeps or hides the auto-detected Devices section.
+# Omit [places] entirely to keep the exact default sidebar.
+#
+# Built-in names: home, desktop, documents, downloads, pictures, music,
+# videos, root, trash
+# Use built-in ids like "downloads", not localized folder names like "Descargas".
+# Entries are deduped by resolved path: the first matching path wins.
+# Entry forms:
+# - "downloads"
+# - { builtin = "downloads", icon = "..." }
+# - { title = "Projects", path = "~/code", icon = "..." }
+# Any non-empty string works, but a single Nerd Font glyph usually looks best.
+#
+# [places]
+# show_devices = true
+# entries = [
+#   "home",
+#   "desktop",
+#   "documents",
+#   { builtin = "downloads", icon = "" },
+#   "pictures",
+#   "music",
+#   "videos",
+#   "root",
+#   { title = "Projects", path = "~/workspace", icon = "󰚝" },
+#   "trash",
+# ]
+#
 # Optional pane widths for the browser body. Values are relative weights across
 # the horizontal space. Set a pane to 0 to hide it.
 #

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -98,7 +98,7 @@ impl Entry {
 pub struct SidebarItem {
     pub kind: SidebarItemKind,
     pub title: String,
-    pub icon: &'static str,
+    pub icon: String,
     pub path: PathBuf,
 }
 
@@ -106,13 +106,13 @@ impl SidebarItem {
     pub fn new(
         kind: SidebarItemKind,
         title: impl Into<String>,
-        icon: &'static str,
+        icon: impl Into<String>,
         path: PathBuf,
     ) -> Self {
         Self {
             kind,
             title: title.into(),
-            icon,
+            icon: icon.into(),
             path,
         }
     }
@@ -129,6 +129,7 @@ pub enum SidebarItemKind {
     Videos,
     Root,
     Trash,
+    Custom,
     Device { removable: bool },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,38 @@ pub(crate) struct UiConfig {
     pub start_in_grid: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PlacesConfig {
+    pub show_devices: bool,
+    pub entries: Vec<PlaceEntrySpec>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BuiltinPlace {
+    Home,
+    Desktop,
+    Documents,
+    Downloads,
+    Pictures,
+    Music,
+    Videos,
+    Root,
+    Trash,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PlaceEntrySpec {
+    Builtin {
+        place: BuiltinPlace,
+        icon: Option<String>,
+    },
+    Custom {
+        title: String,
+        path: PathBuf,
+        icon: Option<String>,
+    },
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct LayoutConfig {
     pub panes: Option<PaneWeights>,
@@ -259,6 +291,7 @@ impl KeyBindings {
 
 struct Config {
     ui: UiConfig,
+    places: PlacesConfig,
     layout: LayoutConfig,
     keys: KeyBindings,
 }
@@ -266,6 +299,7 @@ struct Config {
 #[derive(Deserialize, Default)]
 struct ConfigFile {
     ui: Option<UiConfigOverride>,
+    places: Option<PlacesConfigOverride>,
     layout: Option<LayoutConfigOverride>,
     keys: Option<KeysConfigOverride>,
 }
@@ -276,6 +310,12 @@ struct UiConfigOverride {
     grid_zoom: Option<i64>,
     show_hidden: Option<bool>,
     start_in_grid: Option<bool>,
+}
+
+#[derive(Deserialize, Default)]
+struct PlacesConfigOverride {
+    show_devices: Option<bool>,
+    entries: Option<Vec<toml::Value>>,
 }
 
 #[derive(Deserialize, Default)]
@@ -315,6 +355,10 @@ pub(crate) fn initialize() {
 
 pub(crate) fn ui() -> UiConfig {
     active_config().ui
+}
+
+pub(crate) fn places() -> &'static PlacesConfig {
+    &active_config().places
 }
 
 pub(crate) fn layout() -> LayoutConfig {
@@ -384,6 +428,7 @@ impl Config {
                 show_hidden: false,
                 start_in_grid: false,
             },
+            places: PlacesConfig::default_places(),
             layout: LayoutConfig { panes: None },
             keys: KeyBindings::default_bindings(),
         }
@@ -406,6 +451,9 @@ impl Config {
                 resolved.ui.start_in_grid = start_in_grid;
             }
         }
+        if let Some(places) = parsed.places {
+            resolved.places = PlacesConfig::from_override(places, &resolved.places);
+        }
         if let Some(layout) = parsed.layout {
             match LayoutConfig::from_override(layout) {
                 Ok(layout) => resolved.layout = layout,
@@ -416,6 +464,170 @@ impl Config {
             resolved.keys = KeyBindings::from_override(keys, &KeyBindings::default_bindings());
         }
         Ok(resolved)
+    }
+}
+
+impl PlacesConfig {
+    fn default_places() -> Self {
+        Self {
+            show_devices: true,
+            entries: vec![
+                PlaceEntrySpec::builtin(BuiltinPlace::Home),
+                PlaceEntrySpec::builtin(BuiltinPlace::Desktop),
+                PlaceEntrySpec::builtin(BuiltinPlace::Documents),
+                PlaceEntrySpec::builtin(BuiltinPlace::Downloads),
+                PlaceEntrySpec::builtin(BuiltinPlace::Pictures),
+                PlaceEntrySpec::builtin(BuiltinPlace::Music),
+                PlaceEntrySpec::builtin(BuiltinPlace::Videos),
+                PlaceEntrySpec::builtin(BuiltinPlace::Root),
+                PlaceEntrySpec::builtin(BuiltinPlace::Trash),
+            ],
+        }
+    }
+
+    fn from_override(overrides: PlacesConfigOverride, defaults: &Self) -> Self {
+        let mut resolved = defaults.clone();
+        if let Some(show_devices) = overrides.show_devices {
+            resolved.show_devices = show_devices;
+        }
+        if let Some(entries) = overrides.entries {
+            resolved.entries = entries
+                .iter()
+                .enumerate()
+                .filter_map(|(index, entry)| {
+                    PlaceEntrySpec::from_toml_value(entry, &format!("places.entries[{index}]"))
+                })
+                .collect();
+        }
+        resolved
+    }
+}
+
+impl PlaceEntrySpec {
+    fn builtin(place: BuiltinPlace) -> Self {
+        Self::Builtin { place, icon: None }
+    }
+
+    fn from_toml_value(value: &toml::Value, field_name: &str) -> Option<Self> {
+        match value {
+            toml::Value::String(name) => BuiltinPlace::parse(name).map(Self::builtin),
+            toml::Value::Table(table) => {
+                let icon = parse_place_icon(table.get("icon"), field_name);
+                if let Some(builtin) = table.get("builtin") {
+                    let Some(name) = builtin
+                        .as_str()
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                    else {
+                        eprintln!(
+                            "elio: {field_name}: builtin places require a non-empty string builtin name; \
+                             skipping entry"
+                        );
+                        return None;
+                    };
+                    let Some(place) = BuiltinPlace::parse(name) else {
+                        return None;
+                    };
+                    if table.contains_key("title") || table.contains_key("path") {
+                        eprintln!(
+                            "elio: {field_name}: builtin places only support {{ builtin, icon }}; \
+                             ignoring extra fields"
+                        );
+                    }
+                    return Some(Self::Builtin { place, icon });
+                }
+
+                let title = table
+                    .get("title")
+                    .and_then(toml::Value::as_str)
+                    .map(str::trim)
+                    .filter(|title| !title.is_empty());
+                let Some(title) = title else {
+                    eprintln!(
+                        "elio: {field_name}: custom places require a non-empty string title; \
+                         skipping entry"
+                    );
+                    return None;
+                };
+
+                let path = table
+                    .get("path")
+                    .and_then(toml::Value::as_str)
+                    .map(str::trim)
+                    .filter(|path| !path.is_empty());
+                let Some(path) = path else {
+                    eprintln!(
+                        "elio: {field_name}: custom places require a non-empty string path; \
+                         skipping entry"
+                    );
+                    return None;
+                };
+
+                match expand_custom_place_path(path) {
+                    Ok(path) => Some(Self::Custom {
+                        title: title.to_string(),
+                        path,
+                        icon,
+                    }),
+                    Err(error) => {
+                        eprintln!("elio: {field_name}: {error}; skipping entry");
+                        None
+                    }
+                }
+            }
+            _ => {
+                eprintln!(
+                    "elio: {field_name}: expected a built-in name, {{ builtin, icon? }}, or \
+                     {{ title, path, icon? }} object; skipping entry"
+                );
+                None
+            }
+        }
+    }
+}
+
+fn parse_place_icon(value: Option<&toml::Value>, field_name: &str) -> Option<String> {
+    let Some(value) = value else {
+        return None;
+    };
+    match value {
+        toml::Value::String(icon) => {
+            let icon = icon.trim();
+            if icon.is_empty() {
+                eprintln!("elio: {field_name}: icon must be a non-empty string; using default");
+                None
+            } else {
+                Some(icon.to_string())
+            }
+        }
+        _ => {
+            eprintln!("elio: {field_name}: icon must be a string; using default");
+            None
+        }
+    }
+}
+
+impl BuiltinPlace {
+    fn parse(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "home" => Some(Self::Home),
+            "desktop" => Some(Self::Desktop),
+            "documents" => Some(Self::Documents),
+            "downloads" => Some(Self::Downloads),
+            "pictures" => Some(Self::Pictures),
+            "music" => Some(Self::Music),
+            "videos" => Some(Self::Videos),
+            "root" => Some(Self::Root),
+            "trash" => Some(Self::Trash),
+            _ => {
+                eprintln!(
+                    "elio: unknown places entry {name:?}; expected one of: \
+                     home, desktop, documents, downloads, pictures, music, videos, root, trash \
+                     (use semantic ids like \"downloads\", not localized folder names)"
+                );
+                None
+            }
+        }
     }
 }
 
@@ -453,6 +665,40 @@ impl PaneWeights {
     }
 }
 
+fn expand_custom_place_path(path: &str) -> anyhow::Result<PathBuf> {
+    let expanded = if path == "~" {
+        crate::fs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?
+    } else if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
+        crate::fs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?
+            .join(rest)
+    } else {
+        PathBuf::from(path)
+    };
+
+    if !expanded.is_absolute() {
+        anyhow::bail!("custom place paths must be absolute or start with ~/");
+    }
+
+    Ok(normalize_absolute_path(&expanded))
+}
+
+fn normalize_absolute_path(path: &std::path::Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -477,6 +723,26 @@ mod tests {
     }
 
     #[test]
+    fn config_defaults_places_to_builtin_sidebar_and_devices() {
+        let config = Config::default_config();
+        assert!(config.places.show_devices);
+        assert_eq!(
+            config.places.entries,
+            vec![
+                PlaceEntrySpec::builtin(BuiltinPlace::Home),
+                PlaceEntrySpec::builtin(BuiltinPlace::Desktop),
+                PlaceEntrySpec::builtin(BuiltinPlace::Documents),
+                PlaceEntrySpec::builtin(BuiltinPlace::Downloads),
+                PlaceEntrySpec::builtin(BuiltinPlace::Pictures),
+                PlaceEntrySpec::builtin(BuiltinPlace::Music),
+                PlaceEntrySpec::builtin(BuiltinPlace::Videos),
+                PlaceEntrySpec::builtin(BuiltinPlace::Root),
+                PlaceEntrySpec::builtin(BuiltinPlace::Trash),
+            ]
+        );
+    }
+
+    #[test]
     fn config_can_enable_show_hidden() {
         let config = Config::from_str("[ui]\nshow_hidden = true").expect("config should parse");
         assert!(config.ui.show_hidden);
@@ -486,6 +752,157 @@ mod tests {
     fn config_can_enable_start_in_grid() {
         let config = Config::from_str("[ui]\nstart_in_grid = true").expect("config should parse");
         assert!(config.ui.start_in_grid);
+    }
+
+    #[test]
+    fn config_can_customize_places_entries_and_hide_devices() {
+        let projects = std::env::temp_dir().join("elio-places-projects");
+        let config = Config::from_str(&format!(
+            r#"
+[places]
+show_devices = false
+entries = [
+  "downloads",
+  {{ title = "Projects", path = "{}" }},
+  "trash",
+]
+"#,
+            projects.display()
+        ))
+        .expect("config should parse");
+
+        assert!(!config.places.show_devices);
+        assert_eq!(
+            config.places.entries,
+            vec![
+                PlaceEntrySpec::builtin(BuiltinPlace::Downloads),
+                PlaceEntrySpec::Custom {
+                    title: "Projects".to_string(),
+                    path: normalize_absolute_path(&projects),
+                    icon: None,
+                },
+                PlaceEntrySpec::builtin(BuiltinPlace::Trash),
+            ]
+        );
+    }
+
+    #[test]
+    fn config_places_skips_relative_custom_paths_without_failing_parse() {
+        let config = Config::from_str(
+            r#"
+[places]
+entries = [
+  { title = "Projects", path = "projects" },
+  "downloads",
+]
+"#,
+        )
+        .expect("config should parse");
+
+        assert_eq!(
+            config.places.entries,
+            vec![PlaceEntrySpec::builtin(BuiltinPlace::Downloads)]
+        );
+    }
+
+    #[test]
+    fn config_places_skips_unknown_builtin_names_without_failing_parse() {
+        let config = Config::from_str(
+            r#"
+[places]
+entries = ["downloads", "workspace", "trash"]
+"#,
+        )
+        .expect("config should parse");
+
+        assert_eq!(
+            config.places.entries,
+            vec![
+                PlaceEntrySpec::builtin(BuiltinPlace::Downloads),
+                PlaceEntrySpec::builtin(BuiltinPlace::Trash),
+            ]
+        );
+    }
+
+    #[test]
+    fn config_places_can_customize_icons_for_builtin_and_custom_entries() {
+        let projects = std::env::temp_dir().join("elio-places-projects-icons");
+        let config = Config::from_str(&format!(
+            r#"
+[places]
+entries = [
+  {{ builtin = "downloads", icon = "D" }},
+  {{ title = "Projects", path = "{}", icon = "P" }},
+]
+"#,
+            projects.display()
+        ))
+        .expect("config should parse");
+
+        assert_eq!(
+            config.places.entries,
+            vec![
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Downloads,
+                    icon: Some("D".to_string()),
+                },
+                PlaceEntrySpec::Custom {
+                    title: "Projects".to_string(),
+                    path: normalize_absolute_path(&projects),
+                    icon: Some("P".to_string()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn config_places_accepts_builtin_object_form_without_icon() {
+        let config = Config::from_str(
+            r#"
+[places]
+entries = [
+  { builtin = "downloads" },
+  "trash",
+]
+"#,
+        )
+        .expect("config should parse");
+
+        assert_eq!(
+            config.places.entries,
+            vec![
+                PlaceEntrySpec::builtin(BuiltinPlace::Downloads),
+                PlaceEntrySpec::builtin(BuiltinPlace::Trash),
+            ]
+        );
+    }
+
+    #[test]
+    fn config_places_ignores_invalid_icons_without_skipping_entries() {
+        let projects = std::env::temp_dir().join("elio-places-invalid-icons");
+        let config = Config::from_str(&format!(
+            r#"
+[places]
+entries = [
+  {{ builtin = "downloads", icon = "" }},
+  {{ title = "Projects", path = "{}", icon = "   " }},
+]
+"#,
+            projects.display()
+        ))
+        .expect("config should parse");
+
+        assert_eq!(
+            config.places.entries,
+            vec![
+                PlaceEntrySpec::builtin(BuiltinPlace::Downloads),
+                PlaceEntrySpec::Custom {
+                    title: "Projects".to_string(),
+                    path: normalize_absolute_path(&projects),
+                    icon: None,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -525,9 +525,7 @@ impl PlaceEntrySpec {
                         );
                         return None;
                     };
-                    let Some(place) = BuiltinPlace::parse(name) else {
-                        return None;
-                    };
+                    let place = BuiltinPlace::parse(name)?;
                     if table.contains_key("title") || table.contains_key("path") {
                         eprintln!(
                             "elio: {field_name}: builtin places only support {{ builtin, icon }}; \
@@ -587,9 +585,7 @@ impl PlaceEntrySpec {
 }
 
 fn parse_place_icon(value: Option<&toml::Value>, field_name: &str) -> Option<String> {
-    let Some(value) = value else {
-        return None;
-    };
+    let value = value?;
     match value {
         toml::Value::String(icon) => {
             let icon = icon.trim();
@@ -703,6 +699,10 @@ fn normalize_absolute_path(path: &std::path::Path) -> PathBuf {
 mod tests {
     use super::*;
 
+    fn toml_string(value: &str) -> String {
+        toml::Value::String(value.to_string()).to_string()
+    }
+
     #[test]
     fn config_defaults_hide_top_bar() {
         let config = Config::default_config();
@@ -757,17 +757,18 @@ mod tests {
     #[test]
     fn config_can_customize_places_entries_and_hide_devices() {
         let projects = std::env::temp_dir().join("elio-places-projects");
+        let projects_toml = toml_string(&projects.display().to_string());
         let config = Config::from_str(&format!(
             r#"
 [places]
 show_devices = false
 entries = [
   "downloads",
-  {{ title = "Projects", path = "{}" }},
+  {{ title = "Projects", path = {} }},
   "trash",
 ]
 "#,
-            projects.display()
+            projects_toml
         ))
         .expect("config should parse");
 
@@ -827,15 +828,16 @@ entries = ["downloads", "workspace", "trash"]
     #[test]
     fn config_places_can_customize_icons_for_builtin_and_custom_entries() {
         let projects = std::env::temp_dir().join("elio-places-projects-icons");
+        let projects_toml = toml_string(&projects.display().to_string());
         let config = Config::from_str(&format!(
             r#"
 [places]
 entries = [
   {{ builtin = "downloads", icon = "D" }},
-  {{ title = "Projects", path = "{}", icon = "P" }},
+  {{ title = "Projects", path = {}, icon = "P" }},
 ]
 "#,
-            projects.display()
+            projects_toml
         ))
         .expect("config should parse");
 
@@ -880,15 +882,16 @@ entries = [
     #[test]
     fn config_places_ignores_invalid_icons_without_skipping_entries() {
         let projects = std::env::temp_dir().join("elio-places-invalid-icons");
+        let projects_toml = toml_string(&projects.display().to_string());
         let config = Config::from_str(&format!(
             r#"
 [places]
 entries = [
   {{ builtin = "downloads", icon = "" }},
-  {{ title = "Projects", path = "{}", icon = "   " }},
+  {{ title = "Projects", path = {}, icon = "   " }},
 ]
 "#,
-            projects.display()
+            projects_toml
         ))
         .expect("config should parse");
 

--- a/src/fs/places.rs
+++ b/src/fs/places.rs
@@ -1,4 +1,7 @@
-use crate::app::{SidebarItem, SidebarItemKind, SidebarRow};
+use crate::{
+    app::{SidebarItem, SidebarItemKind, SidebarRow},
+    config::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
+};
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -8,6 +11,21 @@ use std::{
 use std::collections::HashMap;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::fs;
+
+const CUSTOM_PLACE_ICON: &str = "󰉋";
+
+#[derive(Clone, Debug)]
+struct PlaceResolutionContext {
+    home: PathBuf,
+    desktop: Option<PathBuf>,
+    documents: Option<PathBuf>,
+    downloads: Option<PathBuf>,
+    pictures: Option<PathBuf>,
+    music: Option<PathBuf>,
+    videos: Option<PathBuf>,
+    root: Option<PathBuf>,
+    trash: Option<PathBuf>,
+}
 
 /// Returns the current user's home directory.
 ///
@@ -25,16 +43,28 @@ pub(crate) fn build_sidebar_rows() -> Vec<SidebarRow> {
         #[cfg(not(windows))]
         return PathBuf::from("/");
     });
-    let pinned_items = build_pinned_sidebar_items(&home);
+    let context = system_place_resolution_context(home);
+    build_sidebar_rows_with_context(crate::config::places(), &context)
+}
+
+fn build_sidebar_rows_with_context(
+    places: &PlacesConfig,
+    context: &PlaceResolutionContext,
+) -> Vec<SidebarRow> {
+    let pinned_items = build_pinned_sidebar_items(places, context);
     let pinned_paths = pinned_items
         .iter()
-        .map(|item| item.path.clone())
+        .map(|item| path_identity_key(&item.path))
         .collect::<HashSet<_>>();
     let mut rows = pinned_items
         .into_iter()
         .map(SidebarRow::Item)
         .collect::<Vec<_>>();
-    let device_items = mounted_device_items(&home, &pinned_paths);
+    let device_items = if places.show_devices {
+        mounted_device_items(&context.home, &pinned_paths)
+    } else {
+        Vec::new()
+    };
     if !device_items.is_empty() {
         rows.push(SidebarRow::Section { title: "Devices" });
         rows.extend(device_items.into_iter().map(SidebarRow::Item));
@@ -42,79 +72,173 @@ pub(crate) fn build_sidebar_rows() -> Vec<SidebarRow> {
     rows
 }
 
-fn build_pinned_sidebar_items(home: &Path) -> Vec<SidebarItem> {
+fn system_place_resolution_context(home: PathBuf) -> PlaceResolutionContext {
+    PlaceResolutionContext {
+        desktop: dirs::desktop_dir().filter(|path| path.exists()),
+        documents: dirs::document_dir().filter(|path| path.exists()),
+        downloads: dirs::download_dir().filter(|path| path.exists()),
+        pictures: dirs::picture_dir().filter(|path| path.exists()),
+        music: dirs::audio_dir().filter(|path| path.exists()),
+        videos: dirs::video_dir().filter(|path| path.exists()),
+        root: if cfg!(unix) {
+            Some(PathBuf::from("/"))
+        } else {
+            None
+        },
+        trash: trash_dir(&home),
+        home,
+    }
+}
+
+fn build_pinned_sidebar_items(
+    places: &PlacesConfig,
+    context: &PlaceResolutionContext,
+) -> Vec<SidebarItem> {
     let mut items = Vec::new();
+    let mut seen_paths = HashSet::new();
 
-    items.push(SidebarItem::new(
-        SidebarItemKind::Home,
-        "Home",
-        "󰋜",
-        home.to_path_buf(),
-    ));
-
-    // dirs::*_dir() reads XDG_*_DIR on Linux, system folders on macOS/Windows.
-    for (kind, title, path, icon) in [
-        (
-            SidebarItemKind::Desktop,
-            "Desktop",
-            dirs::desktop_dir(),
-            "󰍹",
-        ),
-        (
-            SidebarItemKind::Documents,
-            "Documents",
-            dirs::document_dir(),
-            "󰲃",
-        ),
-        (
-            SidebarItemKind::Downloads,
-            "Downloads",
-            dirs::download_dir(),
-            "󰉍",
-        ),
-        (
-            SidebarItemKind::Pictures,
-            "Pictures",
-            dirs::picture_dir(),
-            "󰉏",
-        ),
-        (SidebarItemKind::Music, "Music", dirs::audio_dir(), "󱍙"),
-        (
-            SidebarItemKind::Videos,
-            if cfg!(target_os = "macos") {
-                "Movies"
-            } else {
-                "Videos"
-            },
-            dirs::video_dir(),
-            "󰕧",
-        ),
-    ] {
-        if let Some(path) = path
-            && path.exists()
-        {
-            items.push(SidebarItem::new(kind, title, icon, path));
+    for entry in &places.entries {
+        let Some(item) = resolve_place_entry(entry, context) else {
+            continue;
+        };
+        if seen_paths.insert(path_identity_key(&item.path)) {
+            items.push(item);
         }
     }
 
-    #[cfg(unix)]
-    items.push(SidebarItem::new(
-        SidebarItemKind::Root,
-        "Root",
-        "󰋊",
-        PathBuf::from("/"),
-    ));
-
-    if let Some(trash) = trash_dir(home) {
-        items.push(SidebarItem::new(
-            SidebarItemKind::Trash,
-            "Trash",
-            "󰩺",
-            trash,
-        ));
-    }
-
     items
+}
+
+fn resolve_place_entry(
+    entry: &PlaceEntrySpec,
+    context: &PlaceResolutionContext,
+) -> Option<SidebarItem> {
+    match entry {
+        PlaceEntrySpec::Builtin { place, icon } => {
+            resolve_builtin_place(*place, icon.as_deref(), context)
+        }
+        PlaceEntrySpec::Custom { title, path, icon } => Some(SidebarItem::new(
+            SidebarItemKind::Custom,
+            title.clone(),
+            icon.as_deref().unwrap_or(CUSTOM_PLACE_ICON),
+            path.clone(),
+        )),
+    }
+}
+
+fn resolve_builtin_place(
+    place: BuiltinPlace,
+    icon_override: Option<&str>,
+    context: &PlaceResolutionContext,
+) -> Option<SidebarItem> {
+    match place {
+        BuiltinPlace::Home => Some(SidebarItem::new(
+            SidebarItemKind::Home,
+            "Home",
+            icon_override.unwrap_or("󰋜"),
+            context.home.clone(),
+        )),
+        BuiltinPlace::Desktop => context.desktop.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Desktop,
+                localized_place_title(&path, "Desktop"),
+                icon_override.unwrap_or("󰍹"),
+                path,
+            )
+        }),
+        BuiltinPlace::Documents => context.documents.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Documents,
+                localized_place_title(&path, "Documents"),
+                icon_override.unwrap_or("󰲃"),
+                path,
+            )
+        }),
+        BuiltinPlace::Downloads => context.downloads.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Downloads,
+                localized_place_title(&path, "Downloads"),
+                icon_override.unwrap_or("󰉍"),
+                path,
+            )
+        }),
+        BuiltinPlace::Pictures => context.pictures.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Pictures,
+                localized_place_title(&path, "Pictures"),
+                icon_override.unwrap_or("󰉏"),
+                path,
+            )
+        }),
+        BuiltinPlace::Music => context.music.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Music,
+                localized_place_title(&path, "Music"),
+                icon_override.unwrap_or("󱍙"),
+                path,
+            )
+        }),
+        BuiltinPlace::Videos => context.videos.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Videos,
+                localized_place_title(&path, videos_label()),
+                icon_override.unwrap_or("󰕧"),
+                path,
+            )
+        }),
+        BuiltinPlace::Root => context.root.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Root,
+                "Root",
+                icon_override.unwrap_or("󰋊"),
+                path,
+            )
+        }),
+        BuiltinPlace::Trash => context.trash.clone().map(|path| {
+            SidebarItem::new(
+                SidebarItemKind::Trash,
+                "Trash",
+                icon_override.unwrap_or("󰩺"),
+                path,
+            )
+        }),
+    }
+}
+
+fn localized_place_title(path: &Path, fallback: &'static str) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn videos_label() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Movies"
+    } else {
+        "Videos"
+    }
+}
+
+fn path_identity_key(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| normalize_absolute_path(path))
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 /// Returns the path to the user's trash directory, or `None` if it cannot be determined.
@@ -161,7 +285,7 @@ fn mounted_device_items(_home: &Path, pinned_paths: &HashSet<PathBuf>) -> Vec<Si
     for entry in entries.flatten() {
         let path = entry.path();
 
-        if pinned_paths.contains(&path) {
+        if pinned_paths.contains(&path_identity_key(&path)) {
             continue;
         }
         if entry.file_name().to_string_lossy().starts_with('.') {
@@ -204,7 +328,7 @@ fn mounted_device_items(_home: &Path, pinned_paths: &HashSet<PathBuf>) -> Vec<Si
     let mut items = Vec::new();
     for letter in b'A'..=b'Z' {
         let path = PathBuf::from(format!("{}:\\", letter as char));
-        if path.exists() && !pinned_paths.contains(&path) {
+        if path.exists() && !pinned_paths.contains(&path_identity_key(&path)) {
             items.push(SidebarItem::new(
                 SidebarItemKind::Device { removable: false },
                 format!("{}:", letter as char),
@@ -241,7 +365,7 @@ fn mounted_device_items(home: &Path, pinned_paths: &HashSet<PathBuf>) -> Vec<Sid
 
         let path = PathBuf::from(mount_point.as_ref());
 
-        if path == Path::new("/") || pinned_paths.contains(&path) {
+        if path == Path::new("/") || pinned_paths.contains(&path_identity_key(&path)) {
             continue;
         }
         if bsd_system_fstype(&fstype) || bsd_hidden_path(&path) {
@@ -409,7 +533,9 @@ fn linux_mount_should_appear(
     pinned_paths: &HashSet<PathBuf>,
     removable: bool,
 ) -> bool {
-    if pinned_paths.contains(&mount.mount_point) || mount.mount_point == Path::new("/") {
+    if pinned_paths.contains(&path_identity_key(&mount.mount_point))
+        || mount.mount_point == Path::new("/")
+    {
         return false;
     }
     if linux_system_mount_type(&mount.fstype) || linux_hidden_mount_path(&mount.mount_point) {
@@ -758,5 +884,199 @@ mod tests {
     fn decode_linux_label_name_unescapes_hex_sequences() {
         let decoded = decode_linux_label_name(OsStr::new("New\\x20vol\\x23A"));
         assert_eq!(decoded, "New vol#A");
+    }
+}
+
+#[cfg(test)]
+mod sidebar_config_tests {
+    use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-places-{label}-{unique}"))
+    }
+
+    fn context_for(root: &Path) -> PlaceResolutionContext {
+        let home = root.join("home");
+        let downloads = home.join("Downloads");
+        let trash = root.join("trash");
+        fs::create_dir_all(&downloads).expect("failed to create downloads");
+        fs::create_dir_all(&trash).expect("failed to create trash");
+        PlaceResolutionContext {
+            home,
+            desktop: None,
+            documents: None,
+            downloads: Some(downloads),
+            pictures: None,
+            music: None,
+            videos: None,
+            root: None,
+            trash: Some(trash),
+        }
+    }
+
+    #[test]
+    fn configured_places_order_and_semantic_kinds_are_preserved() {
+        let root = temp_path("ordered-sidebar");
+        let context = context_for(&root);
+        let projects = root.join("projects");
+        let places = PlacesConfig {
+            show_devices: false,
+            entries: vec![
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Downloads,
+                    icon: Some("D".to_string()),
+                },
+                PlaceEntrySpec::Custom {
+                    title: "Projects".to_string(),
+                    path: projects.clone(),
+                    icon: Some("P".to_string()),
+                },
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Home,
+                    icon: None,
+                },
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Trash,
+                    icon: None,
+                },
+            ],
+        };
+
+        let rows = build_sidebar_rows_with_context(&places, &context);
+        let items = rows.iter().filter_map(SidebarRow::item).collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0].title, "Downloads");
+        assert_eq!(items[0].kind, SidebarItemKind::Downloads);
+        assert_eq!(items[0].icon, "D");
+        assert_eq!(items[1].title, "Projects");
+        assert_eq!(items[1].kind, SidebarItemKind::Custom);
+        assert_eq!(items[1].icon, "P");
+        assert_eq!(items[1].path, projects);
+        assert_eq!(items[2].title, "Home");
+        assert_eq!(items[2].kind, SidebarItemKind::Home);
+        assert_eq!(items[3].title, "Trash");
+        assert_eq!(items[3].kind, SidebarItemKind::Trash);
+        assert!(rows.iter().all(|row| matches!(row, SidebarRow::Item(_))));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn missing_builtin_places_are_skipped_but_nonexistent_custom_places_stay_visible() {
+        let root = temp_path("missing-builtins");
+        let context = context_for(&root);
+        let future_mount = root.join("mnt").join("camera");
+        let places = PlacesConfig {
+            show_devices: false,
+            entries: vec![
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Desktop,
+                    icon: None,
+                },
+                PlaceEntrySpec::Custom {
+                    title: "Camera".to_string(),
+                    path: future_mount.clone(),
+                    icon: None,
+                },
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Downloads,
+                    icon: None,
+                },
+            ],
+        };
+
+        let rows = build_sidebar_rows_with_context(&places, &context);
+        let items = rows.iter().filter_map(SidebarRow::item).collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title, "Camera");
+        assert_eq!(items[0].kind, SidebarItemKind::Custom);
+        assert_eq!(items[0].path, future_mount);
+        assert_eq!(items[1].title, "Downloads");
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn localized_builtin_places_show_resolved_folder_name() {
+        let root = temp_path("localized-builtins");
+        let home = root.join("home");
+        let downloads = home.join("Descargas");
+        fs::create_dir_all(&downloads).expect("failed to create downloads");
+        let context = PlaceResolutionContext {
+            home,
+            desktop: None,
+            documents: None,
+            downloads: Some(downloads.clone()),
+            pictures: None,
+            music: None,
+            videos: None,
+            root: None,
+            trash: None,
+        };
+        let places = PlacesConfig {
+            show_devices: false,
+            entries: vec![PlaceEntrySpec::Builtin {
+                place: BuiltinPlace::Downloads,
+                icon: None,
+            }],
+        };
+
+        let rows = build_sidebar_rows_with_context(&places, &context);
+        let items = rows.iter().filter_map(SidebarRow::item).collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Descargas");
+        assert_eq!(items[0].kind, SidebarItemKind::Downloads);
+        assert_eq!(items[0].path, downloads);
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn places_deduplicate_entries_by_resolved_path() {
+        let root = temp_path("dedupe-sidebar");
+        let context = context_for(&root);
+        let places = PlacesConfig {
+            show_devices: false,
+            entries: vec![
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Home,
+                    icon: None,
+                },
+                PlaceEntrySpec::Custom {
+                    title: "Home 2".to_string(),
+                    path: context.home.clone(),
+                    icon: Some("H".to_string()),
+                },
+                PlaceEntrySpec::Builtin {
+                    place: BuiltinPlace::Downloads,
+                    icon: None,
+                },
+                PlaceEntrySpec::Custom {
+                    title: "Downloads Alias".to_string(),
+                    path: context.home.join("Downloads").join("..").join("Downloads"),
+                    icon: Some("A".to_string()),
+                },
+            ],
+        };
+
+        let rows = build_sidebar_rows_with_context(&places, &context);
+        let items = rows.iter().filter_map(SidebarRow::item).collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title, "Home");
+        assert_eq!(items[1].title, "Downloads");
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
     }
 }

--- a/src/ui/browser/sidebar.rs
+++ b/src/ui/browser/sidebar.rs
@@ -57,7 +57,7 @@ pub(super) fn render_sidebar(
                     palette.panel
                 };
                 let title_width = row.width.saturating_sub(
-                    1u16.saturating_add(helpers::display_width(item.icon) as u16)
+                    1u16.saturating_add(helpers::display_width(item.icon.as_str()) as u16)
                         .saturating_add(2),
                 ) as usize;
                 let top_line = Line::from(vec![
@@ -66,7 +66,7 @@ pub(super) fn render_sidebar(
                         Style::default().fg(if active { palette.accent } else { bg }),
                     ),
                     Span::styled(
-                        item.icon,
+                        item.icon.as_str(),
                         Style::default()
                             .fg(palette.accent)
                             .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary

This PR makes the Places pane configurable from config.toml.

It adds:

- Configurable pinned Places entries and ordering.
- Optional hiding of the auto-detected Devices section.
- Custom path entries.
- Optional icon overrides for built-in and custom Places entries.
- Localized display names for built-in user folders based on the resolved path.

## Behavior

`[places]` now supports:

- **Built-in entries** by stable id (e.g., `"downloads"`).
- **Built-in entries with icon override** (e.g., `{ builtin = "downloads", icon = "" }`).
- **Custom entries** (e.g., `{ title = "Projects", path = "~/workspace", icon = "󰚝" }`).

**Built-in names are:**
`home`, `desktop`, `documents`, `downloads`, `pictures`, `music`, `videos`, `root`, `trash`

**Additional behavior:**
- Built-in IDs are stable config names, not localized folder names.
- Built-in user folders display their resolved folder name in the UI when available.
- Missing built-ins are skipped; nonexistent custom paths remain visible.
- Entries are deduped by resolved path (first matching path wins).
- Omitting `[places]` keeps the exact default sidebar.

## Example

```toml
[places]
show_devices = true
entries = [
    "home",
    "desktop",
    "documents",
    { builtin = "downloads", icon = "" },
    "pictures",
    "music",
    "videos",
    "root",
    { title = "Projects", path = "~/workspace", icon = "󰚝" },
    "trash",
]
```

## Testing

**Verified with:**

- [x] `cargo test config::tests -- --nocapture`
- [x] `cargo test fs::places::sidebar_config_tests -- --nocapture`
- [x] `cargo test -- --nocapture`

**Result:**
- **698 passed; 0 failed**