### PR TITLE
refactor(preview): add appearance contract

### DIFF
--- a/src/preview/appearance.rs
+++ b/src/preview/appearance.rs
@@ -1,0 +1,127 @@
+use crate::core::EntryKind;
+use ratatui::style::Color;
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Palette {
+    pub bg: Color,
+    pub chrome: Color,
+    pub chrome_alt: Color,
+    pub panel: Color,
+    pub panel_alt: Color,
+    pub surface: Color,
+    pub elevated: Color,
+    pub border: Color,
+    pub text: Color,
+    pub muted: Color,
+    pub accent: Color,
+    pub accent_soft: Color,
+    pub accent_text: Color,
+    pub selected_bg: Color,
+    pub selected_border: Color,
+    pub selection_bar: Color,
+    pub yank_bar: Color,
+    pub cut_bar: Color,
+    pub grid_selection_band: Color,
+    pub grid_yank_band: Color,
+    pub grid_cut_band: Color,
+    pub trash_bar: Color,
+    pub restore_bar: Color,
+    pub sidebar_active: Color,
+    pub button_bg: Color,
+    pub button_disabled_bg: Color,
+    pub path_bg: Color,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CodePalette {
+    pub fg: Color,
+    pub bg: Color,
+    pub selection_bg: Color,
+    pub selection_fg: Color,
+    pub caret: Color,
+    pub line_highlight: Color,
+    pub line_number: Color,
+    pub comment: Color,
+    pub string: Color,
+    pub constant: Color,
+    pub keyword: Color,
+    pub function: Color,
+    pub r#type: Color,
+    pub parameter: Color,
+    pub tag: Color,
+    pub operator: Color,
+    pub r#macro: Color,
+    pub invalid: Color,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PathAppearance<'a> {
+    pub icon: &'a str,
+    pub color: Color,
+}
+
+pub(crate) fn palette() -> Palette {
+    let palette = crate::ui::theme::palette();
+    Palette {
+        bg: palette.bg,
+        chrome: palette.chrome,
+        chrome_alt: palette.chrome_alt,
+        panel: palette.panel,
+        panel_alt: palette.panel_alt,
+        surface: palette.surface,
+        elevated: palette.elevated,
+        border: palette.border,
+        text: palette.text,
+        muted: palette.muted,
+        accent: palette.accent,
+        accent_soft: palette.accent_soft,
+        accent_text: palette.accent_text,
+        selected_bg: palette.selected_bg,
+        selected_border: palette.selected_border,
+        selection_bar: palette.selection_bar,
+        yank_bar: palette.yank_bar,
+        cut_bar: palette.cut_bar,
+        grid_selection_band: palette.grid_selection_band,
+        grid_yank_band: palette.grid_yank_band,
+        grid_cut_band: palette.grid_cut_band,
+        trash_bar: palette.trash_bar,
+        restore_bar: palette.restore_bar,
+        sidebar_active: palette.sidebar_active,
+        button_bg: palette.button_bg,
+        button_disabled_bg: palette.button_disabled_bg,
+        path_bg: palette.path_bg,
+    }
+}
+
+pub(crate) fn code_palette() -> CodePalette {
+    let palette = crate::ui::theme::code_preview_palette();
+    CodePalette {
+        fg: palette.fg,
+        bg: palette.bg,
+        selection_bg: palette.selection_bg,
+        selection_fg: palette.selection_fg,
+        caret: palette.caret,
+        line_highlight: palette.line_highlight,
+        line_number: palette.line_number,
+        comment: palette.comment,
+        string: palette.string,
+        constant: palette.constant,
+        keyword: palette.keyword,
+        function: palette.function,
+        r#type: palette.r#type,
+        parameter: palette.parameter,
+        tag: palette.tag,
+        operator: palette.operator,
+        r#macro: palette.r#macro,
+        invalid: palette.invalid,
+    }
+}
+
+pub(crate) fn resolve_path(path: &Path, kind: EntryKind) -> PathAppearance<'static> {
+    let appearance = crate::ui::theme::resolve_path(path, kind);
+    PathAppearance {
+        icon: appearance.icon,
+        color: appearance.color,
+    }
+}

