### PR TITLE
refactor(preview): decouple preview from ui theme

### DIFF
--- a/src/preview/appearance.rs
+++ b/src/preview/appearance.rs
@@ -55,6 +55,8 @@ pub(crate) struct CodePalette {
     pub invalid: Color,
 }
 
+pub(crate) type CodePreviewPalette = CodePalette;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct PathAppearance<'a> {
     pub icon: &'a str,
@@ -116,6 +118,10 @@ pub(crate) fn code_palette() -> CodePalette {
         r#macro: palette.r#macro,
         invalid: palette.invalid,
     }
+}
+
+pub(crate) fn code_preview_palette() -> CodePreviewPalette {
+    code_palette()
 }
 
 pub(crate) fn resolve_path(path: &Path, kind: EntryKind) -> PathAppearance<'static> {

--- a/src/preview/audio.rs
+++ b/src/preview/audio.rs
@@ -1,6 +1,8 @@
-use super::{PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout};
+use super::{
+    PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout,
+    appearance as theme,
+};
 use crate::core::Entry;
-use crate::ui::theme;
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/preview/binary/mod.rs
+++ b/src/preview/binary/mod.rs
@@ -3,7 +3,7 @@ mod macho;
 mod pe;
 
 use super::{PreviewContent, PreviewKind};
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/preview/code/backends/syntect/mod.rs
+++ b/src/preview/code/backends/syntect/mod.rs
@@ -58,7 +58,7 @@ mod tests {
     use super::bundle::{find_syntax, syntax_set};
     use super::semantics::{SemanticRole, semantic_role_for_token};
     use super::*;
-    use crate::ui::theme;
+    use crate::preview::appearance as theme;
     use std::str::FromStr;
     use syntect::{
         easy::ScopeRangeIterator,

--- a/src/preview/code/custom/data.rs
+++ b/src/preview/code/custom/data.rs
@@ -2,7 +2,7 @@ use super::{
     looks_numeric, scan_quoted_segment, split_comment, split_jsonc_segments, split_unquoted_once,
     styled_text,
 };
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{style::Modifier, text::Span};
 
 pub(super) fn highlight_toml_line(

--- a/src/preview/code/custom/directive.rs
+++ b/src/preview/code/custom/directive.rs
@@ -1,5 +1,5 @@
 use super::{looks_numeric, scan_quoted_segment, styled_text};
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{style::Modifier, text::Span};
 
 pub(super) fn highlight_directive_conf_line(

--- a/src/preview/code/custom/ini.rs
+++ b/src/preview/code/custom/ini.rs
@@ -1,5 +1,5 @@
 use super::{split_unquoted_once, styled_text};
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{style::Modifier, text::Span};
 
 pub(super) fn highlight_ini_line(

--- a/src/preview/code/custom/logs.rs
+++ b/src/preview/code/custom/logs.rs
@@ -1,5 +1,5 @@
 use super::{looks_numeric, split_unquoted_once, styled_text};
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{style::Color, style::Modifier, text::Span};
 
 pub(super) fn highlight_log_line(

--- a/src/preview/code/custom/mod.rs
+++ b/src/preview/code/custom/mod.rs
@@ -3,7 +3,7 @@ mod directive;
 mod ini;
 mod logs;
 
-use crate::{file_info::CustomCodeKind, ui::theme};
+use crate::{file_info::CustomCodeKind, preview::appearance as theme};
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/preview/container/archive/render.rs
+++ b/src/preview/container/archive/render.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::text::Line;
 
 pub(super) fn render_archive_preview(config: ArchiveRenderConfig) -> PreviewContent {

--- a/src/preview/container/iso.rs
+++ b/src/preview/container/iso.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::text::Line;
 use std::{fs::File, io::Read, path::Path, process::Command};
 

--- a/src/preview/container/mod.rs
+++ b/src/preview/container/mod.rs
@@ -2,9 +2,8 @@ mod archive;
 mod iso;
 mod torrent;
 
-use super::*;
+use super::{appearance as theme, *};
 use crate::core::EntryKind;
-use crate::ui::theme;
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/preview/container/torrent.rs
+++ b/src/preview/container/torrent.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::text::Line;
 use std::{fs::File, io::Read, path::Path};
 

--- a/src/preview/data/mod.rs
+++ b/src/preview/data/mod.rs
@@ -2,7 +2,7 @@ mod csv;
 mod sqlite;
 
 use super::*;
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -1,7 +1,7 @@
-use super::*;
+use super::{appearance as theme, *};
 use crate::core::{Entry, FileClass};
+use crate::file_info;
 use crate::fs as browser_support;
-use crate::{file_info, ui::theme};
 use image::ImageReader;
 use ratatui::{
     style::Style,

--- a/src/preview/document/metadata.rs
+++ b/src/preview/document/metadata.rs
@@ -1,7 +1,6 @@
 use crate::{
     file_info::DocumentFormat,
-    preview::{PreviewContent, PreviewKind},
-    ui::theme,
+    preview::{PreviewContent, PreviewKind, appearance as theme},
 };
 use ratatui::{
     style::Style,

--- a/src/preview/markdown.rs
+++ b/src/preview/markdown.rs
@@ -1,5 +1,4 @@
-use super::*;
-use crate::ui::theme;
+use super::{appearance as theme, *};
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::{
     style::{Modifier, Style},

--- a/src/preview/structured/kv.rs
+++ b/src/preview/structured/kv.rs
@@ -1,5 +1,5 @@
 use super::{LINE_LIMIT, StructuredPreview, styled};
-use crate::{file_info::StructuredFormat, ui::theme};
+use crate::{file_info::StructuredFormat, preview::appearance as theme};
 use ratatui::{
     style::Modifier,
     text::{Line, Span},

--- a/src/preview/structured/logs/render.rs
+++ b/src/preview/structured/logs/render.rs
@@ -1,6 +1,6 @@
 use super::super::{LINE_LIMIT, StructuredPreview, styled};
 use super::types::{ParsedLogDocument, ParsedLogEntry};
-use crate::{file_info::StructuredFormat, ui::theme};
+use crate::{file_info::StructuredFormat, preview::appearance as theme};
 use ratatui::{
     style::Modifier,
     text::{Line, Span},

--- a/src/preview/structured/tree.rs
+++ b/src/preview/structured/tree.rs
@@ -1,5 +1,5 @@
 use super::{LINE_LIMIT, StructuredPreview, styled};
-use crate::ui::theme;
+use crate::preview::appearance as theme;
 use ratatui::{
     style::Modifier,
     text::{Line, Span},

--- a/src/preview/tests/mod.rs
+++ b/src/preview/tests/mod.rs
@@ -1,5 +1,4 @@
-use super::*;
-use crate::ui::theme;
+use super::{appearance as theme, *};
 use image::ImageFormat;
 use ratatui::{style::Modifier, text::Line};
 #[cfg(unix)]

--- a/src/preview/text.rs
+++ b/src/preview/text.rs
@@ -1,5 +1,4 @@
-use super::*;
-use crate::ui::theme;
+use super::{appearance as theme, *};
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/preview/video.rs
+++ b/src/preview/video.rs
@@ -1,6 +1,8 @@
-use super::{PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout};
+use super::{
+    PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout,
+    appearance as theme,
+};
 use crate::core::Entry;
-use crate::ui::theme;
 use ratatui::{
     style::Style,
     text::{Line, Span},

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -6,8 +6,7 @@ use ratatui::style::Color;
 use std::path::Path;
 
 pub(crate) use self::appearance::{
-    CodePreviewPalette, Palette, code_preview_palette, initialize, palette, resolve_entry,
-    resolve_path,
+    Palette, code_preview_palette, initialize, palette, resolve_entry, resolve_path,
 };
 
 pub(super) fn mix_color(base: Color, tint: Color, tint_weight: u8) -> Color {


### PR DESCRIPTION
## Summary

- route preview theme access through `src/preview/appearance.rs`
- replace direct `crate::ui::theme` imports across preview modules with the preview-owned appearance contract
- narrow `ui::theme` re-exports now that preview no longer imports it directly

## Why

This completes the preview/theme migration started by the appearance-contract PR.

Before this change, preview rendering still imported `ui::theme` directly from many modules. That made `preview` depend on UI internals instead of going through its own seam. With this refactor, preview now depends on a single preview-owned contract in `src/preview/appearance.rs`, which gives the crate a cleaner dependency direction and makes later preview work easier to isolate.

This is a structural refactor only. Behavior is unchanged.

## Testing

**Verified with:**

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

**Result:**

- **All checks passed; behavior remains unchanged.**