### PR TITLE
refactor(core): move shared file model out of app

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+This crate is organized around a small set of layers.
+
+- `core`: shared, dependency-light model types that multiple layers need.
+- `fs` and `file_info`: filesystem access, file classification, and metadata discovery.
+- `preview`: preview construction and rendering-oriented preview data.
+- `app`: runtime coordination, state, jobs, and user actions.
+- `ui`: terminal rendering, layout, and theming.
+
+Current boundary rules:
+
+- Shared file-model types live in `src/core/`, not in `src/app/`.
+- Lower layers such as `fs` and `file_info` may depend on `core`, but should not depend on `app`.
+- `preview` is presentation code, but it should consume stable contracts from lower layers instead of reaching upward into unrelated subsystems.
+- `app` coordinates behavior; it should not be the home for generic data model types that other layers need.
+
+This document is intentionally short. Keep it focused on real dependency rules, and update it as architectural seams become explicit in the code.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,16 +29,17 @@ use std::{
 pub use self::state::App;
 #[cfg(test)]
 pub use self::state::PreviewMetricsSnapshot;
+pub(crate) use crate::core::FileClass;
 pub(crate) use crate::fs::{
     format_item_count, format_size, format_time_ago, rect_contains, sanitize_terminal_text,
 };
 
 pub(crate) use self::types::ClipOp;
-pub(crate) use self::types::FileClass;
 pub use self::types::{
-    CopyHit, Entry, EntryHit, EntryKind, FrameState, GoToHit, PathHit, SearchHit, SearchRow,
-    SearchScope, SidebarItem, SidebarItemKind, SidebarRow, SortMode, ViewMetrics, ViewMode,
+    CopyHit, EntryHit, FrameState, GoToHit, PathHit, SearchHit, SearchRow, SearchScope,
+    SidebarItem, SidebarItemKind, SidebarRow, ViewMetrics, ViewMode,
 };
+pub use crate::core::{Entry, EntryKind, SortMode};
 
 impl App {
     pub fn set_frame_state(&mut self, frame_state: FrameState) -> bool {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -13,6 +13,7 @@ use super::{
     overlays::{comic, epub, images, inline_image, pdf},
     types::*,
 };
+use crate::core::{Entry, SortMode};
 use crate::fs::search::SearchCandidate;
 use crate::preview;
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, time::SystemTime};
+use std::path::PathBuf;
 
 use ratatui::layout::Rect;
 
@@ -24,74 +24,10 @@ impl ViewMode {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum SortMode {
-    Name,
-    Modified,
-    Size,
-}
-
-impl SortMode {
-    pub fn cycle(self) -> Self {
-        match self {
-            Self::Name => Self::Modified,
-            Self::Modified => Self::Size,
-            Self::Size => Self::Name,
-        }
-    }
-
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Name => "Name",
-            Self::Modified => "Modified",
-            Self::Size => "Size",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum EntryKind {
-    Directory,
-    File,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ClipOp {
     Yank,
     Cut,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub(crate) enum FileClass {
-    Directory,
-    Code,
-    Config,
-    Document,
-    License,
-    Image,
-    Audio,
-    Video,
-    Archive,
-    Font,
-    Data,
-    File,
-}
-
-#[derive(Clone, Debug)]
-pub struct Entry {
-    pub path: PathBuf,
-    pub name: String,
-    pub name_key: String,
-    pub kind: EntryKind,
-    pub size: u64,
-    pub modified: Option<SystemTime>,
-    pub readonly: bool,
-}
-
-impl Entry {
-    pub fn is_dir(&self) -> bool {
-        self.kind == EntryKind::Directory
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/core/file_model.rs
+++ b/src/core/file_model.rs
@@ -1,0 +1,65 @@
+use std::{path::PathBuf, time::SystemTime};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SortMode {
+    Name,
+    Modified,
+    Size,
+}
+
+impl SortMode {
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Name => Self::Modified,
+            Self::Modified => Self::Size,
+            Self::Size => Self::Name,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Name => "Name",
+            Self::Modified => "Modified",
+            Self::Size => "Size",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EntryKind {
+    Directory,
+    File,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub(crate) enum FileClass {
+    Directory,
+    Code,
+    Config,
+    Document,
+    License,
+    Image,
+    Audio,
+    Video,
+    Archive,
+    Font,
+    Data,
+    File,
+}
+
+#[derive(Clone, Debug)]
+pub struct Entry {
+    pub path: PathBuf,
+    pub name: String,
+    pub name_key: String,
+    pub kind: EntryKind,
+    pub size: u64,
+    pub modified: Option<SystemTime>,
+    pub readonly: bool,
+}
+
+impl Entry {
+    pub fn is_dir(&self) -> bool {
+        self.kind == EntryKind::Directory
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,4 @@
+mod file_model;
+
+pub(crate) use self::file_model::FileClass;
+pub use self::file_model::{Entry, EntryKind, SortMode};

--- a/src/file_info/archives.rs
+++ b/src/file_info/archives.rs
@@ -1,6 +1,6 @@
 use super::types::plain;
 use super::{CompoundArchiveKind, CompressionKind, DiskImageKind, FileFacts};
-use crate::app::FileClass;
+use crate::core::FileClass;
 
 pub(super) fn inspect_archive_name(name: &str) -> Option<FileFacts> {
     let detail = if let Some(kind) = inspect_compound_archive_name(name) {

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -1,6 +1,6 @@
 use super::types::{disk_image_file_facts, plain, source_only};
 use super::{DiskImageKind, DocumentFormat, FileFacts, PreviewSpec};
-use crate::{app::FileClass, preview::code::registry};
+use crate::{core::FileClass, preview::code::registry};
 
 fn preview_for_extension(ext: &str) -> PreviewSpec {
     registry::language_for_extension(ext)

--- a/src/file_info/license.rs
+++ b/src/file_info/license.rs
@@ -1,5 +1,5 @@
 use super::{FileFacts, PreviewKind};
-use crate::app::FileClass;
+use crate::core::FileClass;
 use std::{fs::File, io::Read, path::Path};
 
 const LICENSE_SNIFF_BYTE_LIMIT: usize = 64 * 1024;
@@ -634,7 +634,7 @@ fn normalize_high_signal_text(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{EntryKind, FileClass};
+    use crate::core::{EntryKind, FileClass};
     use std::{
         fs,
         path::PathBuf,

--- a/src/file_info/tests/mod.rs
+++ b/src/file_info/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app::{EntryKind, FileClass};
+use crate::core::{EntryKind, FileClass};
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/src/file_info/types.rs
+++ b/src/file_info/types.rs
@@ -1,4 +1,4 @@
-use crate::app::FileClass;
+use crate::core::FileClass;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum PreviewKind {

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -1,4 +1,4 @@
-use crate::app::{Entry, EntryKind, SortMode};
+use crate::core::{Entry, EntryKind, SortMode};
 use anyhow::{Context, Result};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod app;
 mod config;
+mod core;
 mod file_info;
 mod fs;
 mod preview;

--- a/src/preview/audio.rs
+++ b/src/preview/audio.rs
@@ -1,5 +1,5 @@
 use super::{PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout};
-use crate::app::Entry;
+use crate::core::Entry;
 use crate::ui::theme;
 use ratatui::{
     style::Style,

--- a/src/preview/container/mod.rs
+++ b/src/preview/container/mod.rs
@@ -3,7 +3,7 @@ mod iso;
 mod torrent;
 
 use super::*;
-use crate::app::EntryKind;
+use crate::core::EntryKind;
 use crate::ui::theme;
 use ratatui::{
     style::Style,

--- a/src/preview/directory.rs
+++ b/src/preview/directory.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app::{Entry, EntryKind};
+use crate::core::{Entry, EntryKind};
 use crate::ui::theme;
 use ratatui::{
     style::Style,

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app::{Entry, FileClass};
+use crate::core::{Entry, FileClass};
 use crate::fs as browser_support;
 use crate::{file_info, ui::theme};
 use image::ImageReader;

--- a/src/preview/tests/helpers.rs
+++ b/src/preview/tests/helpers.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app::{Entry, EntryKind};
+use crate::core::{Entry, EntryKind};
 use flate2::{Compression, write::GzEncoder};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use ratatui::style::Color;

--- a/src/preview/video.rs
+++ b/src/preview/video.rs
@@ -1,5 +1,5 @@
 use super::{PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout};
-use crate::app::Entry;
+use crate::core::Entry;
 use crate::ui::theme;
 use ratatui::{
     style::Style,

--- a/src/ui/theme/appearance/mod.rs
+++ b/src/ui/theme/appearance/mod.rs
@@ -13,7 +13,7 @@ use self::{
     types::{EntryClassCacheKey, ResolvedAppearance, Theme},
 };
 use super::builtin_themes::DEFAULT_THEME_TOML;
-use crate::app::{Entry, EntryKind, FileClass};
+use crate::core::{Entry, EntryKind, FileClass};
 use std::{
     collections::HashMap,
     path::Path,

--- a/src/ui/theme/appearance/parsing.rs
+++ b/src/ui/theme/appearance/parsing.rs
@@ -2,7 +2,7 @@ use super::{
     rules::{default_class_style, normalize_key, rgb, rule_class},
     types::{CodePreviewPalette, Palette, PreviewTheme, RuleOverride, Theme},
 };
-use crate::app::FileClass;
+use crate::core::FileClass;
 use ratatui::style::Color;
 use serde::Deserialize;
 use std::collections::HashMap;

--- a/src/ui/theme/appearance/rules.rs
+++ b/src/ui/theme/appearance/rules.rs
@@ -1,5 +1,5 @@
 use super::types::{ClassStyle, CodePreviewPalette, Palette, PreviewTheme, RuleOverride, Theme};
-use crate::app::FileClass;
+use crate::core::FileClass;
 use ratatui::style::Color;
 use std::collections::HashMap;
 

--- a/src/ui/theme/appearance/types.rs
+++ b/src/ui/theme/appearance/types.rs
@@ -1,4 +1,4 @@
-use crate::app::FileClass;
+use crate::core::FileClass;
 use ratatui::style::Color;
 use std::{collections::HashMap, path::PathBuf};
 

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -1,7 +1,7 @@
 mod appearance;
 mod builtin_themes;
 
-use crate::app::Entry;
+use crate::core::{Entry, EntryKind};
 use ratatui::style::Color;
 use std::path::Path;
 
@@ -37,18 +37,18 @@ pub(super) fn entry_symbol(entry: &Entry) -> &'static str {
 pub(super) fn path_color(path: &Path, is_dir: bool, palette: Palette) -> Color {
     let _ = palette;
     let kind = if is_dir {
-        crate::app::EntryKind::Directory
+        EntryKind::Directory
     } else {
-        crate::app::EntryKind::File
+        EntryKind::File
     };
     resolve_path(path, kind).color
 }
 
 pub(super) fn path_symbol(path: &Path, is_dir: bool) -> &'static str {
     let kind = if is_dir {
-        crate::app::EntryKind::Directory
+        EntryKind::Directory
     } else {
-        crate::app::EntryKind::File
+        EntryKind::File
     };
     resolve_path(path, kind).icon
 }


### PR DESCRIPTION
## Summary

- **New Core Module:** Added `src/core/` for shared file-model types.
- **Type Migration:** Moved `Entry`, `EntryKind`, `SortMode`, and `FileClass` out of `src/app/types.rs`.
- **Refactored Imports:** Updated `fs`, `file_info`, `preview`, `ui`, and `app` to reference the new `core` module.
- **Documentation:** Added `docs/architecture.md` to define and describe the intended layer boundaries.

## Why

These types were shared across multiple subsystems but lived under `app`, forcing lower layers to depend on the application module for generic data structures. Moving them into `src/core/` establishes a cleaner dependency direction:

- Shared model types now reside in a neutral location.
- Lower layers can depend on `core` without reaching into `app`.
- Provides a solid foundation for future architectural boundary-cleanup.

This is a structural refactor only; existing behavior remains unchanged.

## Testing

**Verified with:**

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

**Result:**

- **All tests and linting passed.**