--- a/src/preview/code/backends/plain.rs
+++ b/src/preview/code/backends/plain.rs
@@ -1,4 +1,4 @@
-use crate::ui::theme;
+use crate::preview::appearance;
 use ratatui::{
     style::Style,
     text::{Line, Span},
@@ -13,7 +13,7 @@ pub(in crate::preview::code) fn render_plain_code_preview<F>(
 where
     F: Fn() -> bool,
 {
-    let code_palette = theme::code_preview_palette();
+    let code_palette = appearance::code_palette();
     let source_lines = crate::preview::collect_preview_lines_with_limit(
         text,
         crate::preview::clamp_code_preview_line_limit(line_limit),

--- a/src/preview/code/backends/syntect/render.rs
+++ b/src/preview/code/backends/syntect/render.rs
@@ -1,4 +1,5 @@
 use super::semantics::{SemanticRole, role_color, semantic_role_for_token};
+use crate::preview::appearance;
 use ratatui::{
     style::{Modifier, Style},
     text::{Line, Span},
@@ -24,7 +25,7 @@ where
         crate::preview::clamp_code_preview_line_limit(line_limit),
     );
     let number_width = crate::preview::line_number_width(source_lines.len());
-    let code_palette = crate::ui::theme::code_preview_palette();
+    let code_palette = appearance::code_palette();
     let mut parse_state = ParseState::new(syntax);
     let mut scope_stack = ScopeStack::new();
     let mut rendered = Vec::new();

--- a/src/preview/code/backends/syntect/semantics.rs
+++ b/src/preview/code/backends/syntect/semantics.rs
@@ -1,3 +1,4 @@
+use crate::preview::appearance::CodePalette;
 use ratatui::style::Color;
 use std::sync::OnceLock;
 use syntect::parsing::Scope;
@@ -85,10 +86,7 @@ pub(super) fn looks_like_shell_command_name(token: &str) -> bool {
     chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
 }
 
-pub(super) fn role_color(
-    role: SemanticRole,
-    palette: crate::ui::theme::CodePreviewPalette,
-) -> Color {
+pub(super) fn role_color(role: SemanticRole, palette: CodePalette) -> Color {
     match role {
         SemanticRole::Fg => palette.fg,
         SemanticRole::Comment => palette.comment,

--- a/src/preview/code/backends/syntect/shell.rs
+++ b/src/preview/code/backends/syntect/shell.rs
@@ -1,4 +1,5 @@
 use super::semantics::{SemanticRole, looks_like_shell_command_name, role_color};
+use crate::preview::appearance::{self, CodePalette};
 use ratatui::{
     style::{Modifier, Style},
     text::{Line, Span},
@@ -25,7 +26,7 @@ where
         crate::preview::clamp_code_preview_line_limit(line_limit),
     );
     let number_width = crate::preview::line_number_width(source_lines.len());
-    let code_palette = crate::ui::theme::code_preview_palette();
+    let code_palette = appearance::code_palette();
     let mut rendered = Vec::new();
 
     for (index, line) in source_lines.iter().enumerate() {
@@ -58,10 +59,7 @@ pub(super) fn is_shell_like_syntax(code_syntax: &str) -> bool {
     matches!(code_syntax, "sh" | "bash" | "zsh" | "ksh")
 }
 
-fn render_shell_line(
-    line: &str,
-    palette: crate::ui::theme::CodePreviewPalette,
-) -> Vec<Span<'static>> {
+fn render_shell_line(line: &str, palette: CodePalette) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     let mut state = ShellLineState {
         command_position: true,
@@ -152,11 +150,7 @@ fn render_shell_line(
     spans
 }
 
-fn shell_span(
-    text: &str,
-    role: SemanticRole,
-    palette: crate::ui::theme::CodePreviewPalette,
-) -> Span<'static> {
+fn shell_span(text: &str, role: SemanticRole, palette: CodePalette) -> Span<'static> {
     let mut rendered_style = Style::default().fg(role_color(role, palette));
     if role == SemanticRole::Invalid {
         rendered_style = rendered_style.add_modifier(Modifier::UNDERLINED);
@@ -179,7 +173,7 @@ fn consume_while(text: &str, predicate: impl Fn(char) -> bool) -> Option<usize> 
 fn consume_shell_single_quoted_string(
     text: &str,
     spans: &mut Vec<Span<'static>>,
-    palette: crate::ui::theme::CodePreviewPalette,
+    palette: CodePalette,
 ) -> Option<usize> {
     if !text.starts_with('\'') {
         return None;
@@ -201,7 +195,7 @@ fn consume_shell_single_quoted_string(
 fn consume_shell_double_quoted_string(
     text: &str,
     spans: &mut Vec<Span<'static>>,
-    palette: crate::ui::theme::CodePreviewPalette,
+    palette: CodePalette,
 ) -> Option<usize> {
     if !text.starts_with('"') {
         return None;
@@ -241,7 +235,7 @@ fn consume_shell_double_quoted_string(
 fn consume_shell_variable(
     text: &str,
     spans: &mut Vec<Span<'static>>,
-    palette: crate::ui::theme::CodePreviewPalette,
+    palette: CodePalette,
 ) -> Option<usize> {
     if !text.starts_with('$') {
         return None;

--- a/src/preview/directory.rs
+++ b/src/preview/directory.rs
@@ -1,6 +1,5 @@
-use super::*;
+use super::{appearance, *};
 use crate::core::{Entry, EntryKind};
-use crate::ui::theme;
 use ratatui::{
     style::Style,
     text::{Line, Span},
@@ -43,13 +42,13 @@ pub(super) fn build_directory_preview(entry: &Entry) -> PreviewContent {
                 );
             }
 
-            let palette = theme::palette();
+            let palette = appearance::palette();
             let total_items = items.len();
             let folder_count = items.iter().filter(|item| item.2).count();
             let file_count = total_items.saturating_sub(folder_count);
             let mut lines = Vec::new();
             for (name, path, is_dir) in items.into_iter() {
-                let appearance = theme::resolve_path(
+                let path_appearance = appearance::resolve_path(
                     &path,
                     if is_dir {
                         EntryKind::Directory
@@ -59,9 +58,9 @@ pub(super) fn build_directory_preview(entry: &Entry) -> PreviewContent {
                 );
                 lines.push(Line::from(vec![
                     Span::styled(
-                        format!("{} ", appearance.icon),
+                        format!("{} ", path_appearance.icon),
                         Style::default()
-                            .fg(appearance.color)
+                            .fg(path_appearance.color)
                             .add_modifier(ratatui::style::Modifier::BOLD),
                     ),
                     Span::styled(name, Style::default().fg(palette.text)),

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -1,3 +1,4 @@
+mod appearance;
 mod audio;
 mod binary;
 pub(crate) mod code;

--- a/src/preview/types.rs
+++ b/src/preview/types.rs
@@ -1,5 +1,5 @@
+use super::appearance;
 use crate::fs as browser_support;
-use crate::ui::theme;
 use ratatui::{
     layout::Alignment,
     style::Style,
@@ -551,7 +551,7 @@ fn unavailable_preview(detail: &str, message: &str) -> PreviewContent {
 }
 
 pub(super) fn line_number_span(number: usize, width: usize) -> Span<'static> {
-    let preview = theme::code_preview_palette();
+    let preview = appearance::code_palette();
     Span::styled(
         format!("{number:>width$} ", width = width),
         Style::default().fg(preview.line_number),


### PR DESCRIPTION
## Summary

- **New Module:** Added `src/preview/appearance.rs` to handle preview-specific visual logic.
- **Contract Introduction:** Introduced preview-owned palette and path-appearance types.
- **Refactored Routing:** Routed the initial preview rendering paths through the new appearance contract.
- **Decoupling:** Began removing direct dependencies on `ui::theme` within the first set of preview modules.

## Why

This is a seam-setting step for wider preview/theme decoupling. Moving the entire dependency at once would be too disruptive; this PR establishes a preview-owned appearance contract first. This provides a stable target for the next migration phase without altering existing preview behavior.

## Notes

This PR is an incremental step and does not complete the full preview decoupling. It focuses on establishing the contract and migrating the initial modules.

## Testing

**Verified with:**

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

**Result:**

- **All checks passed; architectural seam established.**