### PR TITLE
refactor(app): split app state into substates

### DIFF
--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -8,22 +8,22 @@ impl App {
     }
 
     pub(crate) fn process_sidebar_refresh(&mut self) -> bool {
-        if self.last_sidebar_refresh_at.elapsed() < SIDEBAR_REFRESH_INTERVAL {
+        if self.navigation.last_sidebar_refresh_at.elapsed() < SIDEBAR_REFRESH_INTERVAL {
             return false;
         }
-        self.last_sidebar_refresh_at = Instant::now();
+        self.navigation.last_sidebar_refresh_at = Instant::now();
 
         let sidebar = crate::fs::build_sidebar_rows();
-        if sidebar == self.sidebar {
+        if sidebar == self.navigation.sidebar {
             return false;
         }
 
-        self.sidebar = sidebar;
+        self.navigation.sidebar = sidebar;
         true
     }
 
     pub fn process_auto_reload(&mut self) -> Result<bool> {
-        while let Ok(event) = self.directory_runtime.watch_rx.try_recv() {
+        while let Ok(event) = self.navigation.directory_runtime.watch_rx.try_recv() {
             match event {
                 crate::fs::DirectoryWatchEvent::Changed(paths)
                     if !crate::fs::event_affects_visible_entries(
@@ -31,32 +31,43 @@ impl App {
                         self.effective_show_hidden(),
                     ) => {}
                 _ => {
-                    self.directory_runtime.pending_reload_at =
+                    self.navigation.directory_runtime.pending_reload_at =
                         Some(Instant::now() + crate::fs::directory_watch_debounce());
                 }
             }
         }
 
-        if let Some(deadline) = self.directory_runtime.pending_reload_at {
+        if let Some(deadline) = self.navigation.directory_runtime.pending_reload_at {
             if Instant::now() < deadline {
                 return Ok(false);
             }
-            self.directory_runtime.pending_reload_at = None;
+            self.navigation.directory_runtime.pending_reload_at = None;
             return self.reload_if_directory_changed();
         }
 
-        if !self.directory_runtime.use_polling_reload {
+        if !self.navigation.directory_runtime.use_polling_reload {
             return Ok(false);
         }
 
-        if self.directory_runtime.pending_fingerprint_scan.is_some() {
+        if self
+            .navigation
+            .directory_runtime
+            .pending_fingerprint_scan
+            .is_some()
+        {
             return Ok(false);
         }
 
-        if self.directory_runtime.last_auto_reload_at.elapsed() < AUTO_RELOAD_INTERVAL {
+        if self
+            .navigation
+            .directory_runtime
+            .last_auto_reload_at
+            .elapsed()
+            < AUTO_RELOAD_INTERVAL
+        {
             return Ok(false);
         }
-        self.directory_runtime.last_auto_reload_at = Instant::now();
+        self.navigation.directory_runtime.last_auto_reload_at = Instant::now();
         self.queue_directory_fingerprint_scan()
     }
 
@@ -64,27 +75,27 @@ impl App {
         &mut self,
         mut load: PendingDirectoryLoad,
     ) -> Result<()> {
-        self.directory_runtime.pending_fingerprint_scan = None;
-        self.directory_token = self.directory_token.wrapping_add(1);
-        load.token = self.directory_token;
+        self.navigation.directory_runtime.pending_fingerprint_scan = None;
+        self.jobs.directory_token = self.jobs.directory_token.wrapping_add(1);
+        load.token = self.jobs.directory_token;
         let request = jobs::DirectoryRequest {
             token: load.token,
             cwd: load.target_cwd.clone(),
             show_hidden: self.effective_show_hidden_for(&load.target_cwd),
-            sort_mode: self.sort_mode,
+            sort_mode: self.navigation.sort_mode,
         };
-        if !self.scheduler.submit_directory(request) {
+        if !self.jobs.scheduler.submit_directory(request) {
             bail!("Directory worker unavailable");
         }
-        self.directory_runtime.pending_load = Some(load);
+        self.navigation.directory_runtime.pending_load = Some(load);
         Ok(())
     }
 
     pub(in crate::app) fn queue_directory_reload(&mut self, refresh_search: bool) -> Result<()> {
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
-            target_cwd: self.cwd.clone(),
-            previous_cwd: self.cwd.clone(),
+            target_cwd: self.navigation.cwd.clone(),
+            previous_cwd: self.navigation.cwd.clone(),
             previous_selected_path: self.selected_entry().map(|entry| entry.path.clone()),
             previous_selection_name: self.selected_entry().map(|entry| entry.name.clone()),
             reselect_path: None,
@@ -99,19 +110,20 @@ impl App {
         load: PendingDirectoryLoad,
         snapshot: crate::fs::DirectorySnapshot,
     ) {
-        self.directory_runtime.pending_fingerprint_scan = None;
-        let cwd_changed = load.target_cwd != self.cwd;
+        self.navigation.directory_runtime.pending_fingerprint_scan = None;
+        let cwd_changed = load.target_cwd != self.navigation.cwd;
         let remembered_view = self.remembered_view_for(&load.target_cwd);
-        self.cwd = load.target_cwd.clone();
-        self.in_trash = Self::path_is_trash(&self.cwd);
-        self.entries = snapshot.entries;
-        self.sidebar = crate::fs::build_sidebar_rows();
-        self.last_sidebar_refresh_at = Instant::now();
-        self.directory_runtime.fingerprint = snapshot.fingerprint;
-        self.directory_runtime.last_auto_reload_at = Instant::now();
+        self.navigation.cwd = load.target_cwd.clone();
+        self.navigation.in_trash = Self::path_is_trash(&self.navigation.cwd);
+        self.navigation.entries = snapshot.entries;
+        self.navigation.sidebar = crate::fs::build_sidebar_rows();
+        self.navigation.last_sidebar_refresh_at = Instant::now();
+        self.navigation.directory_runtime.fingerprint = snapshot.fingerprint;
+        self.navigation.directory_runtime.last_auto_reload_at = Instant::now();
 
-        self.selected = if let Some(path) = &load.reselect_path {
-            self.entries
+        self.navigation.selected = if let Some(path) = &load.reselect_path {
+            self.navigation
+                .entries
                 .iter()
                 .position(|entry| entry.path == *path)
                 .unwrap_or(0)
@@ -119,21 +131,23 @@ impl App {
             .as_ref()
             .and_then(|view| view.selected_path.as_ref())
         {
-            self.entries
+            self.navigation
+                .entries
                 .iter()
                 .position(|entry| entry.path == *path)
                 .unwrap_or(0)
         } else if let Some(name) = &load.previous_selection_name {
-            self.entries
+            self.navigation
+                .entries
                 .iter()
                 .position(|entry| entry.name == *name)
                 .unwrap_or(0)
         } else {
             0
         };
-        self.scroll_row = remembered_view.map_or(0, |view| view.scroll_row);
-        self.last_selection_change_at = Instant::now();
-        self.image_preview.selection_activation_delay = std::time::Duration::ZERO;
+        self.navigation.scroll_row = remembered_view.map_or(0, |view| view.scroll_row);
+        self.input.last_selection_change_at = Instant::now();
+        self.preview.image.selection_activation_delay = std::time::Duration::ZERO;
         self.clamp_selection();
         self.sync_scroll();
         self.remember_current_directory_view();
@@ -141,33 +155,36 @@ impl App {
         self.clear_wheel_scroll();
 
         if cwd_changed {
-            self.selected_paths.clear();
+            self.navigation.selected_paths.clear();
             self.reset_directory_watch();
         }
 
         match load.history_mode {
             DirectoryHistoryMode::None => {}
             DirectoryHistoryMode::PushCurrent => {
-                self.navigation_history.back.push(HistoryEntry {
+                self.navigation.navigation_history.back.push(HistoryEntry {
                     cwd: load.previous_cwd,
                     selected_path: load.previous_selected_path,
                 });
-                self.navigation_history.forward.clear();
+                self.navigation.navigation_history.forward.clear();
             }
             DirectoryHistoryMode::GoBack => {
-                if !self.navigation_history.back.is_empty() {
-                    self.navigation_history.back.pop();
+                if !self.navigation.navigation_history.back.is_empty() {
+                    self.navigation.navigation_history.back.pop();
                 }
-                self.navigation_history.forward.push(HistoryEntry {
-                    cwd: load.previous_cwd,
-                    selected_path: load.previous_selected_path,
-                });
+                self.navigation
+                    .navigation_history
+                    .forward
+                    .push(HistoryEntry {
+                        cwd: load.previous_cwd,
+                        selected_path: load.previous_selected_path,
+                    });
             }
             DirectoryHistoryMode::GoForward => {
-                if !self.navigation_history.forward.is_empty() {
-                    self.navigation_history.forward.pop();
+                if !self.navigation.navigation_history.forward.is_empty() {
+                    self.navigation.navigation_history.forward.pop();
                 }
-                self.navigation_history.back.push(HistoryEntry {
+                self.navigation.navigation_history.back.push(HistoryEntry {
                     cwd: load.previous_cwd,
                     selected_path: load.previous_selected_path,
                 });
@@ -186,15 +203,15 @@ impl App {
     }
 
     fn remembered_view_for(&self, cwd: &Path) -> Option<DirectoryViewMemory> {
-        self.directory_view_memory.get(cwd).cloned()
+        self.navigation.directory_view_memory.get(cwd).cloned()
     }
 
     pub(in crate::app) fn remember_current_directory_view(&mut self) {
-        self.directory_view_memory.insert(
-            self.cwd.clone(),
+        self.navigation.directory_view_memory.insert(
+            self.navigation.cwd.clone(),
             DirectoryViewMemory {
                 selected_path: self.selected_entry().map(|entry| entry.path.clone()),
-                scroll_row: self.scroll_row,
+                scroll_row: self.navigation.scroll_row,
             },
         );
     }
@@ -226,23 +243,26 @@ impl App {
             bail!("{} is not a directory", path.display());
         }
         let normalized = path.canonicalize().unwrap_or(path);
-        if normalized == self.cwd && self.directory_runtime.pending_load.is_none() {
+        if normalized == self.navigation.cwd
+            && self.navigation.directory_runtime.pending_load.is_none()
+        {
             if let Some(path) = reselect_path.as_ref()
                 && self.reselect_visible_entry(path)
             {
                 self.apply_directory_completion(completion);
                 return Ok(());
             }
-            self.status = format!("Already in {}", self.cwd.display());
+            self.status = format!("Already in {}", self.navigation.cwd.display());
             return Ok(());
         }
         if self
+            .navigation
             .directory_runtime
             .pending_load
             .as_ref()
             .is_some_and(|load| load.target_cwd == normalized)
         {
-            if let Some(load) = self.directory_runtime.pending_load.as_mut() {
+            if let Some(load) = self.navigation.directory_runtime.pending_load.as_mut() {
                 if let Some(path) = reselect_path {
                     load.reselect_path = Some(path);
                 }
@@ -260,7 +280,7 @@ impl App {
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
             target_cwd: normalized,
-            previous_cwd: self.cwd.clone(),
+            previous_cwd: self.navigation.cwd.clone(),
             previous_selected_path: self.selected_entry().map(|entry| entry.path.clone()),
             previous_selection_name: None,
             reselect_path,
@@ -271,7 +291,12 @@ impl App {
     }
 
     fn reselect_visible_entry(&mut self, path: &Path) -> bool {
-        let Some(index) = self.entries.iter().position(|entry| entry.path == path) else {
+        let Some(index) = self
+            .navigation
+            .entries
+            .iter()
+            .position(|entry| entry.path == path)
+        else {
             return false;
         };
         self.set_selected(index);
@@ -288,8 +313,8 @@ impl App {
     }
 
     pub(in crate::app) fn go_parent(&mut self) -> Result<()> {
-        let current = self.cwd.clone();
-        let Some(parent) = self.cwd.parent() else {
+        let current = self.navigation.cwd.clone();
+        let Some(parent) = self.navigation.cwd.parent() else {
             self.status = "Already at filesystem root".to_string();
             return Ok(());
         };
@@ -302,33 +327,48 @@ impl App {
     }
 
     pub(in crate::app) fn reset_directory_watch(&mut self) {
-        self.directory_runtime.watch = None;
-        self.directory_runtime.pending_reload_at = None;
-        self.directory_runtime.pending_fingerprint_scan = None;
-        while self.directory_runtime.watch_rx.try_recv().is_ok() {}
+        self.navigation.directory_runtime.watch = None;
+        self.navigation.directory_runtime.pending_reload_at = None;
+        self.navigation.directory_runtime.pending_fingerprint_scan = None;
+        while self
+            .navigation
+            .directory_runtime
+            .watch_rx
+            .try_recv()
+            .is_ok()
+        {}
 
-        match crate::fs::start_directory_watcher(&self.cwd, &self.directory_runtime.watch_tx) {
+        match crate::fs::start_directory_watcher(
+            &self.navigation.cwd,
+            &self.navigation.directory_runtime.watch_tx,
+        ) {
             Ok(watcher) => {
-                self.directory_runtime.watch = Some(watcher);
-                self.directory_runtime.use_polling_reload = false;
+                self.navigation.directory_runtime.watch = Some(watcher);
+                self.navigation.directory_runtime.use_polling_reload = false;
             }
             Err(_) => {
-                self.directory_runtime.use_polling_reload = true;
+                self.navigation.directory_runtime.use_polling_reload = true;
             }
         }
     }
 
     fn reload_if_directory_changed(&mut self) -> Result<bool> {
-        if self.directory_runtime.pending_load.is_some()
-            || self.directory_runtime.pending_fingerprint_scan.is_some()
+        if self.navigation.directory_runtime.pending_load.is_some()
+            || self
+                .navigation
+                .directory_runtime
+                .pending_fingerprint_scan
+                .is_some()
         {
             return Ok(false);
         }
         let show_hidden = self.effective_show_hidden();
-        self.directory_fingerprint_token = self.directory_fingerprint_token.wrapping_add(1);
-        let token = self.directory_fingerprint_token;
-        let cwd = self.cwd.clone();
+        self.jobs.directory_fingerprint_token =
+            self.jobs.directory_fingerprint_token.wrapping_add(1);
+        let token = self.jobs.directory_fingerprint_token;
+        let cwd = self.navigation.cwd.clone();
         if !self
+            .jobs
             .scheduler
             .submit_directory_fingerprint(jobs::DirectoryFingerprintRequest {
                 token,
@@ -338,11 +378,12 @@ impl App {
         {
             return Ok(false);
         }
-        self.directory_runtime.pending_fingerprint_scan = Some(PendingDirectoryFingerprintScan {
-            token,
-            cwd,
-            show_hidden,
-        });
+        self.navigation.directory_runtime.pending_fingerprint_scan =
+            Some(PendingDirectoryFingerprintScan {
+                token,
+                cwd,
+                show_hidden,
+            });
         Ok(false)
     }
 
@@ -351,11 +392,11 @@ impl App {
     }
 
     fn refresh_search_after_directory_reload(&mut self) {
-        let Some(scope) = self.search.as_ref().map(|search| search.scope) else {
+        let Some(scope) = self.overlays.search.as_ref().map(|search| search.scope) else {
             return;
         };
 
-        if let Some(search) = &mut self.search {
+        if let Some(search) = &mut self.overlays.search {
             search.candidates = Arc::new(Vec::new());
             search.matches.clear();
             search.cached_matches = HashMap::from([(String::new(), Vec::new())]);

--- a/src/app/actions/goto.rs
+++ b/src/app/actions/goto.rs
@@ -9,25 +9,28 @@ use std::path::PathBuf;
 
 impl App {
     pub fn goto_is_open(&self) -> bool {
-        self.goto_overlay.is_some()
+        self.overlays.goto.is_some()
     }
 
     pub fn goto_title(&self) -> &str {
-        self.goto_overlay
+        self.overlays
+            .goto
             .as_ref()
             .map(|overlay| overlay.title.as_str())
             .unwrap_or("")
     }
 
     pub fn goto_row_count(&self) -> usize {
-        self.goto_overlay
+        self.overlays
+            .goto
             .as_ref()
             .map(|overlay| overlay.rows.len())
             .unwrap_or(0)
     }
 
     pub fn goto_row_label(&self, index: usize) -> &str {
-        self.goto_overlay
+        self.overlays
+            .goto
             .as_ref()
             .and_then(|overlay| overlay.rows.get(index))
             .map(|row| row.label.as_str())
@@ -35,7 +38,8 @@ impl App {
     }
 
     pub fn goto_row_shortcut(&self, index: usize) -> Option<char> {
-        self.goto_overlay
+        self.overlays
+            .goto
             .as_ref()
             .and_then(|overlay| overlay.rows.get(index))
             .map(|row| row.shortcut)
@@ -44,20 +48,20 @@ impl App {
 
 impl App {
     pub(in crate::app) fn open_goto_overlay(&mut self) {
-        self.help_open = false;
-        self.goto_overlay = Some(build_goto_overlay(self));
+        self.overlays.help = false;
+        self.overlays.goto = Some(build_goto_overlay(self));
         self.status.clear();
     }
 
     pub(in crate::app) fn handle_goto_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.goto_overlay = None;
+            self.overlays.goto = None;
             return Ok(());
         }
 
         match key.code {
             KeyCode::Esc => {
-                self.goto_overlay = None;
+                self.overlays.goto = None;
             }
             KeyCode::Char(ch)
                 if !key
@@ -77,15 +81,17 @@ impl App {
     pub(in crate::app) fn handle_goto_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
         if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
             let inside = self
+                .input
                 .frame_state
                 .goto_panel
                 .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
             if !inside {
-                self.goto_overlay = None;
+                self.overlays.goto = None;
                 return Ok(());
             }
 
             if let Some(hit) = self
+                .input
                 .frame_state
                 .goto_hits
                 .iter()
@@ -101,7 +107,7 @@ impl App {
 
     fn goto_row_index_for_shortcut(&self, ch: char) -> Option<usize> {
         let needle = ch.to_ascii_lowercase();
-        self.goto_overlay.as_ref().and_then(|overlay| {
+        self.overlays.goto.as_ref().and_then(|overlay| {
             overlay
                 .rows
                 .iter()
@@ -111,7 +117,8 @@ impl App {
 
     fn confirm_goto_index(&mut self, index: usize) -> Result<()> {
         let Some(destination) = self
-            .goto_overlay
+            .overlays
+            .goto
             .as_ref()
             .and_then(|overlay| overlay.rows.get(index).map(|row| row.destination.clone()))
         else {
@@ -120,11 +127,11 @@ impl App {
 
         match destination {
             GoToDestination::Top => {
-                self.goto_overlay = None;
+                self.overlays.goto = None;
                 self.select_index(0);
             }
             GoToDestination::Path(path) => {
-                self.goto_overlay = None;
+                self.overlays.goto = None;
                 self.set_dir(path)?;
             }
             GoToDestination::Missing(status) => {
@@ -196,7 +203,8 @@ fn config_label() -> &'static str {
 }
 
 fn downloads_destination(app: &App) -> Option<PathBuf> {
-    app.sidebar
+    app.navigation
+        .sidebar
         .iter()
         .filter_map(|row| row.item())
         .find(|item| item.kind == SidebarItemKind::Downloads)
@@ -216,7 +224,8 @@ fn config_directory() -> Option<PathBuf> {
 }
 
 fn trash_destination(app: &App) -> Option<PathBuf> {
-    app.sidebar
+    app.navigation
+        .sidebar
         .iter()
         .filter_map(|row| row.item())
         .find(|item| item.kind == SidebarItemKind::Trash)

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -10,13 +10,13 @@ impl App {
                 let suffix = if entry.is_dir() { "/" } else { "" };
                 format!(
                     "{}/{}  {}{}",
-                    self.selected.saturating_add(1),
-                    self.entries.len(),
+                    self.navigation.selected.saturating_add(1),
+                    self.navigation.entries.len(),
                     entry.name,
                     suffix,
                 )
             }
-            None => format!("0/0  {}", self.cwd.display()),
+            None => format!("0/0  {}", self.navigation.cwd.display()),
         }
     }
 
@@ -32,15 +32,15 @@ impl App {
 
     pub(in crate::app) fn toggle_view_mode(&mut self) {
         self.clear_wheel_scroll();
-        self.view_mode = self.view_mode.toggle();
+        self.navigation.view_mode = self.navigation.view_mode.toggle();
         self.sync_scroll();
-        self.status = format!("Switched to {} view", self.view_mode.label());
+        self.status = format!("Switched to {} view", self.navigation.view_mode.label());
     }
 
     pub(in crate::app) fn cycle_sort_mode(&mut self) -> Result<()> {
-        self.sort_mode = self.sort_mode.cycle();
+        self.navigation.sort_mode = self.navigation.sort_mode.cycle();
         self.reload()?;
-        self.status = format!("Sort: {}", self.sort_mode.label());
+        self.status = format!("Sort: {}", self.navigation.sort_mode.label());
         Ok(())
     }
 
@@ -49,9 +49,9 @@ impl App {
             self.status = "Trash shows all files".to_string();
             return Ok(());
         }
-        self.show_hidden = !self.show_hidden;
+        self.navigation.show_hidden = !self.navigation.show_hidden;
         self.reload()?;
-        self.status = if self.show_hidden {
+        self.status = if self.navigation.show_hidden {
             "Hidden files shown".to_string()
         } else {
             "Hidden files hidden".to_string()
@@ -60,11 +60,11 @@ impl App {
     }
 
     pub fn can_go_back(&self) -> bool {
-        !self.navigation_history.back.is_empty()
+        !self.navigation.navigation_history.back.is_empty()
     }
 
     pub fn can_go_forward(&self) -> bool {
-        !self.navigation_history.forward.is_empty()
+        !self.navigation.navigation_history.forward.is_empty()
     }
 
     pub(in crate::app) fn set_selected(&mut self, index: usize) {
@@ -72,27 +72,27 @@ impl App {
     }
 
     fn set_selected_with_preview_mode(&mut self, index: usize, preview_mode: PreviewRefreshMode) {
-        let next = index.min(self.entries.len().saturating_sub(1));
-        if next != self.selected {
+        let next = index.min(self.navigation.entries.len().saturating_sub(1));
+        if next != self.navigation.selected {
             let preview_mode =
                 self.effective_preview_refresh_mode_for_selection(next, preview_mode);
-            self.selected = next;
-            self.last_selection_change_at = Instant::now();
-            self.image_preview.selection_activation_delay = match preview_mode {
+            self.navigation.selected = next;
+            self.input.last_selection_change_at = Instant::now();
+            self.preview.image.selection_activation_delay = match preview_mode {
                 PreviewRefreshMode::Immediate => std::time::Duration::ZERO,
                 PreviewRefreshMode::Deferred => IMAGE_SELECTION_ACTIVATION_DELAY,
             };
             match preview_mode {
                 PreviewRefreshMode::Immediate => self.refresh_preview(),
                 PreviewRefreshMode::Deferred => {
-                    self.preview_state.directory_stats = None;
-                    self.scheduler.cancel_directory_stats();
-                    self.preview_state.deferred_refresh_at =
+                    self.preview.state.directory_stats = None;
+                    self.jobs.scheduler.cancel_directory_stats();
+                    self.preview.state.deferred_refresh_at =
                         Some(Instant::now() + HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY);
                 }
             }
         } else {
-            self.selected = next;
+            self.navigation.selected = next;
         }
         self.sync_scroll();
         if matches!(preview_mode, PreviewRefreshMode::Deferred) {
@@ -109,7 +109,7 @@ impl App {
         if preview_mode != PreviewRefreshMode::Immediate {
             return preview_mode;
         }
-        let Some(entry) = self.entries.get(index) else {
+        let Some(entry) = self.navigation.entries.get(index) else {
             return preview_mode;
         };
         let variant = self.preview_request_options_for_entry(entry);
@@ -132,7 +132,7 @@ impl App {
     /// sustained movement defers the preview until motion pauses.
     fn rapid_nav_preview_mode(&self, mode: PreviewRefreshMode) -> PreviewRefreshMode {
         if mode == PreviewRefreshMode::Immediate
-            && self.last_key_nav_at.elapsed() < KEY_NAV_RAPID_THRESHOLD
+            && self.input.last_key_nav_at.elapsed() < KEY_NAV_RAPID_THRESHOLD
         {
             PreviewRefreshMode::Deferred
         } else {
@@ -141,8 +141,8 @@ impl App {
     }
 
     pub(in crate::app) fn set_selected_last(&mut self) {
-        if !self.entries.is_empty() {
-            let last = self.entries.len() - 1;
+        if !self.navigation.entries.is_empty() {
+            let last = self.navigation.entries.len() - 1;
             self.set_selected(last);
         }
     }
@@ -156,51 +156,51 @@ impl App {
         delta: isize,
         preview_mode: PreviewRefreshMode,
     ) {
-        if self.entries.is_empty() {
-            self.selected = 0;
-            self.preview_state.content = PreviewContent::placeholder("No selection");
-            self.preview_state.directory_stats = None;
-            self.scheduler.cancel_directory_stats();
-            self.preview_state.deferred_refresh_at = None;
+        if self.navigation.entries.is_empty() {
+            self.navigation.selected = 0;
+            self.preview.state.content = PreviewContent::placeholder("No selection");
+            self.preview.state.directory_stats = None;
+            self.jobs.scheduler.cancel_directory_stats();
+            self.preview.state.deferred_refresh_at = None;
             return;
         }
 
-        let max_index = self.entries.len().saturating_sub(1) as isize;
-        let next = (self.selected as isize + delta).clamp(0, max_index) as usize;
+        let max_index = self.navigation.entries.len().saturating_sub(1) as isize;
+        let next = (self.navigation.selected as isize + delta).clamp(0, max_index) as usize;
         self.set_selected_with_preview_mode(next, preview_mode);
     }
 
     pub(in crate::app) fn page(&mut self, direction: isize) {
-        let rows = self.frame_state.metrics.rows_visible.max(1) as isize;
+        let rows = self.input.frame_state.metrics.rows_visible.max(1) as isize;
         let mode = self.rapid_nav_preview_mode(PreviewRefreshMode::Immediate);
-        let prev = self.selected;
-        if self.view_mode == ViewMode::Grid {
+        let prev = self.navigation.selected;
+        if self.navigation.view_mode == ViewMode::Grid {
             self.move_grid_vertical_with_preview_mode(direction * rows, mode);
         } else {
             self.set_selected_delta_with_preview_mode(direction * rows, mode);
         }
-        if self.selected != prev {
-            self.last_key_nav_at = Instant::now();
+        if self.navigation.selected != prev {
+            self.input.last_key_nav_at = Instant::now();
         }
     }
 
     /// Keyboard-only: applies rapid-nav deferred preview for Up/Down/j/k, then moves.
     pub(in crate::app) fn move_vertical_keyboard(&mut self, rows: isize) {
         let mode = self.rapid_nav_preview_mode(PreviewRefreshMode::Immediate);
-        let prev = self.selected;
+        let prev = self.navigation.selected;
         self.move_vertical_with_preview_mode(rows, mode);
-        if self.selected != prev {
-            self.last_key_nav_at = Instant::now();
+        if self.navigation.selected != prev {
+            self.input.last_key_nav_at = Instant::now();
         }
     }
 
     /// Keyboard-only: applies rapid-nav deferred preview for grid h/l navigation, then moves.
     pub(in crate::app) fn move_by_keyboard(&mut self, delta: isize) {
         let mode = self.rapid_nav_preview_mode(PreviewRefreshMode::Immediate);
-        let prev = self.selected;
+        let prev = self.navigation.selected;
         self.set_selected_delta_with_preview_mode(delta, mode);
-        if self.selected != prev {
-            self.last_key_nav_at = Instant::now();
+        if self.navigation.selected != prev {
+            self.input.last_key_nav_at = Instant::now();
         }
     }
 
@@ -213,7 +213,7 @@ impl App {
         rows: isize,
         preview_mode: PreviewRefreshMode,
     ) {
-        if self.view_mode == ViewMode::Grid {
+        if self.navigation.view_mode == ViewMode::Grid {
             self.move_grid_vertical_with_preview_mode(rows, preview_mode);
         } else {
             self.set_selected_delta_with_preview_mode(rows, preview_mode);
@@ -229,15 +229,15 @@ impl App {
         rows: isize,
         preview_mode: PreviewRefreshMode,
     ) {
-        if self.entries.is_empty() {
-            self.selected = 0;
+        if self.navigation.entries.is_empty() {
+            self.navigation.selected = 0;
             return;
         }
 
-        let cols = self.frame_state.metrics.cols.max(1);
-        let current_row = self.selected / cols;
-        let current_col = self.selected % cols;
-        let total_rows = self.entries.len().div_ceil(cols);
+        let cols = self.input.frame_state.metrics.cols.max(1);
+        let current_row = self.navigation.selected / cols;
+        let current_col = self.navigation.selected % cols;
+        let total_rows = self.navigation.entries.len().div_ceil(cols);
         let target_row = current_row as isize + rows;
 
         if target_row < 0 || target_row >= total_rows as isize {
@@ -245,7 +245,7 @@ impl App {
         }
 
         let target_index = target_row as usize * cols + current_col;
-        if target_index >= self.entries.len() {
+        if target_index >= self.navigation.entries.len() {
             return;
         }
 
@@ -253,13 +253,13 @@ impl App {
     }
 
     pub(in crate::app) fn adjust_zoom(&mut self, delta: i8) {
-        let next = (self.zoom_level as i8 + delta).clamp(0, 2) as u8;
-        if next == self.zoom_level {
-            self.status = format!("Grid zoom limit: {}", self.zoom_level);
+        let next = (self.navigation.zoom_level as i8 + delta).clamp(0, 2) as u8;
+        if next == self.navigation.zoom_level {
+            self.status = format!("Grid zoom limit: {}", self.navigation.zoom_level);
             return;
         }
-        self.zoom_level = next;
-        self.status = format!("Grid zoom set to {}", self.zoom_level);
+        self.navigation.zoom_level = next;
+        self.status = format!("Grid zoom set to {}", self.navigation.zoom_level);
         self.sync_scroll();
     }
 
@@ -272,52 +272,53 @@ impl App {
     }
 
     pub(in crate::app) fn clamp_selection(&mut self) {
-        if self.entries.is_empty() {
-            self.selected = 0;
-            self.scroll_row = 0;
-            self.preview_state.content = PreviewContent::placeholder("No selection");
-            self.preview_state.directory_stats = None;
-            self.scheduler.cancel_directory_stats();
-            self.preview_state.scroll = 0;
-            self.preview_state.horizontal_scroll = 0;
-        } else if self.selected >= self.entries.len() {
-            self.selected = self.entries.len() - 1;
+        if self.navigation.entries.is_empty() {
+            self.navigation.selected = 0;
+            self.navigation.scroll_row = 0;
+            self.preview.state.content = PreviewContent::placeholder("No selection");
+            self.preview.state.directory_stats = None;
+            self.jobs.scheduler.cancel_directory_stats();
+            self.preview.state.scroll = 0;
+            self.preview.state.horizontal_scroll = 0;
+        } else if self.navigation.selected >= self.navigation.entries.len() {
+            self.navigation.selected = self.navigation.entries.len() - 1;
         }
         self.sync_preview_scroll();
     }
 
     pub(in crate::app) fn sync_scroll(&mut self) -> bool {
-        let previous = self.scroll_row;
-        if self.entries.is_empty() {
-            self.scroll_row = 0;
-            return previous != self.scroll_row;
+        let previous = self.navigation.scroll_row;
+        if self.navigation.entries.is_empty() {
+            self.navigation.scroll_row = 0;
+            return previous != self.navigation.scroll_row;
         }
 
-        let cols = self.frame_state.metrics.cols.max(1);
-        let rows_visible = self.frame_state.metrics.rows_visible.max(1);
-        let selected_row = self.selected / cols;
-        if selected_row < self.scroll_row {
-            self.scroll_row = selected_row;
-        } else if selected_row >= self.scroll_row + rows_visible {
-            self.scroll_row = selected_row + 1 - rows_visible;
+        let cols = self.input.frame_state.metrics.cols.max(1);
+        let rows_visible = self.input.frame_state.metrics.rows_visible.max(1);
+        let selected_row = self.navigation.selected / cols;
+        if selected_row < self.navigation.scroll_row {
+            self.navigation.scroll_row = selected_row;
+        } else if selected_row >= self.navigation.scroll_row + rows_visible {
+            self.navigation.scroll_row = selected_row + 1 - rows_visible;
         }
-        self.scroll_row = self.scroll_row.min(self.max_scroll_row());
-        previous != self.scroll_row
+        self.navigation.scroll_row = self.navigation.scroll_row.min(self.max_scroll_row());
+        previous != self.navigation.scroll_row
     }
 
     fn max_scroll_row(&self) -> usize {
-        if self.entries.is_empty() {
+        if self.navigation.entries.is_empty() {
             return 0;
         }
 
-        let cols = self.frame_state.metrics.cols.max(1);
-        let rows_visible = self.frame_state.metrics.rows_visible.max(1);
-        let total_rows = self.entries.len().div_ceil(cols);
+        let cols = self.input.frame_state.metrics.cols.max(1);
+        let rows_visible = self.input.frame_state.metrics.rows_visible.max(1);
+        let total_rows = self.navigation.entries.len().div_ceil(cols);
         total_rows.saturating_sub(rows_visible)
     }
 
     pub(in crate::app) fn step_sidebar_place(&mut self, delta: isize) -> Result<()> {
         let places = self
+            .navigation
             .sidebar
             .iter()
             .filter_map(|row| row.item())
@@ -326,7 +327,9 @@ impl App {
             return Ok(());
         }
 
-        let current = places.iter().position(|item| item.path == self.cwd);
+        let current = places
+            .iter()
+            .position(|item| item.path == self.navigation.cwd);
         let next = if delta >= 0 {
             current.map(|index| (index + 1) % places.len()).unwrap_or(0)
         } else {
@@ -345,20 +348,22 @@ impl App {
     }
 
     pub(in crate::app) fn go_back(&mut self) -> Result<()> {
-        let Some(previous) = self.navigation_history.back.last().cloned() else {
+        let Some(previous) = self.navigation.navigation_history.back.last().cloned() else {
             self.status = "No previous folder".to_string();
             return Ok(());
         };
         self.set_dir_transition(
             previous.cwd,
             DirectoryHistoryMode::GoBack,
-            previous.selected_path.or_else(|| Some(self.cwd.clone())),
+            previous
+                .selected_path
+                .or_else(|| Some(self.navigation.cwd.clone())),
             DirectoryLoadCompletion::Clear,
         )
     }
 
     pub(in crate::app) fn go_forward(&mut self) -> Result<()> {
-        let Some(next) = self.navigation_history.forward.last().cloned() else {
+        let Some(next) = self.navigation.navigation_history.forward.last().cloned() else {
             self.status = "No next folder".to_string();
             return Ok(());
         };

--- a/src/app/actions/preview/access.rs
+++ b/src/app/actions/preview/access.rs
@@ -3,42 +3,43 @@ use std::sync::Arc;
 
 impl App {
     pub fn preview_lines(&self) -> Vec<Line<'static>> {
-        self.preview_state.content.lines()
+        self.preview.state.content.lines()
     }
 
     pub fn preview_wrapped_lines(&self, visible_cols: usize) -> Arc<[Line<'static>]> {
-        self.preview_state.content.wrapped_lines(visible_cols)
+        self.preview.state.content.wrapped_lines(visible_cols)
     }
 
     pub fn preview_section_label(&self) -> &'static str {
-        self.preview_state.content.section_label()
+        self.preview.state.content.section_label()
     }
 
     pub fn preview_scroll_offset(&self) -> usize {
-        self.preview_state.scroll
+        self.preview.state.scroll
     }
 
     pub fn preview_horizontal_scroll_offset(&self) -> usize {
-        self.preview_state.horizontal_scroll
+        self.preview.state.horizontal_scroll
     }
 
     pub fn preview_total_lines(&self, visible_cols: usize) -> usize {
-        self.preview_state.content.visual_line_count(visible_cols)
+        self.preview.state.content.visual_line_count(visible_cols)
     }
 
     pub fn preview_wraps(&self) -> bool {
-        self.preview_state.content.kind.wraps_in_preview()
+        self.preview.state.content.kind.wraps_in_preview()
     }
 
     pub fn preview_allows_horizontal_scroll(&self) -> bool {
-        self.preview_state.content.kind.allows_horizontal_scroll()
+        self.preview.state.content.kind.allows_horizontal_scroll()
     }
 
     pub fn preview_max_horizontal_scroll(&self, visible_cols: usize) -> usize {
         if !self.preview_allows_horizontal_scroll() {
             return 0;
         }
-        self.preview_state
+        self.preview
+            .state
             .content
             .wrapped_max_line_width(visible_cols)
             .saturating_sub(visible_cols.max(1))
@@ -46,14 +47,16 @@ impl App {
 
     #[cfg(test)]
     pub fn preview_header_detail(&self, visible_rows: usize) -> Option<String> {
-        let visible_cols = self.frame_state.preview_cols_visible;
+        let visible_cols = self.input.frame_state.preview_cols_visible;
         let detail = self
-            .preview_state
+            .preview
+            .state
             .content
-            .header_detail(self.preview_state.scroll, visible_rows);
+            .header_detail(self.preview.state.scroll, visible_rows);
         let wrapped_note =
-            if self.preview_state.content.truncation_note.is_none() && visible_cols > 0 {
-                self.preview_state
+            if self.preview.state.content.truncation_note.is_none() && visible_cols > 0 {
+                self.preview
+                    .state
                     .content
                     .wrapped_truncation_note(visible_cols)
             } else {
@@ -66,7 +69,7 @@ impl App {
             (None, Some(note)) => Some(note),
             (None, None) => None,
         };
-        if let Some(navigation_detail) = self.preview_state.content.navigation_header_detail() {
+        if let Some(navigation_detail) = self.preview.state.content.navigation_header_detail() {
             detail = Some(match detail {
                 Some(detail) if !detail.is_empty() => format!("{detail}  •  {navigation_detail}"),
                 _ => navigation_detail,

--- a/src/app/actions/preview/cache.rs
+++ b/src/app/actions/preview/cache.rs
@@ -18,7 +18,7 @@ impl App {
             code_line_limit,
             code_render_limit: code_line_limit,
         };
-        if let Some(cached) = self.preview_state.result_cache.get(&complete_key)
+        if let Some(cached) = self.preview.state.result_cache.get(&complete_key)
             && cached.size == entry.size
             && cached.modified == entry.modified
         {
@@ -33,7 +33,8 @@ impl App {
             code_render_limit: 0, // placeholder — will search by prefix below
         };
         let _ = partial_key; // not used directly; iterate instead
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .iter()
             .find(|(key, cached)| {
@@ -60,12 +61,13 @@ impl App {
             code_line_limit,
             code_render_limit: code_line_limit,
         };
-        if let Some(cached) = self.preview_state.result_cache.get(&complete_key) {
+        if let Some(cached) = self.preview.state.result_cache.get(&complete_key) {
             return Some(cached.preview.clone());
         }
 
         // Fall back to any matching partial.
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .iter()
             .find(|(key, _)| {
@@ -127,7 +129,7 @@ impl App {
             code_line_limit,
             code_render_limit,
         };
-        self.preview_state.result_cache.insert(
+        self.preview.state.result_cache.insert(
             key.clone(),
             CachedPreview {
                 size: entry.size,
@@ -135,14 +137,15 @@ impl App {
                 preview: preview.clone(),
             },
         );
-        self.preview_state
+        self.preview
+            .state
             .result_order
             .retain(|cached| cached != &key);
-        self.preview_state.result_order.push_back(key);
+        self.preview.state.result_order.push_back(key);
 
-        while self.preview_state.result_order.len() > PREVIEW_CACHE_LIMIT {
-            if let Some(stale_key) = self.preview_state.result_order.pop_front() {
-                self.preview_state.result_cache.remove(&stale_key);
+        while self.preview.state.result_order.len() > PREVIEW_CACHE_LIMIT {
+            if let Some(stale_key) = self.preview.state.result_order.pop_front() {
+                self.preview.state.result_cache.remove(&stale_key);
             }
         }
     }
@@ -159,24 +162,27 @@ impl App {
             size,
             modified,
         };
-        self.preview_state
+        self.preview
+            .state
             .line_count_cache
             .insert(key.clone(), total_lines.max(1));
-        self.preview_state
+        self.preview
+            .state
             .line_count_order
             .retain(|cached| cached != &key);
-        self.preview_state.line_count_order.push_back(key);
+        self.preview.state.line_count_order.push_back(key);
 
-        while self.preview_state.line_count_order.len() > PREVIEW_LINE_COUNT_CACHE_LIMIT {
-            if let Some(stale_key) = self.preview_state.line_count_order.pop_front() {
-                self.preview_state.line_count_cache.remove(&stale_key);
+        while self.preview.state.line_count_order.len() > PREVIEW_LINE_COUNT_CACHE_LIMIT {
+            if let Some(stale_key) = self.preview.state.line_count_order.pop_front() {
+                self.preview.state.line_count_cache.remove(&stale_key);
             }
         }
     }
 
     #[cfg(test)]
     pub(in crate::app) fn has_cached_preview_for_path(&self, path: &std::path::Path) -> bool {
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .keys()
             .any(|key| key.path == path)

--- a/src/app/actions/preview/headers.rs
+++ b/src/app/actions/preview/headers.rs
@@ -48,7 +48,7 @@ impl PreviewHeaderSegment {
 impl App {
     pub(super) fn preview_header_segments(&self, visible_rows: usize) -> Vec<PreviewHeaderSegment> {
         let mut segments = Vec::new();
-        let content = &self.preview_state.content;
+        let content = &self.preview.state.content;
         let directory_stats_detail = self.preview_directory_stats_header_detail();
         let directory_stats_note = self.preview_directory_stats_status_note();
 
@@ -154,8 +154,8 @@ impl App {
             } else if !has_primary_parts && content.kind != PreviewKind::Directory {
                 let rendered_total = content.total_lines();
                 if rendered_total > 0 {
-                    let start = self.preview_state.scroll.saturating_add(1);
-                    let end = (self.preview_state.scroll + visible_rows.max(1)).min(rendered_total);
+                    let start = self.preview.state.scroll.saturating_add(1);
+                    let end = (self.preview.state.scroll + visible_rows.max(1)).min(rendered_total);
                     let range = if rendered_total > visible_rows.max(1) {
                         format!("{start}-{end} / {rendered_total}")
                     } else {
@@ -181,12 +181,13 @@ impl App {
         }
 
         if content.line_coverage.is_none() {
-            let wrapped_note =
-                if content.truncation_note.is_none() && self.frame_state.preview_cols_visible > 0 {
-                    content.wrapped_truncation_note(self.frame_state.preview_cols_visible)
-                } else {
-                    None
-                };
+            let wrapped_note = if content.truncation_note.is_none()
+                && self.input.frame_state.preview_cols_visible > 0
+            {
+                content.wrapped_truncation_note(self.input.frame_state.preview_cols_visible)
+            } else {
+                None
+            };
 
             if let Some(note) = content
                 .truncation_note
@@ -224,12 +225,12 @@ impl App {
     }
 
     fn preview_directory_stats_header_detail(&self) -> Option<(String, Option<String>)> {
-        if self.preview_state.content.kind != PreviewKind::Directory
-            || self.preview_state.load_state.is_some()
+        if self.preview.state.content.kind != PreviewKind::Directory
+            || self.preview.state.load_state.is_some()
         {
             return None;
         }
-        match self.preview_state.directory_stats.as_ref()? {
+        match self.preview.state.directory_stats.as_ref()? {
             PreviewDirectoryStatsState::Loading { .. } => None,
             PreviewDirectoryStatsState::Complete { stats, .. } => {
                 let size = format_size(stats.total_size_bytes);
@@ -258,12 +259,12 @@ impl App {
     }
 
     fn preview_directory_stats_status_note(&self) -> Option<(String, Option<String>)> {
-        if self.preview_state.content.kind != PreviewKind::Directory
-            || self.preview_state.load_state.is_some()
+        if self.preview.state.content.kind != PreviewKind::Directory
+            || self.preview.state.load_state.is_some()
         {
             return None;
         }
-        match self.preview_state.directory_stats.as_ref()? {
+        match self.preview.state.directory_stats.as_ref()? {
             PreviewDirectoryStatsState::Loading { .. } => None,
             PreviewDirectoryStatsState::Complete { .. } => None,
             PreviewDirectoryStatsState::Incomplete { error, .. } => {

--- a/src/app/actions/preview/mod.rs
+++ b/src/app/actions/preview/mod.rs
@@ -43,12 +43,12 @@ mod tests {
         let preview = PreviewContent::new(PreviewKind::Code, vec![Line::from("stale preview")])
             .with_detail("Rust source file");
         app.cache_preview_result(&entry, &variant, &preview);
-        app.entries[app.selected].size += 1;
+        app.navigation.entries[app.navigation.selected].size += 1;
 
         app.refresh_preview();
 
         assert_eq!(
-            app.preview_state.load_state,
+            app.preview.state.load_state,
             Some(PreviewLoadState::Refreshing(entry.path.clone()))
         );
         assert_eq!(
@@ -92,7 +92,7 @@ mod tests {
             app.cache_preview_result_with_code_line_limit(&entry, &variant, 0, &preview);
         }
 
-        assert_eq!(app.preview_state.result_cache.len(), PREVIEW_CACHE_LIMIT);
+        assert_eq!(app.preview.state.result_cache.len(), PREVIEW_CACHE_LIMIT);
         assert!(!app.has_cached_preview_for_path(&oldest_path));
         assert!(app.has_cached_preview_for_path(&newest_path));
 
@@ -116,11 +116,11 @@ mod tests {
             size: entry.size,
             modified: entry.modified,
         };
-        app.preview_state.content =
+        app.preview.state.content =
             PreviewContent::new(PreviewKind::Code, vec![Line::from("fn main() {}")])
                 .with_line_coverage(default_code_preview_line_limit(), None, true);
-        app.preview_state.content.set_total_line_count_pending(true);
-        app.preview_state.pending_line_counts.insert(key.clone());
+        app.preview.state.content.set_total_line_count_pending(true);
+        app.preview.state.pending_line_counts.insert(key.clone());
 
         assert!(app.apply_preview_line_count_result(
             &entry.path,
@@ -128,7 +128,7 @@ mod tests {
             entry.modified,
             Some(1_500)
         ));
-        assert!(!app.preview_state.pending_line_counts.contains(&key));
+        assert!(!app.preview.state.pending_line_counts.contains(&key));
         let expected = format!("{} / 1,500 lines shown", default_code_preview_line_limit());
         assert_eq!(
             app.preview_header_detail_for_width(8, 40).as_deref(),
@@ -155,14 +155,14 @@ mod tests {
             size: entry.size,
             modified: entry.modified,
         };
-        app.preview_state.content =
+        app.preview.state.content =
             PreviewContent::new(PreviewKind::Code, vec![Line::from("fn main() {}")])
                 .with_line_coverage(default_code_preview_line_limit(), None, true);
-        app.preview_state.content.set_total_line_count_pending(true);
-        app.preview_state.pending_line_counts.insert(key.clone());
+        app.preview.state.content.set_total_line_count_pending(true);
+        app.preview.state.pending_line_counts.insert(key.clone());
 
         assert!(app.apply_preview_line_count_result(&entry.path, entry.size, entry.modified, None));
-        assert!(!app.preview_state.pending_line_counts.contains(&key));
+        assert!(!app.preview.state.pending_line_counts.contains(&key));
         let expected = format!("{} lines shown", default_code_preview_line_limit());
         assert_eq!(
             app.preview_header_detail_for_width(8, 40).as_deref(),
@@ -199,11 +199,11 @@ mod tests {
         }
 
         assert_eq!(
-            app.preview_state.line_count_cache.len(),
+            app.preview.state.line_count_cache.len(),
             PREVIEW_LINE_COUNT_CACHE_LIMIT
         );
-        assert!(!app.preview_state.line_count_cache.contains_key(&oldest_key));
-        assert!(app.preview_state.line_count_cache.contains_key(&newest_key));
+        assert!(!app.preview.state.line_count_cache.contains_key(&oldest_key));
+        assert!(app.preview.state.line_count_cache.contains_key(&newest_key));
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/app/actions/preview/prefetch.rs
+++ b/src/app/actions/preview/prefetch.rs
@@ -7,17 +7,17 @@ const AUDIO_ENTRY_PREFETCH_OFFSETS: [isize; 4] = [1, -1, 2, -2];
 
 impl App {
     pub(crate) fn process_preview_prefetch_timers(&mut self) -> bool {
-        let Some(deadline) = self.preview_state.prefetch_ready_at else {
+        let Some(deadline) = self.preview.state.prefetch_ready_at else {
             return false;
         };
         if Instant::now() < deadline
-            || self.preview_state.deferred_refresh_at.is_some()
+            || self.preview.state.deferred_refresh_at.is_some()
             || self.browser_wheel_burst_active()
         {
             return false;
         }
 
-        self.preview_state.prefetch_ready_at = None;
+        self.preview.state.prefetch_ready_at = None;
         self.prefetch_nearby_comic_pages();
         self.prefetch_nearby_comic_entries();
         self.prefetch_nearby_epub_sections();
@@ -27,13 +27,14 @@ impl App {
     }
 
     pub(crate) fn pending_preview_prefetch_timer(&self) -> Option<std::time::Duration> {
-        self.preview_state
+        self.preview
+            .state
             .prefetch_ready_at
             .map(|deadline| deadline.saturating_duration_since(Instant::now()))
     }
 
     pub(in crate::app) fn schedule_preview_prefetch(&mut self) {
-        self.preview_state.prefetch_ready_at = self
+        self.preview.state.prefetch_ready_at = self
             .selected_entry()
             .map(|_| Instant::now() + PREVIEW_PREFETCH_IDLE_DELAY);
     }
@@ -45,11 +46,11 @@ impl App {
                 break;
             }
 
-            let target = self.selected as isize + offset;
+            let target = self.navigation.selected as isize + offset;
             if target < 0 {
                 continue;
             }
-            let Some(entry) = self.entries.get(target as usize).cloned() else {
+            let Some(entry) = self.navigation.entries.get(target as usize).cloned() else {
                 continue;
             };
             let variant = self.preview_request_options_for_entry(&entry);
@@ -67,7 +68,7 @@ impl App {
                 PreviewPriority::Low,
                 PreviewWorkClass::Light,
             );
-            if self.scheduler.submit_preview(request) {
+            if self.jobs.scheduler.submit_preview(request) {
                 queued += 1;
             }
         }
@@ -100,7 +101,7 @@ impl App {
                 PreviewPriority::Low,
                 preview_work_class(&entry, &variant),
             );
-            let _ = self.scheduler.submit_preview(request);
+            let _ = self.jobs.scheduler.submit_preview(request);
         }
     }
 
@@ -113,7 +114,7 @@ impl App {
         if !is_audio_entry(entry) {
             return Vec::new();
         }
-        let Some(area) = self.frame_state.preview_media_area else {
+        let Some(area) = self.input.frame_state.preview_media_area else {
             return Vec::new();
         };
 
@@ -149,11 +150,11 @@ impl App {
         AUDIO_ENTRY_PREFETCH_OFFSETS
             .into_iter()
             .filter_map(|offset| {
-                let target = self.selected as isize + offset;
+                let target = self.navigation.selected as isize + offset;
                 if target < 0 {
                     return None;
                 }
-                let entry = self.entries.get(target as usize)?.clone();
+                let entry = self.navigation.entries.get(target as usize)?.clone();
                 is_audio_entry(&entry).then_some(entry)
             })
             .collect()

--- a/src/app/actions/preview/refresh.rs
+++ b/src/app/actions/preview/refresh.rs
@@ -4,12 +4,12 @@ use crate::preview::{PreviewContent, PreviewKind, loading_preview_for, preview_w
 
 impl App {
     fn clear_preview_directory_stats(&mut self) {
-        self.preview_state.directory_stats = None;
-        self.scheduler.cancel_directory_stats();
+        self.preview.state.directory_stats = None;
+        self.jobs.scheduler.cancel_directory_stats();
     }
 
     fn refresh_current_directory_stats(&mut self) {
-        if self.preview_state.content.kind != PreviewKind::Directory {
+        if self.preview.state.content.kind != PreviewKind::Directory {
             self.clear_preview_directory_stats();
             return;
         }
@@ -22,19 +22,20 @@ impl App {
             return;
         };
 
-        let token = self.preview_state.token;
-        self.preview_state.directory_stats = Some(PreviewDirectoryStatsState::Loading {
+        let token = self.preview.state.token;
+        self.preview.state.directory_stats = Some(PreviewDirectoryStatsState::Loading {
             token,
             path: entry.path.clone(),
         });
         if !self
+            .jobs
             .scheduler
             .submit_directory_stats(DirectoryStatsRequest {
                 token,
                 path: entry.path,
             })
         {
-            self.preview_state.directory_stats = None;
+            self.preview.state.directory_stats = None;
         }
     }
 
@@ -47,15 +48,16 @@ impl App {
         let Some(current_entry) = self.selected_entry() else {
             return false;
         };
-        if self.preview_state.content.kind != PreviewKind::Directory
+        if self.preview.state.content.kind != PreviewKind::Directory
             || !current_entry.is_dir()
             || current_entry.path != path
-            || token != self.preview_state.token
+            || token != self.preview.state.token
         {
             return false;
         }
         if self
-            .preview_state
+            .preview
+            .state
             .directory_stats
             .as_ref()
             .is_some_and(|stats| stats.token() != token || stats.path() != path)
@@ -65,7 +67,7 @@ impl App {
 
         match result {
             crate::fs::DirectoryStatsScanResult::Complete(stats) => {
-                self.preview_state.directory_stats = Some(PreviewDirectoryStatsState::Complete {
+                self.preview.state.directory_stats = Some(PreviewDirectoryStatsState::Complete {
                     token,
                     path: path.to_path_buf(),
                     stats,
@@ -73,7 +75,7 @@ impl App {
                 true
             }
             crate::fs::DirectoryStatsScanResult::Incomplete { partial, error } => {
-                self.preview_state.directory_stats = Some(PreviewDirectoryStatsState::Incomplete {
+                self.preview.state.directory_stats = Some(PreviewDirectoryStatsState::Incomplete {
                     token,
                     path: path.to_path_buf(),
                     partial,
@@ -86,27 +88,27 @@ impl App {
     }
 
     pub(in crate::app) fn refresh_preview(&mut self) {
-        self.preview_state.deferred_refresh_at = None;
-        self.preview_state.prefetch_ready_at = None;
+        self.preview.state.deferred_refresh_at = None;
+        self.preview.state.prefetch_ready_at = None;
         // Reset incremental state on every selection refresh.
-        self.preview_state.incremental_render_in_flight = false;
-        self.preview_state.incremental_render_path = None;
+        self.preview.state.incremental_render_in_flight = false;
+        self.preview.state.incremental_render_path = None;
         self.sync_comic_preview_selection();
         self.sync_epub_preview_selection();
         self.sync_pdf_preview_selection();
         self.sync_image_preview_selection_activation();
-        self.preview_state.token = self.preview_state.token.wrapping_add(1);
+        self.preview.state.token = self.preview.state.token.wrapping_add(1);
         let preview_options = self.current_preview_request_options();
-        self.preview_state.content = match self.selected_entry().cloned() {
+        self.preview.state.content = match self.selected_entry().cloned() {
             Some(entry) if self.should_defer_static_image_preview(&entry) => {
-                self.preview_state.load_state = None;
+                self.preview.state.load_state = None;
                 PreviewContent::new(PreviewKind::Image, Vec::new()).with_detail(
                     self.static_image_preview_detail(&entry)
                         .unwrap_or("Image preview"),
                 )
             }
             Some(entry) if self.should_defer_pdf_document_preview(&entry) => {
-                self.preview_state.load_state = None;
+                self.preview.state.load_state = None;
                 self.cached_preview_for(&entry, &preview_options)
                     .or_else(|| self.stale_cached_preview_for(&entry, &preview_options))
                     .unwrap_or_else(|| {
@@ -116,8 +118,8 @@ impl App {
             }
             Some(entry) => {
                 if let Some(preview) = self.cached_preview_for(&entry, &preview_options) {
-                    self.preview_state.metrics.cache_hits += 1;
-                    self.preview_state.load_state = None;
+                    self.preview.state.metrics.cache_hits += 1;
+                    self.preview.state.load_state = None;
                     // If the cached preview is partial, fire an extension job.
                     if preview.is_incrementally_partial()
                         && let Some(request) = self.build_code_preview_extension_request(
@@ -127,16 +129,16 @@ impl App {
                         )
                     {
                         let entry_path = entry.path.clone();
-                        if self.scheduler.submit_preview(request) {
-                            self.preview_state.incremental_render_in_flight = true;
-                            self.preview_state.incremental_render_path = Some(entry_path);
+                        if self.jobs.scheduler.submit_preview(request) {
+                            self.preview.state.incremental_render_in_flight = true;
+                            self.preview.state.incremental_render_path = Some(entry_path);
                         }
                     }
                     preview
                 } else if let Some(stale_preview) =
                     self.stale_cached_preview_for(&entry, &preview_options)
                 {
-                    self.preview_state.metrics.cache_misses += 1;
+                    self.preview.state.metrics.cache_misses += 1;
                     let loading_path = entry.path.clone();
                     let work_class = preview_work_class(&entry, &preview_options);
                     let request = self.build_preview_request(
@@ -145,16 +147,16 @@ impl App {
                         PreviewPriority::High,
                         work_class,
                     );
-                    if !self.scheduler.submit_preview(request) {
-                        self.preview_state.load_state = None;
+                    if !self.jobs.scheduler.submit_preview(request) {
+                        self.preview.state.load_state = None;
                         stale_preview.with_status_note("Refresh unavailable")
                     } else {
-                        self.preview_state.load_state =
+                        self.preview.state.load_state =
                             Some(PreviewLoadState::Refreshing(loading_path));
                         stale_preview.with_status_note("Refreshing in background")
                     }
                 } else {
-                    self.preview_state.metrics.cache_misses += 1;
+                    self.preview.state.metrics.cache_misses += 1;
                     let placeholder = self.apply_current_epub_loading_navigation(
                         self.apply_current_comic_loading_navigation(loading_preview_for(
                             &entry,
@@ -169,18 +171,18 @@ impl App {
                         PreviewPriority::High,
                         work_class,
                     );
-                    if !self.scheduler.submit_preview(request) {
-                        self.preview_state.load_state = None;
+                    if !self.jobs.scheduler.submit_preview(request) {
+                        self.preview.state.load_state = None;
                         PreviewContent::placeholder("Preview worker unavailable")
                     } else {
-                        self.preview_state.load_state =
+                        self.preview.state.load_state =
                             Some(PreviewLoadState::Placeholder(loading_path));
                         placeholder
                     }
                 }
             }
             None => {
-                self.preview_state.load_state = None;
+                self.preview.state.load_state = None;
                 PreviewContent::placeholder("No selection")
             }
         };
@@ -188,15 +190,15 @@ impl App {
         self.apply_current_epub_preview_metadata();
         self.refresh_current_directory_stats();
         self.sync_current_preview_line_count();
-        self.preview_state.scroll = 0;
-        self.preview_state.horizontal_scroll = 0;
+        self.preview.state.scroll = 0;
+        self.preview.state.horizontal_scroll = 0;
         self.sync_preview_scroll();
         self.refresh_static_image_preloads();
         self.schedule_preview_prefetch();
     }
 
     pub(crate) fn process_preview_refresh_timers(&mut self) -> bool {
-        let Some(deadline) = self.preview_state.deferred_refresh_at else {
+        let Some(deadline) = self.preview.state.deferred_refresh_at else {
             return false;
         };
         if Instant::now() < deadline {
@@ -207,7 +209,8 @@ impl App {
     }
 
     pub(crate) fn pending_preview_refresh_timer(&self) -> Option<std::time::Duration> {
-        self.preview_state
+        self.preview
+            .state
             .deferred_refresh_at
             .map(|deadline| deadline.saturating_duration_since(Instant::now()))
     }
@@ -224,13 +227,14 @@ impl App {
             size,
             modified,
         };
-        self.preview_state.pending_line_counts.remove(&key);
+        self.preview.state.pending_line_counts.remove(&key);
         let Some(total_lines) = total_lines else {
             let should_clear_pending = self.selected_entry().is_some_and(|entry| {
                 entry.path == key.path && entry.size == key.size && entry.modified == key.modified
             });
             if should_clear_pending {
-                self.preview_state
+                self.preview
+                    .state
                     .content
                     .set_total_line_count_pending(false);
                 return true;
@@ -243,7 +247,8 @@ impl App {
             entry.path == key.path && entry.size == key.size && entry.modified == key.modified
         });
         if is_current_entry {
-            self.preview_state
+            self.preview
+                .state
                 .content
                 .apply_total_line_count(total_lines);
             return true;
@@ -252,12 +257,13 @@ impl App {
     }
 
     pub(in crate::app) fn sync_current_preview_line_count(&mut self) {
-        let needs_total_line_count = self.preview_state.content.needs_total_line_count();
+        let needs_total_line_count = self.preview.state.content.needs_total_line_count();
         let Some(entry) = self.selected_entry().cloned() else {
             return;
         };
         if !needs_total_line_count {
-            self.preview_state
+            self.preview
+                .state
                 .content
                 .set_total_line_count_pending(false);
             return;
@@ -268,15 +274,17 @@ impl App {
             size: entry.size,
             modified: entry.modified,
         };
-        if let Some(total_lines) = self.preview_state.line_count_cache.get(&key).copied() {
-            self.preview_state
+        if let Some(total_lines) = self.preview.state.line_count_cache.get(&key).copied() {
+            self.preview
+                .state
                 .content
                 .apply_total_line_count(total_lines);
             return;
         }
 
-        let pending = self.preview_state.pending_line_counts.contains(&key)
+        let pending = self.preview.state.pending_line_counts.contains(&key)
             || self
+                .jobs
                 .scheduler
                 .submit_preview_line_count(PreviewLineCountRequest {
                     path: entry.path,
@@ -284,9 +292,10 @@ impl App {
                     modified: entry.modified,
                 });
         if pending {
-            self.preview_state.pending_line_counts.insert(key);
+            self.preview.state.pending_line_counts.insert(key);
         }
-        self.preview_state
+        self.preview
+            .state
             .content
             .set_total_line_count_pending(pending);
     }

--- a/src/app/actions/preview/request.rs
+++ b/src/app/actions/preview/request.rs
@@ -17,9 +17,10 @@ impl App {
         // but we want them full — they pass code_line_limit as the render limit,
         // which happens to equal code_line_limit and therefore produces a complete render.
         let code_render_limit =
-            initial_code_render_limit(self.frame_state.preview_rows_visible).min(code_line_limit);
+            initial_code_render_limit(self.input.frame_state.preview_rows_visible)
+                .min(code_line_limit);
         PreviewRequest {
-            token: self.preview_state.token,
+            token: self.preview.state.token,
             entry,
             variant,
             code_line_limit,
@@ -43,7 +44,7 @@ impl App {
     ) -> PreviewRequest {
         let code_line_limit = self.preview_code_line_limit_for_entry(&entry);
         PreviewRequest {
-            token: self.preview_state.token,
+            token: self.preview.state.token,
             entry,
             variant,
             code_line_limit,
@@ -68,16 +69,16 @@ impl App {
         variant: PreviewRequestOptions,
         priority: PreviewPriority,
     ) -> Option<PreviewRequest> {
-        if !self.preview_state.content.is_incrementally_partial() {
+        if !self.preview.state.content.is_incrementally_partial() {
             return None;
         }
-        if self.preview_state.incremental_render_in_flight {
+        if self.preview.state.incremental_render_in_flight {
             return None;
         }
         let code_line_limit = self.preview_code_line_limit_for_entry(&entry);
         let work_class = crate::preview::preview_work_class(&entry, &variant);
         Some(PreviewRequest {
-            token: self.preview_state.token,
+            token: self.preview.state.token,
             entry,
             variant,
             code_line_limit,
@@ -100,7 +101,7 @@ impl App {
     pub(in crate::app) fn preview_code_line_limit_for_entry(&self, entry: &Entry) -> usize {
         self.preview_code_line_limit_for_entry_with_rows(
             entry,
-            self.frame_state.preview_rows_visible,
+            self.input.frame_state.preview_rows_visible,
         )
     }
 

--- a/src/app/actions/tests.rs
+++ b/src/app/actions/tests.rs
@@ -14,14 +14,14 @@ fn temp_path(label: &str) -> PathBuf {
 }
 
 fn make_auto_reload_ready(app: &mut App) {
-    app.directory_runtime.last_auto_reload_at =
+    app.navigation.directory_runtime.last_auto_reload_at =
         Instant::now() - AUTO_RELOAD_INTERVAL - Duration::from_millis(1);
 }
 
 fn wait_for_directory_load(app: &mut App) {
     for _ in 0..300 {
         let _ = app.process_background_jobs();
-        if app.directory_runtime.pending_load.is_none() {
+        if app.navigation.directory_runtime.pending_load.is_none() {
             return;
         }
         std::thread::sleep(Duration::from_millis(10));
@@ -33,10 +33,14 @@ fn wait_for_directory_reload(app: &mut App, expected_entries: usize) {
     for _ in 0..500 {
         let _ = app.process_auto_reload();
         let _ = app.process_background_jobs();
-        if app.entries.len() == expected_entries
-            && app.directory_runtime.pending_reload_at.is_none()
-            && app.directory_runtime.pending_fingerprint_scan.is_none()
-            && app.directory_runtime.pending_load.is_none()
+        if app.navigation.entries.len() == expected_entries
+            && app.navigation.directory_runtime.pending_reload_at.is_none()
+            && app
+                .navigation
+                .directory_runtime
+                .pending_fingerprint_scan
+                .is_none()
+            && app.navigation.directory_runtime.pending_load.is_none()
         {
             return;
         }
@@ -44,10 +48,13 @@ fn wait_for_directory_reload(app: &mut App, expected_entries: usize) {
     }
     panic!(
         "timed out waiting for directory reload: entries={}, pending_reload={}, pending_fingerprint_scan={}, pending_load={}, pending_background_work={}",
-        app.entries.len(),
-        app.directory_runtime.pending_reload_at.is_some(),
-        app.directory_runtime.pending_fingerprint_scan.is_some(),
-        app.directory_runtime.pending_load.is_some(),
+        app.navigation.entries.len(),
+        app.navigation.directory_runtime.pending_reload_at.is_some(),
+        app.navigation
+            .directory_runtime
+            .pending_fingerprint_scan
+            .is_some(),
+        app.navigation.directory_runtime.pending_load.is_some(),
         app.has_pending_background_work(),
     );
 }
@@ -59,12 +66,13 @@ fn watcher_reload_detects_new_visible_entries() {
     fs::write(root.join("one.txt"), "hello").expect("failed to write first file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.directory_runtime.watch = None;
-    assert_eq!(app.entries.len(), 1);
+    app.navigation.directory_runtime.watch = None;
+    assert_eq!(app.navigation.entries.len(), 1);
 
     let second = root.join("two.txt");
     fs::write(&second, "world").expect("failed to write second file");
-    app.directory_runtime
+    app.navigation
+        .directory_runtime
         .watch_tx
         .send(crate::fs::DirectoryWatchEvent::Changed(vec![second]))
         .expect("failed to queue watch event");
@@ -74,7 +82,8 @@ fn watcher_reload_detects_new_visible_entries() {
             .expect("watch processing should succeed"),
         "watch processing should debounce before reloading",
     );
-    app.directory_runtime.pending_reload_at = Some(Instant::now() - Duration::from_millis(1));
+    app.navigation.directory_runtime.pending_reload_at =
+        Some(Instant::now() - Duration::from_millis(1));
 
     assert!(
         !app.process_auto_reload()
@@ -82,8 +91,13 @@ fn watcher_reload_detects_new_visible_entries() {
         "watch-driven reload should schedule an async fingerprint scan first",
     );
     wait_for_directory_reload(&mut app, 2);
-    assert_eq!(app.entries.len(), 2);
-    assert!(app.entries.iter().any(|entry| entry.name == "two.txt"));
+    assert_eq!(app.navigation.entries.len(), 2);
+    assert!(
+        app.navigation
+            .entries
+            .iter()
+            .any(|entry| entry.name == "two.txt")
+    );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -95,11 +109,12 @@ fn watcher_rescan_event_triggers_reload() {
     fs::write(root.join("one.txt"), "hello").expect("failed to write first file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.directory_runtime.watch = None;
-    assert_eq!(app.entries.len(), 1);
+    app.navigation.directory_runtime.watch = None;
+    assert_eq!(app.navigation.entries.len(), 1);
 
     fs::write(root.join("two.txt"), "world").expect("failed to write second file");
-    app.directory_runtime
+    app.navigation
+        .directory_runtime
         .watch_tx
         .send(crate::fs::DirectoryWatchEvent::Rescan)
         .expect("failed to queue rescan event");
@@ -109,7 +124,8 @@ fn watcher_rescan_event_triggers_reload() {
             .expect("watch processing should succeed"),
         "watch processing should debounce before reloading",
     );
-    app.directory_runtime.pending_reload_at = Some(Instant::now() - Duration::from_millis(1));
+    app.navigation.directory_runtime.pending_reload_at =
+        Some(Instant::now() - Duration::from_millis(1));
 
     assert!(
         !app.process_auto_reload()
@@ -117,8 +133,13 @@ fn watcher_rescan_event_triggers_reload() {
         "rescan-driven reload should schedule an async fingerprint scan first",
     );
     wait_for_directory_reload(&mut app, 2);
-    assert_eq!(app.entries.len(), 2);
-    assert!(app.entries.iter().any(|entry| entry.name == "two.txt"));
+    assert_eq!(app.navigation.entries.len(), 2);
+    assert!(
+        app.navigation
+            .entries
+            .iter()
+            .any(|entry| entry.name == "two.txt")
+    );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -130,13 +151,14 @@ fn watcher_reload_ignores_hidden_entries_when_hidden_files_are_off() {
     fs::write(root.join("visible.txt"), "hello").expect("failed to write visible file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.directory_runtime.watch = None;
-    assert!(!app.show_hidden);
-    assert_eq!(app.entries.len(), 1);
+    app.navigation.directory_runtime.watch = None;
+    assert!(!app.navigation.show_hidden);
+    assert_eq!(app.navigation.entries.len(), 1);
 
     let hidden = root.join(".secret");
     fs::write(&hidden, "hidden").expect("failed to write hidden file");
-    app.directory_runtime
+    app.navigation
+        .directory_runtime
         .watch_tx
         .send(crate::fs::DirectoryWatchEvent::Changed(vec![hidden]))
         .expect("failed to queue watch event");
@@ -146,9 +168,9 @@ fn watcher_reload_ignores_hidden_entries_when_hidden_files_are_off() {
             .expect("watch processing should succeed"),
         "hidden-only changes should not trigger a reload schedule",
     );
-    assert!(app.directory_runtime.pending_reload_at.is_none());
-    assert_eq!(app.entries.len(), 1);
-    assert_eq!(app.entries[0].name, "visible.txt");
+    assert!(app.navigation.directory_runtime.pending_reload_at.is_none());
+    assert_eq!(app.navigation.entries.len(), 1);
+    assert_eq!(app.navigation.entries[0].name, "visible.txt");
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -159,24 +181,24 @@ fn sidebar_refresh_rebuilds_places_once_per_interval() {
     fs::create_dir_all(&root).expect("failed to create temp root");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.sidebar.clear();
-    app.last_sidebar_refresh_at = Instant::now() - Duration::from_secs(3);
+    app.navigation.sidebar.clear();
+    app.navigation.last_sidebar_refresh_at = Instant::now() - Duration::from_secs(3);
 
     assert!(
         app.process_sidebar_refresh(),
         "stale refresh windows should rebuild places"
     );
     assert!(
-        !app.sidebar.is_empty(),
+        !app.navigation.sidebar.is_empty(),
         "refresh should restore the builtin places list"
     );
 
-    let sidebar_after_refresh = app.sidebar.clone();
+    let sidebar_after_refresh = app.navigation.sidebar.clone();
     assert!(
         !app.process_sidebar_refresh(),
         "freshly refreshed sidebars should not rebuild again immediately"
     );
-    assert_eq!(app.sidebar, sidebar_after_refresh);
+    assert_eq!(app.navigation.sidebar, sidebar_after_refresh);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -188,8 +210,8 @@ fn polling_fallback_respects_its_throttle_window() {
     fs::write(root.join("one.txt"), "hello").expect("failed to write first file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.directory_runtime.watch = None;
-    app.directory_runtime.use_polling_reload = true;
+    app.navigation.directory_runtime.watch = None;
+    app.navigation.directory_runtime.use_polling_reload = true;
     fs::write(root.join("two.txt"), "world").expect("failed to write second file");
 
     assert!(
@@ -197,7 +219,7 @@ fn polling_fallback_respects_its_throttle_window() {
             .expect("auto reload should succeed"),
         "reload should stay idle inside the throttle window",
     );
-    assert_eq!(app.entries.len(), 1);
+    assert_eq!(app.navigation.entries.len(), 1);
 
     make_auto_reload_ready(&mut app);
     assert!(
@@ -206,7 +228,7 @@ fn polling_fallback_respects_its_throttle_window() {
         "reload should schedule an async fingerprint scan once the throttle window has elapsed",
     );
     wait_for_directory_reload(&mut app, 2);
-    assert_eq!(app.entries.len(), 2);
+    assert_eq!(app.navigation.entries.len(), 2);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -244,7 +266,7 @@ fn set_frame_state_does_not_refresh_code_preview_when_visible_rows_change() {
     fs::write(root.join("main.rs"), "fn main() {}\n").expect("failed to write code file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    let initial_preview_token = app.preview_state.token;
+    let initial_preview_token = app.preview.state.token;
 
     app.set_frame_state(FrameState {
         preview_rows_visible: 12,
@@ -252,7 +274,7 @@ fn set_frame_state_does_not_refresh_code_preview_when_visible_rows_change() {
         ..FrameState::default()
     });
 
-    assert_eq!(app.preview_state.token, initial_preview_token);
+    assert_eq!(app.preview.state.token, initial_preview_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -264,7 +286,7 @@ fn set_frame_state_does_not_refresh_plain_text_preview_when_visible_rows_change(
     fs::write(root.join("notes.txt"), "plain text\n").expect("failed to write text file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    let initial_preview_token = app.preview_state.token;
+    let initial_preview_token = app.preview.state.token;
 
     app.set_frame_state(FrameState {
         preview_rows_visible: 12,
@@ -272,7 +294,7 @@ fn set_frame_state_does_not_refresh_plain_text_preview_when_visible_rows_change(
         ..FrameState::default()
     });
 
-    assert_eq!(app.preview_state.token, initial_preview_token);
+    assert_eq!(app.preview.state.token, initial_preview_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -287,10 +309,10 @@ fn set_dir_failure_keeps_previous_directory_state() {
     let missing = root.join("missing");
 
     assert!(app.set_dir(missing).is_err());
-    assert_eq!(app.cwd, root);
-    assert_eq!(app.entries.len(), 1);
-    assert!(app.navigation_history.back.is_empty());
-    assert!(app.navigation_history.forward.is_empty());
+    assert_eq!(app.navigation.cwd, root);
+    assert_eq!(app.navigation.entries.len(), 1);
+    assert!(app.navigation.navigation_history.back.is_empty());
+    assert!(app.navigation.navigation_history.forward.is_empty());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -302,21 +324,21 @@ fn go_back_failure_preserves_history() {
     let missing = root.join("missing");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.navigation_history.back.push(HistoryEntry {
+    app.navigation.navigation_history.back.push(HistoryEntry {
         cwd: missing.clone(),
         selected_path: None,
     });
 
     assert!(app.go_back().is_err());
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
     assert_eq!(
-        app.navigation_history.back,
+        app.navigation.navigation_history.back,
         vec![HistoryEntry {
             cwd: missing,
             selected_path: None,
         }]
     );
-    assert!(app.navigation_history.forward.is_empty());
+    assert!(app.navigation.navigation_history.forward.is_empty());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -331,7 +353,7 @@ fn reload_restores_latest_remembered_view_state() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.set_frame_state(FrameState {
         metrics: ViewMetrics {
             cols: 1,
@@ -344,8 +366,8 @@ fn reload_restores_latest_remembered_view_state() {
     app.select_index(6);
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.selected, 6);
-    assert_eq!(app.scroll_row, 4);
+    assert_eq!(app.navigation.selected, 6);
+    assert_eq!(app.navigation.scroll_row, 4);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -358,10 +380,10 @@ fn same_directory_reselect_updates_pending_load_instead_of_dropping_it() {
     fs::write(&beta, "beta").expect("failed to write beta");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.directory_runtime.pending_load = Some(PendingDirectoryLoad {
+    app.navigation.directory_runtime.pending_load = Some(PendingDirectoryLoad {
         token: 99,
-        target_cwd: app.cwd.clone(),
-        previous_cwd: app.cwd.clone(),
+        target_cwd: app.navigation.cwd.clone(),
+        previous_cwd: app.navigation.cwd.clone(),
         previous_selected_path: app.selected_entry().map(|entry| entry.path.clone()),
         previous_selection_name: None,
         reselect_path: None,
@@ -379,6 +401,7 @@ fn same_directory_reselect_updates_pending_load_instead_of_dropping_it() {
     .expect("same-directory reselect should update the pending load");
 
     let load = app
+        .navigation
         .directory_runtime
         .pending_load
         .as_ref()

--- a/src/app/clipboard/copy.rs
+++ b/src/app/clipboard/copy.rs
@@ -15,25 +15,28 @@ use std::{
 
 impl App {
     pub fn copy_is_open(&self) -> bool {
-        self.copy_overlay.is_some()
+        self.overlays.copy.is_some()
     }
 
     pub fn copy_title(&self) -> &str {
-        self.copy_overlay
+        self.overlays
+            .copy
             .as_ref()
             .map(|overlay| overlay.title.as_str())
             .unwrap_or("")
     }
 
     pub fn copy_row_count(&self) -> usize {
-        self.copy_overlay
+        self.overlays
+            .copy
             .as_ref()
             .map(|overlay| overlay.rows.len())
             .unwrap_or(0)
     }
 
     pub fn copy_row_label(&self, index: usize) -> &str {
-        self.copy_overlay
+        self.overlays
+            .copy
             .as_ref()
             .and_then(|overlay| overlay.rows.get(index))
             .map(|row| row.label.as_str())
@@ -41,7 +44,8 @@ impl App {
     }
 
     pub fn copy_row_shortcut(&self, index: usize) -> Option<char> {
-        self.copy_overlay
+        self.overlays
+            .copy
             .as_ref()
             .and_then(|overlay| overlay.rows.get(index))
             .map(|row| row.shortcut)
@@ -56,20 +60,20 @@ impl App {
             return;
         }
 
-        self.help_open = false;
-        self.copy_overlay = Some(build_copy_overlay(&self.cwd, &paths));
+        self.overlays.help = false;
+        self.overlays.copy = Some(build_copy_overlay(&self.navigation.cwd, &paths));
         self.status.clear();
     }
 
     pub(in crate::app) fn handle_copy_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.copy_overlay = None;
+            self.overlays.copy = None;
             return Ok(());
         }
 
         match key.code {
             KeyCode::Esc => {
-                self.copy_overlay = None;
+                self.overlays.copy = None;
             }
             KeyCode::Char(ch)
                 if !key
@@ -89,15 +93,17 @@ impl App {
     pub(in crate::app) fn handle_copy_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
         if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
             let inside = self
+                .input
                 .frame_state
                 .copy_panel
                 .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
             if !inside {
-                self.copy_overlay = None;
+                self.overlays.copy = None;
                 return Ok(());
             }
 
             if let Some(hit) = self
+                .input
                 .frame_state
                 .copy_hits
                 .iter()
@@ -113,7 +119,7 @@ impl App {
 
     fn copy_row_index_for_shortcut(&self, ch: char) -> Option<usize> {
         let needle = ch.to_ascii_lowercase();
-        self.copy_overlay.as_ref().and_then(|overlay| {
+        self.overlays.copy.as_ref().and_then(|overlay| {
             overlay
                 .rows
                 .iter()
@@ -122,7 +128,7 @@ impl App {
     }
 
     fn confirm_copy_index(&mut self, index: usize) -> Result<()> {
-        let Some((value, status_label)) = self.copy_overlay.as_ref().and_then(|overlay| {
+        let Some((value, status_label)) = self.overlays.copy.as_ref().and_then(|overlay| {
             overlay
                 .rows
                 .get(index)
@@ -133,7 +139,7 @@ impl App {
 
         match write_text_to_system_clipboard(&value) {
             Ok(()) => {
-                self.copy_overlay = None;
+                self.overlays.copy = None;
                 self.status = format!("Copied {status_label}");
             }
             Err(error) => {

--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -12,24 +12,26 @@ use std::path::{Path, PathBuf};
 impl App {
     /// Returns `(count, op)` for the current clipboard, or `None` if empty.
     pub fn clipboard_info(&self) -> Option<(usize, ClipOp)> {
-        self.clipboard.as_ref().map(|c| (c.paths.len(), c.op))
+        self.jobs.clipboard.as_ref().map(|c| (c.paths.len(), c.op))
     }
 
     /// Returns `(completed, total, op)` for an in-progress paste, or `None`.
     pub fn paste_progress(&self) -> Option<(usize, usize, ClipOp)> {
-        self.paste_progress
+        self.jobs
+            .paste_progress
             .as_ref()
             .map(|p| (p.completed, p.total, p.op))
     }
 
     pub fn queued_paste_count(&self) -> usize {
-        self.queued_pastes.len()
+        self.jobs.queued_pastes.len()
     }
 
     /// Returns the clipboard operation for a specific path, if it is in the
     /// clipboard.
     pub fn clipboard_op_for(&self, path: &Path) -> Option<ClipOp> {
-        self.clipboard
+        self.jobs
+            .clipboard
             .as_ref()
             .filter(|c| c.paths.iter().any(|p| p == path))
             .map(|c| c.op)
@@ -42,11 +44,11 @@ impl App {
             return;
         }
         let count = paths.len();
-        self.clipboard = Some(Clipboard {
+        self.jobs.clipboard = Some(Clipboard {
             paths,
             op: ClipOp::Yank,
         });
-        self.selected_paths.clear();
+        self.navigation.selected_paths.clear();
         self.status = if count == 1 {
             "Yanked 1 item".to_string()
         } else {
@@ -61,11 +63,11 @@ impl App {
             return;
         }
         let count = paths.len();
-        self.clipboard = Some(Clipboard {
+        self.jobs.clipboard = Some(Clipboard {
             paths,
             op: ClipOp::Cut,
         });
-        self.selected_paths.clear();
+        self.navigation.selected_paths.clear();
         self.status = if count == 1 {
             "Cut 1 item".to_string()
         } else {
@@ -76,7 +78,7 @@ impl App {
     /// Paste the clipboard contents into the current directory (async with
     /// progress reporting).
     pub(in crate::app) fn paste(&mut self) -> Result<()> {
-        if self.paste_progress.is_some() && self.clipboard.is_none() {
+        if self.jobs.paste_progress.is_some() && self.jobs.clipboard.is_none() {
             self.status = "Paste in progress — yank or cut another item to queue it".to_string();
             return Ok(());
         }
@@ -86,9 +88,9 @@ impl App {
             return Ok(());
         };
 
-        if self.paste_progress.is_some() {
-            self.queued_pastes.push_back(request);
-            let pending = self.queued_pastes.len();
+        if self.jobs.paste_progress.is_some() {
+            self.jobs.queued_pastes.push_back(request);
+            let pending = self.jobs.queued_pastes.len();
             self.status = if pending == 1 {
                 "Queued paste (1 pending)".to_string()
             } else {
@@ -103,13 +105,13 @@ impl App {
     }
 
     pub(super) fn clear_queued_pastes(&mut self) -> usize {
-        let queued = self.queued_pastes.len();
-        self.queued_pastes.clear();
+        let queued = self.jobs.queued_pastes.len();
+        self.jobs.queued_pastes.clear();
         queued
     }
 
     pub(super) fn start_next_queued_paste(&mut self) -> bool {
-        let Some(request) = self.queued_pastes.pop_front() else {
+        let Some(request) = self.jobs.queued_pastes.pop_front() else {
             return false;
         };
         self.start_paste_request(request);
@@ -117,28 +119,28 @@ impl App {
     }
 
     fn take_clipboard_paste(&mut self) -> Option<QueuedPaste> {
-        let clipboard = self.clipboard.take()?;
+        let clipboard = self.jobs.clipboard.take()?;
         if clipboard.paths.is_empty() {
             return None;
         }
         Some(QueuedPaste {
-            dest_dir: self.cwd.clone(),
+            dest_dir: self.navigation.cwd.clone(),
             paths: clipboard.paths,
             op: clipboard.op,
         })
     }
 
     fn start_paste_request(&mut self, request: QueuedPaste) {
-        let token = self.paste_token.wrapping_add(1);
-        self.paste_token = token;
-        self.paste_progress = Some(PasteProgress {
+        let token = self.jobs.paste_token.wrapping_add(1);
+        self.jobs.paste_token = token;
+        self.jobs.paste_progress = Some(PasteProgress {
             completed: 0,
             total: request.paths.len(),
             op: request.op,
         });
-        self.paste_dest_dir = Some(request.dest_dir.clone());
+        self.jobs.paste_dest_dir = Some(request.dest_dir.clone());
 
-        self.scheduler.submit_paste(PasteRequest {
+        self.jobs.scheduler.submit_paste(PasteRequest {
             token,
             dest_dir: request.dest_dir,
             paths: request.paths,
@@ -149,8 +151,8 @@ impl App {
     /// Collect the paths that y/x should act on: all space-selected paths if
     /// any exist (sorted for stable ordering), otherwise the focused entry.
     pub(super) fn clipboard_target_paths(&self) -> Vec<PathBuf> {
-        if !self.selected_paths.is_empty() {
-            let mut paths: Vec<PathBuf> = self.selected_paths.iter().cloned().collect();
+        if !self.navigation.selected_paths.is_empty() {
+            let mut paths: Vec<PathBuf> = self.navigation.selected_paths.iter().cloned().collect();
             paths.sort();
             paths
         } else {

--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -27,7 +27,7 @@ fn temp_path(label: &str) -> PathBuf {
 fn wait_for_paste(app: &mut App) {
     for _ in 0..500 {
         let _ = app.process_background_jobs();
-        if app.paste_progress().is_none() && app.queued_pastes.is_empty() {
+        if app.paste_progress().is_none() && app.jobs.queued_pastes.is_empty() {
             return;
         }
         std::thread::sleep(Duration::from_millis(10));
@@ -39,8 +39,8 @@ fn wait_for_paste_and_reload(app: &mut App) {
     for _ in 0..500 {
         let _ = app.process_background_jobs();
         if app.paste_progress().is_none()
-            && app.queued_pastes.is_empty()
-            && app.directory_runtime.pending_load.is_none()
+            && app.jobs.queued_pastes.is_empty()
+            && app.navigation.directory_runtime.pending_load.is_none()
         {
             return;
         }
@@ -158,7 +158,7 @@ fn yank_and_paste_copies_file_to_destination() {
 
     // Navigate into src_dir so the entry appears in the list.
     let mut app = App::new_at(src_dir.clone()).unwrap();
-    assert_eq!(app.entries.len(), 1);
+    assert_eq!(app.navigation.entries.len(), 1);
 
     // Yank the selected entry.
     app.yank();
@@ -170,7 +170,7 @@ fn yank_and_paste_copies_file_to_destination() {
 
     // Point cwd at the destination (direct assignment avoids the async
     // directory-load path; we only care about the paste behaviour here).
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
 
     // paste() should immediately set up paste_progress.
@@ -216,12 +216,12 @@ fn cut_and_paste_moves_file_to_destination() {
     fs::write(src_dir.join("move_me.txt"), "payload").unwrap();
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
-    assert_eq!(app.entries.len(), 1);
+    assert_eq!(app.navigation.entries.len(), 1);
 
     app.cut();
     assert_eq!(app.clipboard_info(), Some((1, ClipOp::Cut)));
 
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
     wait_for_paste(&mut app);
 
@@ -252,11 +252,11 @@ fn paste_progress_reflects_total_and_is_cleared_after_completion() {
     let mut app = App::new_at(src_dir.clone()).unwrap();
     // Insert both paths into the multi-selection directly (selected_paths is
     // pub(super) within crate::app, which includes this test module).
-    app.selected_paths.insert(src_dir.join("a.txt"));
-    app.selected_paths.insert(src_dir.join("b.txt"));
+    app.navigation.selected_paths.insert(src_dir.join("a.txt"));
+    app.navigation.selected_paths.insert(src_dir.join("b.txt"));
     app.yank();
 
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
 
     // Immediately after paste() the progress should be live with total = 2.
@@ -291,13 +291,13 @@ fn stale_token_paste_results_are_ignored() {
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
     app.yank();
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
 
     // Simulate a newer paste superseding the old one: bump paste_token and
     // clear paste_progress manually so we can verify nothing revives it.
-    app.paste_token = app.paste_token.wrapping_add(1);
-    app.paste_progress = None;
+    app.jobs.paste_token = app.jobs.paste_token.wrapping_add(1);
+    app.jobs.paste_progress = None;
 
     // Drain all incoming results.  Because none carry the current token they
     // must all be silently discarded.
@@ -327,7 +327,7 @@ fn cancelling_paste_clears_progress_and_stops_worker() {
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
     app.yank();
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
 
     assert!(
@@ -336,8 +336,8 @@ fn cancelling_paste_clears_progress_and_stops_worker() {
     );
 
     // Simulate Esc: cancel the current paste token and clear progress immediately.
-    app.scheduler.cancel_paste(app.paste_token);
-    app.paste_progress = None;
+    app.jobs.scheduler.cancel_paste(app.jobs.paste_token);
+    app.jobs.paste_progress = None;
 
     assert!(
         app.paste_progress().is_none(),
@@ -378,24 +378,24 @@ fn new_paste_after_cancel_is_not_affected_by_old_cancel_token() {
 
     // First paste → cancel immediately (token 1 is cancelled).
     app.yank();
-    app.cwd = dst1.clone();
+    app.navigation.cwd = dst1.clone();
     app.paste().unwrap();
-    let cancelled_token = app.paste_token; // == 1
-    app.scheduler.cancel_paste(cancelled_token);
-    app.paste_progress = None;
+    let cancelled_token = app.jobs.paste_token; // == 1
+    app.jobs.scheduler.cancel_paste(cancelled_token);
+    app.jobs.paste_progress = None;
 
     // Re-yank and start a second paste to a different destination.  Its token
     // is 2; cancel_token stored in PasteShared is still 1, so the second
     // paste must NOT be stopped.
-    app.clipboard = Some(super::super::state::Clipboard {
+    app.jobs.clipboard = Some(super::super::state::Clipboard {
         paths: vec![src_dir.join("file.txt")],
         op: ClipOp::Yank,
     });
-    app.cwd = dst2.clone();
+    app.navigation.cwd = dst2.clone();
     app.paste().unwrap();
 
     assert_ne!(
-        app.paste_token, cancelled_token,
+        app.jobs.paste_token, cancelled_token,
         "new paste should have a different token"
     );
 
@@ -427,31 +427,35 @@ fn yank_paste_then_yank_paste_queues_the_second_snapshot() {
     let mut app = App::new_at(src_dir.clone()).unwrap();
 
     app.yank();
-    app.cwd = dst1.clone();
+    app.navigation.cwd = dst1.clone();
     app.paste().unwrap();
 
-    let token_after_first = app.paste_token;
+    let token_after_first = app.jobs.paste_token;
     assert!(app.paste_progress().is_some());
 
     // Queue a second paste after changing both the source selection and the
     // destination directory.  The queued snapshot must preserve both.
-    app.cwd = src_dir.clone();
+    app.navigation.cwd = src_dir.clone();
     app.select_index(1);
     app.yank();
-    app.cwd = dst2.clone();
+    app.navigation.cwd = dst2.clone();
     app.paste().unwrap();
 
     assert_eq!(
-        app.paste_token, token_after_first,
+        app.jobs.paste_token, token_after_first,
         "paste_token must not change until the queued paste actually starts"
     );
-    assert_eq!(app.queued_pastes.len(), 1, "second paste should be queued");
+    assert_eq!(
+        app.jobs.queued_pastes.len(),
+        1,
+        "second paste should be queued"
+    );
     assert!(
         app.status.contains("Queued paste"),
         "status should indicate that the second paste was queued"
     );
-    assert_eq!(app.queued_pastes[0].dest_dir, dst2);
-    assert_eq!(app.queued_pastes[0].paths, vec![src_dir.join("b.txt")]);
+    assert_eq!(app.jobs.queued_pastes[0].dest_dir, dst2);
+    assert_eq!(app.jobs.queued_pastes[0].paths, vec![src_dir.join("b.txt")]);
 
     wait_for_paste(&mut app);
 
@@ -478,24 +482,24 @@ fn queued_paste_with_missing_destination_fails_and_later_queue_continues() {
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
     app.yank();
-    app.cwd = dst1.clone();
+    app.navigation.cwd = dst1.clone();
     app.paste().unwrap();
 
-    app.clipboard = Some(super::super::state::Clipboard {
+    app.jobs.clipboard = Some(super::super::state::Clipboard {
         paths: vec![src_dir.join("b.txt")],
         op: ClipOp::Yank,
     });
-    app.cwd = missing_dst.clone();
+    app.navigation.cwd = missing_dst.clone();
     app.paste().unwrap();
 
-    app.clipboard = Some(super::super::state::Clipboard {
+    app.jobs.clipboard = Some(super::super::state::Clipboard {
         paths: vec![src_dir.join("c.txt")],
         op: ClipOp::Yank,
     });
-    app.cwd = dst3.clone();
+    app.navigation.cwd = dst3.clone();
     app.paste().unwrap();
 
-    assert_eq!(app.queued_pastes.len(), 2);
+    assert_eq!(app.jobs.queued_pastes.len(), 2);
 
     wait_for_paste(&mut app);
 
@@ -525,24 +529,24 @@ fn queued_same_destination_pastes_defer_reload_until_queue_drains() {
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
     app.yank();
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
-    let first_token = app.paste_token;
+    let first_token = app.jobs.paste_token;
 
-    app.clipboard = Some(super::super::state::Clipboard {
+    app.jobs.clipboard = Some(super::super::state::Clipboard {
         paths: vec![src_dir.join("b.txt")],
         op: ClipOp::Yank,
     });
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
 
     let mut queued_started = false;
     for _ in 0..500 {
         let _ = app.process_background_jobs();
-        if app.paste_token != first_token {
+        if app.jobs.paste_token != first_token {
             queued_started = true;
             assert!(
-                app.directory_runtime.pending_load.is_none(),
+                app.navigation.directory_runtime.pending_load.is_none(),
                 "reload should stay deferred while a queued paste to the same destination starts"
             );
             assert!(
@@ -582,16 +586,16 @@ fn esc_cancels_active_paste_and_clears_queued_pastes() {
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
     app.yank();
-    app.cwd = dst1.clone();
+    app.navigation.cwd = dst1.clone();
     app.paste().unwrap();
 
-    app.clipboard = Some(super::super::state::Clipboard {
+    app.jobs.clipboard = Some(super::super::state::Clipboard {
         paths: vec![src_dir.join("b.txt")],
         op: ClipOp::Yank,
     });
-    app.cwd = dst2.clone();
+    app.navigation.cwd = dst2.clone();
     app.paste().unwrap();
-    assert_eq!(app.queued_pastes.len(), 1);
+    assert_eq!(app.jobs.queued_pastes.len(), 1);
 
     app.handle_event(crossterm::event::Event::Key(
         crossterm::event::KeyEvent::from(crossterm::event::KeyCode::Esc),
@@ -600,7 +604,7 @@ fn esc_cancels_active_paste_and_clears_queued_pastes() {
 
     assert!(app.paste_progress().is_none());
     assert!(
-        app.queued_pastes.is_empty(),
+        app.jobs.queued_pastes.is_empty(),
         "Esc should clear queued pastes as well as the active paste"
     );
 
@@ -645,13 +649,13 @@ fn paste_during_active_paste_without_clipboard_explains_how_to_queue() {
 
     let mut app = App::new_at(src_dir.clone()).unwrap();
     app.yank();
-    app.cwd = dst_dir.clone();
+    app.navigation.cwd = dst_dir.clone();
     app.paste().unwrap();
 
-    let token = app.paste_token;
+    let token = app.jobs.paste_token;
     app.paste().unwrap();
 
-    assert_eq!(app.paste_token, token);
+    assert_eq!(app.jobs.paste_token, token);
     assert_eq!(
         app.status,
         "Paste in progress — yank or cut another item to queue it"

--- a/src/app/create/bulk_rename.rs
+++ b/src/app/create/bulk_rename.rs
@@ -16,13 +16,14 @@ use std::{fs, path::PathBuf};
 
 impl App {
     pub(in crate::app) fn open_bulk_rename_prompt(&mut self) {
-        if self.in_trash {
+        if self.navigation.in_trash {
             return;
         }
         let items: Vec<BulkRenameItem> = self
+            .navigation
             .entries
             .iter()
-            .filter(|entry| self.selected_paths.contains(&entry.path))
+            .filter(|entry| self.navigation.selected_paths.contains(&entry.path))
             .map(|entry| BulkRenameItem {
                 path: entry.path.clone(),
                 original_name: entry.name.clone(),
@@ -37,13 +38,13 @@ impl App {
             .iter()
             .map(|item| item.original_name.clone())
             .collect();
-        self.help_open = false;
-        self.search = None;
-        self.create = None;
-        self.rename = None;
-        self.trash = None;
-        self.restore = None;
-        self.bulk_rename = Some(BulkRenameOverlay {
+        self.overlays.help = false;
+        self.overlays.search = None;
+        self.overlays.create = None;
+        self.overlays.rename = None;
+        self.overlays.trash = None;
+        self.overlays.restore = None;
+        self.overlays.bulk_rename = Some(BulkRenameOverlay {
             items,
             new_names,
             cursor_line: 0,
@@ -54,11 +55,11 @@ impl App {
     }
 
     pub fn bulk_rename_is_open(&self) -> bool {
-        self.bulk_rename.is_some()
+        self.overlays.bulk_rename.is_some()
     }
 
     pub fn bulk_rename_title(&self) -> String {
-        let Some(r) = &self.bulk_rename else {
+        let Some(r) = &self.overlays.bulk_rename else {
             return "Rename".to_string();
         };
         if r.items.len() == 1 {
@@ -80,11 +81,15 @@ impl App {
     }
 
     pub fn bulk_rename_item_count(&self) -> usize {
-        self.bulk_rename.as_ref().map_or(0, |r| r.items.len())
+        self.overlays
+            .bulk_rename
+            .as_ref()
+            .map_or(0, |r| r.items.len())
     }
 
     pub fn bulk_rename_new_name(&self, index: usize) -> &str {
-        self.bulk_rename
+        self.overlays
+            .bulk_rename
             .as_ref()
             .and_then(|r| r.new_names.get(index))
             .map(String::as_str)
@@ -92,36 +97,44 @@ impl App {
     }
 
     pub fn bulk_rename_item_is_dir(&self, index: usize) -> bool {
-        self.bulk_rename
+        self.overlays
+            .bulk_rename
             .as_ref()
             .and_then(|r| r.items.get(index))
             .is_some_and(|item| item.is_dir)
     }
 
     pub fn bulk_rename_line_error(&self, index: usize) -> Option<&str> {
-        self.bulk_rename
+        self.overlays
+            .bulk_rename
             .as_ref()
             .and_then(|r| r.line_errors.get(index))
             .and_then(Option::as_deref)
     }
 
     pub fn bulk_rename_cursor_line(&self) -> usize {
-        self.bulk_rename.as_ref().map_or(0, |r| r.cursor_line)
+        self.overlays
+            .bulk_rename
+            .as_ref()
+            .map_or(0, |r| r.cursor_line)
     }
 
     pub fn bulk_rename_cursor_col(&self) -> usize {
-        self.bulk_rename.as_ref().map_or(0, |r| r.cursor_col)
+        self.overlays
+            .bulk_rename
+            .as_ref()
+            .map_or(0, |r| r.cursor_col)
     }
 
     pub(in crate::app) fn handle_bulk_rename_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.bulk_rename = None;
+            self.overlays.bulk_rename = None;
             return Ok(());
         }
 
         match key.code {
             KeyCode::Esc => {
-                self.bulk_rename = None;
+                self.overlays.bulk_rename = None;
             }
             KeyCode::Enter if key.modifiers == KeyModifiers::NONE => {
                 self.confirm_bulk_rename()?;
@@ -136,7 +149,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let new_col = previous_word_start(&r.new_names[r.cursor_line], r.cursor_col);
                     r.cursor_col = new_col;
                     r.preferred_col = new_col;
@@ -146,20 +159,20 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let new_col = next_word_start(&r.new_names[r.cursor_line], r.cursor_col);
                     r.cursor_col = new_col;
                     r.preferred_col = new_col;
                 }
             }
             KeyCode::Left if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     r.cursor_col = r.cursor_col.saturating_sub(1);
                     r.preferred_col = r.cursor_col;
                 }
             }
             KeyCode::Right if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let len = r.new_names[r.cursor_line].chars().count();
                     if r.cursor_col < len {
                         r.cursor_col += 1;
@@ -168,13 +181,13 @@ impl App {
                 }
             }
             KeyCode::Home if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     r.cursor_col = 0;
                     r.preferred_col = 0;
                 }
             }
             KeyCode::End if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     r.cursor_col = r.new_names[r.cursor_line].chars().count();
                     r.preferred_col = r.cursor_col;
                 }
@@ -183,7 +196,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename
+                if let Some(r) = &mut self.overlays.bulk_rename
                     && r.cursor_col > 0
                 {
                     let start = previous_delete_start(&r.new_names[r.cursor_line], r.cursor_col);
@@ -197,7 +210,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename
+                if let Some(r) = &mut self.overlays.bulk_rename
                     && r.cursor_col > 0
                 {
                     let start = previous_delete_start(&r.new_names[r.cursor_line], r.cursor_col);
@@ -211,7 +224,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let end = next_delete_end(&r.new_names[r.cursor_line], r.cursor_col);
                     remove_char_range(&mut r.new_names[r.cursor_line], r.cursor_col, end);
                     r.line_errors[r.cursor_line] = None;
@@ -221,14 +234,14 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::ALT)
                     && !key.modifiers.contains(KeyModifiers::CONTROL) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let end = next_delete_end(&r.new_names[r.cursor_line], r.cursor_col);
                     remove_char_range(&mut r.new_names[r.cursor_line], r.cursor_col, end);
                     r.line_errors[r.cursor_line] = None;
                 }
             }
             KeyCode::Backspace if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename
+                if let Some(r) = &mut self.overlays.bulk_rename
                     && r.cursor_col > 0
                 {
                     let start = char_to_byte(&r.new_names[r.cursor_line], r.cursor_col - 1);
@@ -240,7 +253,7 @@ impl App {
                 }
             }
             KeyCode::Delete if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let len = r.new_names[r.cursor_line].chars().count();
                     if r.cursor_col < len {
                         let start = char_to_byte(&r.new_names[r.cursor_line], r.cursor_col);
@@ -255,7 +268,7 @@ impl App {
                     .modifiers
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.bulk_rename {
+                if let Some(r) = &mut self.overlays.bulk_rename {
                     let byte = char_to_byte(&r.new_names[r.cursor_line], r.cursor_col);
                     r.new_names[r.cursor_line].insert(byte, ch);
                     r.cursor_col += 1;
@@ -269,7 +282,7 @@ impl App {
     }
 
     fn bulk_rename_move_vertical(&mut self, delta: isize) {
-        let Some(r) = &mut self.bulk_rename else {
+        let Some(r) = &mut self.overlays.bulk_rename else {
             return;
         };
         let new_line =
@@ -286,17 +299,18 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 let inside = self
+                    .input
                     .frame_state
                     .rename_panel
                     .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
                 if !inside {
-                    self.bulk_rename = None;
+                    self.overlays.bulk_rename = None;
                     return Ok(());
                 }
-                if let Some(list_area) = self.frame_state.bulk_rename_list_area
+                if let Some(list_area) = self.input.frame_state.bulk_rename_list_area
                     && rect_contains(list_area, mouse.column, mouse.row)
                 {
-                    let scroll_top = self.frame_state.bulk_rename_scroll_top;
+                    let scroll_top = self.input.frame_state.bulk_rename_scroll_top;
                     let row_offset = (mouse.row - list_area.y) as usize;
                     let line_idx = scroll_top + row_offset;
                     let count = self.bulk_rename_item_count();
@@ -304,7 +318,7 @@ impl App {
                         let line_len = self.bulk_rename_new_name(line_idx).chars().count();
                         let char_col = (mouse.column.saturating_sub(list_area.x + 3)) as usize;
                         let cursor_col = char_col.min(line_len);
-                        if let Some(r) = &mut self.bulk_rename {
+                        if let Some(r) = &mut self.overlays.bulk_rename {
                             r.cursor_line = line_idx;
                             r.cursor_col = cursor_col;
                             r.preferred_col = cursor_col;
@@ -324,7 +338,7 @@ impl App {
     }
 
     pub(in crate::app::create) fn confirm_bulk_rename(&mut self) -> Result<()> {
-        let Some(r) = &self.bulk_rename else {
+        let Some(r) = &self.overlays.bulk_rename else {
             return Ok(());
         };
 
@@ -345,7 +359,7 @@ impl App {
             } else if !seen_new_names.insert(new_name.clone()) {
                 Some(format!("\"{}\" appears more than once", new_name))
             } else {
-                let new_path = self.cwd.join(&new_name);
+                let new_path = self.navigation.cwd.join(&new_name);
                 if new_path.exists() && !renaming_paths.contains(&new_path) {
                     Some(format!("\"{}\" already exists", new_name))
                 } else {
@@ -362,7 +376,7 @@ impl App {
         }
 
         if let Some(err_line) = first_error {
-            if let Some(r) = &mut self.bulk_rename {
+            if let Some(r) = &mut self.overlays.bulk_rename {
                 r.line_errors = errors;
                 r.cursor_line = err_line;
                 r.cursor_col = r.cursor_col.min(r.new_names[err_line].chars().count());
@@ -384,8 +398,8 @@ impl App {
             })
             .collect();
 
-        self.bulk_rename = None;
-        self.selected_paths.clear();
+        self.overlays.bulk_rename = None;
+        self.navigation.selected_paths.clear();
 
         let mut renamed = 0usize;
         let mut last_new_path: Option<PathBuf> = None;
@@ -394,7 +408,7 @@ impl App {
             if *new_name == *original_name {
                 continue;
             }
-            let new_path = self.cwd.join(new_name);
+            let new_path = self.navigation.cwd.join(new_name);
             if let Err(error) = fs::rename(old_path, &new_path) {
                 let msg = match error.kind() {
                     std::io::ErrorKind::PermissionDenied => {
@@ -404,8 +418,8 @@ impl App {
                 };
                 self.queue_directory_load(PendingDirectoryLoad {
                     token: 0,
-                    target_cwd: self.cwd.clone(),
-                    previous_cwd: self.cwd.clone(),
+                    target_cwd: self.navigation.cwd.clone(),
+                    previous_cwd: self.navigation.cwd.clone(),
                     previous_selected_path: None,
                     previous_selection_name: None,
                     reselect_path: last_new_path,
@@ -415,7 +429,7 @@ impl App {
                 })?;
                 return Ok(());
             }
-            last_new_path = Some(self.cwd.join(new_name));
+            last_new_path = Some(self.navigation.cwd.join(new_name));
             renamed += 1;
         }
 
@@ -432,8 +446,8 @@ impl App {
         };
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
-            target_cwd: self.cwd.clone(),
-            previous_cwd: self.cwd.clone(),
+            target_cwd: self.navigation.cwd.clone(),
+            previous_cwd: self.navigation.cwd.clone(),
             previous_selected_path: None,
             previous_selection_name: None,
             reselect_path: last_new_path,

--- a/src/app/create/editing.rs
+++ b/src/app/create/editing.rs
@@ -6,7 +6,9 @@ use super::super::text_edit::{
 
 impl App {
     pub(in crate::app::create) fn create_insert_newline(&mut self) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         let tail = {
             let byte = char_to_byte(&c.lines[c.cursor_line], c.cursor_col);
             c.lines[c.cursor_line].split_off(byte)
@@ -19,7 +21,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_move_horizontal(&mut self, delta: isize) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         if delta < 0 {
             if c.cursor_col > 0 {
                 c.cursor_col -= 1;
@@ -40,7 +44,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_move_word(&mut self, direction: isize) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         let line = &c.lines[c.cursor_line];
         let new_col = if direction < 0 {
             previous_word_start(line, c.cursor_col)
@@ -52,7 +58,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_move_vertical(&mut self, delta: isize) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         let new_line =
             (c.cursor_line as isize + delta).clamp(0, c.lines.len() as isize - 1) as usize;
         if new_line == c.cursor_line {
@@ -64,7 +72,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_backspace(&mut self) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         if c.cursor_col > 0 {
             let start = char_to_byte(&c.lines[c.cursor_line], c.cursor_col - 1);
             let end = char_to_byte(&c.lines[c.cursor_line], c.cursor_col);
@@ -84,7 +94,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_delete(&mut self) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         let len = c.lines[c.cursor_line].chars().count();
         if c.cursor_col < len {
             let start = char_to_byte(&c.lines[c.cursor_line], c.cursor_col);
@@ -100,7 +112,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_delete_word_back(&mut self) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         if c.cursor_col == 0 {
             return;
         }
@@ -113,7 +127,9 @@ impl App {
     }
 
     pub(in crate::app::create) fn create_delete_word_forward(&mut self) {
-        let Some(c) = &mut self.create else { return };
+        let Some(c) = &mut self.overlays.create else {
+            return;
+        };
         let line = &mut c.lines[c.cursor_line];
         let end = next_delete_end(line, c.cursor_col);
         remove_char_range(line, c.cursor_col, end);

--- a/src/app/create/mod.rs
+++ b/src/app/create/mod.rs
@@ -27,7 +27,9 @@ mod tests {
     fn wait_for_trash_and_reload(app: &mut App) {
         for _ in 0..500 {
             let _ = app.process_background_jobs();
-            if app.trash_progress().is_none() && app.directory_runtime.pending_load.is_none() {
+            if app.trash_progress().is_none()
+                && app.navigation.directory_runtime.pending_load.is_none()
+            {
                 return;
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -38,7 +40,9 @@ mod tests {
     fn wait_for_restore_and_reload(app: &mut App) {
         for _ in 0..500 {
             let _ = app.process_background_jobs();
-            if app.restore_progress().is_none() && app.directory_runtime.pending_load.is_none() {
+            if app.restore_progress().is_none()
+                && app.navigation.directory_runtime.pending_load.is_none()
+            {
                 return;
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -56,6 +60,7 @@ mod tests {
 
     fn take_pending_status(app: &mut App) -> (String, Option<PathBuf>) {
         let load = app
+            .navigation
             .directory_runtime
             .pending_load
             .take()
@@ -111,13 +116,17 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         app.open_create_prompt();
-        let overlay = app.create.as_mut().expect("create overlay should be open");
+        let overlay = app
+            .overlays
+            .create
+            .as_mut()
+            .expect("create overlay should be open");
         overlay.lines = vec!["notes.txt".to_string(), "/docs/".to_string()];
         overlay.line_errors = vec![None; overlay.lines.len()];
 
         app.confirm_create().expect("create should succeed");
 
-        assert!(app.create.is_none());
+        assert!(app.overlays.create.is_none());
         assert!(root.join("notes.txt").is_file());
         assert!(root.join("docs").is_dir());
 
@@ -125,7 +134,7 @@ mod tests {
         assert_eq!(status, "Created 1 file and 1 folder");
         assert_eq!(reselect_path, Some(root.join("docs")));
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -137,7 +146,11 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         app.open_create_prompt();
-        let overlay = app.create.as_mut().expect("create overlay should be open");
+        let overlay = app
+            .overlays
+            .create
+            .as_mut()
+            .expect("create overlay should be open");
         overlay.lines = vec!["logs/".to_string(), "/logs".to_string()];
         overlay.line_errors = vec![None; overlay.lines.len()];
 
@@ -145,6 +158,7 @@ mod tests {
             .expect("create validation should succeed");
 
         let overlay = app
+            .overlays
             .create
             .as_ref()
             .expect("create overlay should stay open");
@@ -154,9 +168,9 @@ mod tests {
             Some("\"logs\" appears more than once")
         );
         assert!(!root.join("logs").exists());
-        assert!(app.directory_runtime.pending_load.is_none());
+        assert!(app.navigation.directory_runtime.pending_load.is_none());
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -169,14 +183,18 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         app.open_rename_prompt();
-        let overlay = app.rename.as_mut().expect("rename overlay should be open");
+        let overlay = app
+            .overlays
+            .rename
+            .as_mut()
+            .expect("rename overlay should be open");
         assert_eq!(overlay.original_name, "report.txt");
         assert_eq!(overlay.cursor_col, 6);
         overlay.input = "summary.txt".to_string();
 
         app.confirm_rename().expect("rename should succeed");
 
-        assert!(app.rename.is_none());
+        assert!(app.overlays.rename.is_none());
         assert!(!root.join("report.txt").exists());
         assert!(root.join("summary.txt").is_file());
 
@@ -184,7 +202,7 @@ mod tests {
         assert_eq!(status, "Renamed \"report.txt\" → \"summary.txt\"");
         assert_eq!(reselect_path, Some(root.join("summary.txt")));
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -204,11 +222,12 @@ mod tests {
         fs::write(root.join("beta.txt"), "beta").expect("failed to write beta");
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
-        app.selected_paths.insert(root.join("alpha.txt"));
-        app.selected_paths.insert(root.join("beta.txt"));
+        app.navigation.selected_paths.insert(root.join("alpha.txt"));
+        app.navigation.selected_paths.insert(root.join("beta.txt"));
         app.open_bulk_rename_prompt();
 
         let overlay = app
+            .overlays
             .bulk_rename
             .as_mut()
             .expect("bulk rename overlay should be open");
@@ -218,17 +237,17 @@ mod tests {
         app.confirm_bulk_rename()
             .expect("bulk rename should succeed");
 
-        assert!(app.bulk_rename.is_none());
+        assert!(app.overlays.bulk_rename.is_none());
         assert!(root.join("gamma.txt").is_file());
         assert!(root.join("beta.txt").is_file());
         assert!(!root.join("alpha.txt").exists());
-        assert!(app.selected_paths.is_empty());
+        assert!(app.navigation.selected_paths.is_empty());
 
         let (status, reselect_path) = take_pending_status(&mut app);
         assert_eq!(status, "Renamed \"alpha.txt\" → \"gamma.txt\"");
         assert_eq!(reselect_path, Some(root.join("gamma.txt")));
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -241,11 +260,12 @@ mod tests {
         fs::write(root.join("beta.txt"), "beta").expect("failed to write beta");
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
-        app.selected_paths.insert(root.join("alpha.txt"));
-        app.selected_paths.insert(root.join("beta.txt"));
+        app.navigation.selected_paths.insert(root.join("alpha.txt"));
+        app.navigation.selected_paths.insert(root.join("beta.txt"));
         app.open_bulk_rename_prompt();
 
         let overlay = app
+            .overlays
             .bulk_rename
             .as_mut()
             .expect("bulk rename overlay should be open");
@@ -255,6 +275,7 @@ mod tests {
             .expect("bulk rename validation should succeed");
 
         let overlay = app
+            .overlays
             .bulk_rename
             .as_ref()
             .expect("bulk rename overlay should stay open");
@@ -265,9 +286,9 @@ mod tests {
         );
         assert!(root.join("alpha.txt").is_file());
         assert!(root.join("beta.txt").is_file());
-        assert!(app.directory_runtime.pending_load.is_none());
+        assert!(app.navigation.directory_runtime.pending_load.is_none());
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -279,15 +300,15 @@ mod tests {
         fs::write(root.join("gone.txt"), "bye").expect("failed to write file");
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
-        app.in_trash = true;
-        app.selected_paths.insert(root.join("gone.txt"));
+        app.navigation.in_trash = true;
+        app.navigation.selected_paths.insert(root.join("gone.txt"));
         app.open_trash_prompt();
 
         assert_eq!(app.trash_title(), "Delete permanently 1 selected file?");
         app.confirm_trash().expect("trash should succeed");
 
-        assert!(app.trash.is_none());
-        assert!(app.selected_paths.is_empty());
+        assert!(app.overlays.trash.is_none());
+        assert!(app.navigation.selected_paths.is_empty());
 
         // Deletion is async — wait for the background worker *and* the
         // subsequent directory reload to both finish.
@@ -297,7 +318,7 @@ mod tests {
         // Status is set by apply_directory_snapshot once the reload completes.
         assert_eq!(app.status_message(), "Permanently deleted \"gone.txt\"");
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -314,8 +335,8 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         // entries are sorted by name: alpha=0, beta=1, gamma=2
-        app.in_trash = true;
-        app.selected = 1; // cursor on beta.txt
+        app.navigation.in_trash = true;
+        app.navigation.selected = 1; // cursor on beta.txt
         app.remember_current_directory_view(); // simulate a rendered frame committing the position
         app.open_trash_prompt();
         app.confirm_trash().expect("trash should succeed");
@@ -329,7 +350,7 @@ mod tests {
             "cursor should land on gamma.txt (next surviving entry)"
         );
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -345,8 +366,8 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         // entries are sorted by name: alpha=0, beta=1, gamma=2
-        app.in_trash = true;
-        app.selected = 2; // cursor on gamma.txt
+        app.navigation.in_trash = true;
+        app.navigation.selected = 2; // cursor on gamma.txt
         app.remember_current_directory_view(); // simulate a rendered frame committing the position
         app.open_trash_prompt();
         app.confirm_trash().expect("trash should succeed");
@@ -360,7 +381,7 @@ mod tests {
             "cursor should fall back to beta.txt (last surviving entry before cursor)"
         );
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -376,14 +397,14 @@ mod tests {
         fs::write(root.join("gamma.txt"), "c").expect("failed to write gamma");
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
-        app.in_trash = true;
-        app.selected = 1; // cursor on beta.txt
+        app.navigation.in_trash = true;
+        app.navigation.selected = 1; // cursor on beta.txt
         app.remember_current_directory_view(); // simulate a rendered frame committing the position
         app.open_trash_prompt();
         app.confirm_trash().expect("trash should succeed");
 
         // Cancel before the worker starts processing.
-        app.scheduler.cancel_trash(app.trash_token);
+        app.jobs.scheduler.cancel_trash(app.jobs.trash_token);
 
         wait_for_trash_and_reload(&mut app);
 
@@ -409,7 +430,7 @@ mod tests {
             "cursor must point to a surviving entry"
         );
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -424,16 +445,16 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         // in_trash = false → non-permanent batch trash
-        app.selected_paths.insert(root.join("alpha.txt"));
-        app.selected_paths.insert(root.join("beta.txt"));
-        app.selected_paths.insert(root.join("gamma.txt"));
+        app.navigation.selected_paths.insert(root.join("alpha.txt"));
+        app.navigation.selected_paths.insert(root.join("beta.txt"));
+        app.navigation.selected_paths.insert(root.join("gamma.txt"));
         app.open_trash_prompt();
 
         assert_eq!(app.trash_title(), "Trash 3 files?");
         app.confirm_trash().expect("trash should succeed");
 
-        assert!(app.trash.is_none());
-        assert!(app.selected_paths.is_empty());
+        assert!(app.overlays.trash.is_none());
+        assert!(app.navigation.selected_paths.is_empty());
 
         wait_for_trash_and_reload(&mut app);
 
@@ -457,7 +478,7 @@ mod tests {
             }
         }
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -470,14 +491,14 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
         // in_trash = false → non-permanent batch trash
-        app.selected_paths.insert(root.join("notes.txt"));
+        app.navigation.selected_paths.insert(root.join("notes.txt"));
         app.open_trash_prompt();
 
         assert_eq!(app.trash_title(), "Trash 1 selected file?");
         app.confirm_trash().expect("trash should succeed");
 
-        assert!(app.trash.is_none());
-        assert!(app.selected_paths.is_empty());
+        assert!(app.overlays.trash.is_none());
+        assert!(app.navigation.selected_paths.is_empty());
 
         wait_for_trash_and_reload(&mut app);
 
@@ -497,7 +518,7 @@ mod tests {
             }
         }
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -513,7 +534,9 @@ mod tests {
         fs::write(root.join("canary.txt"), "x").expect("failed to write file");
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
-        app.selected_paths.insert(root.join("canary.txt"));
+        app.navigation
+            .selected_paths
+            .insert(root.join("canary.txt"));
         app.open_trash_prompt();
         app.confirm_trash().expect("trash should succeed");
 
@@ -524,7 +547,7 @@ mod tests {
         );
 
         // Simulate Esc: cancel_trash is called but chip must NOT be cleared.
-        app.scheduler.cancel_trash(app.trash_token);
+        app.jobs.scheduler.cancel_trash(app.jobs.trash_token);
         // trash_progress is still Some — chip stays visible.
         assert!(
             app.trash_progress().is_some(),
@@ -561,7 +584,7 @@ mod tests {
             }
         }
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -575,8 +598,8 @@ mod tests {
         fs::write(root.join("gone.txt"), "x").expect("failed to write file");
 
         let mut app = App::new_at(root.clone()).expect("failed to create app");
-        app.in_trash = true;
-        app.selected_paths.insert(root.join("gone.txt"));
+        app.navigation.in_trash = true;
+        app.navigation.selected_paths.insert(root.join("gone.txt"));
         app.open_trash_prompt();
         app.confirm_trash().expect("trash should succeed");
 
@@ -586,9 +609,9 @@ mod tests {
         );
 
         // Simulate Esc for permanent delete: chip clears immediately.
-        let token = app.trash_token;
-        app.scheduler.cancel_trash(token);
-        app.trash_progress = None;
+        let token = app.jobs.trash_token;
+        app.jobs.scheduler.cancel_trash(token);
+        app.jobs.trash_progress = None;
 
         assert!(
             app.trash_progress().is_none(),
@@ -601,7 +624,7 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         // root may or may not still contain gone.txt depending on the race.
         let _ = fs::remove_dir_all(root);
@@ -612,14 +635,14 @@ mod tests {
         let (root, trash_files, original_path, trashed_path) = create_fake_trash_file("restore");
 
         let mut app = App::new_at(trash_files.clone()).expect("failed to create app");
-        app.in_trash = true;
+        app.navigation.in_trash = true;
         app.open_restore_prompt();
 
         assert_eq!(app.restore_title(), "Restore 1 selected file?");
         app.confirm_restore().expect("restore should succeed");
 
-        assert!(app.restore.is_none());
-        assert!(app.selected_paths.is_empty());
+        assert!(app.overlays.restore.is_none());
+        assert!(app.navigation.selected_paths.is_empty());
 
         // Restore is now async — wait for the background worker and
         // subsequent directory reload to both complete.
@@ -629,7 +652,7 @@ mod tests {
         assert!(!trashed_path.exists());
         assert_eq!(app.status_message(), "Restored \"restore-target.txt\"");
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -661,16 +684,20 @@ mod tests {
         }
 
         let mut app = App::new_at(trash_files.clone()).expect("failed to create app");
-        app.in_trash = true;
-        app.selected_paths.insert(trash_files.join("alpha.txt"));
-        app.selected_paths.insert(trash_files.join("beta.txt"));
+        app.navigation.in_trash = true;
+        app.navigation
+            .selected_paths
+            .insert(trash_files.join("alpha.txt"));
+        app.navigation
+            .selected_paths
+            .insert(trash_files.join("beta.txt"));
         app.open_restore_prompt();
 
         assert_eq!(app.restore_title(), "Restore 2 files?");
         app.confirm_restore().expect("restore should succeed");
 
-        assert!(app.restore.is_none());
-        assert!(app.selected_paths.is_empty());
+        assert!(app.overlays.restore.is_none());
+        assert!(app.navigation.selected_paths.is_empty());
 
         wait_for_restore_and_reload(&mut app);
 
@@ -680,7 +707,7 @@ mod tests {
         assert!(!trash_files.join("beta.txt").exists());
         assert_eq!(app.status_message(), "Restored 2 items");
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -693,7 +720,7 @@ mod tests {
             create_fake_trash_file("restore-cancel");
 
         let mut app = App::new_at(trash_files.clone()).expect("failed to create app");
-        app.in_trash = true;
+        app.navigation.in_trash = true;
         app.open_restore_prompt();
         app.confirm_restore().expect("restore should succeed");
 
@@ -703,9 +730,9 @@ mod tests {
         );
 
         // Simulate Esc: chip clears immediately for per-item operations.
-        let token = app.restore_token;
-        app.scheduler.cancel_restore(token);
-        app.restore_progress = None;
+        let token = app.jobs.restore_token;
+        app.jobs.scheduler.cancel_restore(token);
+        app.jobs.restore_progress = None;
 
         assert!(
             app.restore_progress().is_none(),
@@ -718,7 +745,9 @@ mod tests {
         // taken and a directory reload is queued.
         for _ in 0..200 {
             let _ = app.process_background_jobs();
-            if app.restore_source_cwd.is_none() && app.directory_runtime.pending_load.is_none() {
+            if app.jobs.restore_source_cwd.is_none()
+                && app.navigation.directory_runtime.pending_load.is_none()
+            {
                 break;
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -732,7 +761,7 @@ mod tests {
             || status.starts_with("Nothing was restored");
         assert!(valid, "unexpected status: {status:?}");
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         // root may or may not still contain the original file depending on
         // the race; ignore removal errors.
@@ -748,18 +777,18 @@ mod tests {
             create_fake_trash_file("restore-in-progress");
 
         let mut app = App::new_at(trash_files.clone()).expect("failed to create app");
-        app.in_trash = true;
+        app.navigation.in_trash = true;
         app.open_restore_prompt();
         app.confirm_restore().expect("first restore should succeed");
 
         // A second restore is attempted while the first is still in flight.
         app.open_restore_prompt();
-        assert!(app.restore.is_some(), "overlay should open");
+        assert!(app.overlays.restore.is_some(), "overlay should open");
         app.confirm_restore()
             .expect("second confirm should not error");
 
         assert!(
-            app.restore.is_none(),
+            app.overlays.restore.is_none(),
             "overlay should be dismissed by the in-progress guard"
         );
         assert_eq!(
@@ -770,13 +799,15 @@ mod tests {
         // Clean up the background worker.
         for _ in 0..200 {
             let _ = app.process_background_jobs();
-            if app.restore_progress().is_none() && app.directory_runtime.pending_load.is_none() {
+            if app.restore_progress().is_none()
+                && app.navigation.directory_runtime.pending_load.is_none()
+            {
                 break;
             }
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        app.directory_runtime.watch = None;
+        app.navigation.directory_runtime.watch = None;
         drop(app);
         let _ = fs::remove_dir_all(root);
     }

--- a/src/app/create/new_file.rs
+++ b/src/app/create/new_file.rs
@@ -11,15 +11,16 @@ use std::fs;
 
 impl App {
     pub fn create_is_open(&self) -> bool {
-        self.create.is_some()
+        self.overlays.create.is_some()
     }
 
     pub fn create_line_count(&self) -> usize {
-        self.create.as_ref().map_or(0, |c| c.lines.len())
+        self.overlays.create.as_ref().map_or(0, |c| c.lines.len())
     }
 
     pub fn create_line(&self, index: usize) -> &str {
-        self.create
+        self.overlays
+            .create
             .as_ref()
             .and_then(|c| c.lines.get(index))
             .map(String::as_str)
@@ -27,15 +28,15 @@ impl App {
     }
 
     pub fn create_cursor_line(&self) -> usize {
-        self.create.as_ref().map_or(0, |c| c.cursor_line)
+        self.overlays.create.as_ref().map_or(0, |c| c.cursor_line)
     }
 
     pub fn create_cursor_col(&self) -> usize {
-        self.create.as_ref().map_or(0, |c| c.cursor_col)
+        self.overlays.create.as_ref().map_or(0, |c| c.cursor_col)
     }
 
     pub fn create_title(&self) -> String {
-        let Some(c) = &self.create else {
+        let Some(c) = &self.overlays.create else {
             return "Create".to_string();
         };
         let files = c
@@ -69,7 +70,8 @@ impl App {
     }
 
     pub fn create_line_error(&self, index: usize) -> Option<&str> {
-        self.create
+        self.overlays
+            .create
             .as_ref()
             .and_then(|c| c.line_errors.get(index))
             .and_then(Option::as_deref)
@@ -78,9 +80,9 @@ impl App {
 
 impl App {
     pub(in crate::app) fn open_create_prompt(&mut self) {
-        self.help_open = false;
-        self.search = None;
-        self.create = Some(CreateOverlay {
+        self.overlays.help = false;
+        self.overlays.search = None;
+        self.overlays.create = Some(CreateOverlay {
             lines: vec![String::new()],
             cursor_line: 0,
             cursor_col: 0,
@@ -93,13 +95,13 @@ impl App {
 impl App {
     pub(in crate::app) fn handle_create_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.create = None;
+            self.overlays.create = None;
             return Ok(());
         }
 
         match key.code {
             KeyCode::Esc => {
-                self.create = None;
+                self.overlays.create = None;
             }
             KeyCode::Enter
                 if (key.modifiers.contains(KeyModifiers::ALT)
@@ -133,13 +135,13 @@ impl App {
                 self.create_move_horizontal(1);
             }
             KeyCode::Home if key.modifiers == KeyModifiers::NONE => {
-                if let Some(c) = &mut self.create {
+                if let Some(c) = &mut self.overlays.create {
                     c.cursor_col = 0;
                     c.preferred_col = 0;
                 }
             }
             KeyCode::End if key.modifiers == KeyModifiers::NONE => {
-                if let Some(c) = &mut self.create {
+                if let Some(c) = &mut self.overlays.create {
                     let len = c.lines[c.cursor_line].chars().count();
                     c.cursor_col = len;
                     c.preferred_col = len;
@@ -186,7 +188,7 @@ impl App {
                     .modifiers
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
             {
-                if let Some(c) = &mut self.create {
+                if let Some(c) = &mut self.overlays.create {
                     let byte = char_to_byte(&c.lines[c.cursor_line], c.cursor_col);
                     c.lines[c.cursor_line].insert(byte, ch);
                     c.cursor_col += 1;
@@ -205,17 +207,18 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 let inside = self
+                    .input
                     .frame_state
                     .create_panel
                     .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
                 if !inside {
-                    self.create = None;
+                    self.overlays.create = None;
                     return Ok(());
                 }
-                if let Some(list_area) = self.frame_state.create_list_area
+                if let Some(list_area) = self.input.frame_state.create_list_area
                     && rect_contains(list_area, mouse.column, mouse.row)
                 {
-                    let scroll_top = self.frame_state.create_scroll_top;
+                    let scroll_top = self.input.frame_state.create_scroll_top;
                     let row_offset = (mouse.row - list_area.y) as usize;
                     let line_idx = scroll_top + row_offset;
                     let line_count = self.create_line_count();
@@ -223,7 +226,7 @@ impl App {
                         let line_len = self.create_line(line_idx).chars().count();
                         let char_col = (mouse.column.saturating_sub(list_area.x + 3)) as usize;
                         let cursor_col = char_col.min(line_len);
-                        if let Some(c) = &mut self.create {
+                        if let Some(c) = &mut self.overlays.create {
                             c.cursor_line = line_idx;
                             c.cursor_col = cursor_col;
                             c.preferred_col = cursor_col;
@@ -245,7 +248,7 @@ impl App {
 
 impl App {
     pub(in crate::app::create) fn confirm_create(&mut self) -> Result<()> {
-        let Some(c) = &self.create else {
+        let Some(c) = &self.overlays.create else {
             return Ok(());
         };
 
@@ -258,11 +261,12 @@ impl App {
             .collect();
 
         if items.is_empty() {
-            self.create = None;
+            self.overlays.create = None;
             return Ok(());
         }
 
         let mut errors: Vec<Option<String>> = self
+            .overlays
             .create
             .as_ref()
             .expect("create overlay should still be present")
@@ -276,7 +280,7 @@ impl App {
             let msg = if !seen_names.insert(item.name.clone()) {
                 Some(format!("\"{}\" appears more than once", item.name))
             } else {
-                validate_parsed_item(item, &self.cwd)
+                validate_parsed_item(item, &self.navigation.cwd)
             };
             if let Some(msg) = msg {
                 errors[*line_idx] = Some(msg);
@@ -287,7 +291,7 @@ impl App {
         }
 
         if let Some(err_line) = first_error_line {
-            if let Some(c) = &mut self.create {
+            if let Some(c) = &mut self.overlays.create {
                 c.line_errors = errors;
                 c.cursor_line = err_line;
                 c.cursor_col = c.cursor_col.min(c.lines[err_line].chars().count());
@@ -298,7 +302,7 @@ impl App {
 
         let mut last_path: Option<std::path::PathBuf> = None;
         for (_, item) in &items {
-            let path = self.cwd.join(&item.name);
+            let path = self.navigation.cwd.join(&item.name);
             let result = if item.is_dir {
                 fs::create_dir(&path).map_err(anyhow::Error::from)
             } else {
@@ -324,7 +328,7 @@ impl App {
                         _ => None,
                     })
                     .unwrap_or_else(|| error.to_string());
-                if let Some(c) = &mut self.create {
+                if let Some(c) = &mut self.overlays.create {
                     c.line_errors[line_idx] = Some(msg);
                     c.cursor_line = line_idx;
                 }
@@ -333,7 +337,7 @@ impl App {
             last_path = Some(path);
         }
 
-        self.create = None;
+        self.overlays.create = None;
         let files = items.iter().filter(|(_, item)| !item.is_dir).count();
         let dirs = items.iter().filter(|(_, item)| item.is_dir).count();
         let status = match (files, dirs) {
@@ -365,8 +369,8 @@ impl App {
         };
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
-            target_cwd: self.cwd.clone(),
-            previous_cwd: self.cwd.clone(),
+            target_cwd: self.navigation.cwd.clone(),
+            previous_cwd: self.navigation.cwd.clone(),
             previous_selected_path: self.selected_entry().map(|entry| entry.path.clone()),
             previous_selection_name: self.selected_entry().map(|entry| entry.name.clone()),
             reselect_path: last_path,

--- a/src/app/create/rename.rs
+++ b/src/app/create/rename.rs
@@ -13,7 +13,7 @@ use std::fs;
 
 impl App {
     pub(in crate::app) fn open_rename_prompt(&mut self) {
-        if self.in_trash {
+        if self.navigation.in_trash {
             return;
         }
         let Some(entry) = self.selected_entry() else {
@@ -22,12 +22,12 @@ impl App {
         let name = entry.name.clone();
         let is_dir = entry.is_dir();
         let cursor_col = cursor_before_extension(&name);
-        self.help_open = false;
-        self.search = None;
-        self.create = None;
-        self.trash = None;
-        self.restore = None;
-        self.rename = Some(RenameOverlay {
+        self.overlays.help = false;
+        self.overlays.search = None;
+        self.overlays.create = None;
+        self.overlays.trash = None;
+        self.overlays.restore = None;
+        self.overlays.rename = Some(RenameOverlay {
             is_dir,
             original_name: name.clone(),
             input: name,
@@ -37,38 +37,44 @@ impl App {
     }
 
     pub fn rename_is_open(&self) -> bool {
-        self.rename.is_some()
+        self.overlays.rename.is_some()
     }
 
     pub fn rename_input(&self) -> &str {
-        self.rename.as_ref().map_or("", |r| &r.input)
+        self.overlays.rename.as_ref().map_or("", |r| &r.input)
     }
 
     pub fn rename_cursor_col(&self) -> usize {
-        self.rename.as_ref().map_or(0, |r| r.cursor_col)
+        self.overlays.rename.as_ref().map_or(0, |r| r.cursor_col)
     }
 
     pub fn rename_original_name(&self) -> &str {
-        self.rename.as_ref().map_or("", |r| &r.original_name)
+        self.overlays
+            .rename
+            .as_ref()
+            .map_or("", |r| &r.original_name)
     }
 
     pub fn rename_item_is_dir(&self) -> bool {
-        self.rename.as_ref().is_some_and(|r| r.is_dir)
+        self.overlays.rename.as_ref().is_some_and(|r| r.is_dir)
     }
 
     pub fn rename_error(&self) -> Option<&str> {
-        self.rename.as_ref().and_then(|r| r.error.as_deref())
+        self.overlays
+            .rename
+            .as_ref()
+            .and_then(|r| r.error.as_deref())
     }
 
     pub(in crate::app) fn handle_rename_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.rename = None;
+            self.overlays.rename = None;
             return Ok(());
         }
 
         match key.code {
             KeyCode::Esc => {
-                self.rename = None;
+                self.overlays.rename = None;
             }
             KeyCode::Enter if key.modifiers == KeyModifiers::NONE => {
                 self.confirm_rename()?;
@@ -77,7 +83,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let new_col = previous_word_start(&r.input, r.cursor_col);
                     r.cursor_col = new_col;
                 }
@@ -86,18 +92,18 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let new_col = next_word_start(&r.input, r.cursor_col);
                     r.cursor_col = new_col;
                 }
             }
             KeyCode::Left if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     r.cursor_col = r.cursor_col.saturating_sub(1);
                 }
             }
             KeyCode::Right if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let len = r.input.chars().count();
                     if r.cursor_col < len {
                         r.cursor_col += 1;
@@ -105,12 +111,12 @@ impl App {
                 }
             }
             KeyCode::Home if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     r.cursor_col = 0;
                 }
             }
             KeyCode::End if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     r.cursor_col = r.input.chars().count();
                 }
             }
@@ -118,7 +124,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename
+                if let Some(r) = &mut self.overlays.rename
                     && r.cursor_col > 0
                 {
                     let start = previous_delete_start(&r.input, r.cursor_col);
@@ -131,7 +137,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename
+                if let Some(r) = &mut self.overlays.rename
                     && r.cursor_col > 0
                 {
                     let start = previous_delete_start(&r.input, r.cursor_col);
@@ -144,7 +150,7 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let end = next_delete_end(&r.input, r.cursor_col);
                     remove_char_range(&mut r.input, r.cursor_col, end);
                     r.error = None;
@@ -154,14 +160,14 @@ impl App {
                 if key.modifiers.contains(KeyModifiers::ALT)
                     && !key.modifiers.contains(KeyModifiers::CONTROL) =>
             {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let end = next_delete_end(&r.input, r.cursor_col);
                     remove_char_range(&mut r.input, r.cursor_col, end);
                     r.error = None;
                 }
             }
             KeyCode::Backspace if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename
+                if let Some(r) = &mut self.overlays.rename
                     && r.cursor_col > 0
                 {
                     let start = char_to_byte(&r.input, r.cursor_col - 1);
@@ -172,7 +178,7 @@ impl App {
                 }
             }
             KeyCode::Delete if key.modifiers == KeyModifiers::NONE => {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let len = r.input.chars().count();
                     if r.cursor_col < len {
                         let start = char_to_byte(&r.input, r.cursor_col);
@@ -187,7 +193,7 @@ impl App {
                     .modifiers
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
             {
-                if let Some(r) = &mut self.rename {
+                if let Some(r) = &mut self.overlays.rename {
                     let byte = char_to_byte(&r.input, r.cursor_col);
                     r.input.insert(byte, ch);
                     r.cursor_col += 1;
@@ -202,53 +208,55 @@ impl App {
     pub(in crate::app) fn handle_rename_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
         if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
             let inside = self
+                .input
                 .frame_state
                 .rename_panel
                 .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
             if !inside {
-                self.rename = None;
+                self.overlays.rename = None;
             }
         }
         Ok(())
     }
 
     pub(in crate::app::create) fn confirm_rename(&mut self) -> Result<()> {
-        let Some(r) = &self.rename else {
+        let Some(r) = &self.overlays.rename else {
             return Ok(());
         };
         let new_name = r.input.trim().to_string();
         let original_name = r.original_name.clone();
 
         if new_name.is_empty() {
-            if let Some(r) = &mut self.rename {
+            if let Some(r) = &mut self.overlays.rename {
                 r.error = Some("Name cannot be empty".to_string());
             }
             return Ok(());
         }
         if new_name.contains('/') {
-            if let Some(r) = &mut self.rename {
+            if let Some(r) = &mut self.overlays.rename {
                 r.error = Some("Name cannot contain /".to_string());
             }
             return Ok(());
         }
         if new_name == original_name {
-            self.rename = None;
+            self.overlays.rename = None;
             return Ok(());
         }
-        let new_path = self.cwd.join(&new_name);
+        let new_path = self.navigation.cwd.join(&new_name);
         if new_path.exists() {
-            if let Some(r) = &mut self.rename {
+            if let Some(r) = &mut self.overlays.rename {
                 r.error = Some(format!("\"{}\" already exists", new_name));
             }
             return Ok(());
         }
 
         let Some(entry) = self
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.name == original_name)
         else {
-            self.rename = None;
+            self.overlays.rename = None;
             return Ok(());
         };
         let old_path = entry.path.clone();
@@ -260,18 +268,18 @@ impl App {
                 }
                 _ => format!("Could not rename: {error}"),
             };
-            if let Some(r) = &mut self.rename {
+            if let Some(r) = &mut self.overlays.rename {
                 r.error = Some(msg);
             }
             return Ok(());
         }
 
-        self.rename = None;
+        self.overlays.rename = None;
         let status = format!("Renamed \"{}\" → \"{}\"", original_name, new_name);
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
-            target_cwd: self.cwd.clone(),
-            previous_cwd: self.cwd.clone(),
+            target_cwd: self.navigation.cwd.clone(),
+            previous_cwd: self.navigation.cwd.clone(),
             previous_selected_path: None,
             previous_selection_name: None,
             reselect_path: Some(new_path),

--- a/src/app/create/restore.rs
+++ b/src/app/create/restore.rs
@@ -9,7 +9,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 
 impl App {
     pub(in crate::app) fn open_restore_prompt(&mut self) {
-        if !self.in_trash {
+        if !self.navigation.in_trash {
             return;
         }
         let targets = self.selected_trash_targets();
@@ -18,11 +18,11 @@ impl App {
             return;
         }
 
-        self.help_open = false;
-        self.search = None;
-        self.create = None;
-        self.trash = None;
-        self.restore = Some(RestoreOverlay {
+        self.overlays.help = false;
+        self.overlays.search = None;
+        self.overlays.create = None;
+        self.overlays.trash = None;
+        self.overlays.restore = Some(RestoreOverlay {
             targets,
             scroll: 0,
             confirmed: true,
@@ -30,18 +30,19 @@ impl App {
     }
 
     pub fn restore_is_open(&self) -> bool {
-        self.restore.is_some()
+        self.overlays.restore.is_some()
     }
 
     /// Returns `(completed, total)` for an in-progress restore, or `None` when idle.
     pub fn restore_progress(&self) -> Option<(usize, usize)> {
-        self.restore_progress
+        self.jobs
+            .restore_progress
             .as_ref()
             .map(|p| (p.completed, p.total))
     }
 
     pub fn restore_title(&self) -> String {
-        let Some(r) = &self.restore else {
+        let Some(r) = &self.overlays.restore else {
             return String::new();
         };
         match r.targets.len() {
@@ -72,11 +73,14 @@ impl App {
     }
 
     pub fn restore_scroll(&self) -> usize {
-        self.restore.as_ref().map_or(0, |r| r.scroll)
+        self.overlays.restore.as_ref().map_or(0, |r| r.scroll)
     }
 
     pub fn restore_target_count(&self) -> usize {
-        self.restore.as_ref().map_or(0, |r| r.targets.len())
+        self.overlays
+            .restore
+            .as_ref()
+            .map_or(0, |r| r.targets.len())
     }
 
     pub fn restore_visible_rows(&self) -> usize {
@@ -84,71 +88,74 @@ impl App {
     }
 
     pub fn restore_target_name_at(&self, index: usize) -> Option<&str> {
-        self.restore
+        self.overlays
+            .restore
             .as_ref()
             .and_then(|r| r.targets.get(index))
             .map(|target| target.name.as_str())
     }
 
     pub fn restore_target_path_at(&self, index: usize) -> Option<&std::path::Path> {
-        self.restore
+        self.overlays
+            .restore
             .as_ref()
             .and_then(|r| r.targets.get(index))
             .map(|target| target.path.as_path())
     }
 
     pub fn restore_target_is_dir_at(&self, index: usize) -> bool {
-        self.restore
+        self.overlays
+            .restore
             .as_ref()
             .and_then(|r| r.targets.get(index))
             .is_some_and(|target| target.is_dir)
     }
 
     pub fn restore_confirmed(&self) -> bool {
-        self.restore.as_ref().is_some_and(|r| r.confirmed)
+        self.overlays.restore.as_ref().is_some_and(|r| r.confirmed)
     }
 
     pub(in crate::app) fn handle_restore_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.restore = None;
+            self.overlays.restore = None;
             return Ok(());
         }
         match key.code {
             KeyCode::Esc => {
-                self.restore = None;
+                self.overlays.restore = None;
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     r.scroll = r.scroll.saturating_sub(1);
                 }
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     let visible = r.targets.len().min(8);
                     let max_scroll = r.targets.len().saturating_sub(visible);
                     r.scroll = (r.scroll + 1).min(max_scroll);
                 }
             }
             KeyCode::Left | KeyCode::Char('h') => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     r.confirmed = true;
                 }
             }
             KeyCode::Right | KeyCode::Char('l') => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     r.confirmed = false;
                 }
             }
             KeyCode::Tab => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     r.confirmed = !r.confirmed;
                 }
             }
             KeyCode::Enter => {
-                if self.restore.as_ref().is_some_and(|r| r.confirmed) {
+                if self.overlays.restore.as_ref().is_some_and(|r| r.confirmed) {
                     self.confirm_restore()?;
                 } else {
-                    self.restore = None;
+                    self.overlays.restore = None;
                 }
             }
             _ => {}
@@ -160,34 +167,37 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 let inside = self
+                    .input
                     .frame_state
                     .restore_panel
                     .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
                 if !inside {
-                    self.restore = None;
+                    self.overlays.restore = None;
                     return Ok(());
                 }
                 if self
+                    .input
                     .frame_state
                     .restore_confirm_btn
                     .is_some_and(|rect| rect_contains(rect, mouse.column, mouse.row))
                 {
                     self.confirm_restore()?;
                 } else if self
+                    .input
                     .frame_state
                     .restore_cancel_btn
                     .is_some_and(|rect| rect_contains(rect, mouse.column, mouse.row))
                 {
-                    self.restore = None;
+                    self.overlays.restore = None;
                 }
             }
             MouseEventKind::ScrollUp => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     r.scroll = r.scroll.saturating_sub(1);
                 }
             }
             MouseEventKind::ScrollDown => {
-                if let Some(r) = &mut self.restore {
+                if let Some(r) = &mut self.overlays.restore {
                     let visible = r.targets.len().min(8);
                     let max_scroll = r.targets.len().saturating_sub(visible);
                     r.scroll = (r.scroll + 1).min(max_scroll);
@@ -199,28 +209,28 @@ impl App {
     }
 
     pub(in crate::app::create) fn confirm_restore(&mut self) -> Result<()> {
-        if self.restore_progress.is_some() {
+        if self.jobs.restore_progress.is_some() {
             self.status = "Restore in progress — press Esc to cancel".to_string();
-            self.restore = None;
+            self.overlays.restore = None;
             return Ok(());
         }
-        let Some(r) = self.restore.take() else {
+        let Some(r) = self.overlays.restore.take() else {
             return Ok(());
         };
         if r.targets.is_empty() {
             return Ok(());
         }
-        self.selected_paths.clear();
+        self.navigation.selected_paths.clear();
 
-        let token = self.restore_token.wrapping_add(1);
-        self.restore_token = token;
-        self.restore_progress = Some(RestoreProgress {
+        let token = self.jobs.restore_token.wrapping_add(1);
+        self.jobs.restore_token = token;
+        self.jobs.restore_progress = Some(RestoreProgress {
             completed: 0,
             total: r.targets.len(),
         });
-        self.restore_source_cwd = Some(self.cwd.clone());
+        self.jobs.restore_source_cwd = Some(self.navigation.cwd.clone());
 
-        self.scheduler.submit_restore(RestoreRequest {
+        self.jobs.scheduler.submit_restore(RestoreRequest {
             token,
             targets: r.targets,
         });

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 impl App {
     pub(in crate::app) fn cwd_is_trash(&self) -> bool {
-        self.in_trash
+        self.navigation.in_trash
     }
 
     pub(in crate::app) fn path_is_trash(path: &Path) -> bool {
@@ -20,20 +20,21 @@ impl App {
     }
 
     pub(in crate::app) fn effective_show_hidden(&self) -> bool {
-        self.show_hidden || self.in_trash
+        self.navigation.show_hidden || self.navigation.in_trash
     }
 
     pub(in crate::app) fn effective_show_hidden_for(&self, path: &Path) -> bool {
-        self.show_hidden || Self::path_is_trash(path)
+        self.navigation.show_hidden || Self::path_is_trash(path)
     }
 }
 
 impl App {
     pub(in crate::app::create) fn selected_trash_targets(&self) -> Vec<TrashTarget> {
-        if !self.selected_paths.is_empty() {
-            self.entries
+        if !self.navigation.selected_paths.is_empty() {
+            self.navigation
+                .entries
                 .iter()
-                .filter(|entry| self.selected_paths.contains(&entry.path))
+                .filter(|entry| self.navigation.selected_paths.contains(&entry.path))
                 .map(|entry| TrashTarget {
                     path: entry.path.clone(),
                     name: entry.name.clone(),
@@ -61,10 +62,10 @@ impl App {
         }
 
         let permanent = self.cwd_is_trash();
-        self.help_open = false;
-        self.search = None;
-        self.create = None;
-        self.trash = Some(TrashOverlay {
+        self.overlays.help = false;
+        self.overlays.search = None;
+        self.overlays.create = None;
+        self.overlays.trash = Some(TrashOverlay {
             targets,
             scroll: 0,
             confirmed: true,
@@ -73,19 +74,20 @@ impl App {
     }
 
     pub fn trash_is_open(&self) -> bool {
-        self.trash.is_some()
+        self.overlays.trash.is_some()
     }
 
     /// Returns `(completed, total, permanent)` for an in-progress
     /// trash/delete, or `None` when idle.
     pub fn trash_progress(&self) -> Option<(usize, usize, bool)> {
-        self.trash_progress
+        self.jobs
+            .trash_progress
             .as_ref()
             .map(|p| (p.completed, p.total, p.permanent))
     }
 
     pub fn trash_title(&self) -> String {
-        let Some(t) = &self.trash else {
+        let Some(t) = &self.overlays.trash else {
             return String::new();
         };
         let verb = if t.permanent {
@@ -121,11 +123,11 @@ impl App {
     }
 
     pub fn trash_scroll(&self) -> usize {
-        self.trash.as_ref().map_or(0, |t| t.scroll)
+        self.overlays.trash.as_ref().map_or(0, |t| t.scroll)
     }
 
     pub fn trash_target_count(&self) -> usize {
-        self.trash.as_ref().map_or(0, |t| t.targets.len())
+        self.overlays.trash.as_ref().map_or(0, |t| t.targets.len())
     }
 
     pub fn trash_visible_rows(&self) -> usize {
@@ -133,71 +135,74 @@ impl App {
     }
 
     pub fn trash_target_name_at(&self, index: usize) -> Option<&str> {
-        self.trash
+        self.overlays
+            .trash
             .as_ref()
             .and_then(|t| t.targets.get(index))
             .map(|target| target.name.as_str())
     }
 
     pub fn trash_target_path_at(&self, index: usize) -> Option<&std::path::Path> {
-        self.trash
+        self.overlays
+            .trash
             .as_ref()
             .and_then(|t| t.targets.get(index))
             .map(|target| target.path.as_path())
     }
 
     pub fn trash_target_is_dir_at(&self, index: usize) -> bool {
-        self.trash
+        self.overlays
+            .trash
             .as_ref()
             .and_then(|t| t.targets.get(index))
             .is_some_and(|target| target.is_dir)
     }
 
     pub fn trash_confirmed(&self) -> bool {
-        self.trash.as_ref().is_some_and(|t| t.confirmed)
+        self.overlays.trash.as_ref().is_some_and(|t| t.confirmed)
     }
 
     pub(in crate::app) fn handle_trash_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.trash = None;
+            self.overlays.trash = None;
             return Ok(());
         }
         match key.code {
             KeyCode::Esc => {
-                self.trash = None;
+                self.overlays.trash = None;
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     t.scroll = t.scroll.saturating_sub(1);
                 }
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     let visible = t.targets.len().min(8);
                     let max_scroll = t.targets.len().saturating_sub(visible);
                     t.scroll = (t.scroll + 1).min(max_scroll);
                 }
             }
             KeyCode::Left | KeyCode::Char('h') => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     t.confirmed = true;
                 }
             }
             KeyCode::Right | KeyCode::Char('l') => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     t.confirmed = false;
                 }
             }
             KeyCode::Tab => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     t.confirmed = !t.confirmed;
                 }
             }
             KeyCode::Enter => {
-                if self.trash.as_ref().is_some_and(|t| t.confirmed) {
+                if self.overlays.trash.as_ref().is_some_and(|t| t.confirmed) {
                     self.confirm_trash()?;
                 } else {
-                    self.trash = None;
+                    self.overlays.trash = None;
                 }
             }
             _ => {}
@@ -209,34 +214,37 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 let inside = self
+                    .input
                     .frame_state
                     .trash_panel
                     .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
                 if !inside {
-                    self.trash = None;
+                    self.overlays.trash = None;
                     return Ok(());
                 }
                 if self
+                    .input
                     .frame_state
                     .trash_confirm_btn
                     .is_some_and(|rect| rect_contains(rect, mouse.column, mouse.row))
                 {
                     self.confirm_trash()?;
                 } else if self
+                    .input
                     .frame_state
                     .trash_cancel_btn
                     .is_some_and(|rect| rect_contains(rect, mouse.column, mouse.row))
                 {
-                    self.trash = None;
+                    self.overlays.trash = None;
                 }
             }
             MouseEventKind::ScrollUp => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     t.scroll = t.scroll.saturating_sub(1);
                 }
             }
             MouseEventKind::ScrollDown => {
-                if let Some(t) = &mut self.trash {
+                if let Some(t) = &mut self.overlays.trash {
                     let visible = t.targets.len().min(8);
                     let max_scroll = t.targets.len().saturating_sub(visible);
                     t.scroll = (t.scroll + 1).min(max_scroll);
@@ -248,7 +256,7 @@ impl App {
     }
 
     pub(in crate::app::create) fn confirm_trash(&mut self) -> Result<()> {
-        if let Some(prog) = &self.trash_progress {
+        if let Some(prog) = &self.jobs.trash_progress {
             self.status = if prog.permanent {
                 "Delete in progress — press Esc to cancel".to_string()
             } else {
@@ -256,16 +264,16 @@ impl App {
                 // reliably interrupted once started.
                 "Trash in progress".to_string()
             };
-            self.trash = None;
+            self.overlays.trash = None;
             return Ok(());
         }
-        let Some(t) = self.trash.take() else {
+        let Some(t) = self.overlays.trash.take() else {
             return Ok(());
         };
         if t.targets.is_empty() {
             return Ok(());
         }
-        self.selected_paths.clear();
+        self.navigation.selected_paths.clear();
 
         // Compute which entry to land on after deletion: first surviving entry
         // at or after the current cursor, falling back to the last surviving
@@ -273,28 +281,30 @@ impl App {
         let deleted_paths: std::collections::HashSet<_> =
             t.targets.iter().map(|tgt| &tgt.path).collect();
         let next_selection = self
+            .navigation
             .entries
             .iter()
             .enumerate()
             .filter(|(_, e)| !deleted_paths.contains(&e.path))
-            .find(|(i, _)| *i >= self.selected)
+            .find(|(i, _)| *i >= self.navigation.selected)
             .or_else(|| {
-                self.entries
+                self.navigation
+                    .entries
                     .iter()
                     .enumerate()
                     .rfind(|(_, e)| !deleted_paths.contains(&e.path))
             })
             .map(|(_, e)| e.path.clone());
 
-        let token = self.trash_token.wrapping_add(1);
-        self.trash_token = token;
-        self.trash_progress = Some(TrashProgress {
+        let token = self.jobs.trash_token.wrapping_add(1);
+        self.jobs.trash_token = token;
+        self.jobs.trash_progress = Some(TrashProgress {
             completed: 0,
             total: t.targets.len(),
             permanent: t.permanent,
             next_selection,
         });
-        self.trash_source_cwd = Some(self.cwd.clone());
+        self.jobs.trash_source_cwd = Some(self.navigation.cwd.clone());
 
         // Best-effort cross-device detection: if the source appears to be on a
         // different device than the home data dir (where the trash usually lives),
@@ -306,7 +316,7 @@ impl App {
             self.status = "Copying to trash…".to_string();
         }
 
-        self.scheduler.submit_trash(TrashRequest {
+        self.jobs.scheduler.submit_trash(TrashRequest {
             token,
             targets: t.targets,
             permanent: t.permanent,

--- a/src/app/directory_counts.rs
+++ b/src/app/directory_counts.rs
@@ -18,42 +18,48 @@ impl App {
             modified,
             show_hidden,
         };
-        self.directory_item_count_cache
+        self.navigation
+            .directory_item_count_cache
             .insert(key.clone(), item_count);
-        self.directory_item_count_order
+        self.navigation
+            .directory_item_count_order
             .retain(|queued| queued != &key);
-        self.directory_item_count_order.push_back(key.clone());
+        self.navigation
+            .directory_item_count_order
+            .push_back(key.clone());
 
-        while self.directory_item_count_order.len() > DIRECTORY_ITEM_COUNT_CACHE_LIMIT {
-            if let Some(stale_key) = self.directory_item_count_order.pop_front() {
-                self.directory_item_count_cache.remove(&stale_key);
+        while self.navigation.directory_item_count_order.len() > DIRECTORY_ITEM_COUNT_CACHE_LIMIT {
+            if let Some(stale_key) = self.navigation.directory_item_count_order.pop_front() {
+                self.navigation
+                    .directory_item_count_cache
+                    .remove(&stale_key);
             }
         }
     }
 
     pub(super) fn queue_visible_directory_item_counts(&mut self) {
         let viewport = DirectoryCountViewport {
-            fingerprint: self.directory_runtime.fingerprint,
-            scroll_row: self.scroll_row,
-            cols: self.frame_state.metrics.cols.max(1),
-            rows_visible: self.frame_state.metrics.rows_visible.max(1),
+            fingerprint: self.navigation.directory_runtime.fingerprint,
+            scroll_row: self.navigation.scroll_row,
+            cols: self.input.frame_state.metrics.cols.max(1),
+            rows_visible: self.input.frame_state.metrics.rows_visible.max(1),
             show_hidden: self.effective_show_hidden(),
         };
-        if self.directory_count_viewport == Some(viewport) {
+        if self.navigation.directory_count_viewport == Some(viewport) {
             return;
         }
-        self.directory_count_viewport = Some(viewport);
+        self.navigation.directory_count_viewport = Some(viewport);
 
         let requests = self
             .visible_entry_indices()
             .into_iter()
-            .filter_map(|index| self.entries.get(index))
+            .filter_map(|index| self.navigation.entries.get(index))
             .filter(|entry| entry.is_dir())
             .filter_map(|entry| self.directory_item_count_request_for(entry))
             .collect::<Vec<_>>();
 
         for request in requests {
-            let _ = self.scheduler.submit_directory_item_count(request);
+            let _ = self.jobs.scheduler.submit_directory_item_count(request);
         }
     }
 
@@ -68,7 +74,7 @@ impl App {
         }
 
         self.visible_entry_indices().into_iter().any(|index| {
-            self.entries.get(index).is_some_and(|entry| {
+            self.navigation.entries.get(index).is_some_and(|entry| {
                 entry.is_dir() && entry.path == path && entry.modified == modified
             })
         })
@@ -76,7 +82,11 @@ impl App {
 
     fn directory_item_count(&self, entry: &Entry) -> Option<usize> {
         let key = self.directory_item_count_key_for(entry)?;
-        self.directory_item_count_cache.get(&key).copied().flatten()
+        self.navigation
+            .directory_item_count_cache
+            .get(&key)
+            .copied()
+            .flatten()
     }
 
     fn directory_item_count_request_for(
@@ -84,7 +94,11 @@ impl App {
         entry: &Entry,
     ) -> Option<jobs::DirectoryItemCountRequest> {
         let key = self.directory_item_count_key_for(entry)?;
-        if self.directory_item_count_cache.contains_key(&key) {
+        if self
+            .navigation
+            .directory_item_count_cache
+            .contains_key(&key)
+        {
             return None;
         }
         Some(jobs::DirectoryItemCountRequest {
@@ -103,14 +117,14 @@ impl App {
     }
 
     pub(super) fn visible_entry_indices(&self) -> Vec<usize> {
-        if self.entries.is_empty() {
+        if self.navigation.entries.is_empty() {
             return Vec::new();
         }
 
-        let cols = self.frame_state.metrics.cols.max(1);
-        let rows_visible = self.frame_state.metrics.rows_visible.max(1);
-        let start = self.scroll_row.saturating_mul(cols);
+        let cols = self.input.frame_state.metrics.cols.max(1);
+        let rows_visible = self.input.frame_state.metrics.rows_visible.max(1);
+        let start = self.navigation.scroll_row.saturating_mul(cols);
         let limit = rows_visible.saturating_mul(cols);
-        (start..self.entries.len()).take(limit).collect()
+        (start..self.navigation.entries.len()).take(limit).collect()
     }
 }

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -16,35 +16,35 @@ impl App {
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
-        if self.trash.is_some() {
+        if self.overlays.trash.is_some() {
             return self.handle_trash_key(key);
         }
 
-        if self.restore.is_some() {
+        if self.overlays.restore.is_some() {
             return self.handle_restore_key(key);
         }
 
-        if self.create.is_some() {
+        if self.overlays.create.is_some() {
             return self.handle_create_key(key);
         }
 
-        if self.rename.is_some() {
+        if self.overlays.rename.is_some() {
             return self.handle_rename_key(key);
         }
 
-        if self.bulk_rename.is_some() {
+        if self.overlays.bulk_rename.is_some() {
             return self.handle_bulk_rename_key(key);
         }
 
-        if self.goto_overlay.is_some() {
+        if self.overlays.goto.is_some() {
             return self.handle_goto_key(key);
         }
 
-        if self.copy_overlay.is_some() {
+        if self.overlays.copy.is_some() {
             return self.handle_copy_key(key);
         }
 
-        if self.search.is_some() {
+        if self.overlays.search.is_some() {
             return self.handle_search_key(key);
         }
 
@@ -52,41 +52,41 @@ impl App {
             return Ok(());
         }
 
-        if self.help_open {
+        if self.overlays.help {
             if key.modifiers.contains(KeyModifiers::CONTROL)
                 && matches!(key.code, KeyCode::Char('c'))
             {
-                self.help_open = false;
+                self.overlays.help = false;
                 return Ok(());
             }
             if key.code == KeyCode::Esc {
-                self.help_open = false;
+                self.overlays.help = false;
             }
             if is_help_shortcut(key) {
-                self.help_open = false;
+                self.overlays.help = false;
             }
             return Ok(());
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            if let Some(prog) = &self.trash_progress {
-                self.scheduler.cancel_trash(self.trash_token);
+            if let Some(prog) = &self.jobs.trash_progress {
+                self.jobs.scheduler.cancel_trash(self.jobs.trash_token);
                 if prog.permanent {
                     // Permanent delete can be stopped between items; clear chip immediately.
-                    self.trash_progress = None;
+                    self.jobs.trash_progress = None;
                 }
                 // Non-permanent: the batch OS call is atomic and may already be
                 // in flight.  Keep the chip visible; done=true will clear it.
-            } else if self.restore_progress.is_some() {
-                self.scheduler.cancel_restore(self.restore_token);
-                self.restore_progress = None;
-            } else if self.paste_progress.is_some() {
-                self.scheduler.cancel_paste(self.paste_token);
-                self.paste_progress = None;
+            } else if self.jobs.restore_progress.is_some() {
+                self.jobs.scheduler.cancel_restore(self.jobs.restore_token);
+                self.jobs.restore_progress = None;
+            } else if self.jobs.paste_progress.is_some() {
+                self.jobs.scheduler.cancel_paste(self.jobs.paste_token);
+                self.jobs.paste_progress = None;
                 self.clear_queued_pastes();
             } else {
                 self.clear_selection();
-                self.clipboard = None;
+                self.jobs.clipboard = None;
             }
             return Ok(());
         }
@@ -112,7 +112,7 @@ impl App {
             }
         }
 
-        if self.wheel_profile == WheelProfile::HighFrequency
+        if self.input.wheel_profile == WheelProfile::HighFrequency
             && key.modifiers.contains(KeyModifiers::ALT)
             && !key.modifiers.contains(KeyModifiers::CONTROL)
         {
@@ -164,40 +164,40 @@ impl App {
 
         match key.code {
             KeyCode::Esc => {
-                if let Some(prog) = &self.trash_progress {
-                    self.scheduler.cancel_trash(self.trash_token);
+                if let Some(prog) = &self.jobs.trash_progress {
+                    self.jobs.scheduler.cancel_trash(self.jobs.trash_token);
                     if prog.permanent {
-                        self.trash_progress = None;
+                        self.jobs.trash_progress = None;
                     }
-                } else if self.restore_progress.is_some() {
-                    self.scheduler.cancel_restore(self.restore_token);
-                    self.restore_progress = None;
-                } else if self.paste_progress.is_some() {
-                    self.scheduler.cancel_paste(self.paste_token);
-                    self.paste_progress = None;
+                } else if self.jobs.restore_progress.is_some() {
+                    self.jobs.scheduler.cancel_restore(self.jobs.restore_token);
+                    self.jobs.restore_progress = None;
+                } else if self.jobs.paste_progress.is_some() {
+                    self.jobs.scheduler.cancel_paste(self.jobs.paste_token);
+                    self.jobs.paste_progress = None;
                     self.clear_queued_pastes();
                 } else {
                     self.clear_selection();
-                    self.clipboard = None;
+                    self.jobs.clipboard = None;
                 }
             }
             _ if is_help_shortcut(key) => {
                 self.clear_wheel_scroll();
-                self.help_open = true;
+                self.overlays.help = true;
             }
             KeyCode::Tab => self.step_sidebar_place(1)?,
             KeyCode::BackTab => self.step_sidebar_place(-1)?,
             KeyCode::Up | KeyCode::Char('k') => self.move_vertical_keyboard(-1),
             KeyCode::Down | KeyCode::Char('j') => self.move_vertical_keyboard(1),
             KeyCode::Left | KeyCode::Char('h') => {
-                if self.view_mode == ViewMode::Grid {
+                if self.navigation.view_mode == ViewMode::Grid {
                     self.move_by_keyboard(-1);
                 } else {
                     self.go_parent()?;
                 }
             }
             KeyCode::Right | KeyCode::Char('l') => {
-                if self.view_mode == ViewMode::Grid {
+                if self.navigation.view_mode == ViewMode::Grid {
                     self.move_by_keyboard(1);
                 } else if self.selected_entry().is_some_and(Entry::is_dir) {
                     self.open_selected()?;
@@ -214,15 +214,19 @@ impl App {
             KeyCode::Enter => self.open_selected()?,
             KeyCode::Backspace => self.go_parent()?,
             KeyCode::Char(' ') => self.toggle_selection(),
-            KeyCode::Char('+') | KeyCode::Char('=') if self.view_mode == ViewMode::Grid => {
+            KeyCode::Char('+') | KeyCode::Char('=')
+                if self.navigation.view_mode == ViewMode::Grid =>
+            {
                 self.adjust_zoom(1);
             }
-            KeyCode::Char('-') | KeyCode::Char('_') if self.view_mode == ViewMode::Grid => {
+            KeyCode::Char('-') | KeyCode::Char('_')
+                if self.navigation.view_mode == ViewMode::Grid =>
+            {
                 self.adjust_zoom(-1);
             }
             KeyCode::F(2) => {
-                if !self.in_trash {
-                    if !self.selected_paths.is_empty() {
+                if !self.navigation.in_trash {
+                    if !self.navigation.selected_paths.is_empty() {
                         self.open_bulk_rename_prompt();
                     } else {
                         self.open_rename_prompt();
@@ -249,9 +253,9 @@ impl App {
             Action::Trash => self.open_trash_prompt(),
             Action::Create => self.open_create_prompt(),
             Action::Rename => {
-                if self.in_trash {
+                if self.navigation.in_trash {
                     self.open_restore_prompt();
-                } else if !self.selected_paths.is_empty() {
+                } else if !self.navigation.selected_paths.is_empty() {
                     self.open_bulk_rename_prompt();
                 } else {
                     self.open_rename_prompt();
@@ -280,6 +284,7 @@ impl App {
 
         let now = Instant::now();
         if self
+            .input
             .last_navigation_key
             .is_some_and(|(previous_key, previous_at)| {
                 previous_key == navigation_key
@@ -289,7 +294,7 @@ impl App {
             return true;
         }
 
-        self.last_navigation_key = Some((navigation_key, now));
+        self.input.last_navigation_key = Some((navigation_key, now));
         false
     }
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -2,42 +2,42 @@ use super::*;
 
 impl App {
     pub(in crate::app) fn handle_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
-        if self.trash.is_some() {
+        if self.overlays.trash.is_some() {
             return self.handle_trash_mouse(mouse);
         }
 
-        if self.restore.is_some() {
+        if self.overlays.restore.is_some() {
             return self.handle_restore_mouse(mouse);
         }
 
-        if self.create.is_some() {
+        if self.overlays.create.is_some() {
             return self.handle_create_mouse(mouse);
         }
 
-        if self.rename.is_some() {
+        if self.overlays.rename.is_some() {
             return self.handle_rename_mouse(mouse);
         }
 
-        if self.bulk_rename.is_some() {
+        if self.overlays.bulk_rename.is_some() {
             return self.handle_bulk_rename_mouse(mouse);
         }
 
-        if self.goto_overlay.is_some() {
+        if self.overlays.goto.is_some() {
             return self.handle_goto_mouse(mouse);
         }
 
-        if self.copy_overlay.is_some() {
+        if self.overlays.copy.is_some() {
             return self.handle_copy_mouse(mouse);
         }
 
-        if self.search.is_some() {
+        if self.overlays.search.is_some() {
             return self.handle_search_mouse(mouse);
         }
 
-        if self.help_open {
+        if self.overlays.help {
             if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
                 self.clear_wheel_scroll();
-                self.help_open = false;
+                self.overlays.help = false;
             }
             return Ok(());
         }
@@ -45,28 +45,28 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 self.update_wheel_target_from_position(mouse.column, mouse.row);
-                if let Some(rect) = self.frame_state.back_button
+                if let Some(rect) = self.input.frame_state.back_button
                     && rect_contains(rect, mouse.column, mouse.row)
                 {
                     return self.go_back();
                 }
-                if let Some(rect) = self.frame_state.forward_button
+                if let Some(rect) = self.input.frame_state.forward_button
                     && rect_contains(rect, mouse.column, mouse.row)
                 {
                     return self.go_forward();
                 }
-                if let Some(rect) = self.frame_state.parent_button
+                if let Some(rect) = self.input.frame_state.parent_button
                     && rect_contains(rect, mouse.column, mouse.row)
                 {
                     return self.go_parent();
                 }
-                if let Some(rect) = self.frame_state.hidden_button
+                if let Some(rect) = self.input.frame_state.hidden_button
                     && rect_contains(rect, mouse.column, mouse.row)
                 {
                     self.toggle_hidden_files()?;
                     return Ok(());
                 }
-                if let Some(rect) = self.frame_state.view_button
+                if let Some(rect) = self.input.frame_state.view_button
                     && rect_contains(rect, mouse.column, mouse.row)
                 {
                     self.toggle_view_mode();
@@ -74,6 +74,7 @@ impl App {
                 }
 
                 if let Some(target) = self
+                    .input
                     .frame_state
                     .sidebar_hits
                     .iter()
@@ -84,13 +85,18 @@ impl App {
                 }
 
                 if let Some(hit) = self
+                    .input
                     .frame_state
                     .entry_hits
                     .iter()
                     .find(|hit| rect_contains(hit.rect, mouse.column, mouse.row))
                     .cloned()
                 {
-                    let Some(path) = self.entries.get(hit.index).map(|entry| entry.path.clone())
+                    let Some(path) = self
+                        .navigation
+                        .entries
+                        .get(hit.index)
+                        .map(|entry| entry.path.clone())
                     else {
                         return Ok(());
                     };
@@ -98,7 +104,7 @@ impl App {
                     if self.is_double_click(&path) {
                         self.open_selected()?;
                     }
-                    self.last_click = Some(ClickState {
+                    self.input.last_click = Some(ClickState {
                         path,
                         at: Instant::now(),
                     });
@@ -121,7 +127,7 @@ impl App {
                 // ?1003h (any-event tracking) and always carry the true cursor position,
                 // making hover_panel a reliable routing source when scroll event coordinates
                 // are inaccurate (observed in some Alacritty/Ghostty configurations).
-                self.hover_panel = self.panel_target_at(mouse.column, mouse.row);
+                self.input.hover_panel = self.panel_target_at(mouse.column, mouse.row);
                 self.update_wheel_target_from_position(mouse.column, mouse.row);
             }
             _ => {}
@@ -131,12 +137,14 @@ impl App {
 
     fn panel_target_at(&self, column: u16, row: u16) -> Option<WheelTarget> {
         if self
+            .input
             .frame_state
             .preview_panel
             .is_some_and(|rect| rect_contains(rect, column, row))
         {
             Some(WheelTarget::Preview)
         } else if self
+            .input
             .frame_state
             .entries_panel
             .is_some_and(|rect| rect_contains(rect, column, row))
@@ -149,7 +157,7 @@ impl App {
 
     pub(in crate::app) fn update_wheel_target_from_position(&mut self, column: u16, row: u16) {
         if let Some(target) = self.panel_target_at(column, row) {
-            self.last_wheel_target = Some(target);
+            self.input.last_wheel_target = Some(target);
         }
     }
 
@@ -159,30 +167,31 @@ impl App {
         row: u16,
     ) -> Option<WheelTarget> {
         if let Some(target) = self.panel_target_at(column, row) {
-            self.last_wheel_target = Some(target);
+            self.input.last_wheel_target = Some(target);
             return Some(target);
         }
 
-        if let Some(preview) = self.frame_state.preview_panel
+        if let Some(preview) = self.input.frame_state.preview_panel
             && column >= preview.x
         {
-            self.last_wheel_target = Some(WheelTarget::Preview);
-            return self.last_wheel_target;
+            self.input.last_wheel_target = Some(WheelTarget::Preview);
+            return self.input.last_wheel_target;
         }
 
-        if let Some(entries) = self.frame_state.entries_panel
+        if let Some(entries) = self.input.frame_state.entries_panel
             && column >= entries.x
             && column < entries.x.saturating_add(entries.width)
         {
-            self.last_wheel_target = Some(WheelTarget::Entries);
-            return self.last_wheel_target;
+            self.input.last_wheel_target = Some(WheelTarget::Entries);
+            return self.input.last_wheel_target;
         }
 
-        self.last_wheel_target
+        self.input.last_wheel_target
     }
 
     fn is_double_click(&self, path: &Path) -> bool {
-        self.last_click
+        self.input
+            .last_click
             .as_ref()
             .is_some_and(|click| click.path == path && click.at.elapsed() <= DOUBLE_CLICK_WINDOW)
     }

--- a/src/app/input/tests/browser_wheel.rs
+++ b/src/app/input/tests/browser_wheel.rs
@@ -34,8 +34,8 @@ fn browser_wheel_updates_selection_and_preview_immediately() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::Default;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::Default;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -50,7 +50,7 @@ fn browser_wheel_updates_selection_and_preview_immediately() {
         },
         ..FrameState::default()
     });
-    let initial_preview_token = app.preview_state.token;
+    let initial_preview_token = app.preview.state.token;
 
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
@@ -61,9 +61,9 @@ fn browser_wheel_updates_selection_and_preview_immediately() {
     .expect("scroll down should be handled");
     assert!(app.process_pending_scroll());
 
-    assert_eq!(app.selected, 1);
-    assert_eq!(app.scroll_row, 1);
-    assert!(app.preview_state.token > initial_preview_token);
+    assert_eq!(app.navigation.selected, 1);
+    assert_eq!(app.navigation.scroll_row, 1);
+    assert!(app.preview.state.token > initial_preview_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -77,8 +77,8 @@ fn high_frequency_browser_wheel_moves_selection_immediately() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -93,7 +93,7 @@ fn high_frequency_browser_wheel_moves_selection_immediately() {
         },
         ..FrameState::default()
     });
-    let initial_preview_token = app.preview_state.token;
+    let initial_preview_token = app.preview.state.token;
 
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
@@ -103,9 +103,9 @@ fn high_frequency_browser_wheel_moves_selection_immediately() {
     }))
     .expect("scroll down should be handled");
 
-    assert_eq!(app.selected, 1);
-    assert_eq!(app.scroll_row, 1);
-    assert!(app.preview_state.token > initial_preview_token);
+    assert_eq!(app.navigation.selected, 1);
+    assert_eq!(app.navigation.scroll_row, 1);
+    assert!(app.preview.state.token > initial_preview_token);
     assert!(!app.has_pending_scroll());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -121,8 +121,8 @@ fn high_frequency_browser_wheel_keeps_large_flick_distance() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -148,8 +148,8 @@ fn high_frequency_browser_wheel_keeps_large_flick_distance() {
         .expect("scroll down should be handled");
     }
 
-    assert_eq!(app.selected, 4);
-    assert_eq!(app.scroll_row, 4);
+    assert_eq!(app.navigation.selected, 4);
+    assert_eq!(app.navigation.scroll_row, 4);
     assert!(!app.has_pending_scroll());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -164,8 +164,8 @@ fn high_frequency_browser_wheel_defers_preview_refresh_during_burst() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -181,7 +181,7 @@ fn high_frequency_browser_wheel_defers_preview_refresh_during_burst() {
         ..FrameState::default()
     });
 
-    let initial_token = app.preview_state.token;
+    let initial_token = app.preview.state.token;
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
         column: 1,
@@ -189,7 +189,7 @@ fn high_frequency_browser_wheel_defers_preview_refresh_during_burst() {
         modifiers: KeyModifiers::NONE,
     }))
     .expect("first scroll down should be handled");
-    let after_first_token = app.preview_state.token;
+    let after_first_token = app.preview.state.token;
     assert!(after_first_token > initial_token);
 
     app.handle_event(Event::Mouse(MouseEvent {
@@ -200,12 +200,12 @@ fn high_frequency_browser_wheel_defers_preview_refresh_during_burst() {
     }))
     .expect("second scroll down should be handled");
 
-    assert_eq!(app.selected, 2);
-    assert_eq!(app.preview_state.token, after_first_token);
+    assert_eq!(app.navigation.selected, 2);
+    assert_eq!(app.preview.state.token, after_first_token);
 
     thread::sleep(HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY + Duration::from_millis(20));
     assert!(app.process_preview_refresh_timers());
-    assert!(app.preview_state.token > after_first_token);
+    assert!(app.preview.state.token > after_first_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -219,8 +219,8 @@ fn high_frequency_browser_wheel_requests_post_burst_redraw() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -244,12 +244,12 @@ fn high_frequency_browser_wheel_requests_post_burst_redraw() {
     }))
     .expect("scroll down should be handled");
 
-    assert!(app.browser_wheel_post_burst_pending);
+    assert!(app.input.browser_wheel_post_burst_pending);
     assert!(!app.process_browser_wheel_timers());
 
     thread::sleep(WHEEL_SCROLL_BURST_WINDOW + Duration::from_millis(20));
     assert!(app.process_browser_wheel_timers());
-    assert!(!app.browser_wheel_post_burst_pending);
+    assert!(!app.input.browser_wheel_post_burst_pending);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -263,7 +263,7 @@ fn browser_wheel_preserves_preview_when_selection_does_not_change() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
             x: 0,
@@ -278,7 +278,7 @@ fn browser_wheel_preserves_preview_when_selection_does_not_change() {
         ..FrameState::default()
     });
     app.select_index(0);
-    let initial_preview_token = app.preview_state.token;
+    let initial_preview_token = app.preview.state.token;
 
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollUp,
@@ -289,9 +289,9 @@ fn browser_wheel_preserves_preview_when_selection_does_not_change() {
     .expect("scroll up should be handled");
     assert!(!app.process_pending_scroll());
 
-    assert_eq!(app.scroll_row, 0);
-    assert_eq!(app.selected, 0);
-    assert_eq!(app.preview_state.token, initial_preview_token);
+    assert_eq!(app.navigation.scroll_row, 0);
+    assert_eq!(app.navigation.selected, 0);
+    assert_eq!(app.preview.state.token, initial_preview_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/tests/errors.rs
+++ b/src/app/input/tests/errors.rs
@@ -19,7 +19,7 @@ fn opening_a_removed_directory_does_not_bubble_an_error() {
     )))
     .expect("stale directory open should be handled");
 
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -47,7 +47,7 @@ fn opening_a_protected_directory_reports_permission_denied() {
     .expect("protected directory open should be handled");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
     assert!(app.status_message().contains("Permission denied"));
 
     fs::set_permissions(&child, fs::Permissions::from_mode(0o755))

--- a/src/app/input/tests/helpers.rs
+++ b/src/app/input/tests/helpers.rs
@@ -15,7 +15,7 @@ pub(super) fn temp_path(label: &str) -> PathBuf {
         .expect("system time should be after unix epoch")
         .as_nanos();
     let path = env::temp_dir().join(format!("elio-events-{label}-{unique}"));
-    // Pre-canonicalize so that both sides of assert_eq!(app.cwd, root) use the
+    // Pre-canonicalize so that both sides of assert_eq!(app.navigation.cwd, root) use the
     // same path form. On Windows env::temp_dir() returns 8.3 short names while
     // navigate_to() resolves to \\?\ paths; on macOS /var is a symlink to
     // /private/var. Creating the directory first makes canonicalize() succeed.
@@ -26,7 +26,7 @@ pub(super) fn temp_path(label: &str) -> PathBuf {
 pub(super) fn wait_for_directory_load(app: &mut App) {
     for _ in 0..100 {
         let _ = app.process_background_jobs();
-        if app.directory_runtime.pending_load.is_none() {
+        if app.navigation.directory_runtime.pending_load.is_none() {
             return;
         }
         thread::sleep(Duration::from_millis(10));

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -18,14 +18,14 @@ fn shift_slash_opens_and_closes_help_overlay() {
         KeyModifiers::SHIFT,
     )))
     .expect("shift-slash should open help");
-    assert!(app.help_open);
+    assert!(app.overlays.help);
 
     app.handle_event(Event::Key(KeyEvent::new(
         KeyCode::Char('/'),
         KeyModifiers::SHIFT,
     )))
     .expect("shift-slash should close help");
-    assert!(!app.help_open);
+    assert!(!app.overlays.help);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -76,7 +76,7 @@ fn g_opens_goto_overlay_and_goto_shortcuts_keep_g_for_top() {
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     app.select_last();
     assert_eq!(
-        app.selected, 2,
+        app.navigation.selected, 2,
         "G behavior should still reach the last item"
     );
 
@@ -84,7 +84,7 @@ fn g_opens_goto_overlay_and_goto_shortcuts_keep_g_for_top() {
         .expect("g should open go-to overlay");
     assert!(app.goto_is_open());
     assert_eq!(
-        app.selected, 2,
+        app.navigation.selected, 2,
         "opening the go-to overlay should not move selection"
     );
 
@@ -92,14 +92,14 @@ fn g_opens_goto_overlay_and_goto_shortcuts_keep_g_for_top() {
         .expect("g inside go-to overlay should jump to top");
     assert!(!app.goto_is_open());
     assert_eq!(
-        app.selected, 0,
+        app.navigation.selected, 0,
         "go-to g shortcut should move to the top item"
     );
 
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('G'))))
         .expect("capital G should still move to the last item");
     assert_eq!(
-        app.selected, 2,
+        app.navigation.selected, 2,
         "capital G should keep the old bottom-jump behavior"
     );
 
@@ -139,34 +139,34 @@ fn tab_and_shift_tab_cycle_sidebar_locations_and_skip_section_rows() {
     };
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.sidebar = sidebar_rows();
+    app.navigation.sidebar = sidebar_rows();
 
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Tab)))
         .expect("tab should cycle sidebar locations");
     wait_for_directory_load(&mut app);
-    assert_eq!(app.cwd, downloads);
+    assert_eq!(app.navigation.cwd, downloads);
 
-    app.sidebar = sidebar_rows();
+    app.navigation.sidebar = sidebar_rows();
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Tab)))
         .expect("tab should continue into device rows");
     wait_for_directory_load(&mut app);
-    assert_eq!(app.cwd, usb);
+    assert_eq!(app.navigation.cwd, usb);
 
-    app.sidebar = sidebar_rows();
+    app.navigation.sidebar = sidebar_rows();
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Tab)))
         .expect("tab should wrap back to the first sidebar location");
     wait_for_directory_load(&mut app);
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
 
-    app.sidebar = sidebar_rows();
+    app.navigation.sidebar = sidebar_rows();
     app.set_dir(usb.clone()).expect("device path should open");
     wait_for_directory_load(&mut app);
 
-    app.sidebar = sidebar_rows();
+    app.navigation.sidebar = sidebar_rows();
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::BackTab)))
         .expect("shift-tab should walk sidebar locations in reverse");
     wait_for_directory_load(&mut app);
-    assert_eq!(app.cwd, downloads);
+    assert_eq!(app.navigation.cwd, downloads);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -180,35 +180,37 @@ fn repeated_down_arrow_is_throttled_without_starving_hold_repeat() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
 
     app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)))
         .expect("first down arrow should be handled");
 
     let throttled_at = app
+        .input
         .last_navigation_key
         .expect("accepted navigation key should be tracked")
         .1;
     app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)))
         .expect("second down arrow should be handled");
 
-    assert_eq!(app.selected, 1);
+    assert_eq!(app.navigation.selected, 1);
     assert_eq!(
-        app.last_navigation_key
+        app.input
+            .last_navigation_key
             .expect("throttled navigation key should keep prior timestamp")
             .1,
         throttled_at
     );
 
-    app.last_navigation_key = Some((
+    app.input.last_navigation_key = Some((
         NavigationRepeatKey::Down,
         Instant::now() - KEY_REPEAT_NAV_INTERVAL - Duration::from_millis(1),
     ));
     app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)))
         .expect("third down arrow should be handled");
 
-    assert_eq!(app.selected, 2);
+    assert_eq!(app.navigation.selected, 2);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -225,11 +227,11 @@ fn high_frequency_alt_right_scrolls_preview_instead_of_history() {
     .expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
-    app.last_wheel_target = Some(WheelTarget::Entries);
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
+    app.input.last_wheel_target = Some(WheelTarget::Entries);
     app.select_index(0);
-    app.last_selection_change_at =
+    app.input.last_selection_change_at =
         Instant::now() - PREVIEW_AUTO_FOCUS_DELAY - Duration::from_millis(1);
     app.set_frame_state(FrameState {
         preview_panel: Some(Rect {
@@ -246,9 +248,9 @@ fn high_frequency_alt_right_scrolls_preview_instead_of_history() {
     app.handle_event(Event::Key(KeyEvent::new(KeyCode::Right, KeyModifiers::ALT)))
         .expect("alt-right should be handled");
 
-    assert!(app.preview_state.horizontal_scroll > 0);
-    assert_eq!(app.selected, 0);
-    assert_eq!(app.last_wheel_target, Some(WheelTarget::Preview));
+    assert!(app.preview.state.horizontal_scroll > 0);
+    assert_eq!(app.navigation.selected, 0);
+    assert_eq!(app.input.last_wheel_target, Some(WheelTarget::Preview));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -262,11 +264,11 @@ fn high_frequency_down_arrow_keeps_browser_navigation() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
-    app.last_wheel_target = Some(WheelTarget::Preview);
-    app.last_selection_change_at =
+    app.input.last_wheel_target = Some(WheelTarget::Preview);
+    app.input.last_selection_change_at =
         Instant::now() - PREVIEW_AUTO_FOCUS_DELAY - Duration::from_millis(1);
     app.set_frame_state(FrameState {
         preview_panel: Some(Rect {
@@ -283,8 +285,8 @@ fn high_frequency_down_arrow_keeps_browser_navigation() {
     app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)))
         .expect("down arrow should be handled");
 
-    assert_eq!(app.selected, 1);
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.navigation.selected, 1);
+    assert_eq!(app.preview.state.scroll, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -296,10 +298,10 @@ fn high_frequency_right_arrow_in_list_view_still_enters_directory() {
     fs::create_dir_all(&child).expect("failed to create child dir");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
-    app.last_wheel_target = Some(WheelTarget::Preview);
+    app.input.last_wheel_target = Some(WheelTarget::Preview);
 
     app.handle_event(Event::Key(KeyEvent::new(
         KeyCode::Right,
@@ -308,7 +310,7 @@ fn high_frequency_right_arrow_in_list_view_still_enters_directory() {
     .expect("right arrow should be handled");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, child);
+    assert_eq!(app.navigation.cwd, child);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -322,29 +324,29 @@ fn rapid_audio_navigation_defers_second_cold_heavy_preview_refresh() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.set_media_ffprobe_available_for_tests(false);
     app.set_media_ffmpeg_available_for_tests(false);
-    app.last_selection_change_at =
+    app.input.last_selection_change_at =
         Instant::now() - WHEEL_SCROLL_BURST_WINDOW - Duration::from_millis(1);
 
-    let initial_token = app.preview_state.token;
+    let initial_token = app.preview.state.token;
     app.move_vertical(1);
 
     // Cold heavy audio is always deferred regardless of burst window state.
-    assert_eq!(app.selected, 1);
-    assert_eq!(app.preview_state.token, initial_token);
-    assert!(app.preview_state.deferred_refresh_at.is_some());
+    assert_eq!(app.navigation.selected, 1);
+    assert_eq!(app.preview.state.token, initial_token);
+    assert!(app.preview.state.deferred_refresh_at.is_some());
 
     app.move_vertical(1);
 
-    assert_eq!(app.selected, 2);
-    assert_eq!(app.preview_state.token, initial_token);
-    assert!(app.preview_state.deferred_refresh_at.is_some());
+    assert_eq!(app.navigation.selected, 2);
+    assert_eq!(app.preview.state.token, initial_token);
+    assert!(app.preview.state.deferred_refresh_at.is_some());
 
     thread::sleep(HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY + Duration::from_millis(20));
     assert!(app.process_preview_refresh_timers());
-    assert!(app.preview_state.token > initial_token);
+    assert!(app.preview.state.token > initial_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -358,32 +360,32 @@ fn rapid_key_navigation_defers_preview_for_non_heavy_files() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
 
     // First move: last_key_nav_at is in the past → Immediate preview.
-    let token_before = app.preview_state.token;
+    let token_before = app.preview.state.token;
     app.move_vertical_keyboard(1);
-    assert_eq!(app.selected, 1);
+    assert_eq!(app.navigation.selected, 1);
     assert!(
-        app.preview_state.token > token_before,
+        app.preview.state.token > token_before,
         "first move should trigger an immediate preview refresh"
     );
     assert!(
-        app.preview_state.deferred_refresh_at.is_none(),
+        app.preview.state.deferred_refresh_at.is_none(),
         "first move should not leave a deferred timer"
     );
 
     // Second move within KEY_NAV_RAPID_THRESHOLD → Deferred preview.
-    let token_before = app.preview_state.token;
+    let token_before = app.preview.state.token;
     app.move_vertical_keyboard(1);
-    assert_eq!(app.selected, 2);
+    assert_eq!(app.navigation.selected, 2);
     assert_eq!(
-        app.preview_state.token, token_before,
+        app.preview.state.token, token_before,
         "second rapid move should not immediately refresh preview"
     );
     assert!(
-        app.preview_state.deferred_refresh_at.is_some(),
+        app.preview.state.deferred_refresh_at.is_some(),
         "second rapid move should schedule a deferred refresh"
     );
 
@@ -391,7 +393,7 @@ fn rapid_key_navigation_defers_preview_for_non_heavy_files() {
     thread::sleep(HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY + Duration::from_millis(20));
     assert!(app.process_preview_refresh_timers());
     assert!(
-        app.preview_state.token > token_before,
+        app.preview.state.token > token_before,
         "deferred preview should fire after pause"
     );
 
@@ -408,13 +410,13 @@ fn rapid_key_navigation_clears_directory_totals_until_deferred_refresh_runs() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     wait_for_background_preview(&mut app);
     for _ in 0..100 {
         let _ = app.process_background_jobs();
         if matches!(
-            app.preview_state.directory_stats,
+            app.preview.state.directory_stats,
             Some(PreviewDirectoryStatsState::Complete { .. })
         ) {
             break;
@@ -422,18 +424,18 @@ fn rapid_key_navigation_clears_directory_totals_until_deferred_refresh_runs() {
         thread::sleep(Duration::from_millis(10));
     }
     assert!(matches!(
-        app.preview_state.directory_stats,
+        app.preview.state.directory_stats,
         Some(PreviewDirectoryStatsState::Complete { .. })
     ));
 
-    app.last_key_nav_at = Instant::now();
-    let token_before = app.preview_state.token;
+    app.input.last_key_nav_at = Instant::now();
+    let token_before = app.preview.state.token;
     app.move_vertical_keyboard(1);
 
-    assert_eq!(app.selected, 1);
-    assert_eq!(app.preview_state.token, token_before);
-    assert!(app.preview_state.deferred_refresh_at.is_some());
-    assert!(app.preview_state.directory_stats.is_none());
+    assert_eq!(app.navigation.selected, 1);
+    assert_eq!(app.preview.state.token, token_before);
+    assert!(app.preview.state.deferred_refresh_at.is_some());
+    assert!(app.preview.state.directory_stats.is_none());
 
     thread::sleep(HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY + Duration::from_millis(20));
     assert!(app.process_preview_refresh_timers());
@@ -461,8 +463,8 @@ fn high_frequency_alt_right_does_not_trigger_history_navigation() {
     fs::create_dir_all(&child).expect("failed to create child dir");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     app.select_index(0);
     app.open_selected()
         .expect("opening selected directory should succeed");
@@ -473,7 +475,7 @@ fn high_frequency_alt_right_does_not_trigger_history_navigation() {
     app.handle_event(Event::Key(KeyEvent::new(KeyCode::Right, KeyModifiers::ALT)))
         .expect("alt-right should be handled");
 
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(child.as_path())
@@ -517,7 +519,7 @@ fn rebound_yank_key_dispatches_yank_action() {
     wait_for_directory_load(&mut app);
     app.select_index(0);
 
-    assert!(app.clipboard.is_none(), "clipboard should start empty");
+    assert!(app.jobs.clipboard.is_none(), "clipboard should start empty");
 
     // Dispatch the action the rebound key would trigger.
     let action = kb.action_for('Y').expect("Y should be bound");
@@ -525,7 +527,7 @@ fn rebound_yank_key_dispatches_yank_action() {
         .expect("dispatch should succeed");
 
     assert!(
-        app.clipboard.is_some(),
+        app.jobs.clipboard.is_some(),
         "yank should have populated the clipboard"
     );
 

--- a/src/app/input/tests/navigation.rs
+++ b/src/app/input/tests/navigation.rs
@@ -10,7 +10,7 @@ fn right_arrow_does_not_open_selected_file_in_list_view() {
     fs::write(&file_path, "hello").expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
 
     app.handle_event(Event::Key(KeyEvent::new(
@@ -19,7 +19,7 @@ fn right_arrow_does_not_open_selected_file_in_list_view() {
     )))
     .expect("right arrow should be handled");
 
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(file_path.as_path())
@@ -36,7 +36,7 @@ fn right_arrow_enters_selected_directory_in_list_view() {
     fs::create_dir_all(&child).expect("failed to create temp dirs");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
 
     app.handle_event(Event::Key(KeyEvent::new(
@@ -46,7 +46,7 @@ fn right_arrow_enters_selected_directory_in_list_view() {
     .expect("right arrow should be handled");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, child);
+    assert_eq!(app.navigation.cwd, child);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -60,7 +60,7 @@ fn left_arrow_in_list_view_reselects_previous_directory_in_parent() {
     fs::create_dir_all(&child).expect("failed to create child dir");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(1);
     app.open_selected()
         .expect("opening selected directory should succeed");
@@ -70,7 +70,7 @@ fn left_arrow_in_list_view_reselects_previous_directory_in_parent() {
         .expect("left arrow should be handled");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(child.as_path())
@@ -88,7 +88,7 @@ fn go_back_reselects_previous_directory_in_parent() {
     fs::create_dir_all(&child).expect("failed to create child dir");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(1);
     app.open_selected()
         .expect("opening selected directory should succeed");
@@ -97,7 +97,7 @@ fn go_back_reselects_previous_directory_in_parent() {
     app.go_back().expect("go back should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, root);
+    assert_eq!(app.navigation.cwd, root);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(child.as_path())
@@ -113,7 +113,7 @@ fn go_forward_reselects_previous_directory_in_parent() {
     fs::create_dir_all(&child).expect("failed to create child dir");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.open_selected()
         .expect("opening selected directory should succeed");
@@ -124,7 +124,7 @@ fn go_forward_reselects_previous_directory_in_parent() {
     app.go_forward().expect("go forward should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, child);
+    assert_eq!(app.navigation.cwd, child);
     assert!(app.selected_entry().is_none());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -141,7 +141,7 @@ fn go_forward_restores_last_selected_entry_in_directory() {
     fs::write(&beta, "beta").expect("failed to write beta");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.open_selected()
         .expect("opening selected directory should succeed");
@@ -159,7 +159,7 @@ fn go_forward_restores_last_selected_entry_in_directory() {
     app.go_forward().expect("go forward should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, child);
+    assert_eq!(app.navigation.cwd, child);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(beta.as_path())
@@ -179,7 +179,7 @@ fn reopening_directory_restores_last_selected_entry() {
     fs::write(&beta, "beta").expect("failed to write beta");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.open_selected()
         .expect("opening selected directory should succeed");
@@ -197,7 +197,7 @@ fn reopening_directory_restores_last_selected_entry() {
         .expect("reopening selected directory should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, child);
+    assert_eq!(app.navigation.cwd, child);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(beta.as_path())
@@ -217,7 +217,7 @@ fn reopening_directory_restores_scroll_position() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.set_frame_state(FrameState {
         metrics: ViewMetrics {
             cols: 1,
@@ -231,7 +231,7 @@ fn reopening_directory_restores_scroll_position() {
     wait_for_directory_load(&mut app);
 
     app.select_index(6);
-    assert_eq!(app.scroll_row, 4);
+    assert_eq!(app.navigation.scroll_row, 4);
 
     app.go_parent().expect("go parent should succeed");
     wait_for_directory_load(&mut app);
@@ -239,9 +239,9 @@ fn reopening_directory_restores_scroll_position() {
         .expect("reopening selected directory should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, child);
-    assert_eq!(app.selected, 6);
-    assert_eq!(app.scroll_row, 4);
+    assert_eq!(app.navigation.cwd, child);
+    assert_eq!(app.navigation.selected, 6);
+    assert_eq!(app.navigation.scroll_row, 4);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -256,7 +256,7 @@ fn reopening_parent_restores_last_selected_child_directory() {
     fs::create_dir_all(&regueiro).expect("failed to create regueiro dir");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.open_selected().expect("opening home should succeed");
     wait_for_directory_load(&mut app);
@@ -278,7 +278,7 @@ fn reopening_parent_restores_last_selected_child_directory() {
     app.open_selected().expect("reopening home should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, home);
+    assert_eq!(app.navigation.cwd, home);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(regueiro.as_path())
@@ -299,7 +299,7 @@ fn reopening_parent_restores_scroll_position() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.set_frame_state(FrameState {
         metrics: ViewMetrics {
             cols: 1,
@@ -312,7 +312,7 @@ fn reopening_parent_restores_scroll_position() {
     wait_for_directory_load(&mut app);
 
     app.select_index(6);
-    assert_eq!(app.scroll_row, 4);
+    assert_eq!(app.navigation.scroll_row, 4);
 
     app.open_selected()
         .expect("opening remembered child should succeed");
@@ -325,9 +325,9 @@ fn reopening_parent_restores_scroll_position() {
     app.open_selected().expect("reopening home should succeed");
     wait_for_directory_load(&mut app);
 
-    assert_eq!(app.cwd, home);
-    assert_eq!(app.selected, 6);
-    assert_eq!(app.scroll_row, 4);
+    assert_eq!(app.navigation.cwd, home);
+    assert_eq!(app.navigation.selected, 6);
+    assert_eq!(app.navigation.scroll_row, 4);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/tests/preview.rs
+++ b/src/app/input/tests/preview.rs
@@ -14,7 +14,7 @@ fn preview_horizontal_scroll_works_in_list_view() {
     .expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.set_frame_state(FrameState {
         preview_panel: Some(Rect {
@@ -36,7 +36,7 @@ fn preview_horizontal_scroll_works_in_list_view() {
     }))
     .expect("scroll right should be handled");
     assert!(app.process_pending_scroll());
-    assert_eq!(app.preview_state.horizontal_scroll, 2);
+    assert_eq!(app.preview.state.horizontal_scroll, 2);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -55,7 +55,7 @@ fn preview_scroll_resets_when_reselecting_a_file() {
     fs::write(&other, "short\ntext").expect("failed to write other text file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.set_frame_state(FrameState {
         preview_panel: Some(Rect {
@@ -70,9 +70,9 @@ fn preview_scroll_resets_when_reselecting_a_file() {
     });
     wait_for_background_preview(&mut app);
 
-    app.preview_state.scroll = 5;
+    app.preview.state.scroll = 5;
     app.sync_preview_scroll();
-    assert_eq!(app.preview_state.scroll, 5);
+    assert_eq!(app.preview.state.scroll, 5);
 
     app.select_index(1);
     app.select_index(0);
@@ -81,7 +81,7 @@ fn preview_scroll_resets_when_reselecting_a_file() {
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(long.as_path())
     );
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -100,7 +100,7 @@ fn preview_horizontal_scroll_resets_when_reselecting_code() {
     fs::write(&other, "short\ntext").expect("failed to write other text file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.set_frame_state(FrameState {
         preview_panel: Some(Rect {
@@ -114,9 +114,9 @@ fn preview_horizontal_scroll_resets_when_reselecting_code() {
         ..FrameState::default()
     });
 
-    app.preview_state.horizontal_scroll = 3;
+    app.preview.state.horizontal_scroll = 3;
     app.sync_preview_scroll();
-    assert_eq!(app.preview_state.horizontal_scroll, 3);
+    assert_eq!(app.preview.state.horizontal_scroll, 3);
 
     app.select_index(1);
     app.select_index(0);
@@ -125,7 +125,7 @@ fn preview_horizontal_scroll_resets_when_reselecting_code() {
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(code.as_path())
     );
-    assert_eq!(app.preview_state.horizontal_scroll, 0);
+    assert_eq!(app.preview.state.horizontal_scroll, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/tests/preview_wheel.rs
+++ b/src/app/input/tests/preview_wheel.rs
@@ -19,9 +19,10 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
     fs::write(&long_file, &contents).expect("failed to write long file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
     let long_index = app
+        .navigation
         .entries
         .iter()
         .position(|e| e.path == long_file)
@@ -58,7 +59,7 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
         modifiers: KeyModifiers::NONE,
     }))
     .expect("entry scroll should be handled");
-    assert_eq!(app.last_wheel_target, Some(WheelTarget::Entries));
+    assert_eq!(app.input.last_wheel_target, Some(WheelTarget::Entries));
 
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::Moved,
@@ -67,10 +68,10 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
         modifiers: KeyModifiers::NONE,
     }))
     .expect("hover on preview should be handled");
-    assert_eq!(app.last_wheel_target, Some(WheelTarget::Preview));
+    assert_eq!(app.input.last_wheel_target, Some(WheelTarget::Preview));
 
-    let before_scroll = app.preview_state.scroll;
-    let before_selected = app.selected;
+    let before_scroll = app.preview.state.scroll;
+    let before_selected = app.navigation.selected;
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
         column: 45,
@@ -80,11 +81,11 @@ fn high_frequency_preview_wheel_scrolls_preview_after_entries_scroll() {
     .expect("preview scroll should be handled");
 
     assert_eq!(
-        app.selected, before_selected,
+        app.navigation.selected, before_selected,
         "entry selection must not change when scrolling preview"
     );
     assert!(
-        app.preview_state.scroll > before_scroll,
+        app.preview.state.scroll > before_scroll,
         "preview must have scrolled"
     );
 
@@ -103,11 +104,12 @@ fn high_frequency_preview_wheel_scrolls_preview_without_prior_moved_event() {
     fs::write(&long_file, &contents).expect("failed to write long file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
-    app.last_wheel_target = Some(WheelTarget::Entries);
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
+    app.input.last_wheel_target = Some(WheelTarget::Entries);
 
     let long_index = app
+        .navigation
         .entries
         .iter()
         .position(|e| e.path == long_file)
@@ -137,8 +139,8 @@ fn high_frequency_preview_wheel_scrolls_preview_without_prior_moved_event() {
     });
     wait_for_background_preview(&mut app);
 
-    let before_scroll = app.preview_state.scroll;
-    let before_selected = app.selected;
+    let before_scroll = app.preview.state.scroll;
+    let before_selected = app.navigation.selected;
 
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
@@ -149,11 +151,11 @@ fn high_frequency_preview_wheel_scrolls_preview_without_prior_moved_event() {
     .expect("preview scroll should be handled");
 
     assert_eq!(
-        app.selected, before_selected,
+        app.navigation.selected, before_selected,
         "entry selection must not change when scrolling preview"
     );
     assert!(
-        app.preview_state.scroll > before_scroll,
+        app.preview.state.scroll > before_scroll,
         "preview must have scrolled without a prior Moved event"
     );
 
@@ -172,12 +174,13 @@ fn hover_panel_routes_scroll_when_event_coords_are_outside_panels() {
     fs::write(&long_file, &contents).expect("failed to write long file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
-    app.wheel_profile = WheelProfile::HighFrequency;
-    app.last_wheel_target = Some(WheelTarget::Entries);
-    app.hover_panel = None;
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
+    app.input.last_wheel_target = Some(WheelTarget::Entries);
+    app.input.hover_panel = None;
 
     let long_index = app
+        .navigation
         .entries
         .iter()
         .position(|e| e.path == long_file)
@@ -214,10 +217,10 @@ fn hover_panel_routes_scroll_when_event_coords_are_outside_panels() {
         modifiers: KeyModifiers::NONE,
     }))
     .expect("moved event should be handled");
-    assert_eq!(app.hover_panel, Some(WheelTarget::Preview));
+    assert_eq!(app.input.hover_panel, Some(WheelTarget::Preview));
 
-    let before_scroll = app.preview_state.scroll;
-    let before_selected = app.selected;
+    let before_scroll = app.preview.state.scroll;
+    let before_selected = app.navigation.selected;
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
         column: 0,
@@ -227,11 +230,11 @@ fn hover_panel_routes_scroll_when_event_coords_are_outside_panels() {
     .expect("scroll should be handled");
 
     assert_eq!(
-        app.selected, before_selected,
+        app.navigation.selected, before_selected,
         "entry selection must not change"
     );
     assert!(
-        app.preview_state.scroll > before_scroll,
+        app.preview.state.scroll > before_scroll,
         "hover_panel should have routed scroll to preview despite wrong coords"
     );
 
@@ -250,7 +253,7 @@ fn preview_wheel_uses_last_focused_panel_when_coordinates_miss() {
     fs::write(&file_path, contents).expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -287,7 +290,7 @@ fn preview_wheel_uses_last_focused_panel_when_coordinates_miss() {
     .expect("wheel should fall back to last focused preview panel");
 
     assert!(app.process_pending_scroll());
-    assert!(app.preview_state.scroll > 0);
+    assert!(app.preview.state.scroll > 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -304,7 +307,7 @@ fn preview_wheel_follows_hovered_panel_without_click() {
     fs::write(&file_path, contents).expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -341,7 +344,7 @@ fn preview_wheel_follows_hovered_panel_without_click() {
     .expect("wheel should fall back to hovered preview panel");
 
     assert!(app.process_pending_scroll());
-    assert!(app.preview_state.scroll > 0);
+    assert!(app.preview.state.scroll > 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -358,7 +361,7 @@ fn preview_wheel_uses_preview_column_when_row_is_unreliable() {
     fs::write(&file_path, contents).expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -388,7 +391,7 @@ fn preview_wheel_uses_preview_column_when_row_is_unreliable() {
     .expect("wheel should use preview column fallback");
 
     assert!(app.process_pending_scroll());
-    assert!(app.preview_state.scroll > 0);
+    assert!(app.preview.state.scroll > 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -408,7 +411,7 @@ fn preview_wheel_steps_comic_pages_instead_of_scrolling_summary_text() {
     );
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     wait_for_background_preview(&mut app);
     app.set_frame_state(FrameState {
@@ -438,7 +441,8 @@ fn preview_wheel_steps_comic_pages_instead_of_scrolling_summary_text() {
     .expect("preview wheel should be handled");
 
     assert_eq!(
-        app.preview_state
+        app.preview
+            .state
             .content
             .navigation_position
             .as_ref()
@@ -446,21 +450,22 @@ fn preview_wheel_steps_comic_pages_instead_of_scrolling_summary_text() {
         Some(1)
     );
     assert!(app.pending_preview_refresh_timer().is_some());
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
 
     thread::sleep(HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY + Duration::from_millis(20));
     assert!(app.process_preview_refresh_timers());
     wait_for_background_preview(&mut app);
 
     assert_eq!(
-        app.preview_state
+        app.preview
+            .state
             .content
             .navigation_position
             .as_ref()
             .map(|position| position.index),
         Some(1)
     );
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -477,7 +482,7 @@ fn comic_preview_wheel_clears_pending_entry_scroll_before_page_turns() {
     fs::write(root.join("c.txt"), "another entry").expect("failed to write temp text");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     wait_for_background_preview(&mut app);
     app.set_frame_state(FrameState {
@@ -497,7 +502,7 @@ fn comic_preview_wheel_clears_pending_entry_scroll_before_page_turns() {
         preview_cols_visible: 20,
         ..FrameState::default()
     });
-    app.wheel_scroll.vertical.pending = 3;
+    app.input.wheel_scroll.vertical.pending = 3;
 
     app.handle_event(Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
@@ -507,15 +512,15 @@ fn comic_preview_wheel_clears_pending_entry_scroll_before_page_turns() {
     }))
     .expect("preview wheel should be handled");
 
-    assert_eq!(app.selected, 0);
-    assert_eq!(app.wheel_scroll.vertical.pending, 0);
+    assert_eq!(app.navigation.selected, 0);
+    assert_eq!(app.input.wheel_scroll.vertical.pending, 0);
     assert_eq!(
         app.current_preview_request_options().comic_page_index(),
         Some(1)
     );
 
     let _ = app.process_pending_scroll();
-    assert_eq!(app.selected, 0);
+    assert_eq!(app.navigation.selected, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -535,7 +540,7 @@ fn preview_wheel_steps_cbr_pages_instead_of_scrolling_summary_text() {
     );
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     wait_for_background_preview(&mut app);
     app.set_frame_state(FrameState {
@@ -565,7 +570,8 @@ fn preview_wheel_steps_cbr_pages_instead_of_scrolling_summary_text() {
     .expect("preview wheel should be handled");
 
     assert_eq!(
-        app.preview_state
+        app.preview
+            .state
             .content
             .navigation_position
             .as_ref()
@@ -573,21 +579,22 @@ fn preview_wheel_steps_cbr_pages_instead_of_scrolling_summary_text() {
         Some(1)
     );
     assert!(app.pending_preview_refresh_timer().is_some());
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
 
     thread::sleep(HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY + Duration::from_millis(20));
     assert!(app.process_preview_refresh_timers());
     wait_for_background_preview(&mut app);
 
     assert_eq!(
-        app.preview_state
+        app.preview
+            .state
             .content
             .navigation_position
             .as_ref()
             .map(|position| position.index),
         Some(1)
     );
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -610,7 +617,7 @@ fn preview_wheel_scrolls_epub_section_before_advancing_to_next_section() {
     );
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.view_mode = ViewMode::List;
+    app.navigation.view_mode = ViewMode::List;
     app.select_index(0);
     wait_for_background_preview(&mut app);
     app.set_frame_state(FrameState {
@@ -640,13 +647,13 @@ fn preview_wheel_scrolls_epub_section_before_advancing_to_next_section() {
     .expect("preview wheel should be handled");
 
     assert!(app.process_pending_scroll());
-    assert!(app.preview_state.scroll > 0);
-    assert_eq!(app.preview_state.content.ebook_section_index, Some(0));
+    assert!(app.preview.state.scroll > 0);
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(0));
 
     let max_scroll = app
-        .preview_total_lines(app.frame_state.preview_cols_visible.max(1))
-        .saturating_sub(app.frame_state.preview_rows_visible.max(1));
-    app.preview_state.scroll = max_scroll;
+        .preview_total_lines(app.input.frame_state.preview_cols_visible.max(1))
+        .saturating_sub(app.input.frame_state.preview_rows_visible.max(1));
+    app.preview.state.scroll = max_scroll;
     app.sync_preview_scroll();
 
     app.handle_event(Event::Mouse(MouseEvent {
@@ -657,9 +664,9 @@ fn preview_wheel_scrolls_epub_section_before_advancing_to_next_section() {
     }))
     .expect("preview wheel should advance the section at the bottom boundary");
 
-    assert_eq!(app.preview_state.scroll, 0);
-    assert_eq!(app.preview_state.content.ebook_section_index, Some(1));
-    assert_eq!(app.preview_state.content.ebook_section_count, Some(2));
+    assert_eq!(app.preview.state.scroll, 0);
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(1));
+    assert_eq!(app.preview.state.content.ebook_section_count, Some(2));
     assert!(
         app.preview_header_detail(10)
             .as_deref()
@@ -668,13 +675,13 @@ fn preview_wheel_scrolls_epub_section_before_advancing_to_next_section() {
 
     wait_for_background_preview(&mut app);
 
-    assert_eq!(app.preview_state.content.ebook_section_index, Some(1));
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(1));
     assert!(
         app.preview_lines()
             .iter()
             .any(|line| line.to_string().contains("Second chapter text."))
     );
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/wheel.rs
+++ b/src/app/input/wheel.rs
@@ -63,21 +63,21 @@ impl App {
     pub fn process_pending_scroll(&mut self) -> bool {
         let mut dirty = false;
 
-        if self.search.is_some() {
-            self.wheel_scroll.vertical.pending = 0;
-            self.wheel_scroll.horizontal.pending = 0;
-            self.wheel_scroll.preview.pending = 0;
-            self.wheel_scroll.preview_horizontal.pending = 0;
+        if self.overlays.search.is_some() {
+            self.input.wheel_scroll.vertical.pending = 0;
+            self.input.wheel_scroll.horizontal.pending = 0;
+            self.input.wheel_scroll.preview.pending = 0;
+            self.input.wheel_scroll.preview_horizontal.pending = 0;
             dirty |= self.flush_search_scroll();
         } else {
-            self.wheel_scroll.search.pending = 0;
+            self.input.wheel_scroll.search.pending = 0;
             dirty |= self.flush_entry_vertical_scroll();
             dirty |= self.flush_preview_scroll();
             dirty |= self.flush_preview_horizontal_scroll();
-            if self.view_mode == ViewMode::Grid {
+            if self.navigation.view_mode == ViewMode::Grid {
                 dirty |= self.flush_entry_horizontal_scroll();
             } else {
-                self.wheel_scroll.horizontal.pending = 0;
+                self.input.wheel_scroll.horizontal.pending = 0;
             }
         }
 
@@ -85,11 +85,11 @@ impl App {
     }
 
     pub fn has_pending_scroll(&self) -> bool {
-        self.wheel_scroll.vertical.pending != 0
-            || self.wheel_scroll.horizontal.pending != 0
-            || self.wheel_scroll.preview.pending != 0
-            || self.wheel_scroll.preview_horizontal.pending != 0
-            || self.wheel_scroll.search.pending != 0
+        self.input.wheel_scroll.vertical.pending != 0
+            || self.input.wheel_scroll.horizontal.pending != 0
+            || self.input.wheel_scroll.preview.pending != 0
+            || self.input.wheel_scroll.preview_horizontal.pending != 0
+            || self.input.wheel_scroll.search.pending != 0
     }
 
     pub(in crate::app) fn handle_wheel_event(&mut self, mouse: MouseEvent, delta: isize) {
@@ -97,8 +97,9 @@ impl App {
         // unreliable. hover_panel is tracked exclusively from MouseEventKind::Moved events
         // (via ?1003h any-event tracking), which always carry the true cursor position.
         // Use it as the primary routing source; fall back to scroll event coords, then auto-focus.
-        let target = if self.wheel_profile == WheelProfile::HighFrequency {
-            self.hover_panel
+        let target = if self.input.wheel_profile == WheelProfile::HighFrequency {
+            self.input
+                .hover_panel
                 .or_else(|| self.resolve_wheel_target(mouse.column, mouse.row))
                 .or_else(|| self.preview_auto_focus_target(false))
         } else {
@@ -122,32 +123,37 @@ impl App {
                 if mouse.modifiers.contains(KeyModifiers::SHIFT)
                     && self.preview_allows_horizontal_scroll()
                 {
-                    if self.wheel_profile == WheelProfile::HighFrequency {
+                    if self.input.wheel_profile == WheelProfile::HighFrequency {
                         let _ = self.scroll_preview_columns_immediately(delta);
                     } else {
                         Self::queue_scroll(
-                            &mut self.wheel_scroll.preview_horizontal,
+                            &mut self.input.wheel_scroll.preview_horizontal,
                             delta,
                             PREVIEW_HORIZONTAL_WHEEL_TUNING,
                         );
                     }
-                } else if self.wheel_profile == WheelProfile::HighFrequency {
+                } else if self.input.wheel_profile == WheelProfile::HighFrequency {
                     let _ = self.scroll_preview_immediately(delta);
                 } else {
-                    Self::queue_scroll(&mut self.wheel_scroll.preview, delta, PREVIEW_WHEEL_TUNING);
+                    Self::queue_scroll(
+                        &mut self.input.wheel_scroll.preview,
+                        delta,
+                        PREVIEW_WHEEL_TUNING,
+                    );
                 }
             }
             Some(WheelTarget::Entries) | None => {
                 self.focus_entry_scroll();
-                if self.view_mode == ViewMode::Grid && mouse.modifiers.contains(KeyModifiers::SHIFT)
+                if self.navigation.view_mode == ViewMode::Grid
+                    && mouse.modifiers.contains(KeyModifiers::SHIFT)
                 {
                     let tuning = self.entry_horizontal_wheel_tuning();
-                    Self::queue_scroll(&mut self.wheel_scroll.horizontal, delta, tuning);
-                } else if self.wheel_profile == WheelProfile::HighFrequency {
+                    Self::queue_scroll(&mut self.input.wheel_scroll.horizontal, delta, tuning);
+                } else if self.input.wheel_profile == WheelProfile::HighFrequency {
                     let _ = self.scroll_entry_immediately(delta);
                 } else {
                     let tuning = self.entry_wheel_tuning();
-                    Self::queue_scroll(&mut self.wheel_scroll.vertical, delta, tuning);
+                    Self::queue_scroll(&mut self.input.wheel_scroll.vertical, delta, tuning);
                 }
             }
         }
@@ -158,8 +164,9 @@ impl App {
         mouse: MouseEvent,
         delta: isize,
     ) {
-        let target = if self.wheel_profile == WheelProfile::HighFrequency {
-            self.hover_panel
+        let target = if self.input.wheel_profile == WheelProfile::HighFrequency {
+            self.input
+                .hover_panel
                 .or_else(|| self.resolve_wheel_target(mouse.column, mouse.row))
                 .or_else(|| self.preview_auto_focus_target(true))
         } else {
@@ -170,11 +177,11 @@ impl App {
             Some(WheelTarget::Preview) => {
                 self.focus_preview_scroll();
                 if self.preview_allows_horizontal_scroll() {
-                    if self.wheel_profile == WheelProfile::HighFrequency {
+                    if self.input.wheel_profile == WheelProfile::HighFrequency {
                         let _ = self.scroll_preview_columns_immediately(delta);
                     } else {
                         Self::queue_scroll(
-                            &mut self.wheel_scroll.preview_horizontal,
+                            &mut self.input.wheel_scroll.preview_horizontal,
                             delta,
                             PREVIEW_HORIZONTAL_WHEEL_TUNING,
                         );
@@ -182,18 +189,22 @@ impl App {
                 }
             }
             Some(WheelTarget::Entries) | None => {
-                if self.view_mode != ViewMode::Grid {
+                if self.navigation.view_mode != ViewMode::Grid {
                     return;
                 }
                 self.focus_entry_scroll();
                 let tuning = self.entry_horizontal_wheel_tuning();
-                Self::queue_scroll(&mut self.wheel_scroll.horizontal, delta, tuning);
+                Self::queue_scroll(&mut self.input.wheel_scroll.horizontal, delta, tuning);
             }
         }
     }
 
     pub(in crate::app) fn queue_search_wheel(&mut self, delta: isize) {
-        Self::queue_scroll(&mut self.wheel_scroll.search, delta, SEARCH_WHEEL_TUNING);
+        Self::queue_scroll(
+            &mut self.input.wheel_scroll.search,
+            delta,
+            SEARCH_WHEEL_TUNING,
+        );
     }
 
     pub(in crate::app) fn queue_scroll(lane: &mut ScrollLane, delta: isize, tuning: WheelTuning) {
@@ -258,15 +269,15 @@ impl App {
     }
 
     fn focus_preview_scroll(&mut self) {
-        self.last_wheel_target = Some(WheelTarget::Preview);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.vertical);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.horizontal);
+        self.input.last_wheel_target = Some(WheelTarget::Preview);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.vertical);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.horizontal);
     }
 
     fn focus_entry_scroll(&mut self) {
-        self.last_wheel_target = Some(WheelTarget::Entries);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.preview);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.preview_horizontal);
+        self.input.last_wheel_target = Some(WheelTarget::Entries);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.preview);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.preview_horizontal);
     }
 
     fn reset_scroll_lane(lane: &mut ScrollLane) {
@@ -280,72 +291,75 @@ impl App {
 
     fn flush_entry_vertical_scroll(&mut self) -> bool {
         let interval = self.entry_scroll_interval();
-        let Some(step) = Self::consume_scroll_step(&mut self.wheel_scroll.vertical, interval)
+        let Some(step) = Self::consume_scroll_step(&mut self.input.wheel_scroll.vertical, interval)
         else {
             return false;
         };
 
         let mut dirty = false;
         let total_steps =
-            self.entry_vertical_steps_per_flush(self.wheel_scroll.vertical.pending.abs() + 1);
+            self.entry_vertical_steps_per_flush(self.input.wheel_scroll.vertical.pending.abs() + 1);
         for step_index in 0..total_steps {
             if step_index > 0 {
-                if self.wheel_scroll.vertical.pending.signum() != step {
+                if self.input.wheel_scroll.vertical.pending.signum() != step {
                     break;
                 }
-                self.wheel_scroll.vertical.pending -= step;
+                self.input.wheel_scroll.vertical.pending -= step;
             }
 
-            let previous = self.selected;
+            let previous = self.navigation.selected;
             self.move_vertical(step);
-            dirty |= previous != self.selected;
+            dirty |= previous != self.navigation.selected;
         }
         dirty
     }
 
     fn flush_entry_horizontal_scroll(&mut self) -> bool {
         let Some(step) = Self::consume_scroll_step(
-            &mut self.wheel_scroll.horizontal,
+            &mut self.input.wheel_scroll.horizontal,
             WHEEL_SCROLL_INTERVAL_HORIZONTAL,
         ) else {
             return false;
         };
 
-        let previous = self.selected;
+        let previous = self.navigation.selected;
         self.move_by(step);
-        previous != self.selected
+        previous != self.navigation.selected
     }
 
     fn scroll_entry_immediately(&mut self, delta: isize) -> bool {
-        let burst_count = Self::register_scroll_input(&mut self.wheel_scroll.vertical, delta);
-        self.browser_wheel_post_burst_pending = true;
-        self.wheel_scroll.vertical.pending = 0;
-        self.wheel_scroll.vertical.remainder = 0;
+        let burst_count = Self::register_scroll_input(&mut self.input.wheel_scroll.vertical, delta);
+        self.input.browser_wheel_post_burst_pending = true;
+        self.input.wheel_scroll.vertical.pending = 0;
+        self.input.wheel_scroll.vertical.remainder = 0;
         let step = self.high_frequency_entry_step_multiplier(burst_count);
         let preview_mode = if burst_count <= 1 {
             PreviewRefreshMode::Immediate
         } else {
             PreviewRefreshMode::Deferred
         };
-        let previous = self.selected;
+        let previous = self.navigation.selected;
         self.move_vertical_with_preview_mode(delta * step, preview_mode);
-        previous != self.selected
+        previous != self.navigation.selected
     }
 
     fn flush_search_scroll(&mut self) -> bool {
-        let Some(step) =
-            Self::consume_scroll_step(&mut self.wheel_scroll.search, WHEEL_SCROLL_INTERVAL_SEARCH)
-        else {
+        let Some(step) = Self::consume_scroll_step(
+            &mut self.input.wheel_scroll.search,
+            WHEEL_SCROLL_INTERVAL_SEARCH,
+        ) else {
             return false;
         };
 
         let previous = self
+            .overlays
             .search
             .as_ref()
             .map(|search| search.selected)
             .unwrap_or(0);
         self.move_search_selection(step);
-        self.search
+        self.overlays
+            .search
             .as_ref()
             .map(|search| search.selected != previous)
             .unwrap_or(false)
@@ -353,14 +367,14 @@ impl App {
 
     fn flush_preview_scroll(&mut self) -> bool {
         let Some(step) = Self::consume_scroll_step(
-            &mut self.wheel_scroll.preview,
+            &mut self.input.wheel_scroll.preview,
             WHEEL_SCROLL_INTERVAL_PREVIEW,
         ) else {
             return false;
         };
         let mut dirty = self.scroll_preview_lines(step);
-        if self.wheel_scroll.preview.pending.signum() == step {
-            self.wheel_scroll.preview.pending -= step;
+        if self.input.wheel_scroll.preview.pending.signum() == step {
+            self.input.wheel_scroll.preview.pending -= step;
             dirty |= self.scroll_preview_lines(step);
         }
         dirty
@@ -368,65 +382,67 @@ impl App {
 
     fn flush_preview_horizontal_scroll(&mut self) -> bool {
         let Some(step) = Self::consume_scroll_step(
-            &mut self.wheel_scroll.preview_horizontal,
+            &mut self.input.wheel_scroll.preview_horizontal,
             WHEEL_SCROLL_INTERVAL_PREVIEW_HORIZONTAL,
         ) else {
             return false;
         };
         let mut dirty = self.scroll_preview_columns(step);
-        if self.wheel_scroll.preview_horizontal.pending.signum() == step {
-            self.wheel_scroll.preview_horizontal.pending -= step;
+        if self.input.wheel_scroll.preview_horizontal.pending.signum() == step {
+            self.input.wheel_scroll.preview_horizontal.pending -= step;
             dirty |= self.scroll_preview_columns(step);
         }
         dirty
     }
 
     fn preview_scroll_step(&self) -> usize {
-        self.frame_state
+        self.input
+            .frame_state
             .preview_rows_visible
             .saturating_div(6)
             .clamp(2, 4)
     }
 
     fn preview_horizontal_scroll_step(&self) -> usize {
-        self.frame_state
+        self.input
+            .frame_state
             .preview_cols_visible
             .saturating_div(8)
             .clamp(2, 6)
     }
 
     pub(in crate::app) fn sync_preview_scroll(&mut self) -> bool {
-        let previous = self.preview_state.scroll;
-        let previous_horizontal = self.preview_state.horizontal_scroll;
-        let visible_rows = self.frame_state.preview_rows_visible;
-        let visible_cols = self.frame_state.preview_cols_visible;
+        let previous = self.preview.state.scroll;
+        let previous_horizontal = self.preview.state.horizontal_scroll;
+        let visible_rows = self.input.frame_state.preview_rows_visible;
+        let visible_cols = self.input.frame_state.preview_cols_visible;
         let max_scroll = self
             .preview_total_lines(visible_cols)
             .saturating_sub(visible_rows.max(1));
-        self.preview_state.scroll = self.preview_state.scroll.min(max_scroll);
+        self.preview.state.scroll = self.preview.state.scroll.min(max_scroll);
         let max_horizontal = self.preview_max_horizontal_scroll(visible_cols);
-        self.preview_state.horizontal_scroll =
-            self.preview_state.horizontal_scroll.min(max_horizontal);
+        self.preview.state.horizontal_scroll =
+            self.preview.state.horizontal_scroll.min(max_horizontal);
         // When scroll is clamped at the rendered boundary, fire an extension.
         self.maybe_request_code_preview_extension();
-        previous != self.preview_state.scroll
-            || previous_horizontal != self.preview_state.horizontal_scroll
+        previous != self.preview.state.scroll
+            || previous_horizontal != self.preview.state.horizontal_scroll
     }
 
     /// Fire an incremental extension job when the user has scrolled close
     /// enough to the bottom of the currently-rendered partial preview.
     fn maybe_request_code_preview_extension(&mut self) {
-        if !self.preview_state.content.is_incrementally_partial() {
+        if !self.preview.state.content.is_incrementally_partial() {
             return;
         }
-        if self.preview_state.incremental_render_in_flight {
+        if self.preview.state.incremental_render_in_flight {
             return;
         }
-        let Some(render_limit) = self.preview_state.content.incremental_render_limit else {
+        let Some(render_limit) = self.preview.state.content.incremental_render_limit else {
             return;
         };
-        let scroll = self.preview_state.scroll;
-        let visible_rows = self.frame_state.preview_rows_visible;
+        let scroll = self.preview.state.scroll;
+        let visible_rows = self.input.frame_state.preview_rows_visible;
         let bottom_edge = scroll.saturating_add(visible_rows);
         if bottom_edge + INCREMENTAL_RENDER_LOOKAHEAD < render_limit {
             return;
@@ -444,44 +460,44 @@ impl App {
             return;
         };
         let entry_path = entry.path.clone();
-        if self.scheduler.submit_preview(request) {
-            self.preview_state.incremental_render_in_flight = true;
-            self.preview_state.incremental_render_path = Some(entry_path);
+        if self.jobs.scheduler.submit_preview(request) {
+            self.preview.state.incremental_render_in_flight = true;
+            self.preview.state.incremental_render_path = Some(entry_path);
         }
     }
 
     pub(in crate::app) fn clear_wheel_scroll(&mut self) {
-        Self::reset_scroll_lane(&mut self.wheel_scroll.vertical);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.horizontal);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.preview);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.preview_horizontal);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.search);
-        self.browser_wheel_post_burst_pending = false;
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.vertical);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.horizontal);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.preview);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.preview_horizontal);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.search);
+        self.input.browser_wheel_post_burst_pending = false;
     }
 
     fn entry_wheel_tuning(&self) -> WheelTuning {
-        match self.wheel_profile {
+        match self.input.wheel_profile {
             WheelProfile::Default => ENTRY_WHEEL_TUNING,
             WheelProfile::HighFrequency => HIGH_FREQUENCY_ENTRY_WHEEL_TUNING,
         }
     }
 
     fn entry_horizontal_wheel_tuning(&self) -> WheelTuning {
-        match self.wheel_profile {
+        match self.input.wheel_profile {
             WheelProfile::Default => ENTRY_HORIZONTAL_WHEEL_TUNING,
             WheelProfile::HighFrequency => HIGH_FREQUENCY_ENTRY_HORIZONTAL_WHEEL_TUNING,
         }
     }
 
     fn entry_scroll_interval(&self) -> Duration {
-        match self.wheel_profile {
+        match self.input.wheel_profile {
             WheelProfile::Default => WHEEL_SCROLL_INTERVAL_VERTICAL,
             WheelProfile::HighFrequency => WHEEL_SCROLL_INTERVAL_VERTICAL_HIGH_FREQUENCY,
         }
     }
 
     fn entry_vertical_steps_per_flush(&self, pending: isize) -> usize {
-        if self.wheel_profile != WheelProfile::HighFrequency {
+        if self.input.wheel_profile != WheelProfile::HighFrequency {
             return 1;
         }
 
@@ -499,34 +515,37 @@ impl App {
     }
 
     pub(in crate::app) fn handle_horizontal_navigation_key(&mut self, delta: isize) -> bool {
-        if self.last_wheel_target == Some(WheelTarget::Preview) {
-            if self.wheel_profile == WheelProfile::HighFrequency {
+        if self.input.last_wheel_target == Some(WheelTarget::Preview) {
+            if self.input.wheel_profile == WheelProfile::HighFrequency {
                 let _ = self.scroll_preview_columns(delta);
                 return true;
             }
             if self.preview_allows_horizontal_scroll()
-                && self.preview_max_horizontal_scroll(self.frame_state.preview_cols_visible.max(1))
-                    > 0
+                && self.preview_max_horizontal_scroll(
+                    self.input.frame_state.preview_cols_visible.max(1),
+                ) > 0
             {
                 return self.scroll_preview_columns(delta);
             }
-            self.last_wheel_target = Some(WheelTarget::Entries);
+            self.input.last_wheel_target = Some(WheelTarget::Entries);
         }
 
-        if self.wheel_profile == WheelProfile::HighFrequency
+        if self.input.wheel_profile == WheelProfile::HighFrequency
             && self.preview_auto_focus_target(true) == Some(WheelTarget::Preview)
             && self.preview_allows_horizontal_scroll()
         {
-            self.last_wheel_target = Some(WheelTarget::Preview);
+            self.input.last_wheel_target = Some(WheelTarget::Preview);
             let _ = self.scroll_preview_columns(delta);
             return true;
         }
 
-        if self.wheel_profile == WheelProfile::HighFrequency && self.view_mode == ViewMode::Grid {
-            self.last_wheel_target = Some(WheelTarget::Entries);
+        if self.input.wheel_profile == WheelProfile::HighFrequency
+            && self.navigation.view_mode == ViewMode::Grid
+        {
+            self.input.last_wheel_target = Some(WheelTarget::Entries);
             self.focus_entry_scroll();
             let tuning = self.entry_horizontal_wheel_tuning();
-            Self::queue_scroll(&mut self.wheel_scroll.horizontal, delta, tuning);
+            Self::queue_scroll(&mut self.input.wheel_scroll.horizontal, delta, tuning);
             return true;
         }
 
@@ -547,8 +566,8 @@ impl App {
             return false;
         }
 
-        Self::reset_scroll_lane(&mut self.wheel_scroll.preview);
-        Self::reset_scroll_lane(&mut self.wheel_scroll.preview_horizontal);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.preview);
+        Self::reset_scroll_lane(&mut self.input.wheel_scroll.preview_horizontal);
         self.step_epub_section(delta)
     }
 
@@ -557,8 +576,8 @@ impl App {
             return false;
         }
 
-        let visible_cols = self.frame_state.preview_cols_visible.max(1);
-        let visible_rows = self.frame_state.preview_rows_visible.max(1);
+        let visible_cols = self.input.frame_state.preview_cols_visible.max(1);
+        let visible_rows = self.input.frame_state.preview_rows_visible.max(1);
         let total_lines = self.preview_total_lines(visible_cols);
         if total_lines <= visible_rows {
             return true;
@@ -566,27 +585,29 @@ impl App {
 
         let max_scroll = total_lines.saturating_sub(visible_rows);
         if delta.is_negative() {
-            self.preview_state.scroll == 0
+            self.preview.state.scroll == 0
         } else {
-            self.preview_state.scroll >= max_scroll
+            self.preview.state.scroll >= max_scroll
         }
     }
 
     fn preview_has_vertical_overflow(&self) -> bool {
-        let visible_cols = self.frame_state.preview_cols_visible.max(1);
-        let visible_rows = self.frame_state.preview_rows_visible.max(1);
+        let visible_cols = self.input.frame_state.preview_cols_visible.max(1);
+        let visible_rows = self.input.frame_state.preview_rows_visible.max(1);
         self.preview_total_lines(visible_cols) > visible_rows
     }
 
     fn preview_auto_focus_ready(&self) -> bool {
         self.preview_has_vertical_overflow()
-            && self.last_selection_change_at.elapsed() >= PREVIEW_AUTO_FOCUS_DELAY
+            && self.input.last_selection_change_at.elapsed() >= PREVIEW_AUTO_FOCUS_DELAY
     }
 
     fn preview_horizontal_auto_focus_ready(&self) -> bool {
         self.preview_allows_horizontal_scroll()
-            && self.preview_max_horizontal_scroll(self.frame_state.preview_cols_visible.max(1)) > 0
-            && self.last_selection_change_at.elapsed() >= PREVIEW_AUTO_FOCUS_DELAY
+            && self
+                .preview_max_horizontal_scroll(self.input.frame_state.preview_cols_visible.max(1))
+                > 0
+            && self.input.last_selection_change_at.elapsed() >= PREVIEW_AUTO_FOCUS_DELAY
     }
 
     fn preview_auto_focus_target(&self, horizontal: bool) -> Option<WheelTarget> {
@@ -594,7 +615,7 @@ impl App {
         // preview has scrollable content. Does NOT use last_wheel_target stickiness —
         // cursor position (via resolve_wheel_target) is always consulted first, so this
         // only fires when the cursor is genuinely ambiguous (e.g. in sidebar/toolbar).
-        if self.wheel_profile != WheelProfile::HighFrequency {
+        if self.input.wheel_profile != WheelProfile::HighFrequency {
             return None;
         }
 
@@ -608,40 +629,44 @@ impl App {
     }
 
     fn scroll_preview_lines(&mut self, delta: isize) -> bool {
-        let previous = self.preview_state.scroll;
+        let previous = self.preview.state.scroll;
         let step = self.preview_scroll_step();
         if delta.is_negative() {
-            self.preview_state.scroll = self
-                .preview_state
+            self.preview.state.scroll = self
+                .preview
+                .state
                 .scroll
                 .saturating_sub(step.saturating_mul(delta.unsigned_abs()));
         } else {
-            self.preview_state.scroll = self
-                .preview_state
+            self.preview.state.scroll = self
+                .preview
+                .state
                 .scroll
                 .saturating_add(step.saturating_mul(delta as usize));
         }
         // sync_preview_scroll already calls maybe_request_code_preview_extension.
         self.sync_preview_scroll();
-        previous != self.preview_state.scroll
+        previous != self.preview.state.scroll
     }
 
     pub(in crate::app) fn scroll_preview_columns(&mut self, delta: isize) -> bool {
-        let previous = self.preview_state.horizontal_scroll;
+        let previous = self.preview.state.horizontal_scroll;
         let step = self.preview_horizontal_scroll_step();
         if delta.is_negative() {
-            self.preview_state.horizontal_scroll = self
-                .preview_state
+            self.preview.state.horizontal_scroll = self
+                .preview
+                .state
                 .horizontal_scroll
                 .saturating_sub(step.saturating_mul(delta.unsigned_abs()));
         } else {
-            self.preview_state.horizontal_scroll = self
-                .preview_state
+            self.preview.state.horizontal_scroll = self
+                .preview
+                .state
                 .horizontal_scroll
                 .saturating_add(step.saturating_mul(delta as usize));
         }
         self.sync_preview_scroll();
-        previous != self.preview_state.horizontal_scroll
+        previous != self.preview.state.horizontal_scroll
     }
 
     // Scroll preview immediately without queuing, mirroring scroll_entry_immediately.
@@ -649,14 +674,14 @@ impl App {
     // terminal sends many raw wheel events. The queue system causes lag and stalls in
     // these terminals because it caps pending steps and applies burst throttle divisors.
     fn scroll_preview_immediately(&mut self, delta: isize) -> bool {
-        self.wheel_scroll.preview.pending = 0;
-        self.wheel_scroll.preview.remainder = 0;
+        self.input.wheel_scroll.preview.pending = 0;
+        self.input.wheel_scroll.preview.remainder = 0;
         self.scroll_preview_lines(delta)
     }
 
     fn scroll_preview_columns_immediately(&mut self, delta: isize) -> bool {
-        self.wheel_scroll.preview_horizontal.pending = 0;
-        self.wheel_scroll.preview_horizontal.remainder = 0;
+        self.input.wheel_scroll.preview_horizontal.pending = 0;
+        self.input.wheel_scroll.preview_horizontal.remainder = 0;
         self.scroll_preview_columns(delta)
     }
 }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -49,23 +49,23 @@ impl App {
         while processed < JOB_RESULT_APPLY_MAX_PER_TICK
             && started_at.elapsed() < JOB_RESULT_APPLY_TIME_BUDGET
         {
-            let Ok(job) = self.scheduler.try_recv() else {
+            let Ok(job) = self.jobs.scheduler.try_recv() else {
                 break;
             };
             processed += 1;
             match job {
                 JobResult::Directory(build) => {
-                    let Some(load) = self.directory_runtime.pending_load.clone() else {
+                    let Some(load) = self.navigation.directory_runtime.pending_load.clone() else {
                         continue;
                     };
-                    if build.token != self.directory_token
+                    if build.token != self.jobs.directory_token
                         || build.token != load.token
                         || build.cwd != load.target_cwd
                     {
                         continue;
                     }
 
-                    self.directory_runtime.pending_load = None;
+                    self.navigation.directory_runtime.pending_load = None;
                     dirty = true;
 
                     match build.result {
@@ -76,10 +76,15 @@ impl App {
                     }
                 }
                 JobResult::DirectoryFingerprint(build) => {
-                    let Some(scan) = self.directory_runtime.pending_fingerprint_scan.clone() else {
+                    let Some(scan) = self
+                        .navigation
+                        .directory_runtime
+                        .pending_fingerprint_scan
+                        .clone()
+                    else {
                         continue;
                     };
-                    if build.token != self.directory_fingerprint_token
+                    if build.token != self.jobs.directory_fingerprint_token
                         || build.token != scan.token
                         || build.cwd != scan.cwd
                         || build.show_hidden != scan.show_hidden
@@ -87,13 +92,13 @@ impl App {
                         continue;
                     }
 
-                    self.directory_runtime.pending_fingerprint_scan = None;
+                    self.navigation.directory_runtime.pending_fingerprint_scan = None;
 
                     let Ok(fingerprint) = build.result else {
                         continue;
                     };
-                    if self.directory_runtime.pending_load.is_some()
-                        || fingerprint == self.directory_runtime.fingerprint
+                    if self.navigation.directory_runtime.pending_load.is_some()
+                        || fingerprint == self.navigation.directory_runtime.fingerprint
                     {
                         continue;
                     }
@@ -139,25 +144,25 @@ impl App {
                     dirty |= self.apply_image_prepare_build(build);
                 }
                 JobResult::Search(build) => {
-                    if build.token != self.search_token
-                        || build.cwd != self.cwd
-                        || build.show_hidden != self.show_hidden
+                    if build.token != self.jobs.search_token
+                        || build.cwd != self.navigation.cwd
+                        || build.show_hidden != self.navigation.show_hidden
                     {
                         continue;
                     }
 
-                    self.search_loading = false;
+                    self.jobs.search_loading = false;
                     dirty = true;
 
                     match build.result {
                         Ok(candidates) => {
-                            self.search_cache = Some(SearchCache {
+                            self.jobs.search_cache = Some(SearchCache {
                                 cwd: build.cwd,
                                 scope: build.scope,
                                 show_hidden: build.show_hidden,
                                 candidates: candidates.clone(),
                             });
-                            if let Some(search) = &mut self.search
+                            if let Some(search) = &mut self.overlays.search
                                 && search.scope == build.scope
                             {
                                 search.candidates = candidates;
@@ -171,8 +176,8 @@ impl App {
                             self.refresh_search_matches("");
                         }
                         Err(error) => {
-                            self.search_cache = None;
-                            if let Some(search) = &mut self.search
+                            self.jobs.search_cache = None;
+                            if let Some(search) = &mut self.overlays.search
                                 && search.scope == build.scope
                             {
                                 search.candidates = Arc::new(Vec::new());
@@ -188,17 +193,19 @@ impl App {
                     }
                 }
                 JobResult::Paste(build) => {
-                    if build.token != self.paste_token {
+                    if build.token != self.jobs.paste_token {
                         continue;
                     }
                     if build.done {
-                        self.paste_progress = None;
+                        self.jobs.paste_progress = None;
                         let dest_dir = self
+                            .jobs
                             .paste_dest_dir
                             .take()
-                            .unwrap_or_else(|| self.cwd.clone());
+                            .unwrap_or_else(|| self.navigation.cwd.clone());
                         let status = build.status.unwrap_or_default();
                         let next_queued_dest = self
+                            .jobs
                             .queued_pastes
                             .front()
                             .map(|queued| queued.dest_dir.as_path());
@@ -208,19 +215,20 @@ impl App {
                         // destination directory and not mid-navigation to
                         // somewhere else (which would cancel their navigation).
                         let nav_target = self
+                            .navigation
                             .directory_runtime
                             .pending_load
                             .as_ref()
                             .map(|l| l.target_cwd.as_path());
                         let nav_to_dest = nav_target == Some(dest_dir.as_path());
-                        if dest_dir == self.cwd
+                        if dest_dir == self.navigation.cwd
                             && (nav_target.is_none() || nav_to_dest)
                             && !defer_reload_for_same_dest
                         {
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,
                                 target_cwd: dest_dir,
-                                previous_cwd: self.cwd.clone(),
+                                previous_cwd: self.navigation.cwd.clone(),
                                 previous_selected_path: None,
                                 previous_selection_name: None,
                                 reselect_path: None,
@@ -238,13 +246,13 @@ impl App {
                             self.status = status;
                         }
                         self.start_next_queued_paste();
-                    } else if let Some(prog) = &mut self.paste_progress {
+                    } else if let Some(prog) = &mut self.jobs.paste_progress {
                         prog.completed = build.completed;
                     }
                     dirty = true;
                 }
                 JobResult::Trash(build) => {
-                    if build.token != self.trash_token {
+                    if build.token != self.jobs.trash_token {
                         continue;
                     }
                     if build.done {
@@ -253,30 +261,34 @@ impl App {
                         // operations leave some entries intact, so using the
                         // pre-computed survivor path would move the cursor
                         // away from entries that are still present.
-                        let next_selection = self.trash_progress.take().and_then(|p| {
+                        let next_selection = self.jobs.trash_progress.take().and_then(|p| {
                             (build.completed == p.total)
                                 .then_some(p.next_selection)
                                 .flatten()
                         });
                         let source_cwd = self
+                            .jobs
                             .trash_source_cwd
                             .take()
-                            .unwrap_or_else(|| self.cwd.clone());
+                            .unwrap_or_else(|| self.navigation.cwd.clone());
                         let status = build.status.unwrap_or_default();
                         // Only reload in-place when the user is still in the
                         // source directory and not mid-navigation to somewhere
                         // else (which would cancel their navigation).
                         let nav_target = self
+                            .navigation
                             .directory_runtime
                             .pending_load
                             .as_ref()
                             .map(|l| l.target_cwd.as_path());
                         let nav_to_source = nav_target == Some(source_cwd.as_path());
-                        if source_cwd == self.cwd && (nav_target.is_none() || nav_to_source) {
+                        if source_cwd == self.navigation.cwd
+                            && (nav_target.is_none() || nav_to_source)
+                        {
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,
                                 target_cwd: source_cwd,
-                                previous_cwd: self.cwd.clone(),
+                                previous_cwd: self.navigation.cwd.clone(),
                                 previous_selected_path: None,
                                 previous_selection_name: None,
                                 reselect_path: next_selection,
@@ -289,33 +301,37 @@ impl App {
                             // Navigation will load source_cwd fresh if they return.
                             self.status = status;
                         }
-                    } else if let Some(prog) = &mut self.trash_progress {
+                    } else if let Some(prog) = &mut self.jobs.trash_progress {
                         prog.completed = build.completed;
                     }
                     dirty = true;
                 }
                 JobResult::Restore(build) => {
-                    if build.token != self.restore_token {
+                    if build.token != self.jobs.restore_token {
                         continue;
                     }
                     if build.done {
-                        self.restore_progress = None;
+                        self.jobs.restore_progress = None;
                         let source_cwd = self
+                            .jobs
                             .restore_source_cwd
                             .take()
-                            .unwrap_or_else(|| self.cwd.clone());
+                            .unwrap_or_else(|| self.navigation.cwd.clone());
                         let status = build.status.unwrap_or_default();
                         let nav_target = self
+                            .navigation
                             .directory_runtime
                             .pending_load
                             .as_ref()
                             .map(|l| l.target_cwd.as_path());
                         let nav_to_source = nav_target == Some(source_cwd.as_path());
-                        if source_cwd == self.cwd && (nav_target.is_none() || nav_to_source) {
+                        if source_cwd == self.navigation.cwd
+                            && (nav_target.is_none() || nav_to_source)
+                        {
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,
                                 target_cwd: source_cwd,
-                                previous_cwd: self.cwd.clone(),
+                                previous_cwd: self.navigation.cwd.clone(),
                                 previous_selected_path: None,
                                 previous_selection_name: None,
                                 reselect_path: None,
@@ -326,7 +342,7 @@ impl App {
                         } else {
                             self.status = status;
                         }
-                    } else if let Some(prog) = &mut self.restore_progress {
+                    } else if let Some(prog) = &mut self.jobs.restore_progress {
                         prog.completed = build.completed;
                     }
                     dirty = true;
@@ -359,7 +375,7 @@ impl App {
                         .unwrap_or(false);
                     let is_current_variant =
                         build.variant == self.current_preview_request_options();
-                    if build.token != self.preview_state.token
+                    if build.token != self.preview.state.token
                         || !is_current_entry
                         || !is_current_variant
                         || build.code_line_limit
@@ -380,7 +396,7 @@ impl App {
                             && build.code_line_limit
                                 == self.preview_code_line_limit_for_entry(&build.entry)
                             && matches!(
-                                &self.preview_state.load_state,
+                                &self.preview.state.load_state,
                                 Some(PreviewLoadState::Placeholder(p) | PreviewLoadState::Refreshing(p))
                                     if p == &build.entry.path
                             );
@@ -394,13 +410,13 @@ impl App {
                             // Clear the in-flight flag if this stale drop belongs to our
                             // outstanding extension job (prevents stuck state when the
                             // user navigates away mid-extension).
-                            if self.preview_state.incremental_render_path.as_deref()
+                            if self.preview.state.incremental_render_path.as_deref()
                                 == Some(build.entry.path.as_path())
                             {
-                                self.preview_state.incremental_render_in_flight = false;
-                                self.preview_state.incremental_render_path = None;
+                                self.preview.state.incremental_render_in_flight = false;
+                                self.preview.state.incremental_render_path = None;
                             }
-                            self.preview_state.metrics.stale_results_dropped += 1;
+                            self.preview.state.metrics.stale_results_dropped += 1;
                             continue;
                         }
                     }
@@ -409,28 +425,28 @@ impl App {
                     // currently-displayed partial preview.  If so, replace the content
                     // WITHOUT resetting scroll so there are no visual artifacts.
                     let is_extension_result = build.result.incremental_render_limit.is_none()
-                        && self.preview_state.content.is_incrementally_partial()
+                        && self.preview.state.content.is_incrementally_partial()
                         && is_current_entry
                         && is_current_variant;
 
-                    self.preview_state.content = build.result;
-                    if self.preview_state.content.kind != preview::PreviewKind::Directory {
-                        self.preview_state.directory_stats = None;
+                    self.preview.state.content = build.result;
+                    if self.preview.state.content.kind != preview::PreviewKind::Directory {
+                        self.preview.state.directory_stats = None;
                     }
-                    self.preview_state.load_state = None;
+                    self.preview.state.load_state = None;
                     self.apply_current_comic_preview_metadata();
                     self.apply_current_epub_preview_metadata();
                     self.sync_current_preview_line_count();
 
                     if is_extension_result {
                         // Extension result: preserve scroll, just clamp if needed.
-                        self.preview_state.incremental_render_in_flight = false;
-                        self.preview_state.incremental_render_path = None;
+                        self.preview.state.incremental_render_in_flight = false;
+                        self.preview.state.incremental_render_path = None;
                         self.sync_preview_scroll();
                     } else {
                         // Normal first-time render: reset scroll.
-                        self.preview_state.scroll = 0;
-                        self.preview_state.horizontal_scroll = 0;
+                        self.preview.state.scroll = 0;
+                        self.preview.state.horizontal_scroll = 0;
                         self.sync_preview_scroll();
                     }
 
@@ -441,7 +457,7 @@ impl App {
                         self.prefetch_nearby_audio_previews();
                         self.schedule_preview_prefetch();
                     }
-                    self.preview_state.metrics.applied_results += 1;
+                    self.preview.state.metrics.applied_results += 1;
                     dirty = true;
                 }
             }
@@ -449,9 +465,9 @@ impl App {
 
         if (processed == JOB_RESULT_APPLY_MAX_PER_TICK
             || (processed > 0 && started_at.elapsed() >= JOB_RESULT_APPLY_TIME_BUDGET))
-            && let Ok(job) = self.scheduler.try_recv()
+            && let Ok(job) = self.jobs.scheduler.try_recv()
         {
-            self.scheduler.defer_result(job);
+            self.jobs.scheduler.defer_result(job);
         }
 
         dirty

--- a/src/app/jobs/results/tests/async_previews.rs
+++ b/src/app/jobs/results/tests/async_previews.rs
@@ -98,12 +98,12 @@ fn epub_preview_keeps_section_navigation_while_next_section_loads() {
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     wait_for_background_preview(&mut app);
 
-    assert_eq!(app.preview_state.content.ebook_section_index, Some(0));
-    assert_eq!(app.preview_state.content.ebook_section_count, Some(2));
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(0));
+    assert_eq!(app.preview.state.content.ebook_section_count, Some(2));
     assert!(app.step_epub_section(1));
     assert!(app.preview_lines().is_empty());
-    assert_eq!(app.preview_state.content.ebook_section_index, Some(1));
-    assert_eq!(app.preview_state.content.ebook_section_count, Some(2));
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(1));
+    assert_eq!(app.preview.state.content.ebook_section_count, Some(2));
     assert_eq!(
         app.preview_header_detail(10).as_deref(),
         Some("EPUB ebook  •  Section 2/2")
@@ -111,9 +111,9 @@ fn epub_preview_keeps_section_navigation_while_next_section_loads() {
 
     wait_for_background_preview(&mut app);
 
-    assert_eq!(app.preview_state.content.ebook_section_index, Some(1));
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(1));
     assert_eq!(
-        app.preview_state.content.ebook_section_title.as_deref(),
+        app.preview.state.content.ebook_section_title.as_deref(),
         Some("Second Step")
     );
     assert!(
@@ -146,7 +146,7 @@ fn comic_preview_loads_when_token_is_stale_but_placeholder_is_current() {
     // Simulate the race: bump the token without calling refresh_preview() so
     // load_state stays Placeholder and no replacement job is submitted.  The
     // original job will arrive with the now-stale token.
-    app.preview_state.token = app.preview_state.token.wrapping_add(1);
+    app.preview.state.token = app.preview.state.token.wrapping_add(1);
 
     // Without the rescue the result would be dropped and this would time out.
     wait_for_background_preview(&mut app);
@@ -182,8 +182,8 @@ fn comic_preview_loads_when_token_is_stale_and_load_state_is_refreshing() {
     // Simulate the Refreshing race: switch load_state to Refreshing (as it
     // would be after refresh_preview found a stale cache hit) and bump the
     // token so the in-flight job will arrive stale against a Refreshing state.
-    app.preview_state.load_state = Some(PreviewLoadState::Refreshing(archive.clone()));
-    app.preview_state.token = app.preview_state.token.wrapping_add(1);
+    app.preview.state.load_state = Some(PreviewLoadState::Refreshing(archive.clone()));
+    app.preview.state.token = app.preview.state.token.wrapping_add(1);
 
     // Without the extended rescue (Placeholder OR Refreshing), the result
     // would be dropped and this would time out.

--- a/src/app/jobs/results/tests/cache.rs
+++ b/src/app/jobs/results/tests/cache.rs
@@ -112,9 +112,9 @@ fn archive_preview_resets_scroll_after_async_refresh() {
     });
     wait_for_background_preview(&mut app);
 
-    app.preview_state.scroll = 2;
+    app.preview.state.scroll = 2;
     app.sync_preview_scroll();
-    assert_eq!(app.preview_state.scroll, 2);
+    assert_eq!(app.preview.state.scroll, 2);
 
     app.set_selected(1);
 
@@ -131,7 +131,7 @@ fn archive_preview_resets_scroll_after_async_refresh() {
 
     app.set_selected(0);
     assert_eq!(app.preview_section_label(), "Archive");
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
     assert!(app.preview_header_detail(10).is_some());
     assert!(
         app.preview_lines()
@@ -142,7 +142,7 @@ fn archive_preview_resets_scroll_after_async_refresh() {
     wait_for_background_preview(&mut app);
 
     assert_eq!(app.preview_section_label(), "Archive");
-    assert_eq!(app.preview_state.scroll, 0);
+    assert_eq!(app.preview.state.scroll, 0);
     assert!(
         app.preview_header_detail(10)
             .as_deref()
@@ -175,9 +175,10 @@ fn stale_preview_results_are_counted_in_metrics() {
 
     app.set_selected(1);
     let metrics_before = app.preview_metrics();
-    app.scheduler
+    app.jobs
+        .scheduler
         .defer_result(JobResult::Preview(Box::new(PreviewBuild {
-            token: app.preview_state.token.wrapping_add(1),
+            token: app.preview.state.token.wrapping_add(1),
             entry: stale_entry,
             variant: preview::PreviewRequestOptions::Default,
             code_line_limit: 0,

--- a/src/app/jobs/results/tests/headers.rs
+++ b/src/app/jobs/results/tests/headers.rs
@@ -35,19 +35,20 @@ fn directory_header_marks_incomplete_totals_without_claiming_exactness() {
         .selected_entry()
         .cloned()
         .expect("directory entry should be selected");
-    let token = app.preview_state.token.wrapping_add(1);
-    app.scheduler.cancel_directory_stats();
+    let token = app.preview.state.token.wrapping_add(1);
+    app.jobs.scheduler.cancel_directory_stats();
     // Seed a settled directory preview state so this assertion does not depend
     // on how quickly the background preview worker finishes on slower CI VMs.
-    app.preview_state.token = token;
-    app.preview_state.content =
+    app.preview.state.token = token;
+    app.preview.state.content =
         PreviewContent::new(PreviewKind::Directory, Vec::new()).with_detail("1 item");
-    app.preview_state.load_state = None;
-    app.preview_state.directory_stats = Some(PreviewDirectoryStatsState::Loading {
+    app.preview.state.load_state = None;
+    app.preview.state.directory_stats = Some(PreviewDirectoryStatsState::Loading {
         token,
         path: entry.path.clone(),
     });
-    app.scheduler
+    app.jobs
+        .scheduler
         .defer_result(JobResult::DirectoryStats(DirectoryStatsBuild {
             token,
             path: entry.path.clone(),
@@ -83,7 +84,7 @@ fn stale_directory_totals_result_is_ignored_after_selection_changes() {
     fs::write(b_dir.join("b.txt"), vec![b'b'; 200]).expect("failed to write b.txt");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    let stale_token = app.preview_state.token;
+    let stale_token = app.preview.state.token;
     let stale_entry = app
         .selected_entry()
         .cloned()
@@ -95,7 +96,8 @@ fn stale_directory_totals_result_is_ignored_after_selection_changes() {
         .cloned()
         .expect("b-dir should be selected second");
 
-    app.scheduler
+    app.jobs
+        .scheduler
         .defer_result(JobResult::DirectoryStats(DirectoryStatsBuild {
             token: stale_token,
             path: stale_entry.path.clone(),
@@ -109,7 +111,8 @@ fn stale_directory_totals_result_is_ignored_after_selection_changes() {
 
     let _ = app.process_background_jobs();
     assert_eq!(
-        app.preview_state
+        app.preview
+            .state
             .directory_stats
             .as_ref()
             .map(PreviewDirectoryStatsState::path),
@@ -192,11 +195,11 @@ fn narrow_code_header_prefers_compact_subtype_and_drops_low_priority_notes() {
     let root = temp_path("narrow-code-header");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.preview_state.content =
+    app.preview.state.content =
         PreviewContent::new(PreviewKind::Code, vec![Line::from("fn main() {}")])
             .with_detail("Rust source file")
             .with_line_coverage(default_code_preview_line_limit(), None, true);
-    app.preview_state.content.set_total_line_count_pending(true);
+    app.preview.state.content.set_total_line_count_pending(true);
 
     assert_eq!(
         app.preview_header_detail_for_width(8, 20).as_deref(),

--- a/src/app/jobs/results/tests/helpers.rs
+++ b/src/app/jobs/results/tests/helpers.rs
@@ -309,7 +309,8 @@ pub(super) fn wait_for_preview_total_line_count(app: &mut App, expected_total: u
     let mut last_seen = None;
     for _ in 0..200 {
         let current = app
-            .preview_state
+            .preview
+            .state
             .content
             .line_coverage
             .as_ref()
@@ -329,7 +330,7 @@ pub(super) fn wait_for_preview_total_line_count(app: &mut App, expected_total: u
 pub(super) fn wait_for_directory_load(app: &mut App) {
     for _ in 0..200 {
         let _ = app.process_background_jobs();
-        if app.directory_runtime.pending_load.is_none() {
+        if app.navigation.directory_runtime.pending_load.is_none() {
             return;
         }
         thread::sleep(Duration::from_millis(10));

--- a/src/app/jobs/results/tests/scheduler.rs
+++ b/src/app/jobs/results/tests/scheduler.rs
@@ -10,7 +10,8 @@ fn background_job_processing_yields_after_a_burst_of_results() {
     wait_for_directory_load(&mut app);
 
     for index in 0..20 {
-        app.scheduler
+        app.jobs
+            .scheduler
             .defer_result(JobResult::PreviewLineCount(PreviewLineCountBuild {
                 path: root.join(format!("item-{index}.txt")),
                 size: index as u64 + 1,
@@ -20,8 +21,8 @@ fn background_job_processing_yields_after_a_burst_of_results() {
     }
 
     let _ = app.process_background_jobs();
-    assert!(!app.preview_state.line_count_cache.is_empty());
-    assert!(app.preview_state.line_count_cache.len() < 20);
+    assert!(!app.preview.state.line_count_cache.is_empty());
+    assert!(app.preview.state.line_count_cache.len() < 20);
     assert!(app.has_pending_background_work());
 
     for _ in 0..10 {
@@ -31,7 +32,7 @@ fn background_job_processing_yields_after_a_burst_of_results() {
         }
     }
 
-    assert_eq!(app.preview_state.line_count_cache.len(), 20);
+    assert_eq!(app.preview.state.line_count_cache.len(), 20);
     assert!(!app.has_pending_background_work());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,15 +46,15 @@ impl App {
         let previous_code_line_limit = self.selected_entry().map(|entry| {
             self.preview_code_line_limit_for_entry_with_rows(
                 entry,
-                self.frame_state.preview_rows_visible,
+                self.input.frame_state.preview_rows_visible,
             )
         });
-        self.frame_state = frame_state;
+        self.input.frame_state = frame_state;
         let mut dirty = self.sync_scroll() | self.sync_search_scroll() | self.sync_preview_scroll();
         let next_code_line_limit = self.selected_entry().map(|entry| {
             self.preview_code_line_limit_for_entry_with_rows(
                 entry,
-                self.frame_state.preview_rows_visible,
+                self.input.frame_state.preview_rows_visible,
             )
         });
         if previous_code_line_limit != next_code_line_limit {
@@ -70,22 +70,26 @@ impl App {
     }
 
     pub fn selected_entry(&self) -> Option<&Entry> {
-        self.entries.get(self.selected)
+        self.navigation.entries.get(self.navigation.selected)
     }
 
     pub fn has_pending_auto_reload(&self) -> bool {
-        self.directory_runtime.pending_reload_at.is_some()
+        self.navigation
+            .directory_runtime
+            .pending_reload_at
+            .is_some()
     }
 
     pub fn has_pending_background_work(&self) -> bool {
-        self.scheduler.has_pending_work()
+        self.jobs.scheduler.has_pending_work()
     }
 
     pub(crate) fn browser_wheel_burst_active(&self) -> bool {
-        self.wheel_profile == WheelProfile::HighFrequency
-            && self.search.is_none()
-            && self.last_wheel_target == Some(WheelTarget::Entries)
+        self.input.wheel_profile == WheelProfile::HighFrequency
+            && self.overlays.search.is_none()
+            && self.input.last_wheel_target == Some(WheelTarget::Entries)
             && self
+                .input
                 .wheel_scroll
                 .vertical
                 .last_input_at
@@ -93,18 +97,19 @@ impl App {
     }
 
     pub(crate) fn pending_browser_wheel_timer(&self) -> Option<Duration> {
-        if !self.browser_wheel_post_burst_pending {
+        if !self.input.browser_wheel_post_burst_pending {
             return None;
         }
-        self.wheel_scroll
+        self.input
+            .wheel_scroll
             .vertical
             .last_input_at
             .map(|at| WHEEL_SCROLL_BURST_WINDOW.saturating_sub(at.elapsed()))
     }
 
     pub(crate) fn process_browser_wheel_timers(&mut self) -> bool {
-        if self.browser_wheel_post_burst_pending && !self.browser_wheel_burst_active() {
-            self.browser_wheel_post_burst_pending = false;
+        if self.input.browser_wheel_post_burst_pending && !self.browser_wheel_burst_active() {
+            self.input.browser_wheel_post_burst_pending = false;
             return true;
         }
         false
@@ -112,12 +117,12 @@ impl App {
 
     #[cfg(test)]
     pub fn scheduler_metrics(&self) -> SchedulerMetricsSnapshot {
-        self.scheduler.metrics_snapshot()
+        self.jobs.scheduler.metrics_snapshot()
     }
 
     #[cfg(test)]
     pub fn preview_metrics(&self) -> PreviewMetricsSnapshot {
-        self.preview_state.metrics.snapshot()
+        self.preview.state.metrics.snapshot()
     }
 
     pub fn report_runtime_error(&mut self, context: &str, error: &anyhow::Error) {

--- a/src/app/overlays/comic.rs
+++ b/src/app/overlays/comic.rs
@@ -29,15 +29,15 @@ struct ComicSession {
 impl App {
     pub(in crate::app) fn sync_comic_preview_selection(&mut self) {
         let Some(entry) = self.selected_entry() else {
-            self.comic_preview.session = None;
+            self.preview.comic.session = None;
             return;
         };
         if !is_comic_entry(entry) {
-            self.comic_preview.session = None;
+            self.preview.comic.session = None;
             return;
         }
 
-        let keep_session = self.comic_preview.session.as_ref().is_some_and(|session| {
+        let keep_session = self.preview.comic.session.as_ref().is_some_and(|session| {
             session.path == entry.path
                 && session.size == entry.size
                 && session.modified == entry.modified
@@ -46,7 +46,7 @@ impl App {
             return;
         }
 
-        self.comic_preview.session = Some(ComicSession {
+        self.preview.comic.session = Some(ComicSession {
             path: entry.path.clone(),
             size: entry.size,
             modified: entry.modified,
@@ -58,7 +58,8 @@ impl App {
     pub(in crate::app) fn comic_preview_request_options(
         &self,
     ) -> Option<preview::PreviewRequestOptions> {
-        self.comic_preview
+        self.preview
+            .comic
             .session
             .as_ref()
             .map(|session| preview::PreviewRequestOptions::ComicPage(session.current_page))
@@ -72,7 +73,7 @@ impl App {
     }
 
     pub(in crate::app) fn comic_preview_wheel_capture_active(&self) -> bool {
-        self.comic_preview.session.is_some()
+        self.preview.comic.session.is_some()
     }
 
     /// Called just after a page image (comic or fixed-layout EPUB) is rendered
@@ -81,7 +82,8 @@ impl App {
     /// whether to keep or clear the stale overlay on navigation.
     pub(in crate::app) fn record_comic_page_image_displayed(&mut self) {
         let is_page_image = self
-            .preview_state
+            .preview
+            .state
             .content
             .preview_visual
             .as_ref()
@@ -92,8 +94,9 @@ impl App {
             // session.  Both are updated in sync_*_preview_selection() which
             // runs inside refresh_preview(), so during a deferred navigation
             // they still point to the file whose page is actually on screen.
-            self.comic_preview.displayed_page_source = self
-                .comic_preview
+            self.preview.comic.displayed_page_source = self
+                .preview
+                .comic
                 .session
                 .as_ref()
                 .map(|s| s.path.clone())
@@ -107,12 +110,13 @@ impl App {
     /// Both being `None` is treated as matching (no session info available).
     pub(in crate::app) fn displayed_comic_page_belongs_to_current_session(&self) -> bool {
         let current_source = self
-            .comic_preview
+            .preview
+            .comic
             .session
             .as_ref()
             .map(|s| s.path.as_path())
             .or_else(|| self.epub_preview_session_path());
-        self.comic_preview.displayed_page_source.as_deref() == current_source
+        self.preview.comic.displayed_page_source.as_deref() == current_source
     }
 
     pub(in crate::app) fn apply_current_comic_preview_metadata(&mut self) {
@@ -122,14 +126,14 @@ impl App {
         else {
             return;
         };
-        let Some(session) = self.comic_preview.session.as_mut() else {
+        let Some(session) = self.preview.comic.session.as_mut() else {
             return;
         };
         if session.path != path || session.size != size || session.modified != modified {
             return;
         }
 
-        let Some(position) = self.preview_state.content.navigation_position.as_ref() else {
+        let Some(position) = self.preview.state.content.navigation_position.as_ref() else {
             return;
         };
         if position.label != "Page" {
@@ -144,7 +148,7 @@ impl App {
         &self,
         preview: preview::PreviewContent,
     ) -> preview::PreviewContent {
-        let Some(session) = self.comic_preview.session.as_ref() else {
+        let Some(session) = self.preview.comic.session.as_ref() else {
             return preview;
         };
         let Some(total_pages) = session.total_pages else {
@@ -166,13 +170,14 @@ impl App {
         delta: isize,
         preview_mode: PreviewRefreshMode,
     ) -> bool {
-        let Some(session) = self.comic_preview.session.as_mut() else {
+        let Some(session) = self.preview.comic.session.as_mut() else {
             return false;
         };
         let total_pages = session
             .total_pages
             .or(self
-                .preview_state
+                .preview
+                .state
                 .content
                 .navigation_position
                 .as_ref()
@@ -196,22 +201,22 @@ impl App {
 
         match preview_mode {
             PreviewRefreshMode::Immediate => {
-                self.image_preview.selection_activation_delay = std::time::Duration::ZERO;
-                self.preview_state.deferred_refresh_at = Some(Instant::now());
+                self.preview.image.selection_activation_delay = std::time::Duration::ZERO;
+                self.preview.state.deferred_refresh_at = Some(Instant::now());
                 self.refresh_preview();
             }
             PreviewRefreshMode::Deferred => {
-                self.last_selection_change_at = Instant::now();
-                self.image_preview.selection_activation_delay = IMAGE_SELECTION_ACTIVATION_DELAY;
-                self.preview_state.deferred_refresh_at =
+                self.input.last_selection_change_at = Instant::now();
+                self.preview.image.selection_activation_delay = IMAGE_SELECTION_ACTIVATION_DELAY;
+                self.preview.state.deferred_refresh_at =
                     Some(Instant::now() + HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY);
-                if let Some(position) = self.preview_state.content.navigation_position.as_mut()
+                if let Some(position) = self.preview.state.content.navigation_position.as_mut()
                     && position.label == "Page"
                 {
                     position.index = session.current_page;
                 }
-                self.preview_state.scroll = 0;
-                self.preview_state.horizontal_scroll = 0;
+                self.preview.state.scroll = 0;
+                self.preview.state.horizontal_scroll = 0;
                 self.sync_preview_scroll();
             }
         }
@@ -219,13 +224,14 @@ impl App {
     }
 
     pub(in crate::app) fn comic_prefetch_page_indices(&self) -> Vec<usize> {
-        let Some(session) = self.comic_preview.session.as_ref() else {
+        let Some(session) = self.preview.comic.session.as_ref() else {
             return Vec::new();
         };
         let total_pages = session
             .total_pages
             .or(self
-                .preview_state
+                .preview
+                .state
                 .content
                 .navigation_position
                 .as_ref()
@@ -269,7 +275,7 @@ impl App {
                 PreviewPriority::Low,
                 preview_work_class(&entry, &variant),
             );
-            let _ = self.scheduler.submit_preview(request);
+            let _ = self.jobs.scheduler.submit_preview(request);
         }
     }
 
@@ -300,7 +306,7 @@ impl App {
                 PreviewPriority::Low,
                 preview_work_class(&entry, &variant),
             );
-            let _ = self.scheduler.submit_preview(request);
+            let _ = self.jobs.scheduler.submit_preview(request);
         }
     }
 
@@ -313,7 +319,7 @@ impl App {
         if !is_comic_entry(entry) {
             return Vec::new();
         }
-        let Some(area) = self.frame_state.preview_media_area else {
+        let Some(area) = self.input.frame_state.preview_media_area else {
             return Vec::new();
         };
 
@@ -335,7 +341,7 @@ impl App {
     pub(in crate::app) fn nearby_comic_entry_preview_visual_overlay_requests(
         &self,
     ) -> Vec<crate::app::overlays::images::StaticImageOverlayRequest> {
-        let Some(area) = self.frame_state.preview_media_area else {
+        let Some(area) = self.input.frame_state.preview_media_area else {
             return Vec::new();
         };
 
@@ -371,7 +377,8 @@ impl App {
     }
 
     fn cached_comic_page_count(&self, entry: &Entry) -> Option<usize> {
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .iter()
             .find_map(|(key, cached)| {
@@ -391,7 +398,8 @@ impl App {
         path: &std::path::Path,
         page: usize,
     ) -> bool {
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .contains_key(&PreviewCacheKey {
                 path: path.to_path_buf(),
@@ -412,10 +420,10 @@ impl App {
         COMIC_ENTRY_PREFETCH_OFFSETS
             .into_iter()
             .filter_map(|offset| {
-                let target = self.selected as isize + offset;
+                let target = self.navigation.selected as isize + offset;
                 (target >= 0)
                     .then_some(target as usize)
-                    .and_then(|index| self.entries.get(index))
+                    .and_then(|index| self.navigation.entries.get(index))
                     .filter(|candidate| is_comic_entry(candidate))
                     .cloned()
             })

--- a/src/app/overlays/epub.rs
+++ b/src/app/overlays/epub.rs
@@ -25,15 +25,15 @@ struct EpubSession {
 impl App {
     pub(in crate::app) fn sync_epub_preview_selection(&mut self) {
         let Some(entry) = self.selected_entry() else {
-            self.epub_preview.session = None;
+            self.preview.epub.session = None;
             return;
         };
         if !is_epub_entry(entry) {
-            self.epub_preview.session = None;
+            self.preview.epub.session = None;
             return;
         }
 
-        let keep_session = self.epub_preview.session.as_ref().is_some_and(|session| {
+        let keep_session = self.preview.epub.session.as_ref().is_some_and(|session| {
             session.path == entry.path
                 && session.size == entry.size
                 && session.modified == entry.modified
@@ -42,7 +42,7 @@ impl App {
             return;
         }
 
-        self.epub_preview.session = Some(EpubSession {
+        self.preview.epub.session = Some(EpubSession {
             path: entry.path.clone(),
             size: entry.size,
             modified: entry.modified,
@@ -54,7 +54,8 @@ impl App {
     pub(in crate::app) fn epub_preview_request_options(
         &self,
     ) -> Option<preview::PreviewRequestOptions> {
-        self.epub_preview
+        self.preview
+            .epub
             .session
             .as_ref()
             .map(|session| preview::PreviewRequestOptions::EpubSection(session.current_section))
@@ -68,11 +69,11 @@ impl App {
     }
 
     pub(in crate::app) fn epub_preview_wheel_capture_active(&self) -> bool {
-        self.epub_preview.session.is_some()
+        self.preview.epub.session.is_some()
     }
 
     pub(in crate::app) fn epub_preview_session_path(&self) -> Option<&std::path::Path> {
-        self.epub_preview.session.as_ref().map(|s| s.path.as_path())
+        self.preview.epub.session.as_ref().map(|s| s.path.as_path())
     }
 
     pub(in crate::app) fn apply_current_epub_preview_metadata(&mut self) {
@@ -82,17 +83,17 @@ impl App {
         else {
             return;
         };
-        let Some(session) = self.epub_preview.session.as_mut() else {
+        let Some(session) = self.preview.epub.session.as_mut() else {
             return;
         };
         if session.path != path || session.size != size || session.modified != modified {
             return;
         }
 
-        if let Some(total_sections) = self.preview_state.content.ebook_section_count {
+        if let Some(total_sections) = self.preview.state.content.ebook_section_count {
             session.total_sections = Some(total_sections);
         }
-        if let Some(section_index) = self.preview_state.content.ebook_section_index {
+        if let Some(section_index) = self.preview.state.content.ebook_section_index {
             session.current_section = section_index;
         }
     }
@@ -101,7 +102,7 @@ impl App {
         &self,
         preview: preview::PreviewContent,
     ) -> preview::PreviewContent {
-        let Some(session) = self.epub_preview.session.as_ref() else {
+        let Some(session) = self.preview.epub.session.as_ref() else {
             return preview;
         };
         let Some(total_sections) = session.total_sections else {
@@ -115,12 +116,12 @@ impl App {
     }
 
     pub(in crate::app) fn step_epub_section(&mut self, delta: isize) -> bool {
-        let Some(session) = self.epub_preview.session.as_mut() else {
+        let Some(session) = self.preview.epub.session.as_mut() else {
             return false;
         };
         let total_sections = session
             .total_sections
-            .or(self.preview_state.content.ebook_section_count)
+            .or(self.preview.state.content.ebook_section_count)
             .unwrap_or(0);
         if total_sections == 0 {
             return false;
@@ -137,18 +138,18 @@ impl App {
             return false;
         }
 
-        self.preview_state.deferred_refresh_at = Some(Instant::now());
+        self.preview.state.deferred_refresh_at = Some(Instant::now());
         self.refresh_preview();
         true
     }
 
     pub(in crate::app) fn epub_prefetch_section_indices(&self) -> Vec<usize> {
-        let Some(session) = self.epub_preview.session.as_ref() else {
+        let Some(session) = self.preview.epub.session.as_ref() else {
             return Vec::new();
         };
         let total_sections = session
             .total_sections
-            .or(self.preview_state.content.ebook_section_count)
+            .or(self.preview.state.content.ebook_section_count)
             .unwrap_or(0);
         if total_sections == 0 {
             return Vec::new();
@@ -187,7 +188,7 @@ impl App {
                 PreviewPriority::Low,
                 preview_work_class(&entry, &variant),
             );
-            let _ = self.scheduler.submit_preview(request);
+            let _ = self.jobs.scheduler.submit_preview(request);
         }
     }
 
@@ -200,7 +201,7 @@ impl App {
         if !is_epub_entry(entry) {
             return Vec::new();
         }
-        let Some(area) = self.frame_state.preview_media_area else {
+        let Some(area) = self.input.frame_state.preview_media_area else {
             return Vec::new();
         };
 
@@ -220,7 +221,8 @@ impl App {
     }
 
     fn cached_epub_section_count(&self, entry: &Entry) -> Option<usize> {
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .iter()
             .find_map(|(key, cached)| {
@@ -238,7 +240,8 @@ impl App {
         path: &std::path::Path,
         section: usize,
     ) -> bool {
-        self.preview_state
+        self.preview
+            .state
             .result_cache
             .contains_key(&PreviewCacheKey {
                 path: path.to_path_buf(),

--- a/src/app/overlays/images/cache.rs
+++ b/src/app/overlays/images/cache.rs
@@ -7,21 +7,22 @@ use std::{fs, path::PathBuf, sync::Arc};
 
 impl App {
     fn cached_static_image_display_path(&mut self, key: &StaticImageKey) -> Option<PathBuf> {
-        if let Some(path) = self.image_preview.rendered_images.get(key)
+        if let Some(path) = self.preview.image.rendered_images.get(key)
             && path.exists()
         {
             return Some(path.clone());
         }
 
-        self.image_preview.rendered_images.remove(key);
-        self.image_preview
+        self.preview.image.rendered_images.remove(key);
+        self.preview
+            .image
             .render_order
             .retain(|queued| queued != key);
         None
     }
 
     fn cached_static_image_inline_payload(&self, key: &StaticImageKey) -> Option<Arc<str>> {
-        self.image_preview.inline_payloads.get(key).cloned()
+        self.preview.image.inline_payloads.get(key).cloned()
     }
 
     pub(super) fn remember_static_image_inline_payload(
@@ -29,16 +30,18 @@ impl App {
         key: StaticImageKey,
         payload: Arc<str>,
     ) {
-        self.image_preview
+        self.preview
+            .image
             .inline_payloads
             .insert(key.clone(), payload);
-        self.image_preview
+        self.preview
+            .image
             .payload_order
             .retain(|queued| queued != &key);
-        self.image_preview.payload_order.push_back(key);
-        while self.image_preview.payload_order.len() > STATIC_IMAGE_INLINE_PAYLOAD_CACHE_LIMIT {
-            if let Some(stale_key) = self.image_preview.payload_order.pop_front() {
-                self.image_preview.inline_payloads.remove(&stale_key);
+        self.preview.image.payload_order.push_back(key);
+        while self.preview.image.payload_order.len() > STATIC_IMAGE_INLINE_PAYLOAD_CACHE_LIMIT {
+            if let Some(stale_key) = self.preview.image.payload_order.pop_front() {
+                self.preview.image.inline_payloads.remove(&stale_key);
             }
         }
     }
@@ -48,7 +51,7 @@ impl App {
         key: &StaticImageKey,
         request: &StaticImageOverlayRequest,
     ) -> Option<PreparedStaticImage> {
-        let dimensions = self.image_preview.dimensions.get(key).copied()?;
+        let dimensions = self.preview.image.dimensions.get(key).copied()?;
         let inline_payload = if request.prepare_inline_payload {
             Some(self.cached_static_image_inline_payload(key)?)
         } else {
@@ -71,14 +74,15 @@ impl App {
     }
 
     pub(super) fn remember_rendered_static_image(&mut self, key: StaticImageKey, path: PathBuf) {
-        self.image_preview.rendered_images.insert(key.clone(), path);
-        self.image_preview
+        self.preview.image.rendered_images.insert(key.clone(), path);
+        self.preview
+            .image
             .render_order
             .retain(|queued| queued != &key);
-        self.image_preview.render_order.push_back(key);
-        while self.image_preview.render_order.len() > STATIC_IMAGE_RENDER_CACHE_LIMIT {
-            if let Some(stale_key) = self.image_preview.render_order.pop_front()
-                && let Some(stale_path) = self.image_preview.rendered_images.remove(&stale_key)
+        self.preview.image.render_order.push_back(key);
+        while self.preview.image.render_order.len() > STATIC_IMAGE_RENDER_CACHE_LIMIT {
+            if let Some(stale_key) = self.preview.image.render_order.pop_front()
+                && let Some(stale_path) = self.preview.image.rendered_images.remove(&stale_key)
             {
                 let _ = fs::remove_file(stale_path);
             }

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -69,10 +69,10 @@ impl App {
         if let Some(prepared) = self.direct_static_image_for_overlay(request) {
             return StaticImageOverlayPreparation::Ready(prepared);
         }
-        if self.image_preview.pending_prepares.contains(&key) {
+        if self.preview.image.pending_prepares.contains(&key) {
             return StaticImageOverlayPreparation::Pending;
         }
-        if self.image_preview.failed_images.contains(&key) {
+        if self.preview.image.failed_images.contains(&key) {
             StaticImageOverlayPreparation::Failed
         } else {
             // No prepare job is running and the key has not failed.  This can happen when a job
@@ -93,15 +93,16 @@ impl App {
         }
 
         let key = StaticImageKey::from_request(request);
-        self.image_preview.failed_images.remove(&key);
+        self.preview.image.failed_images.remove(&key);
         let dimensions = self
-            .image_preview
+            .preview
+            .image
             .dimensions
             .get(&key)
             .copied()
             .or_else(|| read_png_dimensions(&request.path))
             .or_else(|| read_raster_dimensions(&request.path))?;
-        self.image_preview.dimensions.insert(key, dimensions);
+        self.preview.image.dimensions.insert(key, dimensions);
 
         Some(PreparedStaticImage {
             display_path: request.path.clone(),
@@ -137,8 +138,8 @@ mod tests {
 
     fn configure_terminal_image_support(app: &mut App) {
         let (cells_width, cells_height) = crossterm::terminal::size().unwrap_or((120, 40));
-        app.terminal_images.protocol = ImageProtocol::KittyGraphics;
-        app.terminal_images.window = Some(TerminalWindowSize {
+        app.preview.terminal_images.protocol = ImageProtocol::KittyGraphics;
+        app.preview.terminal_images.window = Some(TerminalWindowSize {
             cells_width,
             cells_height,
             pixels_width: 1920,
@@ -163,7 +164,7 @@ mod tests {
             .file_name()
             .and_then(|name| name.to_str())
             .expect("file name should be valid utf-8");
-        app.entries = vec![Entry {
+        app.navigation.entries = vec![Entry {
             path: path.to_path_buf(),
             name: name.to_string(),
             name_key: name.to_ascii_lowercase(),
@@ -172,15 +173,15 @@ mod tests {
             modified: metadata.modified().ok(),
             readonly: false,
         }];
-        app.selected = 0;
-        app.frame_state.preview_content_area = Some(Rect {
+        app.navigation.selected = 0;
+        app.input.frame_state.preview_content_area = Some(Rect {
             x: 2,
             y: 3,
             width: 48,
             height: 20,
         });
-        app.frame_state.metrics.cols = 1;
-        app.frame_state.metrics.rows_visible = 6;
+        app.input.frame_state.metrics.cols = 1;
+        app.input.frame_state.metrics.rows_visible = 6;
     }
 
     fn build_selected_static_image_app(label: &str, file_name: &str) -> (App, PathBuf, PathBuf) {
@@ -191,7 +192,7 @@ mod tests {
 
         let mut app = App::new_at(root.clone()).expect("app should initialize");
         configure_terminal_image_support(&mut app);
-        app.pdf_preview.pdf_tools_available = true;
+        app.preview.pdf.pdf_tools_available = true;
         set_single_test_entry(&mut app, &image_path);
         app.refresh_preview();
 
@@ -199,7 +200,7 @@ mod tests {
     }
 
     fn ready_static_image_overlay(app: &mut App) -> StaticImageOverlayRequest {
-        app.image_preview.selection_activation_delay = Duration::ZERO;
+        app.preview.image.selection_activation_delay = Duration::ZERO;
         app.sync_image_preview_selection_activation();
         app.active_static_image_overlay_request()
             .expect("static image overlay request should exist")
@@ -232,8 +233,8 @@ mod tests {
             }
         }
 
-        assert!(app.image_preview.dimensions.contains_key(&key));
-        assert!(!app.image_preview.pending_prepares.contains(&key));
+        assert!(app.preview.image.dimensions.contains_key(&key));
+        assert!(!app.preview.image.pending_prepares.contains(&key));
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -250,7 +251,7 @@ mod tests {
         write_test_raster_image(&rendered_path, ImageFormat::Png, 320, 180);
         let payload: Arc<str> = Arc::from("YWJj");
 
-        app.image_preview.dimensions.insert(
+        app.preview.image.dimensions.insert(
             key.clone(),
             RenderedImageDimensions {
                 width_px: 320,
@@ -282,7 +283,7 @@ mod tests {
     fn repeated_present_static_image_overlay_is_a_noop_when_nothing_changed() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("no-op-render", "demo.png");
-        app.image_preview.selection_activation_delay = Duration::ZERO;
+        app.preview.image.selection_activation_delay = Duration::ZERO;
         app.sync_image_preview_selection_activation();
 
         let mut first = Vec::new();
@@ -308,12 +309,12 @@ mod tests {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("kitty-resize-clear", "demo.png");
         let request = ready_static_image_overlay(&mut app);
-        app.image_preview.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
             &request,
             request.area,
             request.area,
         ));
-        app.image_preview.displayed_excluded = vec![Rect {
+        app.preview.image.displayed_excluded = vec![Rect {
             x: 4,
             y: 5,
             width: 6,
@@ -324,7 +325,7 @@ mod tests {
 
         assert!(app.take_pending_kitty_resize_clear());
         assert!(!app.static_image_overlay_displayed());
-        assert!(app.image_preview.displayed_excluded.is_empty());
+        assert!(app.preview.image.displayed_excluded.is_empty());
         assert!(!app.take_pending_kitty_resize_clear());
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -335,8 +336,8 @@ mod tests {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("iterm-resize-no-clear", "demo.png");
         let request = ready_static_image_overlay(&mut app);
-        app.terminal_images.protocol = ImageProtocol::ItermInline;
-        app.image_preview.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+        app.preview.terminal_images.protocol = ImageProtocol::ItermInline;
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
             &request,
             request.area,
             request.area,
@@ -354,7 +355,7 @@ mod tests {
     fn exclusion_only_updates_redraw_without_clearing_the_existing_image() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("excluded-redraw", "demo.png");
-        app.image_preview.selection_activation_delay = Duration::ZERO;
+        app.preview.image.selection_activation_delay = Duration::ZERO;
         app.sync_image_preview_selection_activation();
 
         let mut initial = Vec::new();
@@ -387,7 +388,7 @@ mod tests {
             !output.contains(build_kitty_clear_sequence()),
             "exclusion-only redraw should not clear the previous image first"
         );
-        assert_eq!(app.image_preview.displayed_excluded, excluded);
+        assert_eq!(app.preview.image.displayed_excluded, excluded);
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/app/overlays/images/preload.rs
+++ b/src/app/overlays/images/preload.rs
@@ -11,7 +11,7 @@ impl App {
         // the actual current entry and retain or re-queue jobs for the wrong one.  Skip the
         // preview visual entirely; the correct job will be submitted once refresh_preview() fires
         // and preview_state.content is updated.
-        let current_preview_visual = if self.preview_state.deferred_refresh_at.is_none() {
+        let current_preview_visual = if self.preview.state.deferred_refresh_at.is_none() {
             self.active_preview_visual_overlay_request()
         } else {
             None
@@ -44,8 +44,9 @@ impl App {
         // the user takes a non-rapid action (folder navigation, preview scroll, etc.).
         // Skip the cancellation step while deferred; the correct jobs will be pruned on
         // the next non-deferred refresh_static_image_preloads() call.
-        if self.preview_state.deferred_refresh_at.is_none() {
-            self.image_preview
+        if self.preview.state.deferred_refresh_at.is_none() {
+            self.preview
+                .image
                 .pending_prepares
                 .retain(|key| desired.contains(key));
             let current_job = current
@@ -55,7 +56,8 @@ impl App {
                 .iter()
                 .map(|request| self.image_prepare_request_for_overlay(request))
                 .collect::<Vec<_>>();
-            self.scheduler
+            self.jobs
+                .scheduler
                 .retain_image_prepares(current_job.as_ref(), &nearby_jobs);
         }
 
@@ -73,19 +75,19 @@ impl App {
 
     pub(in crate::app) fn refresh_static_image_preloads_if_needed(&mut self) {
         let viewport = StaticImagePreloadViewport {
-            selected: self.selected,
-            scroll_row: self.scroll_row,
-            cols: self.frame_state.metrics.cols.max(1),
-            rows_visible: self.frame_state.metrics.rows_visible.max(1),
-            preview_content_area: self.frame_state.preview_content_area,
-            preview_media_area: self.frame_state.preview_media_area,
-            protocol: self.terminal_images.protocol,
+            selected: self.navigation.selected,
+            scroll_row: self.navigation.scroll_row,
+            cols: self.input.frame_state.metrics.cols.max(1),
+            rows_visible: self.input.frame_state.metrics.rows_visible.max(1),
+            preview_content_area: self.input.frame_state.preview_content_area,
+            preview_media_area: self.input.frame_state.preview_media_area,
+            protocol: self.preview.terminal_images.protocol,
             window: self.cached_terminal_window(),
         };
-        if self.image_preview.preload_viewport == Some(viewport) {
+        if self.preview.image.preload_viewport == Some(viewport) {
             return;
         }
-        self.image_preview.preload_viewport = Some(viewport);
+        self.preview.image.preload_viewport = Some(viewport);
         self.refresh_static_image_preloads();
     }
 
@@ -102,7 +104,7 @@ impl App {
             build.force_render_to_cache,
             build.prepare_inline_payload,
         );
-        self.image_preview.pending_prepares.remove(&key);
+        self.preview.image.pending_prepares.remove(&key);
         let is_current = self
             .active_static_image_overlay_request()
             .as_ref()
@@ -118,8 +120,9 @@ impl App {
 
         match build.result {
             Some(prepared) => {
-                self.image_preview.failed_images.remove(&key);
-                self.image_preview
+                self.preview.image.failed_images.remove(&key);
+                self.preview
+                    .image
                     .dimensions
                     .insert(key.clone(), prepared.dimensions);
                 if let Some(payload) = prepared.inline_payload {
@@ -132,7 +135,7 @@ impl App {
                 is_current
             }
             None => {
-                self.image_preview.failed_images.insert(key);
+                self.preview.image.failed_images.insert(key);
                 if is_current {
                     self.refresh_preview();
                     true
@@ -151,12 +154,13 @@ impl App {
         let mut requests = self
             .visible_entry_indices()
             .into_iter()
-            .filter(|&index| index != self.selected)
+            .filter(|&index| index != self.navigation.selected)
             .filter_map(|index| {
-                self.entries
+                self.navigation
+                    .entries
                     .get(index)
                     .and_then(|entry| self.static_image_overlay_request_for_entry(entry))
-                    .map(|request| (index.abs_diff(self.selected), request))
+                    .map(|request| (index.abs_diff(self.navigation.selected), request))
             })
             .filter(|(_, request)| current_path != Some(&request.path))
             .collect::<Vec<_>>();
@@ -174,8 +178,8 @@ impl App {
         priority: jobs::ImageJobPriority,
     ) {
         let key = StaticImageKey::from_request(request);
-        if self.image_preview.failed_images.contains(&key)
-            || self.image_preview.pending_prepares.contains(&key)
+        if self.preview.image.failed_images.contains(&key)
+            || self.preview.image.pending_prepares.contains(&key)
             || self
                 .cached_prepared_static_image_for_overlay(&key, request)
                 .is_some()
@@ -185,11 +189,11 @@ impl App {
 
         let job = self.image_prepare_request_for_overlay(request);
         let submit = match priority {
-            jobs::ImageJobPriority::Current => self.scheduler.submit_image_prepare(job),
-            jobs::ImageJobPriority::Nearby => self.scheduler.submit_nearby_image_prepare(job),
+            jobs::ImageJobPriority::Current => self.jobs.scheduler.submit_image_prepare(job),
+            jobs::ImageJobPriority::Nearby => self.jobs.scheduler.submit_nearby_image_prepare(job),
         };
         if submit {
-            self.image_preview.pending_prepares.insert(key);
+            self.preview.image.pending_prepares.insert(key);
         }
     }
 

--- a/src/app/overlays/images/present.rs
+++ b/src/app/overlays/images/present.rs
@@ -61,8 +61,8 @@ impl App {
             placement,
             self.static_image_clear_area(&request),
         );
-        let image_changed = self.image_preview.displayed.as_ref() != Some(&displayed);
-        let excluded_changed = excluded != self.image_preview.displayed_excluded.as_slice();
+        let image_changed = self.preview.image.displayed.as_ref() != Some(&displayed);
+        let excluded_changed = excluded != self.preview.image.displayed_excluded.as_slice();
         let needs_repaint = force_repaint && protocol == ImageProtocol::ItermInline;
         if !image_changed && !excluded_changed && !needs_repaint {
             preview_log("present_static_image_overlay: already displayed → Displayed");
@@ -98,8 +98,8 @@ impl App {
             }
         }
 
-        self.image_preview.displayed = Some(displayed);
-        self.image_preview.displayed_excluded = excluded.to_vec();
+        self.preview.image.displayed = Some(displayed);
+        self.preview.image.displayed_excluded = excluded.to_vec();
         self.clear_pending_iterm_popup_restore();
         Ok(OverlayPresentState::Displayed)
     }
@@ -151,8 +151,8 @@ impl App {
             placement,
             self.static_image_clear_area(&request),
         );
-        let image_changed = self.image_preview.displayed.as_ref() != Some(&displayed);
-        let excluded_changed = excluded != self.image_preview.displayed_excluded.as_slice();
+        let image_changed = self.preview.image.displayed.as_ref() != Some(&displayed);
+        let excluded_changed = excluded != self.preview.image.displayed_excluded.as_slice();
         let needs_repaint = force_repaint && protocol == ImageProtocol::ItermInline;
         if !image_changed && !excluded_changed && !needs_repaint {
             preview_log("present_preview_visual_overlay: already displayed → Displayed");
@@ -184,9 +184,9 @@ impl App {
             }
         }
 
-        self.image_preview.displayed = Some(displayed);
+        self.preview.image.displayed = Some(displayed);
         self.record_comic_page_image_displayed();
-        self.image_preview.displayed_excluded = excluded.to_vec();
+        self.preview.image.displayed_excluded = excluded.to_vec();
         self.clear_pending_iterm_popup_restore();
         Ok(OverlayPresentState::Displayed)
     }
@@ -197,7 +197,8 @@ impl App {
             .or_else(|| self.active_preview_visual_overlay_request_unchecked())?;
         let window_size = self.cached_terminal_window()?;
         let image_dimensions = self
-            .image_preview
+            .preview
+            .image
             .dimensions
             .get(&StaticImageKey::from_request(&request))
             .copied()?;
@@ -209,15 +210,17 @@ impl App {
     }
 
     fn static_image_clear_area(&self, request: &StaticImageOverlayRequest) -> Rect {
-        if self.terminal_images.protocol == ImageProtocol::ItermInline {
+        if self.preview.terminal_images.protocol == ImageProtocol::ItermInline {
             if request.mode == StaticImageOverlayMode::Inline {
                 return self
+                    .input
                     .frame_state
                     .preview_body_area
                     .or_else(|| self.preview_body_area())
                     .unwrap_or(request.area);
             }
             return self
+                .input
                 .frame_state
                 .preview_content_area
                 .unwrap_or(request.area);
@@ -227,8 +230,8 @@ impl App {
 
     fn preview_body_area(&self) -> Option<Rect> {
         match (
-            self.frame_state.preview_media_area,
-            self.frame_state.preview_content_area,
+            self.input.frame_state.preview_media_area,
+            self.input.frame_state.preview_content_area,
         ) {
             (Some(media), Some(content)) => Some(union_rect(media, content)),
             (Some(media), None) => Some(media),
@@ -243,7 +246,7 @@ impl App {
         dimensions: RenderedImageDimensions,
         window_size: TerminalWindowSize,
     ) -> Rect {
-        if self.terminal_images.protocol == ImageProtocol::KittyGraphics {
+        if self.preview.terminal_images.protocol == ImageProtocol::KittyGraphics {
             request.area
         } else {
             fit_image_area(

--- a/src/app/overlays/images/state.rs
+++ b/src/app/overlays/images/state.rs
@@ -17,7 +17,8 @@ use std::time::{Duration, Instant};
 
 impl App {
     fn current_page_preview_visual_active(&self) -> bool {
-        self.preview_state
+        self.preview
+            .state
             .content
             .preview_visual
             .as_ref()
@@ -25,19 +26,20 @@ impl App {
     }
 
     pub(crate) fn process_image_preview_timers(&mut self) -> bool {
-        let Some(ready_at) = self.image_preview.activation_ready_at else {
+        let Some(ready_at) = self.preview.image.activation_ready_at else {
             return false;
         };
         if Instant::now() < ready_at {
             return false;
         }
-        self.image_preview.activation_ready_at = None;
+        self.preview.image.activation_ready_at = None;
         self.active_static_image_overlay_request().is_some()
             || self.active_preview_visual_overlay_request().is_some()
     }
 
     pub(crate) fn pending_image_preview_timer(&self) -> Option<Duration> {
-        self.image_preview
+        self.preview
+            .image
             .activation_ready_at
             .map(|ready_at| ready_at.saturating_duration_since(Instant::now()))
     }
@@ -47,7 +49,8 @@ impl App {
             return false;
         };
         !self
-            .image_preview
+            .preview
+            .image
             .failed_images
             .contains(&StaticImageKey::from_request(&request))
     }
@@ -55,7 +58,8 @@ impl App {
     pub(in crate::app) fn static_image_preview_header_detail(&self) -> Option<String> {
         let request = self.active_static_image_overlay_request()?;
         let dimensions = self
-            .image_preview
+            .preview
+            .image
             .dimensions
             .get(&StaticImageKey::from_request(&request))
             .copied()?;
@@ -80,7 +84,7 @@ impl App {
 
         let request = self.active_static_image_overlay_request()?;
         let key = StaticImageKey::from_request(&request);
-        if self.image_preview.failed_images.contains(&key) {
+        if self.preview.image.failed_images.contains(&key) {
             return Some("Image preview unavailable".to_string());
         }
         if !self.image_selection_activation_ready() {
@@ -103,23 +107,24 @@ impl App {
         if let Some(entry) = self.selected_entry()
             && static_image_detail_label(entry).is_none()
         {
-            self.image_preview.failed_images.clear();
+            self.preview.image.failed_images.clear();
         }
     }
 
     pub(in crate::app) fn sync_image_preview_selection_activation(&mut self) {
-        self.image_preview.activation_ready_at = self
+        self.preview.image.activation_ready_at = self
             .active_static_image_overlay_request()
             .or_else(|| self.active_preview_visual_overlay_request())
             .and_then(|_| {
-                let ready_at =
-                    self.last_selection_change_at + self.image_preview.selection_activation_delay;
+                let ready_at = self.input.last_selection_change_at
+                    + self.preview.image.selection_activation_delay;
                 (Instant::now() < ready_at).then_some(ready_at)
             });
     }
 
     pub(in crate::app) fn mark_static_image_failed(&mut self, request: &StaticImageOverlayRequest) {
-        self.image_preview
+        self.preview
+            .image
             .failed_images
             .insert(StaticImageKey::from_request(request));
     }
@@ -128,7 +133,7 @@ impl App {
         &self,
         request: &StaticImageOverlayRequest,
     ) -> bool {
-        self.terminal_images.protocol == ImageProtocol::KittyGraphics
+        self.preview.terminal_images.protocol == ImageProtocol::KittyGraphics
             && !request.force_render_to_cache
             && static_image_format_for_overlay_request(request) == Some(StaticImageFormat::Png)
     }
@@ -137,7 +142,7 @@ impl App {
         &self,
         request: &StaticImageOverlayRequest,
     ) -> bool {
-        match self.terminal_images.protocol {
+        match self.preview.terminal_images.protocol {
             ImageProtocol::KittyGraphics => self.static_image_can_display_directly_now(request),
             ImageProtocol::ItermInline => static_image_supports_iterm_source_passthrough(request),
             ImageProtocol::None => false,
@@ -153,48 +158,52 @@ impl App {
 
     pub(super) fn magick_available(&mut self) -> bool {
         *self
-            .image_preview
+            .preview
+            .image
             .magick_available
             .get_or_insert_with(|| command_exists("magick"))
     }
 
     pub(super) fn resvg_available(&mut self) -> bool {
         *self
-            .image_preview
+            .preview
+            .image
             .resvg_available
             .get_or_insert_with(|| command_exists("resvg"))
     }
 
     pub(super) fn ffmpeg_available(&mut self) -> bool {
         *self
-            .image_preview
+            .preview
+            .image
             .ffmpeg_available
             .get_or_insert_with(|| command_exists("ffmpeg"))
     }
 
     #[cfg(test)]
     pub(in crate::app) fn set_ffmpeg_available_for_tests(&mut self, available: bool) {
-        self.image_preview.ffmpeg_available = Some(available);
+        self.preview.image.ffmpeg_available = Some(available);
     }
 
     pub(in crate::app) fn image_selection_activation_ready(&self) -> bool {
-        self.image_preview.activation_ready_at.is_none()
+        self.preview.image.activation_ready_at.is_none()
     }
 
     pub(in crate::app) fn static_image_overlay_displayed(&self) -> bool {
-        self.image_preview.displayed.is_some()
+        self.preview.image.displayed.is_some()
     }
 
     pub(in crate::app) fn displayed_static_image_clear_area(&self) -> Option<Rect> {
-        self.image_preview
+        self.preview
+            .image
             .displayed
             .as_ref()
             .map(|displayed| displayed.clear_area)
     }
 
     pub(in crate::app) fn clear_displayed_static_image(&mut self) {
-        self.image_preview.displayed = None;
-        self.image_preview.displayed_excluded.clear();
+        self.preview.image.displayed = None;
+        self.preview.image.displayed_excluded.clear();
     }
 
     pub(in crate::app) fn preview_visual_force_render_to_cache(
@@ -209,7 +218,8 @@ impl App {
             return true;
         };
         let ffmpeg_available = self
-            .image_preview
+            .preview
+            .image
             .ffmpeg_available
             .unwrap_or_else(|| command_exists("ffmpeg"));
         !static_image_can_prepare_inline(visual.size, format, ffmpeg_available)
@@ -218,12 +228,12 @@ impl App {
     pub(in crate::app) fn displayed_static_image_matches_active(&self) -> bool {
         self.active_static_image_display_target()
             .as_ref()
-            .zip(self.image_preview.displayed.as_ref())
+            .zip(self.preview.image.displayed.as_ref())
             .is_some_and(|(active, displayed)| active == displayed)
     }
 
     pub(in crate::app) fn keep_displayed_static_image_overlay_while_pending(&self) -> bool {
-        let Some(displayed) = self.image_preview.displayed.as_ref() else {
+        let Some(displayed) = self.preview.image.displayed.as_ref() else {
             return false;
         };
         match displayed.mode {
@@ -261,7 +271,8 @@ impl App {
     }
 
     pub(in crate::app) fn displayed_static_image_replaces_preview(&self) -> bool {
-        self.image_preview
+        self.preview
+            .image
             .displayed
             .as_ref()
             .is_some_and(|displayed| displayed.mode == StaticImageOverlayMode::FullPane)
@@ -277,7 +288,7 @@ impl App {
         }
         static_image_detail_label(entry)?;
 
-        let area = self.frame_state.preview_content_area?;
+        let area = self.input.frame_state.preview_content_area?;
         if area.width == 0 || area.height == 0 {
             return None;
         }
@@ -291,12 +302,14 @@ impl App {
             target_height_px: image_target_height_px(area, self.cached_terminal_window()),
             mode: StaticImageOverlayMode::FullPane,
             force_render_to_cache: false,
-            prepare_inline_payload: self.terminal_images.protocol == ImageProtocol::ItermInline,
+            prepare_inline_payload: self.preview.terminal_images.protocol
+                == ImageProtocol::ItermInline,
         })
     }
 
     fn current_page_preview_loading_active(&self) -> bool {
-        self.preview_state
+        self.preview
+            .state
             .load_state
             .as_ref()
             .is_some_and(|load_state| {
@@ -317,15 +330,15 @@ impl App {
         request: &StaticImageOverlayRequest,
     ) -> bool {
         let key = StaticImageKey::from_request(request);
-        if self.image_preview.failed_images.contains(&key) {
+        if self.preview.image.failed_images.contains(&key) {
             return false;
         }
         if !self.image_selection_activation_ready() {
             return true;
         }
 
-        self.image_preview.pending_prepares.contains(&key)
+        self.preview.image.pending_prepares.contains(&key)
             || (self.static_image_requires_prepare(request)
-                && !self.image_preview.dimensions.contains_key(&key))
+                && !self.preview.image.dimensions.contains_key(&key))
     }
 }

--- a/src/app/overlays/inline_image.rs
+++ b/src/app/overlays/inline_image.rs
@@ -90,16 +90,19 @@ impl App {
             env::var_os("KITTY_WINDOW_ID").is_some(),
             env::var_os("WARP_SESSION_ID").is_some(),
         ));
-        self.terminal_images.protocol = protocol;
-        self.pdf_preview.pdf_tools_available = pdf_preview_tools_available();
+        self.preview.terminal_images.protocol = protocol;
+        self.preview.pdf.pdf_tools_available = pdf_preview_tools_available();
         self.refresh_terminal_image_window_size();
-        preview_log(format_args!("  window={:?}", self.terminal_images.window));
+        preview_log(format_args!(
+            "  window={:?}",
+            self.preview.terminal_images.window
+        ));
         self.sync_pdf_preview_selection();
     }
 
     pub(crate) fn handle_terminal_image_resize(&mut self) {
         self.refresh_terminal_image_window_size();
-        if self.terminal_images.protocol == ImageProtocol::KittyGraphics
+        if self.preview.terminal_images.protocol == ImageProtocol::KittyGraphics
             && (self.static_image_overlay_displayed() || self.pdf_overlay_displayed())
         {
             // Kitty/Ghostty unicode placeholders are normal terminal cells. During
@@ -107,28 +110,28 @@ impl App {
             // so erasing only the old image rect is not enough — some placeholder
             // text may survive outside the previous bounds. Force a full-screen
             // clear on the next draw so ratatui repaints the entire alt screen.
-            self.terminal_images.pending_kitty_resize_clear = true;
+            self.preview.terminal_images.pending_kitty_resize_clear = true;
         }
         self.handle_pdf_overlay_resize();
     }
 
     pub(crate) fn take_pending_kitty_resize_clear(&mut self) -> bool {
-        if !self.terminal_images.pending_kitty_resize_clear {
+        if !self.preview.terminal_images.pending_kitty_resize_clear {
             return false;
         }
 
-        self.terminal_images.pending_kitty_resize_clear = false;
+        self.preview.terminal_images.pending_kitty_resize_clear = false;
         self.clear_displayed_static_image();
         self.clear_displayed_pdf_overlay();
         true
     }
 
     pub(in crate::app) fn terminal_image_overlay_available(&self) -> bool {
-        self.terminal_images.protocol != ImageProtocol::None
+        self.preview.terminal_images.protocol != ImageProtocol::None
     }
 
     pub(in crate::app) fn cached_terminal_window(&self) -> Option<TerminalWindowSize> {
-        self.terminal_images.window
+        self.preview.terminal_images.window
     }
 
     /// Returns iTerm2 erase bytes that must be written to the terminal **before**
@@ -148,7 +151,7 @@ impl App {
     /// draw forces the terminal to show blank content, which ratatui then
     /// overpaints correctly.
     pub(crate) fn kitty_pre_draw_erase(&self) -> Vec<u8> {
-        if self.terminal_images.protocol != ImageProtocol::KittyGraphics {
+        if self.preview.terminal_images.protocol != ImageProtocol::KittyGraphics {
             return Vec::new();
         }
         let keep_stale = self.keep_displayed_static_image_overlay_while_pending();
@@ -166,10 +169,10 @@ impl App {
     }
 
     pub(crate) fn iterm_pre_draw_erase(&mut self) -> Vec<u8> {
-        if self.terminal_images.protocol != ImageProtocol::ItermInline {
+        if self.preview.terminal_images.protocol != ImageProtocol::ItermInline {
             return Vec::new();
         }
-        let mut areas = std::mem::take(&mut self.terminal_images.pending_iterm_erase);
+        let mut areas = std::mem::take(&mut self.preview.terminal_images.pending_iterm_erase);
         let keep_stale = self.keep_displayed_static_image_overlay_while_pending();
         if self.static_image_overlay_displayed()
             && !self.displayed_static_image_matches_active()
@@ -195,11 +198,11 @@ impl App {
     }
 
     pub(crate) fn present_preview_overlay(&mut self) -> Result<Vec<u8>> {
-        if self.browser_wheel_burst_active() || self.preview_state.deferred_refresh_at.is_some() {
+        if self.browser_wheel_burst_active() || self.preview.state.deferred_refresh_at.is_some() {
             return Ok(Vec::new());
         }
 
-        let protocol = self.terminal_images.protocol;
+        let protocol = self.preview.terminal_images.protocol;
         if protocol == ImageProtocol::None {
             preview_log("present_preview_overlay: no protocol → clear");
             return self.clear_preview_overlay();
@@ -210,10 +213,10 @@ impl App {
             && popup_open
             && (self.static_image_overlay_displayed() || self.pdf_overlay_displayed())
         {
-            self.terminal_images.pending_iterm_popup_restore = true;
+            self.preview.terminal_images.pending_iterm_popup_restore = true;
         }
         let force_iterm_popup_repaint = protocol == ImageProtocol::ItermInline
-            && self.terminal_images.pending_iterm_popup_restore
+            && self.preview.terminal_images.pending_iterm_popup_restore
             && !popup_open;
 
         // For Kitty, collect rects occupied by open popups so the image can be
@@ -275,7 +278,7 @@ impl App {
             OverlayPresentState::Displayed | OverlayPresentState::Waiting => Ok(out),
             OverlayPresentState::NotRequested if keep_stale_page_preview_overlay => Ok(out),
             OverlayPresentState::NotRequested => {
-                self.terminal_images.pending_iterm_popup_restore = false;
+                self.preview.terminal_images.pending_iterm_popup_restore = false;
                 out.extend(self.clear_preview_overlay()?);
                 Ok(out)
             }
@@ -284,54 +287,54 @@ impl App {
 
     fn collect_popup_rects(&self) -> Vec<Rect> {
         let mut rects = Vec::new();
-        if let Some(r) = self.frame_state.trash_panel {
+        if let Some(r) = self.input.frame_state.trash_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.restore_panel {
+        if let Some(r) = self.input.frame_state.restore_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.create_panel {
+        if let Some(r) = self.input.frame_state.create_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.rename_panel {
+        if let Some(r) = self.input.frame_state.rename_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.goto_panel {
+        if let Some(r) = self.input.frame_state.goto_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.copy_panel {
+        if let Some(r) = self.input.frame_state.copy_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.search_panel {
+        if let Some(r) = self.input.frame_state.search_panel {
             rects.push(r);
         }
-        if let Some(r) = self.frame_state.help_panel {
+        if let Some(r) = self.input.frame_state.help_panel {
             rects.push(r);
         }
         rects
     }
 
     fn any_modal_overlay_open(&self) -> bool {
-        self.trash.is_some()
-            || self.restore.is_some()
-            || self.create.is_some()
-            || self.rename.is_some()
-            || self.bulk_rename.is_some()
-            || self.goto_overlay.is_some()
-            || self.copy_overlay.is_some()
-            || self.search.is_some()
-            || self.help_open
+        self.overlays.trash.is_some()
+            || self.overlays.restore.is_some()
+            || self.overlays.create.is_some()
+            || self.overlays.rename.is_some()
+            || self.overlays.bulk_rename.is_some()
+            || self.overlays.goto.is_some()
+            || self.overlays.copy.is_some()
+            || self.overlays.search.is_some()
+            || self.overlays.help
     }
 
     pub(in crate::app) fn clear_pending_iterm_popup_restore(&mut self) {
-        self.terminal_images.pending_iterm_popup_restore = false;
+        self.preview.terminal_images.pending_iterm_popup_restore = false;
     }
 
     pub(crate) fn clear_preview_overlay(&mut self) -> Result<Vec<u8>> {
         if !self.static_image_overlay_displayed() && !self.pdf_overlay_displayed() {
             return Ok(Vec::new());
         }
-        let bytes = clear_terminal_images(self.terminal_images.protocol)
+        let bytes = clear_terminal_images(self.preview.terminal_images.protocol)
             .context("failed to clear preview overlay")?;
         // iTerm2 erase is emitted by iterm_pre_draw_erase() *before* terminal.draw(),
         // so ratatui naturally overpaints with the correct panel background. Nothing
@@ -343,14 +346,14 @@ impl App {
     }
 
     pub(crate) fn queue_forced_iterm_preview_erase(&mut self) {
-        if self.terminal_images.protocol != ImageProtocol::ItermInline {
+        if self.preview.terminal_images.protocol != ImageProtocol::ItermInline {
             return;
         }
         if let Some(area) = self.displayed_static_image_clear_area() {
-            push_unique_rect(&mut self.terminal_images.pending_iterm_erase, area);
+            push_unique_rect(&mut self.preview.terminal_images.pending_iterm_erase, area);
         }
         if let Some(area) = self.displayed_pdf_overlay_area() {
-            push_unique_rect(&mut self.terminal_images.pending_iterm_erase, area);
+            push_unique_rect(&mut self.preview.terminal_images.pending_iterm_erase, area);
         }
     }
 
@@ -364,18 +367,20 @@ impl App {
     }
 
     fn refresh_terminal_image_window_size(&mut self) {
-        self.terminal_images.window = (self.terminal_images.protocol != ImageProtocol::None)
+        self.preview.terminal_images.window = (self.preview.terminal_images.protocol
+            != ImageProtocol::None)
             .then(query_terminal_window_size)
             .flatten();
     }
 
     fn expand_iterm_erase_area(&self, area: Rect) -> Rect {
         let safe_bounds = self
+            .input
             .frame_state
             .preview_body_area
-            .or(self.frame_state.preview_content_area)
+            .or(self.input.frame_state.preview_content_area)
             .unwrap_or(area);
-        let Some(bounds) = self.frame_state.preview_panel.or(Some(safe_bounds)) else {
+        let Some(bounds) = self.input.frame_state.preview_panel.or(Some(safe_bounds)) else {
             return area;
         };
         let clamped = intersect_rect(area, safe_bounds).unwrap_or(area);

--- a/src/app/overlays/pdf/cache.rs
+++ b/src/app/overlays/pdf/cache.rs
@@ -17,12 +17,12 @@ impl App {
         if let Some(path) = self.cached_pdf_render_path(key) {
             return Some(path);
         }
-        if self.pdf_preview.failed_renders.contains(key)
-            || self.pdf_preview.pending_renders.contains(key)
+        if self.preview.pdf.failed_renders.contains(key)
+            || self.preview.pdf.pending_renders.contains(key)
         {
             return None;
         }
-        if !self.scheduler.submit_pdf_render(
+        if !self.jobs.scheduler.submit_pdf_render(
             jobs::PdfRenderRequest {
                 path: key.path.clone(),
                 size: key.size,
@@ -33,10 +33,10 @@ impl App {
             },
             jobs::PdfJobPriority::Current,
         ) {
-            self.pdf_preview.failed_renders.insert(key.clone());
+            self.preview.pdf.failed_renders.insert(key.clone());
             return None;
         }
-        self.pdf_preview.pending_renders.insert(key.clone());
+        self.preview.pdf.pending_renders.insert(key.clone());
         None
     }
 
@@ -45,15 +45,15 @@ impl App {
         request: &PdfOverlayRequest,
     ) -> Option<PdfPageDimensions> {
         let key = PdfPageKey::from_request(request);
-        if let Some(dimensions) = self.pdf_preview.page_dimensions.get(&key).copied() {
+        if let Some(dimensions) = self.preview.pdf.page_dimensions.get(&key).copied() {
             return Some(dimensions);
         }
-        if self.pdf_preview.failed_page_probes.contains(&key)
-            || self.pdf_preview.pending_page_probes.contains(&key)
+        if self.preview.pdf.failed_page_probes.contains(&key)
+            || self.preview.pdf.pending_page_probes.contains(&key)
         {
             return None;
         }
-        if !self.scheduler.submit_pdf_probe(
+        if !self.jobs.scheduler.submit_pdf_probe(
             jobs::PdfProbeRequest {
                 path: request.path.clone(),
                 size: request.size,
@@ -62,10 +62,10 @@ impl App {
             },
             jobs::PdfJobPriority::Current,
         ) {
-            self.pdf_preview.failed_page_probes.insert(key);
+            self.preview.pdf.failed_page_probes.insert(key);
             return None;
         }
-        self.pdf_preview.pending_page_probes.insert(key);
+        self.preview.pdf.pending_page_probes.insert(key);
         None
     }
 
@@ -79,27 +79,28 @@ impl App {
     }
 
     fn cached_pdf_page_dimensions(&self, request: &PdfOverlayRequest) -> Option<PdfPageDimensions> {
-        self.pdf_preview
+        self.preview
+            .pdf
             .page_dimensions
             .get(&PdfPageKey::from_request(request))
             .copied()
     }
 
     pub(super) fn cached_pdf_render_path(&mut self, key: &PdfRenderKey) -> Option<PathBuf> {
-        if let Some(path) = self.pdf_preview.rendered_pages.get(key)
+        if let Some(path) = self.preview.pdf.rendered_pages.get(key)
             && path.exists()
         {
             return Some(path.clone());
         }
 
-        self.pdf_preview.rendered_pages.remove(key);
-        self.pdf_preview.rendered_page_dimensions.remove(key);
-        self.pdf_preview.render_order.retain(|queued| queued != key);
+        self.preview.pdf.rendered_pages.remove(key);
+        self.preview.pdf.rendered_page_dimensions.remove(key);
+        self.preview.pdf.render_order.retain(|queued| queued != key);
         None
     }
 
     pub(super) fn cached_render_exists(&self, key: &PdfRenderKey) -> bool {
-        self.pdf_preview.rendered_pages.contains_key(key)
+        self.preview.pdf.rendered_pages.contains_key(key)
     }
 
     pub(super) fn remember_rendered_pdf(
@@ -108,21 +109,23 @@ impl App {
         path: PathBuf,
         dimensions: Option<RenderedImageDimensions>,
     ) {
-        self.pdf_preview.rendered_pages.insert(key.clone(), path);
+        self.preview.pdf.rendered_pages.insert(key.clone(), path);
         if let Some(dimensions) = dimensions {
-            self.pdf_preview
+            self.preview
+                .pdf
                 .rendered_page_dimensions
                 .insert(key.clone(), dimensions);
         }
-        self.pdf_preview
+        self.preview
+            .pdf
             .render_order
             .retain(|queued| queued != &key);
-        self.pdf_preview.render_order.push_back(key);
-        while self.pdf_preview.render_order.len() > PDF_RENDER_CACHE_LIMIT {
-            if let Some(stale_key) = self.pdf_preview.render_order.pop_front()
-                && let Some(stale_path) = self.pdf_preview.rendered_pages.remove(&stale_key)
+        self.preview.pdf.render_order.push_back(key);
+        while self.preview.pdf.render_order.len() > PDF_RENDER_CACHE_LIMIT {
+            if let Some(stale_key) = self.preview.pdf.render_order.pop_front()
+                && let Some(stale_path) = self.preview.pdf.rendered_pages.remove(&stale_key)
             {
-                self.pdf_preview.rendered_page_dimensions.remove(&stale_key);
+                self.preview.pdf.rendered_page_dimensions.remove(&stale_key);
                 let _ = fs::remove_file(stale_path);
             }
         }
@@ -164,12 +167,13 @@ impl App {
         key: &PdfRenderKey,
         rendered: &Path,
     ) -> Option<RenderedImageDimensions> {
-        if let Some(dimensions) = self.pdf_preview.rendered_page_dimensions.get(key).copied() {
+        if let Some(dimensions) = self.preview.pdf.rendered_page_dimensions.get(key).copied() {
             return Some(dimensions);
         }
 
         let dimensions = read_png_dimensions(rendered)?;
-        self.pdf_preview
+        self.preview
+            .pdf
             .rendered_page_dimensions
             .insert(key.clone(), dimensions);
         Some(dimensions)
@@ -183,7 +187,8 @@ impl App {
         let window_size = self.cached_terminal_window()?;
         let render_key = self.pdf_render_key_from_request(request, fallback);
         let image_dimensions = self
-            .pdf_preview
+            .preview
+            .pdf
             .rendered_page_dimensions
             .get(&render_key)
             .copied()?;

--- a/src/app/overlays/pdf/prefetch.rs
+++ b/src/app/overlays/pdf/prefetch.rs
@@ -7,7 +7,7 @@ use crate::app::{App, jobs};
 
 impl App {
     pub(super) fn refresh_pdf_prefetch_window(&mut self) {
-        let Some(session) = self.pdf_preview.session.as_ref() else {
+        let Some(session) = self.preview.pdf.session.as_ref() else {
             self.clear_pending_pdf_work();
             return;
         };
@@ -16,9 +16,10 @@ impl App {
         let modified = session.modified;
 
         let window_pages = self.pdf_probe_window_pages();
-        self.scheduler
+        self.jobs
+            .scheduler
             .retain_pdf_probe_pages(&path, size, modified, &window_pages);
-        self.pdf_preview.pending_page_probes.retain(|key| {
+        self.preview.pdf.pending_page_probes.retain(|key| {
             key.path == path
                 && key.size == size
                 && key.modified == modified
@@ -26,9 +27,10 @@ impl App {
         });
 
         let render_variants = self.desired_pdf_render_variants();
-        self.scheduler
+        self.jobs
+            .scheduler
             .retain_pdf_render_variants(&path, size, modified, &render_variants);
-        self.pdf_preview.pending_renders.retain(|key| {
+        self.preview.pdf.pending_renders.retain(|key| {
             key.path == path
                 && key.size == size
                 && key.modified == modified
@@ -56,7 +58,7 @@ impl App {
     }
 
     fn try_queue_pdf_probe_page(&mut self, page: usize) {
-        let Some(session) = &self.pdf_preview.session else {
+        let Some(session) = &self.preview.pdf.session else {
             return;
         };
 
@@ -79,7 +81,7 @@ impl App {
     }
 
     fn pdf_probe_window_pages(&self) -> Vec<usize> {
-        let Some(session) = self.pdf_preview.session.as_ref() else {
+        let Some(session) = self.preview.pdf.session.as_ref() else {
             return Vec::new();
         };
 
@@ -94,7 +96,7 @@ impl App {
     }
 
     pub(super) fn pdf_prefetch_probe_pages(&self) -> Vec<usize> {
-        let Some(session) = self.pdf_preview.session.as_ref() else {
+        let Some(session) = self.preview.pdf.session.as_ref() else {
             return Vec::new();
         };
         self.pdf_prefetch_pages(
@@ -106,7 +108,7 @@ impl App {
     }
 
     pub(super) fn pdf_prefetch_render_pages(&self) -> Vec<usize> {
-        let Some(session) = self.pdf_preview.session.as_ref() else {
+        let Some(session) = self.preview.pdf.session.as_ref() else {
             return Vec::new();
         };
         self.pdf_prefetch_pages(
@@ -121,7 +123,8 @@ impl App {
         self.active_pdf_overlay_request()
             .as_ref()
             .is_some_and(|request| {
-                self.pdf_preview
+                self.preview
+                    .pdf
                     .page_dimensions
                     .contains_key(&PdfPageKey::from_request(request))
             })
@@ -132,8 +135,8 @@ impl App {
             return None;
         }
 
-        let session = self.pdf_preview.session.as_ref()?;
-        let area = self.frame_state.preview_content_area?;
+        let session = self.preview.pdf.session.as_ref()?;
+        let area = self.input.frame_state.preview_content_area?;
         if area.width == 0 || area.height == 0 {
             return None;
         }
@@ -154,7 +157,7 @@ impl App {
     }
 
     fn desired_pdf_render_variants(&self) -> Vec<(usize, u32, u32)> {
-        let Some(session) = self.pdf_preview.session.as_ref() else {
+        let Some(session) = self.preview.pdf.session.as_ref() else {
             return Vec::new();
         };
 
@@ -182,7 +185,7 @@ impl App {
         let Some(total_pages) = total_pages else {
             return Vec::new();
         };
-        let prefer_backward = self.pdf_preview.last_navigation_direction < 0;
+        let prefer_backward = self.preview.pdf.last_navigation_direction < 0;
         let mut pages = Vec::new();
 
         if prefer_backward {
@@ -217,7 +220,7 @@ impl App {
     }
 
     fn queue_current_pdf_probe(&mut self) {
-        let Some(session) = &self.pdf_preview.session else {
+        let Some(session) = &self.preview.pdf.session else {
             return;
         };
 
@@ -240,14 +243,14 @@ impl App {
     }
 
     fn submit_pdf_probe_key(&mut self, key: PdfPageKey, priority: jobs::PdfJobPriority) {
-        if self.pdf_preview.page_dimensions.contains_key(&key)
-            || self.pdf_preview.pending_page_probes.contains(&key)
-            || self.pdf_preview.failed_page_probes.contains(&key)
+        if self.preview.pdf.page_dimensions.contains_key(&key)
+            || self.preview.pdf.pending_page_probes.contains(&key)
+            || self.preview.pdf.failed_page_probes.contains(&key)
         {
             return;
         }
 
-        if self.scheduler.submit_pdf_probe(
+        if self.jobs.scheduler.submit_pdf_probe(
             jobs::PdfProbeRequest {
                 path: key.path.clone(),
                 size: key.size,
@@ -256,21 +259,21 @@ impl App {
             },
             priority,
         ) {
-            self.pdf_preview.pending_page_probes.insert(key);
+            self.preview.pdf.pending_page_probes.insert(key);
         } else {
-            self.pdf_preview.failed_page_probes.insert(key);
+            self.preview.pdf.failed_page_probes.insert(key);
         }
     }
 
     fn submit_pdf_render_key(&mut self, key: PdfRenderKey, priority: jobs::PdfJobPriority) {
         if self.cached_render_exists(&key)
-            || self.pdf_preview.pending_renders.contains(&key)
-            || self.pdf_preview.failed_renders.contains(&key)
+            || self.preview.pdf.pending_renders.contains(&key)
+            || self.preview.pdf.failed_renders.contains(&key)
         {
             return;
         }
 
-        if self.scheduler.submit_pdf_render(
+        if self.jobs.scheduler.submit_pdf_render(
             jobs::PdfRenderRequest {
                 path: key.path.clone(),
                 size: key.size,
@@ -281,9 +284,9 @@ impl App {
             },
             priority,
         ) {
-            self.pdf_preview.pending_renders.insert(key);
+            self.preview.pdf.pending_renders.insert(key);
         } else {
-            self.pdf_preview.failed_renders.insert(key);
+            self.preview.pdf.failed_renders.insert(key);
         }
     }
 }

--- a/src/app/overlays/pdf/present.rs
+++ b/src/app/overlays/pdf/present.rs
@@ -49,8 +49,8 @@ impl App {
             placement.image_area
         ));
         let displayed = DisplayedPdfPreview::from_request(&request, placement);
-        let image_changed = self.pdf_preview.displayed.as_ref() != Some(&displayed);
-        let excluded_changed = excluded != self.pdf_preview.displayed_excluded.as_slice();
+        let image_changed = self.preview.pdf.displayed.as_ref() != Some(&displayed);
+        let excluded_changed = excluded != self.preview.pdf.displayed_excluded.as_slice();
         let needs_repaint = force_repaint && protocol == ImageProtocol::ItermInline;
         if !image_changed && !excluded_changed && !needs_repaint {
             preview_log("present_pdf_overlay: already displayed → Displayed");
@@ -66,16 +66,16 @@ impl App {
             bytes.len()
         ));
         out.extend(bytes);
-        self.pdf_preview.displayed = Some(displayed);
-        self.pdf_preview.displayed_excluded = excluded.to_vec();
+        self.preview.pdf.displayed = Some(displayed);
+        self.preview.pdf.displayed_excluded = excluded.to_vec();
         self.clear_pending_iterm_popup_restore();
         Ok(OverlayPresentState::Displayed)
     }
 
     pub(crate) fn preview_prefers_pdf_surface(&self) -> bool {
         if !self.terminal_image_overlay_available()
-            || !self.pdf_preview.pdf_tools_available
-            || self.pdf_preview.session.is_none()
+            || !self.preview.pdf.pdf_tools_available
+            || self.preview.pdf.session.is_none()
         {
             return false;
         }
@@ -91,11 +91,11 @@ impl App {
         }
 
         let page_key = self.pdf_page_key_from_request(&request);
-        if self.pdf_preview.failed_page_probes.contains(&page_key) {
+        if self.preview.pdf.failed_page_probes.contains(&page_key) {
             return false;
         }
-        if self.pdf_preview.pending_page_probes.contains(&page_key)
-            || !self.pdf_preview.page_dimensions.contains_key(&page_key)
+        if self.preview.pdf.pending_page_probes.contains(&page_key)
+            || !self.preview.pdf.page_dimensions.contains_key(&page_key)
         {
             return true;
         }
@@ -104,10 +104,10 @@ impl App {
             return false;
         };
         let render_key = self.pdf_render_key_from_request(&request, placement);
-        if self.pdf_preview.failed_renders.contains(&render_key) {
+        if self.preview.pdf.failed_renders.contains(&render_key) {
             return false;
         }
-        self.pdf_preview.pending_renders.contains(&render_key)
+        self.preview.pdf.pending_renders.contains(&render_key)
             || self.cached_render_exists(&render_key)
     }
 
@@ -122,19 +122,19 @@ impl App {
 
         let request = self.active_pdf_overlay_request()?;
         let page_key = self.pdf_page_key_from_request(&request);
-        if self.pdf_preview.failed_page_probes.contains(&page_key) {
+        if self.preview.pdf.failed_page_probes.contains(&page_key) {
             return Some("PDF preview unavailable".to_string());
         }
         if !self.pdf_selection_activation_ready()
-            || !self.pdf_preview.page_dimensions.contains_key(&page_key)
-            || self.pdf_preview.pending_page_probes.contains(&page_key)
+            || !self.preview.pdf.page_dimensions.contains_key(&page_key)
+            || self.preview.pdf.pending_page_probes.contains(&page_key)
         {
             return None;
         }
 
         let placement = self.overlay_placement_for_request(&request)?;
         let render_key = self.pdf_render_key_from_request(&request, placement);
-        if self.pdf_preview.failed_renders.contains(&render_key) {
+        if self.preview.pdf.failed_renders.contains(&render_key) {
             return Some("PDF preview unavailable".to_string());
         }
         if self.cached_render_exists(&render_key) {
@@ -144,25 +144,26 @@ impl App {
     }
 
     pub(in crate::app) fn pdf_overlay_displayed(&self) -> bool {
-        self.pdf_preview.displayed.is_some()
+        self.preview.pdf.displayed.is_some()
     }
 
     pub(in crate::app) fn displayed_pdf_overlay_area(&self) -> Option<Rect> {
-        self.pdf_preview
+        self.preview
+            .pdf
             .displayed
             .as_ref()
             .map(|displayed| displayed.area)
     }
 
     pub(in crate::app) fn clear_displayed_pdf_overlay(&mut self) {
-        self.pdf_preview.displayed = None;
-        self.pdf_preview.displayed_excluded.clear();
+        self.preview.pdf.displayed = None;
+        self.preview.pdf.displayed_excluded.clear();
     }
 
     pub(in crate::app) fn displayed_pdf_overlay_matches_active(&self) -> bool {
         self.active_pdf_display_target()
             .as_ref()
-            .zip(self.pdf_preview.displayed.as_ref())
+            .zip(self.preview.pdf.displayed.as_ref())
             .is_some_and(|(active, displayed)| active == displayed)
     }
 

--- a/src/app/overlays/pdf/session.rs
+++ b/src/app/overlays/pdf/session.rs
@@ -9,32 +9,33 @@ use std::time::{Duration, Instant};
 
 impl App {
     pub(in crate::app) fn handle_pdf_overlay_resize(&mut self) {
-        if self.pdf_preview.session.is_some() {
-            self.pdf_preview.activation_ready_at = None;
+        if self.preview.pdf.session.is_some() {
+            self.preview.pdf.activation_ready_at = None;
             self.refresh_pdf_prefetch_window();
         }
     }
 
     pub(crate) fn process_pdf_preview_timers(&mut self) -> bool {
-        let Some(ready_at) = self.pdf_preview.activation_ready_at else {
+        let Some(ready_at) = self.preview.pdf.activation_ready_at else {
             return false;
         };
         if Instant::now() < ready_at {
             return false;
         }
 
-        self.pdf_preview.activation_ready_at = None;
-        self.pdf_preview.session.is_some()
+        self.preview.pdf.activation_ready_at = None;
+        self.preview.pdf.session.is_some()
     }
 
     pub(crate) fn pending_pdf_preview_timer(&self) -> Option<Duration> {
-        self.pdf_preview
+        self.preview
+            .pdf
             .activation_ready_at
             .map(|ready_at| ready_at.saturating_duration_since(Instant::now()))
     }
 
     pub(in crate::app) fn pdf_preview_header_detail(&self) -> Option<String> {
-        let session = self.pdf_preview.session.as_ref()?;
+        let session = self.preview.pdf.session.as_ref()?;
         if !self.terminal_image_overlay_available() {
             return None;
         }
@@ -47,7 +48,7 @@ impl App {
     }
 
     pub(in crate::app) fn step_pdf_page(&mut self, delta: isize) -> bool {
-        let Some(session) = &mut self.pdf_preview.session else {
+        let Some(session) = &mut self.preview.pdf.session else {
             return false;
         };
 
@@ -62,8 +63,8 @@ impl App {
         session.current_page = next_page.clamp(PDF_PAGE_MIN, max_page.max(PDF_PAGE_MIN));
         let changed = session.current_page != previous_page;
         if changed {
-            self.pdf_preview.last_navigation_direction = delta.signum();
-            self.pdf_preview.activation_ready_at = None;
+            self.preview.pdf.last_navigation_direction = delta.signum();
+            self.preview.pdf.activation_ready_at = None;
             self.refresh_pdf_prefetch_window();
         }
         changed
@@ -71,30 +72,30 @@ impl App {
 
     pub(in crate::app) fn sync_pdf_preview_selection(&mut self) {
         self.clear_failed_static_image_state_if_needed();
-        if !self.terminal_image_overlay_available() || !self.pdf_preview.pdf_tools_available {
-            self.pdf_preview.session = None;
-            self.pdf_preview.activation_ready_at = None;
+        if !self.terminal_image_overlay_available() || !self.preview.pdf.pdf_tools_available {
+            self.preview.pdf.session = None;
+            self.preview.pdf.activation_ready_at = None;
             self.clear_pending_pdf_work();
             self.clear_pdf_page_status();
             return;
         }
 
         let Some(entry) = self.selected_entry() else {
-            self.pdf_preview.session = None;
-            self.pdf_preview.activation_ready_at = None;
+            self.preview.pdf.session = None;
+            self.preview.pdf.activation_ready_at = None;
             self.clear_pending_pdf_work();
             self.clear_pdf_page_status();
             return;
         };
         if !is_pdf_entry(entry) {
-            self.pdf_preview.session = None;
-            self.pdf_preview.activation_ready_at = None;
+            self.preview.pdf.session = None;
+            self.preview.pdf.activation_ready_at = None;
             self.clear_pending_pdf_work();
             self.clear_pdf_page_status();
             return;
         }
 
-        let should_keep_session = self.pdf_preview.session.as_ref().is_some_and(|session| {
+        let should_keep_session = self.preview.pdf.session.as_ref().is_some_and(|session| {
             session.path == entry.path
                 && session.size == entry.size
                 && session.modified == entry.modified
@@ -103,15 +104,15 @@ impl App {
             return;
         }
 
-        self.pdf_preview.session = Some(PdfSession {
+        self.preview.pdf.session = Some(PdfSession {
             path: entry.path.clone(),
             size: entry.size,
             modified: entry.modified,
             current_page: PDF_PAGE_MIN,
             total_pages: self.cached_pdf_total_pages(entry),
         });
-        self.pdf_preview.last_navigation_direction = 0;
-        self.pdf_preview.activation_ready_at =
+        self.preview.pdf.last_navigation_direction = 0;
+        self.preview.pdf.activation_ready_at =
             Some(Instant::now() + PDF_SELECTION_ACTIVATION_DELAY);
         self.refresh_pdf_prefetch_window();
         self.clear_pdf_page_status();
@@ -122,8 +123,8 @@ impl App {
             return None;
         }
 
-        let session = self.pdf_preview.session.as_ref()?;
-        let area = self.frame_state.preview_content_area?;
+        let session = self.preview.pdf.session.as_ref()?;
+        let area = self.input.frame_state.preview_content_area?;
         if area.width == 0 || area.height == 0 {
             return None;
         }
@@ -144,28 +145,30 @@ impl App {
             modified: build.modified,
             page: build.page,
         };
-        self.pdf_preview.pending_page_probes.remove(&key);
+        self.preview.pdf.pending_page_probes.remove(&key);
 
         let current_request = self.active_pdf_overlay_request();
         let current_key = current_request.as_ref().map(PdfPageKey::from_request);
         let is_current_key = current_key.as_ref() == Some(&key);
         let current_document = self
-            .pdf_preview
+            .preview
+            .pdf
             .session
             .as_ref()
             .map(PdfDocumentKey::from_session);
 
         match build.result {
             Ok(result) => {
-                self.pdf_preview.failed_page_probes.remove(&key);
+                self.preview.pdf.failed_page_probes.remove(&key);
                 let mut dirty = current_key.as_ref() == Some(&key);
                 if let Some(total_pages) = result.total_pages {
                     let document_key = PdfDocumentKey::from_page_key(&key);
-                    self.pdf_preview
+                    self.preview
+                        .pdf
                         .document_page_counts
                         .insert(document_key.clone(), total_pages);
                     if current_document.as_ref() == Some(&document_key)
-                        && let Some(session) = &mut self.pdf_preview.session
+                        && let Some(session) = &mut self.preview.pdf.session
                     {
                         let previous_total = session.total_pages;
                         session.total_pages = Some(total_pages);
@@ -174,7 +177,7 @@ impl App {
                             .clamp(PDF_PAGE_MIN, total_pages.max(PDF_PAGE_MIN));
                         if clamped_page != session.current_page {
                             session.current_page = clamped_page;
-                            self.pdf_preview.activation_ready_at = Some(Instant::now());
+                            self.preview.pdf.activation_ready_at = Some(Instant::now());
                             dirty = true;
                         }
                         if previous_total != session.total_pages {
@@ -183,7 +186,7 @@ impl App {
                     }
                 }
                 if let (Some(width_pts), Some(height_pts)) = (result.width_pts, result.height_pts) {
-                    self.pdf_preview.page_dimensions.insert(
+                    self.preview.pdf.page_dimensions.insert(
                         key.clone(),
                         PdfPageDimensions {
                             width_pts,
@@ -196,7 +199,7 @@ impl App {
                 dirty
             }
             Err(_) => {
-                self.pdf_preview.failed_page_probes.insert(key);
+                self.preview.pdf.failed_page_probes.insert(key);
                 if is_current_key {
                     self.refresh_preview();
                     true
@@ -216,7 +219,7 @@ impl App {
             width_px: build.width_px,
             height_px: build.height_px,
         };
-        self.pdf_preview.pending_renders.remove(&key);
+        self.preview.pdf.pending_renders.remove(&key);
         let is_current_key = self
             .active_pdf_render_key()
             .as_ref()
@@ -224,7 +227,7 @@ impl App {
 
         match build.result {
             Ok(Some(path)) => {
-                self.pdf_preview.failed_renders.remove(&key);
+                self.preview.pdf.failed_renders.remove(&key);
                 let image_dimensions = read_png_dimensions(&path);
                 self.remember_rendered_pdf(key.clone(), path, image_dimensions);
                 let dirty = is_current_key;
@@ -232,7 +235,7 @@ impl App {
                 dirty
             }
             Ok(None) | Err(_) => {
-                self.pdf_preview.failed_renders.insert(key);
+                self.preview.pdf.failed_renders.insert(key);
                 if is_current_key {
                     self.refresh_preview();
                     true
@@ -250,14 +253,16 @@ impl App {
     }
 
     fn cached_pdf_total_pages(&self, entry: &Entry) -> Option<usize> {
-        self.pdf_preview
+        self.preview
+            .pdf
             .document_page_counts
             .get(&PdfDocumentKey::from_entry(entry))
             .copied()
     }
 
     pub(super) fn pdf_selection_activation_ready(&self) -> bool {
-        self.pdf_preview
+        self.preview
+            .pdf
             .activation_ready_at
             .is_none_or(|ready_at| Instant::now() >= ready_at)
     }
@@ -267,9 +272,9 @@ impl App {
     }
 
     pub(super) fn clear_pending_pdf_work(&mut self) {
-        self.pdf_preview.pending_page_probes.clear();
-        self.pdf_preview.pending_renders.clear();
-        self.scheduler.clear_pending_pdf_jobs();
+        self.preview.pdf.pending_page_probes.clear();
+        self.preview.pdf.pending_renders.clear();
+        self.jobs.scheduler.clear_pending_pdf_jobs();
     }
 }
 

--- a/src/app/overlays/pdf/tests/helpers.rs
+++ b/src/app/overlays/pdf/tests/helpers.rs
@@ -22,8 +22,8 @@ pub(super) fn temp_root(label: &str) -> PathBuf {
 
 pub(super) fn configure_terminal_image_support(app: &mut App) {
     let (cells_width, cells_height) = crossterm::terminal::size().unwrap_or((120, 40));
-    app.terminal_images.protocol = ImageProtocol::KittyGraphics;
-    app.terminal_images.window = Some(TerminalWindowSize {
+    app.preview.terminal_images.protocol = ImageProtocol::KittyGraphics;
+    app.preview.terminal_images.window = Some(TerminalWindowSize {
         cells_width,
         cells_height,
         pixels_width: 1920,
@@ -33,8 +33,8 @@ pub(super) fn configure_terminal_image_support(app: &mut App) {
 
 pub(super) fn configure_iterm_image_support(app: &mut App) {
     let (cells_width, cells_height) = crossterm::terminal::size().unwrap_or((120, 40));
-    app.terminal_images.protocol = ImageProtocol::ItermInline;
-    app.terminal_images.window = Some(TerminalWindowSize {
+    app.preview.terminal_images.protocol = ImageProtocol::ItermInline;
+    app.preview.terminal_images.window = Some(TerminalWindowSize {
         cells_width,
         cells_height,
         pixels_width: 1920,
@@ -48,21 +48,21 @@ pub(super) fn build_pdf_overlay_test_app(label: &str) -> (App, PathBuf) {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.pdf_preview.session = Some(PdfSession {
+    app.preview.pdf.pdf_tools_available = true;
+    app.preview.pdf.session = Some(PdfSession {
         path: root.join("demo.pdf"),
         size: 128,
         modified: None,
         current_page: 1,
         total_pages: None,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.pdf_preview.activation_ready_at = Some(Instant::now());
+    app.preview.pdf.activation_ready_at = Some(Instant::now());
     (app, root)
 }
 
@@ -74,8 +74,8 @@ pub(super) fn build_selected_pdf_app(label: &str) -> (App, PathBuf) {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.frame_state.preview_content_area = Some(Rect {
+    app.preview.pdf.pdf_tools_available = true;
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
@@ -177,7 +177,7 @@ pub(super) fn set_single_test_entry(app: &mut App, path: &Path) {
         .file_name()
         .and_then(|name| name.to_str())
         .expect("file name should be valid utf-8");
-    app.entries = vec![Entry {
+    app.navigation.entries = vec![Entry {
         path: path.to_path_buf(),
         name: name.to_string(),
         name_key: name.to_ascii_lowercase(),
@@ -186,15 +186,15 @@ pub(super) fn set_single_test_entry(app: &mut App, path: &Path) {
         modified: None,
         readonly: false,
     }];
-    app.selected = 0;
-    app.frame_state.preview_content_area = Some(Rect {
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.frame_state.metrics.cols = 1;
-    app.frame_state.metrics.rows_visible = 6;
+    app.input.frame_state.metrics.cols = 1;
+    app.input.frame_state.metrics.rows_visible = 6;
 }
 
 pub(super) fn build_selected_static_image_app(label: &str, file_name: &str) -> (App, PathBuf) {
@@ -220,15 +220,15 @@ pub(super) fn build_selected_static_image_app(label: &str, file_name: &str) -> (
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.frame_state.preview_content_area = Some(Rect {
+    app.preview.pdf.pdf_tools_available = true;
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.frame_state.metrics.cols = 1;
-    app.frame_state.metrics.rows_visible = 6;
+    app.input.frame_state.metrics.cols = 1;
+    app.input.frame_state.metrics.rows_visible = 6;
     app.refresh_preview();
     (app, root)
 }
@@ -255,15 +255,15 @@ pub(super) fn build_selected_extensionless_png_app(label: &str, file_name: &str)
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.frame_state.preview_content_area = Some(Rect {
+    app.preview.pdf.pdf_tools_available = true;
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.frame_state.metrics.cols = 1;
-    app.frame_state.metrics.rows_visible = 6;
+    app.input.frame_state.metrics.cols = 1;
+    app.input.frame_state.metrics.rows_visible = 6;
     app.refresh_preview();
     (app, root)
 }
@@ -296,15 +296,15 @@ pub(super) fn build_multi_static_image_app(label: &str, file_names: &[&str]) -> 
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.frame_state.preview_content_area = Some(Rect {
+    app.preview.pdf.pdf_tools_available = true;
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.frame_state.metrics.cols = 1;
-    app.frame_state.metrics.rows_visible = 6;
+    app.input.frame_state.metrics.cols = 1;
+    app.input.frame_state.metrics.rows_visible = 6;
     app.refresh_preview();
     (app, root)
 }

--- a/src/app/overlays/pdf/tests/pipeline.rs
+++ b/src/app/overlays/pdf/tests/pipeline.rs
@@ -5,7 +5,8 @@ use super::helpers::*;
 fn apply_pdf_probe_build_updates_current_session_and_cached_dimensions() {
     let (mut app, root) = build_pdf_overlay_test_app("probe-apply");
     let session = app
-        .pdf_preview
+        .preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist");
@@ -16,7 +17,7 @@ fn apply_pdf_probe_build_updates_current_session_and_cached_dimensions() {
         modified: None,
         page: 5,
     };
-    app.pdf_preview.pending_page_probes.insert(key.clone());
+    app.preview.pdf.pending_page_probes.insert(key.clone());
 
     let dirty = app.apply_pdf_probe_build(jobs::PdfProbeBuild {
         path: root.join("demo.pdf"),
@@ -32,21 +33,23 @@ fn apply_pdf_probe_build_updates_current_session_and_cached_dimensions() {
 
     assert!(dirty);
     assert_eq!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .session
             .as_ref()
             .map(|session| session.current_page),
         Some(3)
     );
     assert_eq!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .session
             .as_ref()
             .and_then(|session| session.total_pages),
         Some(3)
     );
     assert_eq!(
-        app.pdf_preview.page_dimensions.get(&key),
+        app.preview.pdf.page_dimensions.get(&key),
         Some(&PdfPageDimensions {
             width_pts: 300.0,
             height_pts: 144.0,
@@ -68,22 +71,23 @@ fn cached_pdf_render_path_drops_missing_files_from_cache() {
         height_px: 960,
     };
     let missing_path = root.join("missing-render.png");
-    app.pdf_preview
+    app.preview
+        .pdf
         .rendered_pages
         .insert(key.clone(), missing_path.clone());
-    app.pdf_preview.rendered_page_dimensions.insert(
+    app.preview.pdf.rendered_page_dimensions.insert(
         key.clone(),
         RenderedImageDimensions {
             width_px: 704,
             height_px: 960,
         },
     );
-    app.pdf_preview.render_order.push_back(key.clone());
+    app.preview.pdf.render_order.push_back(key.clone());
 
     assert_eq!(app.cached_pdf_render_path(&key), None);
-    assert!(!app.pdf_preview.rendered_pages.contains_key(&key));
-    assert!(!app.pdf_preview.rendered_page_dimensions.contains_key(&key));
-    assert!(!app.pdf_preview.render_order.contains(&key));
+    assert!(!app.preview.pdf.rendered_pages.contains_key(&key));
+    assert!(!app.preview.pdf.rendered_page_dimensions.contains_key(&key));
+    assert!(!app.preview.pdf.render_order.contains(&key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -95,7 +99,7 @@ fn apply_pdf_probe_build_queues_render_for_current_page() {
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let page_key = PdfPageKey::from_request(&request);
-    app.pdf_preview.pending_page_probes.insert(page_key);
+    app.preview.pdf.pending_page_probes.insert(page_key);
 
     let dirty = app.apply_pdf_probe_build(jobs::PdfProbeBuild {
         path: request.path.clone(),
@@ -115,8 +119,8 @@ fn apply_pdf_probe_build_queues_render_for_current_page() {
     let render_key = PdfRenderKey::from_request(&request, placement);
 
     assert!(dirty);
-    assert!(app.pdf_preview.pending_renders.contains(&render_key));
-    assert!(app.scheduler.has_pending_work());
+    assert!(app.preview.pdf.pending_renders.contains(&render_key));
+    assert!(app.jobs.scheduler.has_pending_work());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -124,12 +128,12 @@ fn apply_pdf_probe_build_queues_render_for_current_page() {
 #[test]
 fn apply_pdf_probe_build_queues_render_even_before_selection_activation_is_ready() {
     let (mut app, root) = build_pdf_overlay_test_app("probe-render-before-activation");
-    app.pdf_preview.activation_ready_at = Some(Instant::now() + Duration::from_secs(5));
+    app.preview.pdf.activation_ready_at = Some(Instant::now() + Duration::from_secs(5));
     let request = app
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let page_key = PdfPageKey::from_request(&request);
-    app.pdf_preview.pending_page_probes.insert(page_key);
+    app.preview.pdf.pending_page_probes.insert(page_key);
 
     let dirty = app.apply_pdf_probe_build(jobs::PdfProbeBuild {
         path: request.path.clone(),
@@ -149,8 +153,8 @@ fn apply_pdf_probe_build_queues_render_even_before_selection_activation_is_ready
     let render_key = PdfRenderKey::from_request(&request, placement);
 
     assert!(dirty);
-    assert!(app.pdf_preview.pending_renders.contains(&render_key));
-    assert!(app.scheduler.has_pending_work());
+    assert!(app.preview.pdf.pending_renders.contains(&render_key));
+    assert!(app.jobs.scheduler.has_pending_work());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -159,7 +163,8 @@ fn apply_pdf_probe_build_queues_render_even_before_selection_activation_is_ready
 fn apply_pdf_probe_build_prefetches_adjacent_page_probes_once_total_is_known() {
     let (mut app, root) = build_pdf_overlay_test_app("probe-prefetch-pages");
     let session = app
-        .pdf_preview
+        .preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist");
@@ -169,7 +174,7 @@ fn apply_pdf_probe_build_prefetches_adjacent_page_probes_once_total_is_known() {
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let page_key = PdfPageKey::from_request(&request);
-    app.pdf_preview.pending_page_probes.insert(page_key);
+    app.preview.pdf.pending_page_probes.insert(page_key);
 
     let dirty = app.apply_pdf_probe_build(jobs::PdfProbeBuild {
         path: request.path.clone(),
@@ -184,19 +189,19 @@ fn apply_pdf_probe_build_prefetches_adjacent_page_probes_once_total_is_known() {
     });
 
     assert!(dirty);
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: request.path.clone(),
         size: request.size,
         modified: request.modified,
         page: 1,
     }));
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: request.path.clone(),
         size: request.size,
         modified: request.modified,
         page: 3,
     }));
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: request.path,
         size: request.size,
         modified: request.modified,
@@ -240,11 +245,12 @@ fn remember_rendered_pdf_evicts_oldest_cached_page_when_limit_is_exceeded() {
         );
     }
 
-    assert_eq!(app.pdf_preview.rendered_pages.len(), PDF_RENDER_CACHE_LIMIT);
-    assert_eq!(app.pdf_preview.render_order.len(), PDF_RENDER_CACHE_LIMIT);
-    assert!(!app.pdf_preview.rendered_pages.contains_key(&first_key));
+    assert_eq!(app.preview.pdf.rendered_pages.len(), PDF_RENDER_CACHE_LIMIT);
+    assert_eq!(app.preview.pdf.render_order.len(), PDF_RENDER_CACHE_LIMIT);
+    assert!(!app.preview.pdf.rendered_pages.contains_key(&first_key));
     assert!(
-        !app.pdf_preview
+        !app.preview
+            .pdf
             .rendered_page_dimensions
             .contains_key(&first_key)
     );
@@ -257,7 +263,8 @@ fn remember_rendered_pdf_evicts_oldest_cached_page_when_limit_is_exceeded() {
 fn apply_pdf_render_build_prefetches_next_page_when_current_page_is_ready() {
     let (mut app, root) = build_pdf_overlay_test_app("render-prefetch-next");
     let session = app
-        .pdf_preview
+        .preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist");
@@ -271,11 +278,12 @@ fn apply_pdf_render_build_prefetches_next_page_when_current_page_is_ready() {
             modified: None,
             page,
             area: app
+                .input
                 .frame_state
                 .preview_content_area
                 .expect("preview content area should be set"),
         };
-        app.pdf_preview.page_dimensions.insert(
+        app.preview.pdf.page_dimensions.insert(
             PdfPageKey::from_request(&request),
             PdfPageDimensions {
                 width_pts: 612.0,
@@ -290,7 +298,7 @@ fn apply_pdf_render_build_prefetches_next_page_when_current_page_is_ready() {
     let current_key = app
         .pdf_render_key_for_page(2)
         .expect("current PDF render key should be available");
-    app.pdf_preview.pending_renders.insert(current_key.clone());
+    app.preview.pdf.pending_renders.insert(current_key.clone());
 
     let rendered_path = root.join("current-page.png");
     fs::write(&rendered_path, b"png").expect("failed to write rendered page placeholder");
@@ -310,7 +318,7 @@ fn apply_pdf_render_build_prefetches_next_page_when_current_page_is_ready() {
         .expect("next page render key should be available");
 
     assert!(dirty);
-    assert!(app.pdf_preview.pending_renders.contains(&next_key));
+    assert!(app.preview.pdf.pending_renders.contains(&next_key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/overlays/pdf/tests/protocols.rs
+++ b/src/app/overlays/pdf/tests/protocols.rs
@@ -244,13 +244,13 @@ fn build_kitty_clear_sequence_deletes_visible_images() {
 fn iterm_full_pane_static_image_clear_area_excludes_preview_header_and_border() {
     let (mut app, root) = build_selected_static_image_app("iterm-clear-area", "demo.png");
     configure_iterm_image_support(&mut app);
-    app.frame_state.preview_panel = Some(Rect {
+    app.input.frame_state.preview_panel = Some(Rect {
         x: 1,
         y: 1,
         width: 50,
         height: 24,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
@@ -277,19 +277,19 @@ fn iterm_full_pane_static_image_clear_area_excludes_preview_header_and_border() 
 fn iterm_full_pane_static_image_erase_expands_to_body_bottom_edge() {
     let (mut app, root) = build_selected_static_image_app("iterm-erase-bottom-edge", "demo.png");
     configure_iterm_image_support(&mut app);
-    app.frame_state.preview_panel = Some(Rect {
+    app.input.frame_state.preview_panel = Some(Rect {
         x: 1,
         y: 1,
         width: 50,
         height: 24,
     });
-    app.frame_state.preview_body_area = Some(Rect {
+    app.input.frame_state.preview_body_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 21,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,

--- a/src/app/overlays/pdf/tests/session.rs
+++ b/src/app/overlays/pdf/tests/session.rs
@@ -5,8 +5,8 @@ use super::helpers::*;
 fn pdf_preview_page_navigation_clamps_to_document_bounds() {
     let mut app = App::new_at(std::env::temp_dir()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.pdf_preview.session = Some(PdfSession {
+    app.preview.pdf.pdf_tools_available = true;
+    app.preview.pdf.session = Some(PdfSession {
         path: PathBuf::from("demo.pdf"),
         size: 1,
         modified: None,
@@ -16,7 +16,8 @@ fn pdf_preview_page_navigation_clamps_to_document_bounds() {
 
     assert!(app.step_pdf_page(1));
     assert_eq!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .session
             .as_ref()
             .map(|session| session.current_page),
@@ -24,7 +25,8 @@ fn pdf_preview_page_navigation_clamps_to_document_bounds() {
     );
     assert!(!app.step_pdf_page(1));
     assert_eq!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .session
             .as_ref()
             .map(|session| session.current_page),
@@ -32,7 +34,8 @@ fn pdf_preview_page_navigation_clamps_to_document_bounds() {
     );
     assert!(app.step_pdf_page(-2));
     assert_eq!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .session
             .as_ref()
             .map(|session| session.current_page),
@@ -44,13 +47,13 @@ fn pdf_preview_page_navigation_clamps_to_document_bounds() {
 #[test]
 fn present_pdf_overlay_waits_for_selection_activation_before_queueing_probe() {
     let (mut app, root) = build_pdf_overlay_test_app("activation-delay");
-    app.pdf_preview.activation_ready_at = Some(Instant::now() + Duration::from_secs(5));
+    app.preview.pdf.activation_ready_at = Some(Instant::now() + Duration::from_secs(5));
 
     app.present_preview_overlay()
         .expect("presenting a delayed PDF overlay should not fail");
 
-    assert!(app.pdf_preview.pending_page_probes.is_empty());
-    assert!(!app.scheduler.has_pending_work());
+    assert!(app.preview.pdf.pending_page_probes.is_empty());
+    assert!(!app.jobs.scheduler.has_pending_work());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -68,9 +71,9 @@ fn present_pdf_overlay_queues_current_probe_only_once() {
     app.present_preview_overlay()
         .expect("retrying a PDF overlay should not fail");
 
-    assert_eq!(app.pdf_preview.pending_page_probes.len(), 1);
-    assert!(app.pdf_preview.pending_page_probes.contains(&key));
-    assert!(app.scheduler.has_pending_work());
+    assert_eq!(app.preview.pdf.pending_page_probes.len(), 1);
+    assert!(app.preview.pdf.pending_page_probes.contains(&key));
+    assert!(app.jobs.scheduler.has_pending_work());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -78,11 +81,11 @@ fn present_pdf_overlay_queues_current_probe_only_once() {
 #[test]
 fn process_pdf_preview_timers_releases_selection_activation_once() {
     let (mut app, root) = build_pdf_overlay_test_app("activation-timer");
-    app.pdf_preview.activation_ready_at = Some(Instant::now() - Duration::from_millis(1));
+    app.preview.pdf.activation_ready_at = Some(Instant::now() - Duration::from_millis(1));
 
     assert!(app.process_pdf_preview_timers());
     assert!(!app.process_pdf_preview_timers());
-    assert!(app.pdf_preview.activation_ready_at.is_none());
+    assert!(app.preview.pdf.activation_ready_at.is_none());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -91,13 +94,14 @@ fn process_pdf_preview_timers_releases_selection_activation_once() {
 fn pdf_prefetch_pages_prefers_backward_order_after_reverse_navigation() {
     let (mut app, root) = build_pdf_overlay_test_app("prefetch-backward-order");
     let session = app
-        .pdf_preview
+        .preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist");
     session.current_page = 4;
     session.total_pages = Some(6);
-    app.pdf_preview.last_navigation_direction = -1;
+    app.preview.pdf.last_navigation_direction = -1;
 
     assert_eq!(app.pdf_prefetch_probe_pages(), vec![3, 2, 5]);
     assert_eq!(app.pdf_prefetch_render_pages(), vec![3, 2, 5]);
@@ -119,18 +123,20 @@ fn sync_pdf_preview_selection_reuses_cached_total_page_count() {
         modified: None,
         readonly: false,
     };
-    app.entries = vec![entry.clone()];
-    app.selected = 0;
+    app.navigation.entries = vec![entry.clone()];
+    app.navigation.selected = 0;
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.pdf_preview
+    app.preview.pdf.pdf_tools_available = true;
+    app.preview
+        .pdf
         .document_page_counts
         .insert(PdfDocumentKey::from_entry(&entry), 12);
 
     app.sync_pdf_preview_selection();
 
     assert_eq!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .session
             .as_ref()
             .and_then(|session| session.total_pages),
@@ -154,18 +160,19 @@ fn sync_pdf_preview_selection_prefetches_forward_probe_window_when_page_count_is
         modified: None,
         readonly: false,
     };
-    app.entries = vec![entry.clone()];
-    app.selected = 0;
+    app.navigation.entries = vec![entry.clone()];
+    app.navigation.selected = 0;
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
-    app.pdf_preview
+    app.preview.pdf.pdf_tools_available = true;
+    app.preview
+        .pdf
         .document_page_counts
         .insert(PdfDocumentKey::from_entry(&entry), 12);
 
     app.sync_pdf_preview_selection();
 
     assert_eq!(
-        app.pdf_preview.pending_page_probes,
+        app.preview.pdf.pending_page_probes,
         [PDF_PAGE_MIN, 2, 3]
             .into_iter()
             .map(|page| PdfPageKey {
@@ -194,15 +201,15 @@ fn sync_pdf_preview_selection_queues_initial_probe_for_current_page() {
         modified: None,
         readonly: false,
     };
-    app.entries = vec![entry.clone()];
-    app.selected = 0;
+    app.navigation.entries = vec![entry.clone()];
+    app.navigation.selected = 0;
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
+    app.preview.pdf.pdf_tools_available = true;
 
     app.sync_pdf_preview_selection();
 
-    assert!(app.scheduler.has_pending_work());
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.jobs.scheduler.has_pending_work());
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: entry.path,
         size: entry.size,
         modified: entry.modified,
@@ -219,7 +226,7 @@ fn preview_uses_image_overlay_only_for_current_render_target() {
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let key = PdfPageKey::from_request(&request);
-    app.pdf_preview.page_dimensions.insert(
+    app.preview.pdf.page_dimensions.insert(
         key,
         PdfPageDimensions {
             width_pts: 595.0,
@@ -230,18 +237,19 @@ fn preview_uses_image_overlay_only_for_current_render_target() {
         .overlay_placement_for_request(&request)
         .expect("overlay placement should be available");
     let render_key = PdfRenderKey::from_request(&request, placement);
-    app.pdf_preview.rendered_page_dimensions.insert(
+    app.preview.pdf.rendered_page_dimensions.insert(
         render_key,
         RenderedImageDimensions {
             width_px: placement.render_width_px,
             height_px: placement.render_height_px,
         },
     );
-    app.pdf_preview.displayed = Some(DisplayedPdfPreview::from_request(&request, placement));
+    app.preview.pdf.displayed = Some(DisplayedPdfPreview::from_request(&request, placement));
 
     assert!(app.preview_uses_image_overlay());
 
-    app.pdf_preview
+    app.preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist")
@@ -264,14 +272,14 @@ fn leaving_static_image_selection_clears_overlay_without_recursion() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.frame_state.metrics.cols = 1;
-    app.frame_state.metrics.rows_visible = 6;
+    app.input.frame_state.metrics.cols = 1;
+    app.input.frame_state.metrics.rows_visible = 6;
     app.refresh_preview();
 
     assert_eq!(
@@ -279,7 +287,7 @@ fn leaving_static_image_selection_clears_overlay_without_recursion() {
         Some(fade_path.as_path())
     );
 
-    app.last_selection_change_at = Instant::now() - Duration::from_secs(1);
+    app.input.last_selection_change_at = Instant::now() - Duration::from_secs(1);
     app.sync_image_preview_selection_activation();
     app.present_preview_overlay()
         .expect("presenting a static image overlay should not fail");
@@ -309,18 +317,20 @@ fn step_pdf_page_queues_render_immediately_when_dimensions_are_cached() {
         modified: None,
         page: 2,
         area: app
+            .input
             .frame_state
             .preview_content_area
             .expect("preview content area should be set"),
     };
-    app.pdf_preview.page_dimensions.insert(
+    app.preview.pdf.page_dimensions.insert(
         PdfPageKey::from_request(&next_request),
         PdfPageDimensions {
             width_pts: 612.0,
             height_pts: 792.0,
         },
     );
-    app.pdf_preview
+    app.preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist")
@@ -335,7 +345,7 @@ fn step_pdf_page_queues_render_immediately_when_dimensions_are_cached() {
         .overlay_placement_for_request(&active_request)
         .expect("overlay placement should be available");
     let render_key = PdfRenderKey::from_request(&active_request, placement);
-    assert!(app.pdf_preview.pending_renders.contains(&render_key));
+    assert!(app.preview.pdf.pending_renders.contains(&render_key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -343,13 +353,13 @@ fn step_pdf_page_queues_render_immediately_when_dimensions_are_cached() {
 #[test]
 fn handle_pdf_overlay_resize_prunes_stale_render_variant_and_queues_new_current_render() {
     let (mut app, root) = build_pdf_overlay_test_app("resize-render-prune");
-    app.terminal_images.window = Some(TerminalWindowSize {
+    app.preview.terminal_images.window = Some(TerminalWindowSize {
         cells_width: 100,
         cells_height: 50,
         pixels_width: 1000,
         pixels_height: 1000,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 16,
@@ -360,7 +370,7 @@ fn handle_pdf_overlay_resize_prunes_stale_render_variant_and_queues_new_current_
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let page_key = PdfPageKey::from_request(&request);
-    app.pdf_preview.page_dimensions.insert(
+    app.preview.pdf.page_dimensions.insert(
         page_key,
         PdfPageDimensions {
             width_pts: 612.0,
@@ -371,11 +381,12 @@ fn handle_pdf_overlay_resize_prunes_stale_render_variant_and_queues_new_current_
         .overlay_placement_for_request(&request)
         .expect("original placement should be available");
     let old_render_key = PdfRenderKey::from_request(&request, old_placement);
-    app.pdf_preview
+    app.preview
+        .pdf
         .pending_renders
         .insert(old_render_key.clone());
 
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 3,
         width: 64,
@@ -392,10 +403,11 @@ fn handle_pdf_overlay_resize_prunes_stale_render_variant_and_queues_new_current_
     let resized_render_key = PdfRenderKey::from_request(&resized_request, resized_placement);
 
     assert_ne!(old_render_key, resized_render_key);
-    assert!(app.pdf_preview.activation_ready_at.is_none());
-    assert!(!app.pdf_preview.pending_renders.contains(&old_render_key));
+    assert!(app.preview.pdf.activation_ready_at.is_none());
+    assert!(!app.preview.pdf.pending_renders.contains(&old_render_key));
     assert!(
-        app.pdf_preview
+        app.preview
+            .pdf
             .pending_renders
             .contains(&resized_render_key)
     );
@@ -407,7 +419,8 @@ fn handle_pdf_overlay_resize_prunes_stale_render_variant_and_queues_new_current_
 fn step_pdf_page_prunes_stale_probe_window_and_prefetches_forward_pages() {
     let (mut app, root) = build_pdf_overlay_test_app("page-step-prune");
     let session = app
-        .pdf_preview
+        .preview
+        .pdf
         .session
         .as_mut()
         .expect("PDF session should exist");
@@ -415,7 +428,7 @@ fn step_pdf_page_prunes_stale_probe_window_and_prefetches_forward_pages() {
     session.total_pages = Some(5);
 
     for page in [1, 2, 3] {
-        app.pdf_preview.pending_page_probes.insert(PdfPageKey {
+        app.preview.pdf.pending_page_probes.insert(PdfPageKey {
             path: root.join("demo.pdf"),
             size: 128,
             modified: None,
@@ -425,31 +438,31 @@ fn step_pdf_page_prunes_stale_probe_window_and_prefetches_forward_pages() {
 
     assert!(app.step_pdf_page(1));
 
-    assert!(!app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(!app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: root.join("demo.pdf"),
         size: 128,
         modified: None,
         page: 1,
     }));
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: root.join("demo.pdf"),
         size: 128,
         modified: None,
         page: 2,
     }));
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: root.join("demo.pdf"),
         size: 128,
         modified: None,
         page: 3,
     }));
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: root.join("demo.pdf"),
         size: 128,
         modified: None,
         page: 4,
     }));
-    assert!(app.pdf_preview.pending_page_probes.contains(&PdfPageKey {
+    assert!(app.preview.pdf.pending_page_probes.contains(&PdfPageKey {
         path: root.join("demo.pdf"),
         size: 128,
         modified: None,
@@ -469,7 +482,7 @@ fn pdf_preview_placeholder_message_stays_silent_while_loading() {
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let page_key = PdfPageKey::from_request(&request);
-    app.pdf_preview.page_dimensions.insert(
+    app.preview.pdf.page_dimensions.insert(
         page_key,
         PdfPageDimensions {
             width_pts: 595.0,
@@ -479,7 +492,8 @@ fn pdf_preview_placeholder_message_stays_silent_while_loading() {
     let placement = app
         .overlay_placement_for_request(&request)
         .expect("overlay placement should be available");
-    app.pdf_preview
+    app.preview
+        .pdf
         .pending_renders
         .insert(PdfRenderKey::from_request(&request, placement));
 
@@ -495,7 +509,7 @@ fn preview_prefers_pdf_surface_falls_back_after_overlay_failure() {
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
     let page_key = PdfPageKey::from_request(&request);
-    app.pdf_preview.failed_page_probes.insert(page_key);
+    app.preview.pdf.failed_page_probes.insert(page_key);
 
     assert!(!app.preview_prefers_pdf_surface());
 
@@ -514,12 +528,12 @@ fn refresh_preview_uses_blank_pdf_surface_preview_when_active() {
         after.preview_jobs_submitted_high,
         before.preview_jobs_submitted_high
     );
-    assert_eq!(app.preview_state.content.kind, PreviewKind::Document);
+    assert_eq!(app.preview.state.content.kind, PreviewKind::Document);
     assert_eq!(
-        app.preview_state.content.detail.as_deref(),
+        app.preview.state.content.detail.as_deref(),
         Some("PDF document")
     );
-    assert!(app.preview_state.content.lines.is_empty());
+    assert!(app.preview.state.content.lines.is_empty());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -527,18 +541,19 @@ fn refresh_preview_uses_blank_pdf_surface_preview_when_active() {
 #[test]
 fn refresh_preview_restores_pdf_metadata_fallback_after_probe_failure() {
     let (mut app, root) = build_selected_pdf_app("pdf-fallback-preview");
-    app.pdf_preview.activation_ready_at = Some(Instant::now());
+    app.preview.pdf.activation_ready_at = Some(Instant::now());
     let request = app
         .active_pdf_overlay_request()
         .expect("PDF overlay request should be available");
-    app.pdf_preview
+    app.preview
+        .pdf
         .failed_page_probes
         .insert(PdfPageKey::from_request(&request));
 
     app.refresh_preview();
 
     assert!(!app.preview_prefers_pdf_surface());
-    assert!(!app.preview_state.content.lines.is_empty());
+    assert!(!app.preview.state.content.lines.is_empty());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -548,7 +563,7 @@ fn sync_pdf_preview_selection_clears_stale_pdf_page_status() {
     let mut app = App::new_at(std::env::temp_dir()).expect("app should initialize");
     app.status = "PDF page 3/10".to_string();
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
+    app.preview.pdf.pdf_tools_available = true;
 
     app.sync_pdf_preview_selection();
 

--- a/src/app/overlays/pdf/tests/static_images/overlay.rs
+++ b/src/app/overlays/pdf/tests/static_images/overlay.rs
@@ -13,9 +13,9 @@ fn refresh_preview_uses_blank_static_image_surface_preview_when_backend_enabled(
     ] {
         let (app, root) = build_selected_static_image_app("image-placeholder", file_name);
 
-        assert_eq!(app.preview_state.content.kind, PreviewKind::Image);
-        assert_eq!(app.preview_state.content.detail.as_deref(), Some(detail));
-        assert!(app.preview_state.content.lines.is_empty());
+        assert_eq!(app.preview.state.content.kind, PreviewKind::Image);
+        assert_eq!(app.preview.state.content.detail.as_deref(), Some(detail));
+        assert!(app.preview.state.content.lines.is_empty());
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
@@ -45,9 +45,9 @@ fn preview_prefers_image_surface_for_supported_static_images_when_backend_enable
 fn preview_prefers_image_surface_for_extensionless_png_when_backend_enabled() {
     let (app, root) = build_selected_extensionless_png_app("image-surface-noext", "background");
 
-    assert_eq!(app.preview_state.content.kind, PreviewKind::Image);
+    assert_eq!(app.preview.state.content.kind, PreviewKind::Image);
     assert_eq!(
-        app.preview_state.content.detail.as_deref(),
+        app.preview.state.content.detail.as_deref(),
         Some("PNG image")
     );
     assert!(app.preview_prefers_static_image_surface());
@@ -72,7 +72,7 @@ fn immediate_selection_changes_do_not_delay_static_image_activation() {
 #[test]
 fn static_image_surface_remains_available_without_pdf_tooling() {
     let (mut app, root) = build_selected_static_image_app("image-no-pdf-tools", "demo.png");
-    app.pdf_preview.pdf_tools_available = false;
+    app.preview.pdf.pdf_tools_available = false;
     app.refresh_preview();
 
     assert!(app.preview_prefers_static_image_surface());
@@ -99,7 +99,7 @@ fn refresh_preview_preloads_current_and_visible_nearby_static_images() {
     let expected = app
         .visible_entry_indices()
         .into_iter()
-        .filter_map(|index| app.entries.get(index))
+        .filter_map(|index| app.navigation.entries.get(index))
         .filter(|entry| crate::app::overlays::images::static_image_detail_label(entry).is_some())
         .filter(|entry| {
             crate::file_info::inspect_path_cached(
@@ -126,8 +126,8 @@ fn refresh_preview_preloads_current_and_visible_nearby_static_images() {
 
     for key in expected {
         assert!(
-            app.image_preview.pending_prepares.contains(&key)
-                || app.image_preview.dimensions.contains_key(&key),
+            app.preview.image.pending_prepares.contains(&key)
+                || app.preview.image.dimensions.contains_key(&key),
             "expected image preload for {:?}",
             key
         );

--- a/src/app/overlays/pdf/tests/static_images/preparation.rs
+++ b/src/app/overlays/pdf/tests/static_images/preparation.rs
@@ -6,7 +6,7 @@ fn current_small_jpeg_queues_background_prepare_for_overlay() {
     fs::create_dir_all(&root).expect("failed to create temp root");
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
+    app.preview.pdf.pdf_tools_available = true;
 
     let path = root.join("photo.jpg");
     write_test_raster_image(&path, ImageFormat::Jpeg, 600, 300);
@@ -21,7 +21,7 @@ fn current_small_jpeg_queues_background_prepare_for_overlay() {
         crate::app::overlays::images::StaticImageOverlayPreparation::Pending => {}
         _ => panic!("small jpeg should prepare in the background"),
     }
-    assert!(app.image_preview.pending_prepares.contains(&key));
+    assert!(app.preview.image.pending_prepares.contains(&key));
     assert_eq!(app.preview_overlay_placeholder_message(), None);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -37,7 +37,7 @@ fn current_large_jpeg_queues_background_prepare_when_ffmpeg_is_available() {
     fs::create_dir_all(&root).expect("failed to create temp root");
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
+    app.preview.pdf.pdf_tools_available = true;
 
     let path = root.join("photo.jpg");
     write_test_raster_image(&path, ImageFormat::Jpeg, 3200, 1800);
@@ -52,7 +52,7 @@ fn current_large_jpeg_queues_background_prepare_when_ffmpeg_is_available() {
         crate::app::overlays::images::StaticImageOverlayPreparation::Pending => {}
         _ => panic!("large jpeg should prepare in the background when ffmpeg is available"),
     }
-    assert!(app.image_preview.pending_prepares.contains(&key));
+    assert!(app.preview.image.pending_prepares.contains(&key));
     assert_eq!(app.preview_overlay_placeholder_message(), None);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/app/overlays/pdf/tests/static_images/protocols.rs
+++ b/src/app/overlays/pdf/tests/static_images/protocols.rs
@@ -6,7 +6,7 @@ fn current_extensionless_png_uses_direct_kitty_source_overlay() {
     fs::create_dir_all(&root).expect("failed to create temp root");
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.pdf_preview.pdf_tools_available = true;
+    app.preview.pdf.pdf_tools_available = true;
 
     let path = root.join("background");
     write_test_raster_image(&path, ImageFormat::Png, 600, 300);
@@ -30,7 +30,7 @@ fn current_extensionless_png_uses_direct_kitty_source_overlay() {
         }
         _ => panic!("extensionless png should render directly in kitty"),
     }
-    assert!(!app.image_preview.pending_prepares.contains(&key));
+    assert!(!app.preview.image.pending_prepares.contains(&key));
     assert!(app.pending_image_preview_timer().is_none());
     assert_eq!(app.preview_overlay_placeholder_message(), None);
 
@@ -42,14 +42,14 @@ fn prepared_full_pane_image_uses_full_pane_kitty_placement() {
     let root = temp_root("image-placement-from-rendered-png");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let mut app = App::new_at(root.clone()).expect("app should initialize");
-    app.terminal_images.protocol = ImageProtocol::KittyGraphics;
-    app.terminal_images.window = Some(TerminalWindowSize {
+    app.preview.terminal_images.protocol = ImageProtocol::KittyGraphics;
+    app.preview.terminal_images.window = Some(TerminalWindowSize {
         cells_width: 100,
         cells_height: 50,
         pixels_width: 1000,
         pixels_height: 1000,
     });
-    app.pdf_preview.pdf_tools_available = true;
+    app.preview.pdf.pdf_tools_available = true;
 
     let path = root.join("photo.jpg");
     write_test_raster_image(&path, ImageFormat::Jpeg, 1600, 900);
@@ -83,7 +83,7 @@ fn prepared_full_pane_image_uses_full_pane_kitty_placement() {
     });
 
     assert!(dirty);
-    app.image_preview.selection_activation_delay = Duration::ZERO;
+    app.preview.image.selection_activation_delay = Duration::ZERO;
     app.sync_image_preview_selection_activation();
 
     let output = String::from_utf8(

--- a/src/app/overlays/preview_visual.rs
+++ b/src/app/overlays/preview_visual.rs
@@ -13,7 +13,7 @@ const PREVIEW_INLINE_PAGE_MIN_TEXT_HEIGHT: u16 = 6;
 impl App {
     pub(crate) fn preview_visual_rows(&self, area: Rect) -> Option<u16> {
         if !self.terminal_image_overlay_available()
-            || self.preview_state.content.preview_visual.is_none()
+            || self.preview.state.content.preview_visual.is_none()
         {
             return None;
         }
@@ -42,7 +42,7 @@ impl App {
             return None;
         }
 
-        let rows = if self.preview_state.content.kind == preview::PreviewKind::Video {
+        let rows = if self.preview.state.content.kind == preview::PreviewKind::Video {
             (area.height / 2)
                 .clamp(
                     PREVIEW_INLINE_COVER_MIN_HEIGHT,
@@ -86,7 +86,8 @@ impl App {
     }
 
     fn current_preview_visual_kind(&self) -> Option<preview::PreviewVisualKind> {
-        self.preview_state
+        self.preview
+            .state
             .content
             .preview_visual
             .as_ref()
@@ -94,7 +95,8 @@ impl App {
     }
 
     fn current_preview_visual_layout(&self) -> Option<preview::PreviewVisualLayout> {
-        self.preview_state
+        self.preview
+            .state
             .content
             .preview_visual
             .as_ref()
@@ -111,7 +113,8 @@ impl App {
             Some(request) => request,
             None => return false,
         };
-        self.image_preview
+        self.preview
+            .image
             .failed_images
             .contains(&images::StaticImageKey::from_request(&request))
     }
@@ -120,9 +123,9 @@ impl App {
         &self,
         area: Rect,
     ) -> Option<images::StaticImageOverlayRequest> {
-        let visual = self.preview_state.content.preview_visual.as_ref()?;
+        let visual = self.preview.state.content.preview_visual.as_ref()?;
         Some(self.preview_visual_overlay_request_for_visual(
-            self.preview_state.content.kind,
+            self.preview.state.content.kind,
             visual,
             area,
         ))
@@ -143,7 +146,8 @@ impl App {
             target_height_px: images::image_target_height_px(area, self.cached_terminal_window()),
             mode: images::StaticImageOverlayMode::Inline,
             force_render_to_cache: self.preview_visual_force_render_to_cache(visual),
-            prepare_inline_payload: self.terminal_images.protocol == ImageProtocol::ItermInline,
+            prepare_inline_payload: self.preview.terminal_images.protocol
+                == ImageProtocol::ItermInline,
         }
     }
 
@@ -157,11 +161,11 @@ impl App {
                     .split(body_area)[0],
             );
         }
-        self.frame_state.preview_media_area
+        self.input.frame_state.preview_media_area
     }
 
     fn current_preview_body_render_area(&self) -> Option<Rect> {
-        let body_area = self.frame_state.preview_body_area?;
+        let body_area = self.input.frame_state.preview_body_area?;
         Some(if body_area.width >= 6 {
             Layout::default()
                 .direction(Direction::Horizontal)

--- a/src/app/overlays/preview_visual/tests/cache.rs
+++ b/src/app/overlays/preview_visual/tests/cache.rs
@@ -14,7 +14,7 @@ fn page_image_overlay_request_uses_asset_metadata_without_forcing_render_cache()
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries = vec![Entry {
+    app.navigation.entries = vec![Entry {
         path: root.join("book.cbz"),
         name: "book.cbz".to_string(),
         name_key: "book.cbz".to_string(),
@@ -23,14 +23,14 @@ fn page_image_overlay_request_uses_asset_metadata_without_forcing_render_cache()
         modified: None,
         readonly: false,
     }];
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Archive, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Archive, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::Inline,
@@ -61,15 +61,15 @@ fn oversized_page_overlay_request_forces_rendered_cache() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -157,15 +157,15 @@ fn current_comic_prepare_build_marks_preview_dirty() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -179,13 +179,15 @@ fn current_comic_prepare_build_marks_preview_dirty() {
         size: metadata.len(),
         modified: None,
         target_width_px: image_target_width_px(
-            app.frame_state
+            app.input
+                .frame_state
                 .preview_media_area
                 .expect("preview media area should exist"),
             app.cached_terminal_window(),
         ),
         target_height_px: image_target_height_px(
-            app.frame_state
+            app.input
+                .frame_state
                 .preview_media_area
                 .expect("preview media area should exist"),
             app.cached_terminal_window(),

--- a/src/app/overlays/preview_visual/tests/comic.rs
+++ b/src/app/overlays/preview_visual/tests/comic.rs
@@ -28,15 +28,15 @@ fn comic_jpeg_page_prepares_in_background_before_display() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -50,14 +50,14 @@ fn comic_jpeg_page_prepares_in_background_before_display() {
     let key = StaticImageKey::from_request(&request);
 
     app.refresh_static_image_preloads();
-    assert!(app.image_preview.pending_prepares.contains(&key));
+    assert!(app.preview.image.pending_prepares.contains(&key));
     app.present_preview_overlay()
         .expect("presenting a comic jpeg overlay should not fail");
     assert!(!app.static_image_overlay_displayed());
     wait_for_displayed_preview_overlay(&mut app);
 
     assert!(app.static_image_overlay_displayed());
-    assert!(app.image_preview.dimensions.contains_key(&key));
+    assert!(app.preview.image.dimensions.contains_key(&key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -77,15 +77,15 @@ fn comic_overlay_keeps_previous_page_visible_while_next_page_waits() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -98,7 +98,7 @@ fn comic_overlay_keeps_previous_page_visible_while_next_page_waits() {
     wait_for_displayed_preview_overlay(&mut app);
     assert!(app.static_image_overlay_displayed());
 
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -111,13 +111,13 @@ fn comic_overlay_keeps_previous_page_visible_while_next_page_waits() {
         .expect("next comic preview request should be available");
     let next_key = StaticImageKey::from_request(&next_request);
     app.refresh_static_image_preloads();
-    app.last_selection_change_at = Instant::now() - std::time::Duration::from_secs(1);
+    app.input.last_selection_change_at = Instant::now() - std::time::Duration::from_secs(1);
     app.sync_image_preview_selection_activation();
 
     app.present_preview_overlay()
         .expect("pending comic page transition should not fail");
     assert!(app.static_image_overlay_displayed());
-    assert!(app.image_preview.pending_prepares.contains(&next_key));
+    assert!(app.preview.image.pending_prepares.contains(&next_key));
     assert!(!app.displayed_static_image_matches_active());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -142,15 +142,15 @@ fn comic_overlay_clears_previous_file_page_while_next_comic_preview_loads() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_navigation_position("Page", 0, 2, None)
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
@@ -163,7 +163,7 @@ fn comic_overlay_clears_previous_file_page_while_next_comic_preview_loads() {
     wait_for_displayed_preview_overlay(&mut app);
     assert!(app.static_image_overlay_displayed());
 
-    app.entries = vec![Entry {
+    app.navigation.entries = vec![Entry {
         path: archive.clone(),
         name: "issue.cbz".to_string(),
         name_key: "issue.cbz".to_string(),
@@ -172,11 +172,11 @@ fn comic_overlay_clears_previous_file_page_while_next_comic_preview_loads() {
         modified: archive_metadata.modified().ok(),
         readonly: false,
     }];
-    app.selected = 0;
+    app.navigation.selected = 0;
     app.sync_comic_preview_selection();
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_navigation_position("Page", 1, 2, None);
-    app.preview_state.load_state = Some(PreviewLoadState::Placeholder(archive));
+    app.preview.state.load_state = Some(PreviewLoadState::Placeholder(archive));
     app.present_preview_overlay()
         .expect("presenting the overlay during cross-file loading should not fail");
 
@@ -219,10 +219,10 @@ fn epub_overlay_clears_previous_file_page_while_next_epub_preview_loads() {
     // Advance the preview token so any preview job submitted by App::new_at
     // for the initial directory scan becomes stale and cannot overwrite the
     // manually-set preview content below.
-    app.preview_state.token = app.preview_state.token.wrapping_add(1);
+    app.preview.state.token = app.preview.state.token.wrapping_add(1);
 
     // Select epub_a and display its page image.
-    app.entries = vec![crate::app::Entry {
+    app.navigation.entries = vec![crate::app::Entry {
         path: epub_a.clone(),
         name: "book_a.epub".to_string(),
         name_key: "book_a.epub".to_string(),
@@ -231,15 +231,15 @@ fn epub_overlay_clears_previous_file_page_while_next_epub_preview_loads() {
         modified: epub_a_meta.modified().ok(),
         readonly: false,
     }];
-    app.selected = 0;
+    app.navigation.selected = 0;
     app.sync_epub_preview_selection();
-    app.frame_state.preview_media_area = Some(Rect {
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -253,7 +253,7 @@ fn epub_overlay_clears_previous_file_page_while_next_epub_preview_loads() {
 
     // Navigate to epub_b: update the entry, sync the EPUB session, and put the
     // preview into the loading (Placeholder) state with no visual yet.
-    app.entries = vec![crate::app::Entry {
+    app.navigation.entries = vec![crate::app::Entry {
         path: epub_b.clone(),
         name: "book_b.epub".to_string(),
         name_key: "book_b.epub".to_string(),
@@ -262,11 +262,11 @@ fn epub_overlay_clears_previous_file_page_while_next_epub_preview_loads() {
         modified: epub_b_meta.modified().ok(),
         readonly: false,
     }];
-    app.selected = 0;
+    app.navigation.selected = 0;
     app.sync_epub_preview_selection();
-    app.preview_state.content =
+    app.preview.state.content =
         PreviewContent::new(PreviewKind::Document, Vec::new()).with_detail("EPUB ebook");
-    app.preview_state.load_state = Some(crate::app::state::PreviewLoadState::Placeholder(epub_b));
+    app.preview.state.load_state = Some(crate::app::state::PreviewLoadState::Placeholder(epub_b));
 
     app.present_preview_overlay()
         .expect("presenting overlay during cross-EPUB loading should not fail");

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -3,8 +3,8 @@ use ratatui::text::Line;
 
 fn configure_iterm_image_support(app: &mut App) {
     let (cells_width, cells_height) = crossterm::terminal::size().unwrap_or((120, 40));
-    app.terminal_images.protocol = ImageProtocol::ItermInline;
-    app.terminal_images.window = Some(TerminalWindowSize {
+    app.preview.terminal_images.protocol = ImageProtocol::ItermInline;
+    app.preview.terminal_images.window = Some(TerminalWindowSize {
         cells_width,
         cells_height,
         pixels_width: 1920,
@@ -19,7 +19,7 @@ fn page_image_visual_uses_full_preview_height() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.preview_state.content = PreviewContent::new(PreviewKind::Archive, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Archive, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -48,7 +48,7 @@ fn failed_full_height_page_image_falls_back_to_text_layout() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -73,7 +73,8 @@ fn failed_full_height_page_image_falls_back_to_text_layout() {
         force_render_to_cache: false,
         prepare_inline_payload: false,
     };
-    app.image_preview
+    app.preview
+        .image
         .failed_images
         .insert(StaticImageKey::from_request(&request));
 
@@ -90,7 +91,7 @@ fn inline_page_image_leaves_room_for_summary_text() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::Inline,
@@ -120,7 +121,7 @@ fn inline_cover_uses_more_of_the_preview_panel_height() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.preview_state.content = PreviewContent::new(PreviewKind::Video, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Video, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::Cover,
             layout: PreviewVisualLayout::Inline,
@@ -149,7 +150,7 @@ fn non_video_inline_cover_keeps_default_compact_height() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::Cover,
             layout: PreviewVisualLayout::Inline,
@@ -184,15 +185,15 @@ fn document_page_image_prepares_in_background_before_display() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -206,14 +207,14 @@ fn document_page_image_prepares_in_background_before_display() {
     let key = StaticImageKey::from_request(&request);
 
     app.refresh_static_image_preloads();
-    assert!(app.image_preview.pending_prepares.contains(&key));
+    assert!(app.preview.image.pending_prepares.contains(&key));
     app.present_preview_overlay()
         .expect("presenting a document page overlay should not fail");
     assert!(!app.static_image_overlay_displayed());
     wait_for_displayed_preview_overlay(&mut app);
 
     assert!(app.static_image_overlay_displayed());
-    assert!(app.image_preview.dimensions.contains_key(&key));
+    assert!(app.preview.image.dimensions.contains_key(&key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -230,27 +231,27 @@ fn iterm_inline_page_image_clear_area_covers_preview_body_without_header() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_iterm_image_support(&mut app);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_panel = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_panel = Some(Rect {
         x: 1,
         y: 1,
         width: 50,
         height: 24,
     });
-    app.frame_state.preview_media_area = Some(Rect {
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 12,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 15,
         width: 48,
         height: 8,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::Inline,
@@ -290,15 +291,15 @@ fn document_overlay_keeps_previous_page_visible_while_next_page_waits() {
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
     app.set_ffmpeg_available_for_tests(true);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -311,7 +312,7 @@ fn document_overlay_keeps_previous_page_visible_while_next_page_waits() {
     wait_for_displayed_preview_overlay(&mut app);
     assert!(app.static_image_overlay_displayed());
 
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -324,13 +325,13 @@ fn document_overlay_keeps_previous_page_visible_while_next_page_waits() {
         .expect("next document preview request should be available");
     let next_key = StaticImageKey::from_request(&next_request);
     app.refresh_static_image_preloads();
-    app.last_selection_change_at = Instant::now() - std::time::Duration::from_secs(1);
+    app.input.last_selection_change_at = Instant::now() - std::time::Duration::from_secs(1);
     app.sync_image_preview_selection_activation();
 
     app.present_preview_overlay()
         .expect("pending document page transition should not fail");
     assert!(app.static_image_overlay_displayed());
-    assert!(app.image_preview.pending_prepares.contains(&next_key));
+    assert!(app.preview.image.pending_prepares.contains(&next_key));
     assert!(!app.displayed_static_image_matches_active());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -348,27 +349,27 @@ fn iterm_popup_keeps_the_displayed_image_visible() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_iterm_image_support(&mut app);
-    app.entries.clear();
-    app.selected = 0;
-    app.frame_state.preview_panel = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_panel = Some(Rect {
         x: 1,
         y: 1,
         width: 50,
         height: 24,
     });
-    app.frame_state.preview_media_area = Some(Rect {
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 12,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 15,
         width: 48,
         height: 8,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::Inline,
@@ -381,7 +382,7 @@ fn iterm_popup_keeps_the_displayed_image_visible() {
     wait_for_displayed_preview_overlay(&mut app);
     assert!(app.static_image_overlay_displayed());
 
-    app.help_open = true;
+    app.overlays.help = true;
     assert!(app.iterm_pre_draw_erase().is_empty());
     let out = app
         .present_preview_overlay()
@@ -391,7 +392,7 @@ fn iterm_popup_keeps_the_displayed_image_visible() {
     assert!(app.static_image_overlay_displayed());
     assert!(app.iterm_pre_draw_erase().is_empty());
 
-    app.help_open = false;
+    app.overlays.help = false;
     let restore = String::from_utf8(
         app.present_preview_overlay()
             .expect("closing the popup should redraw the image"),
@@ -421,22 +422,22 @@ fn iterm_pre_draw_erase_detects_cover_layout_change_before_frame_update() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_iterm_image_support(&mut app);
-    app.entries.clear();
-    app.selected = 0;
-    app.image_preview.selection_activation_delay = Duration::ZERO;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.entries.clear();
+    app.navigation.selected = 0;
+    app.preview.image.selection_activation_delay = Duration::ZERO;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.frame_state.preview_content_area = Some(Rect {
+    app.input.frame_state.preview_content_area = Some(Rect {
         x: 2,
         y: 23,
         width: 48,
         height: 0,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
             layout: PreviewVisualLayout::FullHeight,
@@ -453,13 +454,13 @@ fn iterm_pre_draw_erase_detects_cover_layout_change_before_frame_update() {
     wait_for_displayed_preview_overlay(&mut app);
     assert!(app.static_image_overlay_displayed());
 
-    app.frame_state.preview_panel = Some(Rect {
+    app.input.frame_state.preview_panel = Some(Rect {
         x: 1,
         y: 1,
         width: 50,
         height: 24,
     });
-    app.frame_state.preview_body_area = Some(Rect {
+    app.input.frame_state.preview_body_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
@@ -468,7 +469,7 @@ fn iterm_pre_draw_erase_detects_cover_layout_change_before_frame_update() {
 
     // Simulate the next EPUB section switching to an inline cover + text
     // layout before the frame state has been recomputed by ratatui.
-    app.preview_state.content = PreviewContent::new(
+    app.preview.state.content = PreviewContent::new(
         PreviewKind::Document,
         vec![Line::from("Chapter text starts here.")],
     )

--- a/src/app/overlays/preview_visual/tests/mod.rs
+++ b/src/app/overlays/preview_visual/tests/mod.rs
@@ -31,8 +31,8 @@ fn temp_root(label: &str) -> PathBuf {
 
 fn configure_terminal_image_support(app: &mut App) {
     let (cells_width, cells_height) = crossterm::terminal::size().unwrap_or((120, 40));
-    app.terminal_images.protocol = ImageProtocol::KittyGraphics;
-    app.terminal_images.window = Some(TerminalWindowSize {
+    app.preview.terminal_images.protocol = ImageProtocol::KittyGraphics;
+    app.preview.terminal_images.window = Some(TerminalWindowSize {
         cells_width,
         cells_height,
         pixels_width: 1920,

--- a/src/app/overlays/preview_visual/tests/preload.rs
+++ b/src/app/overlays/preview_visual/tests/preload.rs
@@ -59,7 +59,7 @@ fn cached_adjacent_comic_page_queues_background_image_prepare() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.entries = vec![Entry {
+    app.navigation.entries = vec![Entry {
         path: archive.clone(),
         name: "issue.cbz".to_string(),
         name_key: "issue.cbz".to_string(),
@@ -68,15 +68,15 @@ fn cached_adjacent_comic_page_queues_background_image_prepare() {
         modified: archive_metadata.modified().ok(),
         readonly: false,
     }];
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
     app.sync_comic_preview_selection();
-    app.preview_state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
         .with_navigation_position("Page", 0, 2, None)
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
@@ -111,7 +111,8 @@ fn cached_adjacent_comic_page_queues_background_image_prepare() {
             .preview_visual
             .as_ref()
             .expect("adjacent preview should have a visual"),
-        app.frame_state
+        app.input
+            .frame_state
             .preview_media_area
             .expect("preview media area should exist"),
     );
@@ -119,7 +120,7 @@ fn cached_adjacent_comic_page_queues_background_image_prepare() {
 
     app.refresh_static_image_preloads();
 
-    assert!(app.image_preview.pending_prepares.contains(&adjacent_key));
+    assert!(app.preview.image.pending_prepares.contains(&adjacent_key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -139,7 +140,7 @@ fn cached_adjacent_epub_section_queues_background_image_prepare() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.entries = vec![Entry {
+    app.navigation.entries = vec![Entry {
         path: epub.clone(),
         name: "story.epub".to_string(),
         name_key: "story.epub".to_string(),
@@ -148,15 +149,15 @@ fn cached_adjacent_epub_section_queues_background_image_prepare() {
         modified: epub_metadata.modified().ok(),
         readonly: false,
     }];
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
     app.sync_epub_preview_selection();
-    app.preview_state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
         .with_ebook_section(0, 2, Some("Page 1".to_string()))
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::PageImage,
@@ -191,7 +192,8 @@ fn cached_adjacent_epub_section_queues_background_image_prepare() {
             .preview_visual
             .as_ref()
             .expect("adjacent preview should have a visual"),
-        app.frame_state
+        app.input
+            .frame_state
             .preview_media_area
             .expect("preview media area should exist"),
     );
@@ -199,7 +201,7 @@ fn cached_adjacent_epub_section_queues_background_image_prepare() {
 
     app.refresh_static_image_preloads();
 
-    assert!(app.image_preview.pending_prepares.contains(&adjacent_key));
+    assert!(app.preview.image.pending_prepares.contains(&adjacent_key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -222,8 +224,8 @@ fn cached_adjacent_audio_cover_queues_background_image_prepare() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.terminal_images.protocol = ImageProtocol::ItermInline;
-    app.entries = vec![
+    app.preview.terminal_images.protocol = ImageProtocol::ItermInline;
+    app.navigation.entries = vec![
         Entry {
             path: first.clone(),
             name: "001.mp3".to_string(),
@@ -243,14 +245,14 @@ fn cached_adjacent_audio_cover_queues_background_image_prepare() {
             readonly: false,
         },
     ];
-    app.selected = 0;
-    app.frame_state.preview_media_area = Some(Rect {
+    app.navigation.selected = 0;
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
         height: 20,
     });
-    app.preview_state.content = PreviewContent::new(PreviewKind::Audio, Vec::new())
+    app.preview.state.content = PreviewContent::new(PreviewKind::Audio, Vec::new())
         .with_detail("MP3 audio")
         .with_preview_visual(PreviewVisual {
             kind: PreviewVisualKind::Cover,
@@ -269,7 +271,7 @@ fn cached_adjacent_audio_cover_queues_background_image_prepare() {
             size: next_cover_metadata.len(),
             modified: next_cover_metadata.modified().ok(),
         });
-    let adjacent_entry = app.entries[1].clone();
+    let adjacent_entry = app.navigation.entries[1].clone();
     app.cache_preview_result(
         &adjacent_entry,
         &preview::PreviewRequestOptions::Default,
@@ -281,7 +283,8 @@ fn cached_adjacent_audio_cover_queues_background_image_prepare() {
             .preview_visual
             .as_ref()
             .expect("adjacent preview should have a visual"),
-        app.frame_state
+        app.input
+            .frame_state
             .preview_media_area
             .expect("preview media area should exist"),
     );
@@ -289,7 +292,7 @@ fn cached_adjacent_audio_cover_queues_background_image_prepare() {
 
     app.refresh_static_image_preloads();
 
-    assert!(app.image_preview.pending_prepares.contains(&adjacent_key));
+    assert!(app.preview.image.pending_prepares.contains(&adjacent_key));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
@@ -305,7 +308,7 @@ fn stale_adjacent_comic_preview_result_immediately_queues_image_prepare() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.frame_state.preview_media_area = Some(Rect {
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
@@ -335,8 +338,8 @@ fn stale_adjacent_comic_preview_result_immediately_queues_image_prepare() {
 
     let adjacent_key = adjacent_key.expect("adjacent comic preview should be cached");
     assert!(
-        app.image_preview.pending_prepares.contains(&adjacent_key)
-            || app.image_preview.dimensions.contains_key(&adjacent_key)
+        app.preview.image.pending_prepares.contains(&adjacent_key)
+            || app.preview.image.dimensions.contains_key(&adjacent_key)
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -355,7 +358,7 @@ fn cached_adjacent_comic_entry_preview_immediately_queues_image_prepare() {
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     configure_terminal_image_support(&mut app);
-    app.frame_state.preview_media_area = Some(Rect {
+    app.input.frame_state.preview_media_area = Some(Rect {
         x: 2,
         y: 3,
         width: 48,
@@ -386,8 +389,8 @@ fn cached_adjacent_comic_entry_preview_immediately_queues_image_prepare() {
 
     let adjacent_key = adjacent_key.expect("adjacent comic entry preview should be cached");
     assert!(
-        app.image_preview.pending_prepares.contains(&adjacent_key)
-            || app.image_preview.dimensions.contains_key(&adjacent_key)
+        app.preview.image.pending_prepares.contains(&adjacent_key)
+            || app.preview.image.dimensions.contains_key(&adjacent_key)
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/app/search/index.rs
+++ b/src/app/search/index.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 impl App {
     pub(in crate::app) fn refresh_search_matches(&mut self, _previous_query: &str) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         search.query_cursor = search.query_cursor.min(search.query.chars().count());
@@ -41,18 +41,18 @@ impl App {
     }
 
     pub(crate) fn prewarm_search_index(&mut self, scope: SearchScope) {
-        self.search_token = self.search_token.wrapping_add(1);
-        self.search_loading = true;
-        self.search_cache = None;
+        self.jobs.search_token = self.jobs.search_token.wrapping_add(1);
+        self.jobs.search_loading = true;
+        self.jobs.search_cache = None;
         let request = SearchRequest {
-            token: self.search_token,
-            cwd: self.cwd.clone(),
+            token: self.jobs.search_token,
+            cwd: self.navigation.cwd.clone(),
             scope,
             show_hidden: self.effective_show_hidden(),
         };
-        if !self.scheduler.submit_search(request) {
-            self.search_loading = false;
-            if let Some(search) = &mut self.search
+        if !self.jobs.scheduler.submit_search(request) {
+            self.jobs.search_loading = false;
+            if let Some(search) = &mut self.overlays.search
                 && search.scope == scope
             {
                 search.loading = false;

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -5,46 +5,53 @@ use std::{collections::HashMap, ffi::OsStr, path::PathBuf, sync::Arc};
 
 impl App {
     pub fn search_is_open(&self) -> bool {
-        self.search.is_some()
+        self.overlays.search.is_some()
     }
 
     pub fn search_query(&self) -> &str {
-        self.search
+        self.overlays
+            .search
             .as_ref()
             .map(|search| search.query.as_str())
             .unwrap_or("")
     }
 
     pub fn search_match_count(&self) -> usize {
-        self.search
+        self.overlays
+            .search
             .as_ref()
             .map(|search| search.matches.len())
             .unwrap_or(0)
     }
 
     pub fn search_candidate_count(&self) -> usize {
-        self.search
+        self.overlays
+            .search
             .as_ref()
             .and_then(|search| search.cached_matches.get("").map(Vec::len))
             .unwrap_or(0)
     }
 
     pub fn search_scope(&self) -> Option<SearchScope> {
-        self.search.as_ref().map(|search| search.scope)
+        self.overlays.search.as_ref().map(|search| search.scope)
     }
 
     pub fn search_is_loading(&self) -> bool {
-        self.search.as_ref().is_some_and(|search| search.loading)
+        self.overlays
+            .search
+            .as_ref()
+            .is_some_and(|search| search.loading)
     }
 
     pub fn search_error(&self) -> Option<&str> {
-        self.search
+        self.overlays
+            .search
             .as_ref()
             .and_then(|search| search.error.as_deref())
     }
 
     pub fn search_rows(&self, max_rows: usize) -> Vec<SearchRow> {
-        let Some(search) = &self.search else {
+        let Some(search) = &self.overlays.search else {
             return Vec::new();
         };
 
@@ -66,14 +73,15 @@ impl App {
 
     pub(in crate::app) fn open_fuzzy_finder(&mut self, scope: SearchScope) -> Result<()> {
         self.clear_wheel_scroll();
-        self.help_open = false;
+        self.overlays.help = false;
         let cached = self
+            .jobs
             .search_cache
             .as_ref()
             .filter(|cache| {
-                cache.cwd == self.cwd
+                cache.cwd == self.navigation.cwd
                     && cache.scope == scope
-                    && cache.show_hidden == self.show_hidden
+                    && cache.show_hidden == self.navigation.show_hidden
             })
             .map(|cache| cache.candidates.clone());
         let candidates = cached.clone().unwrap_or_else(|| Arc::new(Vec::new()));
@@ -87,7 +95,7 @@ impl App {
         if cached.is_none() {
             self.prewarm_search_index(scope);
         }
-        self.search = Some(SearchOverlay {
+        self.overlays.search = Some(SearchOverlay {
             scope,
             query: String::new(),
             query_cursor: 0,
@@ -105,7 +113,7 @@ impl App {
 
     pub(in crate::app) fn handle_search_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.search = None;
+            self.overlays.search = None;
             self.clear_wheel_scroll();
             self.status.clear();
             return Ok(());
@@ -113,7 +121,7 @@ impl App {
 
         match key.code {
             KeyCode::Esc => {
-                self.search = None;
+                self.overlays.search = None;
                 self.clear_wheel_scroll();
                 self.status.clear();
             }
@@ -134,44 +142,48 @@ impl App {
             KeyCode::End => self.move_search_cursor_to_end(),
             _ if search_key_deletes_previous_word(key) => {
                 let previous_query = self
+                    .overlays
                     .search
                     .as_ref()
                     .map(|search| search.query.clone())
                     .unwrap_or_default();
-                if let Some(search) = &mut self.search {
+                if let Some(search) = &mut self.overlays.search {
                     remove_word_before_cursor(&mut search.query, &mut search.query_cursor);
                 }
                 self.refresh_search_matches(&previous_query);
             }
             KeyCode::Backspace => {
                 let previous_query = self
+                    .overlays
                     .search
                     .as_ref()
                     .map(|search| search.query.clone())
                     .unwrap_or_default();
-                if let Some(search) = &mut self.search {
+                if let Some(search) = &mut self.overlays.search {
                     remove_char_before_cursor(&mut search.query, &mut search.query_cursor);
                 }
                 self.refresh_search_matches(&previous_query);
             }
             _ if search_key_deletes_next_word(key) => {
                 let previous_query = self
+                    .overlays
                     .search
                     .as_ref()
                     .map(|search| search.query.clone())
                     .unwrap_or_default();
-                if let Some(search) = &mut self.search {
+                if let Some(search) = &mut self.overlays.search {
                     remove_word_at_cursor(&mut search.query, search.query_cursor);
                 }
                 self.refresh_search_matches(&previous_query);
             }
             KeyCode::Delete => {
                 let previous_query = self
+                    .overlays
                     .search
                     .as_ref()
                     .map(|search| search.query.clone())
                     .unwrap_or_default();
-                if let Some(search) = &mut self.search {
+                if let Some(search) = &mut self.overlays.search {
                     remove_char_at_cursor(&mut search.query, search.query_cursor);
                 }
                 self.refresh_search_matches(&previous_query);
@@ -182,11 +194,12 @@ impl App {
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
             {
                 let previous_query = self
+                    .overlays
                     .search
                     .as_ref()
                     .map(|search| search.query.clone())
                     .unwrap_or_default();
-                if let Some(search) = &mut self.search {
+                if let Some(search) = &mut self.overlays.search {
                     insert_char_at_cursor(&mut search.query, &mut search.query_cursor, ch);
                 }
                 self.refresh_search_matches(&previous_query);
@@ -200,6 +213,7 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 if let Some(hit) = self
+                    .input
                     .frame_state
                     .search_hits
                     .iter()
@@ -209,11 +223,12 @@ impl App {
                     self.select_search_index(hit.index);
                     self.confirm_search_selection()?;
                 } else if self
+                    .input
                     .frame_state
                     .search_panel
                     .is_none_or(|rect| !rect_contains(rect, mouse.column, mouse.row))
                 {
-                    self.search = None;
+                    self.overlays.search = None;
                     self.clear_wheel_scroll();
                     self.status.clear();
                 }
@@ -226,7 +241,7 @@ impl App {
     }
 
     pub(in crate::app) fn move_search_selection(&mut self, delta: isize) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         if search.matches.is_empty() {
@@ -241,14 +256,15 @@ impl App {
     }
 
     pub fn search_query_cursor(&self) -> usize {
-        self.search
+        self.overlays
+            .search
             .as_ref()
             .map(|search| search.query_cursor.min(search.query.chars().count()))
             .unwrap_or(0)
     }
 
     fn move_search_cursor(&mut self, delta: isize) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         let max = search.query.chars().count() as isize;
@@ -256,40 +272,40 @@ impl App {
     }
 
     fn move_search_cursor_to_previous_word(&mut self) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         search.query_cursor = previous_word_start(&search.query, search.query_cursor);
     }
 
     fn move_search_cursor_to_next_word(&mut self) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         search.query_cursor = next_word_start(&search.query, search.query_cursor);
     }
 
     fn move_search_cursor_to(&mut self, index: usize) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         search.query_cursor = index.min(search.query.chars().count());
     }
 
     fn move_search_cursor_to_end(&mut self) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         search.query_cursor = search.query.chars().count();
     }
 
     fn page_search(&mut self, direction: isize) {
-        let visible = self.frame_state.search_rows_visible.max(1) as isize;
+        let visible = self.input.frame_state.search_rows_visible.max(1) as isize;
         self.move_search_selection(direction * visible);
     }
 
     fn select_search_index(&mut self, index: usize) {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return;
         };
         if search.matches.is_empty() {
@@ -302,7 +318,7 @@ impl App {
     }
 
     pub(in crate::app::search) fn confirm_search_selection(&mut self) -> Result<()> {
-        let Some(path) = self.search.as_ref().and_then(|search| {
+        let Some(path) = self.overlays.search.as_ref().and_then(|search| {
             search
                 .matches
                 .get(search.selected)
@@ -314,12 +330,12 @@ impl App {
         };
 
         self.reveal_path(path)?;
-        self.search = None;
+        self.overlays.search = None;
         Ok(())
     }
 
     pub(in crate::app) fn sync_search_scroll(&mut self) -> bool {
-        let Some(search) = &mut self.search else {
+        let Some(search) = &mut self.overlays.search else {
             return false;
         };
         if search.matches.is_empty() {
@@ -329,7 +345,7 @@ impl App {
         }
 
         let previous = search.scroll;
-        let rows_visible = self.frame_state.search_rows_visible.max(1);
+        let rows_visible = self.input.frame_state.search_rows_visible.max(1);
         if search.selected < search.scroll {
             search.scroll = search.selected;
         } else if search.selected >= search.scroll + rows_visible {

--- a/src/app/search/tests.rs
+++ b/src/app/search/tests.rs
@@ -24,14 +24,14 @@ fn opening_search_restarts_index_when_cache_missing_even_if_loading() {
     fs::create_dir_all(root.join(".hidden-root/needle")).expect("failed to create temp tree");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.search_loading = true;
-    let previous_token = app.search_token;
+    app.jobs.search_loading = true;
+    let previous_token = app.jobs.search_token;
 
     app.open_fuzzy_finder(SearchScope::Folders)
         .expect("failed to open search");
 
-    assert!(app.search_loading);
-    assert!(app.search_token > previous_token);
+    assert!(app.jobs.search_loading);
+    assert!(app.jobs.search_token > previous_token);
 
     fs::remove_dir_all(root).expect("failed to remove temp tree");
 }
@@ -42,8 +42,8 @@ fn opening_search_ignores_hidden_cache_when_browser_hides_dotfiles() {
     fs::create_dir_all(root.join(".hidden-root/needle")).expect("failed to create temp tree");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.show_hidden = false;
-    app.search_cache = Some(SearchCache {
+    app.navigation.show_hidden = false;
+    app.jobs.search_cache = Some(SearchCache {
         cwd: root.clone(),
         scope: SearchScope::Folders,
         show_hidden: true,
@@ -93,7 +93,7 @@ fn refining_query_rechecks_full_candidate_set() {
         is_dir: true,
     });
 
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Folders,
         query: "f".to_string(),
         query_cursor: 1,
@@ -107,6 +107,7 @@ fn refining_query_rechecks_full_candidate_set() {
     });
     app.refresh_search_matches("");
     let fastfetch_index = app
+        .overlays
         .search
         .as_ref()
         .and_then(|search| {
@@ -117,19 +118,20 @@ fn refining_query_rechecks_full_candidate_set() {
         })
         .expect("fastfetch candidate should exist");
     assert!(
-        !app.search
+        !app.overlays
+            .search
             .as_ref()
             .expect("search should be open")
             .matches
             .contains(&fastfetch_index)
     );
 
-    if let Some(search) = &mut app.search {
+    if let Some(search) = &mut app.overlays.search {
         search.query = "fastfetch".to_string();
     }
     app.refresh_search_matches("f");
 
-    let search = app.search.as_ref().expect("search should be open");
+    let search = app.overlays.search.as_ref().expect("search should be open");
     assert_eq!(search.matches.first().copied(), Some(fastfetch_index));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -141,7 +143,7 @@ fn search_query_cursor_inserts_and_deletes_in_place() {
     fs::create_dir_all(&root).expect("failed to create temp root");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Folders,
         query: "fatch".to_string(),
         query_cursor: 2,
@@ -175,7 +177,7 @@ fn search_query_ctrl_arrows_move_across_word_boundaries() {
     fs::create_dir_all(&root).expect("failed to create temp root");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Folders,
         query: "foo bar/baz".to_string(),
         query_cursor: "foo bar/baz".chars().count(),
@@ -221,7 +223,7 @@ fn search_query_ctrl_backspace_and_delete_remove_word_units() {
     fs::create_dir_all(&root).expect("failed to create temp root");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Folders,
         query: "foo bar/baz".to_string(),
         query_cursor: 8,
@@ -258,7 +260,7 @@ fn search_query_terminal_fallback_word_delete_bindings_work() {
     fs::create_dir_all(&root).expect("failed to create temp root");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Folders,
         query: "foo bar/baz".to_string(),
         query_cursor: 8,
@@ -281,7 +283,7 @@ fn search_query_terminal_fallback_word_delete_bindings_work() {
     assert_eq!(app.search_query(), "foo baz");
     assert_eq!(app.search_query_cursor(), 4);
 
-    if let Some(search) = &mut app.search {
+    if let Some(search) = &mut app.overlays.search {
         search.query = "foo bar baz".to_string();
         search.query_cursor = 4;
     }
@@ -291,7 +293,7 @@ fn search_query_terminal_fallback_word_delete_bindings_work() {
     assert_eq!(app.search_query(), "foo baz");
     assert_eq!(app.search_query_cursor(), 4);
 
-    if let Some(search) = &mut app.search {
+    if let Some(search) = &mut app.overlays.search {
         search.query = "foo bar".to_string();
         search.query_cursor = 7;
     }
@@ -310,7 +312,7 @@ fn search_rows_ignore_stale_match_indexes() {
     fs::create_dir_all(&root).expect("failed to create temp root");
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Folders,
         query: String::new(),
         query_cursor: 0,
@@ -342,7 +344,7 @@ fn confirm_search_selection_selects_file_already_in_current_directory() {
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(alpha.as_path())
     );
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Files,
         query: "beta".to_string(),
         query_cursor: 4,
@@ -365,8 +367,8 @@ fn confirm_search_selection_selects_file_already_in_current_directory() {
     app.confirm_search_selection()
         .expect("search selection should succeed");
 
-    assert!(app.search.is_none());
-    assert_eq!(app.cwd, root);
+    assert!(app.overlays.search.is_none());
+    assert_eq!(app.navigation.cwd, root);
     assert_eq!(
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(beta.as_path())
@@ -383,7 +385,7 @@ fn confirm_search_selection_keeps_overlay_open_when_reveal_fails() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     let missing = root.join("missing/file.txt");
-    app.search = Some(SearchOverlay {
+    app.overlays.search = Some(SearchOverlay {
         scope: SearchScope::Files,
         query: "missing".to_string(),
         query_cursor: 7,
@@ -404,8 +406,8 @@ fn confirm_search_selection_keeps_overlay_open_when_reveal_fails() {
     });
 
     assert!(app.confirm_search_selection().is_err());
-    assert!(app.search.is_some());
-    assert_eq!(app.cwd, root);
+    assert!(app.overlays.search.is_some());
+    assert_eq!(app.navigation.cwd, root);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -2,11 +2,11 @@ use super::*;
 
 impl App {
     pub fn is_selected(&self, path: &std::path::Path) -> bool {
-        self.selected_paths.contains(path)
+        self.navigation.selected_paths.contains(path)
     }
 
     pub fn selection_count(&self) -> usize {
-        self.selected_paths.len()
+        self.navigation.selected_paths.len()
     }
 
     pub(in crate::app) fn toggle_selection(&mut self) {
@@ -14,19 +14,24 @@ impl App {
             return;
         };
         let path = entry.path.clone();
-        if !self.selected_paths.remove(&path) {
-            self.selected_paths.insert(path);
+        if !self.navigation.selected_paths.remove(&path) {
+            self.navigation.selected_paths.insert(path);
         }
-        if self.view_mode == ViewMode::List {
+        if self.navigation.view_mode == ViewMode::List {
             self.move_vertical(1);
         }
     }
 
     pub(in crate::app) fn select_all(&mut self) {
-        self.selected_paths = self.entries.iter().map(|e| e.path.clone()).collect();
+        self.navigation.selected_paths = self
+            .navigation
+            .entries
+            .iter()
+            .map(|e| e.path.clone())
+            .collect();
     }
 
     pub(in crate::app) fn clear_selection(&mut self) {
-        self.selected_paths.clear();
+        self.navigation.selected_paths.clear();
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -447,88 +447,109 @@ pub(super) struct DirectoryRuntime {
     pub(super) last_auto_reload_at: Instant,
 }
 
-pub struct App {
-    pub cwd: PathBuf,
-    pub entries: Vec<Entry>,
-    pub sidebar: Vec<SidebarRow>,
-    pub selected: usize,
-    pub scroll_row: usize,
-    pub view_mode: ViewMode,
-    pub zoom_level: u8,
-    pub sort_mode: SortMode,
-    pub show_hidden: bool,
+pub(crate) struct NavigationState {
+    pub(crate) cwd: PathBuf,
+    pub(crate) entries: Vec<Entry>,
+    pub(crate) sidebar: Vec<SidebarRow>,
+    pub(crate) selected: usize,
+    pub(crate) scroll_row: usize,
+    pub(crate) view_mode: ViewMode,
+    pub(crate) zoom_level: u8,
+    pub(crate) sort_mode: SortMode,
+    pub(crate) show_hidden: bool,
     /// True when the loaded directory is the trash folder.
     /// Set in apply_directory_snapshot so it's only true once the load completes.
-    pub(super) in_trash: bool,
-    pub status: String,
-    pub help_open: bool,
-    pub should_quit: bool,
-    pub(super) navigation_history: NavigationHistory,
-    pub(super) preview_state: PreviewState,
-    pub(super) comic_preview: comic::ComicPreviewState,
-    pub(super) epub_preview: epub::EpubPreviewState,
-    pub(super) image_preview: images::ImagePreviewState,
-    pub(super) media_preview: MediaPreviewState,
-    pub(super) pdf_preview: pdf::PdfPreviewState,
-    pub(super) terminal_images: inline_image::TerminalImageState,
-    pub(super) frame_state: FrameState,
-    pub(super) selected_paths: HashSet<PathBuf>,
-    pub(super) clipboard: Option<Clipboard>,
-    pub(super) paste_token: u64,
-    pub(super) paste_progress: Option<PasteProgress>,
-    pub(super) queued_pastes: VecDeque<QueuedPaste>,
-    /// Destination directory of the in-flight paste.  Kept separately from
+    pub(in crate::app) in_trash: bool,
+    pub(in crate::app) navigation_history: NavigationHistory,
+    pub(in crate::app) selected_paths: HashSet<PathBuf>,
+    pub(in crate::app) directory_item_count_cache: HashMap<DirectoryItemCountKey, Option<usize>>,
+    pub(in crate::app) directory_item_count_order: VecDeque<DirectoryItemCountKey>,
+    pub(in crate::app) directory_count_viewport: Option<DirectoryCountViewport>,
+    pub(in crate::app) directory_view_memory: HashMap<PathBuf, DirectoryViewMemory>,
+    pub(in crate::app) directory_runtime: DirectoryRuntime,
+    pub(in crate::app) last_sidebar_refresh_at: Instant,
+}
+
+pub(in crate::app) struct PreviewRuntime {
+    pub(in crate::app) state: PreviewState,
+    pub(in crate::app) comic: comic::ComicPreviewState,
+    pub(in crate::app) epub: epub::EpubPreviewState,
+    pub(in crate::app) image: images::ImagePreviewState,
+    pub(in crate::app) media: MediaPreviewState,
+    pub(in crate::app) pdf: pdf::PdfPreviewState,
+    pub(in crate::app) terminal_images: inline_image::TerminalImageState,
+}
+
+#[derive(Default)]
+pub(crate) struct OverlayState {
+    pub(in crate::app) trash: Option<TrashOverlay>,
+    pub(in crate::app) restore: Option<RestoreOverlay>,
+    pub(in crate::app) create: Option<CreateOverlay>,
+    pub(in crate::app) rename: Option<RenameOverlay>,
+    pub(in crate::app) bulk_rename: Option<BulkRenameOverlay>,
+    pub(in crate::app) goto: Option<GoToOverlay>,
+    pub(in crate::app) copy: Option<CopyOverlay>,
+    pub(in crate::app) search: Option<SearchOverlay>,
+    pub(crate) help: bool,
+}
+
+pub(in crate::app) struct JobRuntime {
+    pub(in crate::app) directory_token: u64,
+    pub(in crate::app) directory_fingerprint_token: u64,
+    pub(in crate::app) search_token: u64,
+    pub(in crate::app) search_loading: bool,
+    pub(in crate::app) search_cache: Option<SearchCache>,
+    pub(in crate::app) scheduler: JobScheduler,
+    pub(in crate::app) clipboard: Option<Clipboard>,
+    pub(in crate::app) paste_token: u64,
+    pub(in crate::app) paste_progress: Option<PasteProgress>,
+    pub(in crate::app) queued_pastes: VecDeque<QueuedPaste>,
+    /// Destination directory of the in-flight paste. Kept separately from
     /// `paste_progress` so that cancelling the chip does not lose the context
     /// needed by the completion handler to reload the right directory.
-    pub(super) paste_dest_dir: Option<PathBuf>,
-    pub(super) trash_token: u64,
-    pub(super) trash_progress: Option<TrashProgress>,
-    /// Source directory of the in-flight trash.  Kept separately from
+    pub(in crate::app) paste_dest_dir: Option<PathBuf>,
+    pub(in crate::app) trash_token: u64,
+    pub(in crate::app) trash_progress: Option<TrashProgress>,
+    /// Source directory of the in-flight trash. Kept separately from
     /// `trash_progress` for the same reason as `paste_dest_dir`.
-    pub(super) trash_source_cwd: Option<PathBuf>,
-    pub(super) trash: Option<TrashOverlay>,
-    pub(super) restore_token: u64,
-    pub(super) restore_progress: Option<RestoreProgress>,
-    /// Source directory of the in-flight restore.  Kept separately from
+    pub(in crate::app) trash_source_cwd: Option<PathBuf>,
+    pub(in crate::app) restore_token: u64,
+    pub(in crate::app) restore_progress: Option<RestoreProgress>,
+    /// Source directory of the in-flight restore. Kept separately from
     /// `restore_progress` so that cancelling the chip does not lose the
     /// context needed by the completion handler.
-    pub(super) restore_source_cwd: Option<PathBuf>,
-    pub(super) restore: Option<RestoreOverlay>,
-    pub(super) create: Option<CreateOverlay>,
-    pub(super) rename: Option<RenameOverlay>,
-    pub(super) bulk_rename: Option<BulkRenameOverlay>,
-    pub(super) goto_overlay: Option<GoToOverlay>,
-    pub(super) copy_overlay: Option<CopyOverlay>,
-    pub(super) search: Option<SearchOverlay>,
-    pub(super) search_cache: Option<SearchCache>,
-    pub(super) search_loading: bool,
-    pub(super) search_token: u64,
-    pub(super) directory_token: u64,
-    pub(super) directory_fingerprint_token: u64,
-    pub(super) scheduler: JobScheduler,
-    pub(super) directory_item_count_cache: HashMap<DirectoryItemCountKey, Option<usize>>,
-    pub(super) directory_item_count_order: VecDeque<DirectoryItemCountKey>,
-    pub(super) directory_count_viewport: Option<DirectoryCountViewport>,
-    pub(super) directory_view_memory: HashMap<PathBuf, DirectoryViewMemory>,
-    pub(super) directory_runtime: DirectoryRuntime,
-    pub(super) last_sidebar_refresh_at: Instant,
-    pub(super) last_click: Option<ClickState>,
-    pub(super) wheel_scroll: ScrollState,
-    pub(super) wheel_profile: WheelProfile,
-    pub(super) last_wheel_target: Option<WheelTarget>,
+    pub(in crate::app) restore_source_cwd: Option<PathBuf>,
+}
+
+pub(in crate::app) struct InputRuntime {
+    pub(in crate::app) frame_state: FrameState,
+    pub(in crate::app) last_click: Option<ClickState>,
+    pub(in crate::app) wheel_scroll: ScrollState,
+    pub(in crate::app) wheel_profile: WheelProfile,
+    pub(in crate::app) last_wheel_target: Option<WheelTarget>,
     // Cursor panel tracked exclusively from MouseEventKind::Moved events.
     // These events come from ?1003h (any-event tracking) and always carry the true
     // cursor position, so this is a reliable fallback when scroll event coordinates
     // are wrong or absent (observed in some Alacritty/Ghostty configurations).
-    pub(super) hover_panel: Option<WheelTarget>,
-    pub(super) browser_wheel_post_burst_pending: bool,
-    pub(super) last_navigation_key: Option<(NavigationRepeatKey, Instant)>,
-    pub(super) last_selection_change_at: Instant,
+    pub(in crate::app) hover_panel: Option<WheelTarget>,
+    pub(in crate::app) browser_wheel_post_burst_pending: bool,
+    pub(in crate::app) last_navigation_key: Option<(NavigationRepeatKey, Instant)>,
+    pub(in crate::app) last_selection_change_at: Instant,
     /// Tracks when keyboard navigation last moved the selection.
     /// Only updated by `move_vertical_keyboard`, `move_by_keyboard`, and `page`
     /// (all keyboard-only paths), not by direct selection or wheel input, so it
     /// does not interfere with wheel auto-focus routing.
-    pub(super) last_key_nav_at: Instant,
+    pub(in crate::app) last_key_nav_at: Instant,
+}
+
+pub struct App {
+    pub(crate) navigation: NavigationState,
+    pub(in crate::app) preview: PreviewRuntime,
+    pub(crate) overlays: OverlayState,
+    pub(in crate::app) jobs: JobRuntime,
+    pub(in crate::app) input: InputRuntime,
+    pub(in crate::app) status: String,
+    pub(crate) should_quit: bool,
 }
 
 impl App {
@@ -541,114 +562,114 @@ impl App {
         let scheduler = JobScheduler::new();
         let (directory_watch_tx, directory_watch_rx) = std::sync::mpsc::channel();
         let mut app = Self {
-            cwd,
-            entries: Vec::new(),
-            sidebar: Vec::new(),
-            selected: 0,
-            scroll_row: 0,
-            view_mode: startup_view_mode(crate::config::ui().start_in_grid),
-            zoom_level: crate::config::ui().grid_zoom,
-            sort_mode: SortMode::Name,
-            show_hidden: crate::config::ui().show_hidden,
-            in_trash: false,
+            navigation: NavigationState {
+                cwd,
+                entries: Vec::new(),
+                sidebar: Vec::new(),
+                selected: 0,
+                scroll_row: 0,
+                view_mode: startup_view_mode(crate::config::ui().start_in_grid),
+                zoom_level: crate::config::ui().grid_zoom,
+                sort_mode: SortMode::Name,
+                show_hidden: crate::config::ui().show_hidden,
+                in_trash: false,
+                navigation_history: NavigationHistory::default(),
+                selected_paths: HashSet::new(),
+                directory_item_count_cache: HashMap::new(),
+                directory_item_count_order: VecDeque::new(),
+                directory_count_viewport: None,
+                directory_view_memory: HashMap::new(),
+                directory_runtime: DirectoryRuntime {
+                    fingerprint: crate::fs::DirectoryFingerprint::default(),
+                    watch_tx: directory_watch_tx,
+                    watch_rx: directory_watch_rx,
+                    watch: None,
+                    pending_reload_at: None,
+                    pending_fingerprint_scan: None,
+                    pending_load: None,
+                    use_polling_reload: true,
+                    last_auto_reload_at: Instant::now(),
+                },
+                last_sidebar_refresh_at: Instant::now(),
+            },
+            preview: PreviewRuntime {
+                state: PreviewState {
+                    scroll: 0,
+                    horizontal_scroll: 0,
+                    content: preview::PreviewContent::placeholder("No selection"),
+                    token: 0,
+                    metrics: PreviewMetrics::default(),
+                    load_state: None,
+                    directory_stats: None,
+                    deferred_refresh_at: None,
+                    prefetch_ready_at: None,
+                    result_cache: HashMap::new(),
+                    result_order: VecDeque::new(),
+                    line_count_cache: HashMap::new(),
+                    line_count_order: VecDeque::new(),
+                    pending_line_counts: HashSet::new(),
+                    incremental_render_in_flight: false,
+                    incremental_render_path: None,
+                },
+                comic: comic::ComicPreviewState::default(),
+                epub: epub::EpubPreviewState::default(),
+                image: images::ImagePreviewState::default(),
+                media: MediaPreviewState::default(),
+                pdf: pdf::PdfPreviewState::default(),
+                terminal_images: inline_image::TerminalImageState::default(),
+            },
+            overlays: OverlayState::default(),
+            jobs: JobRuntime {
+                directory_token: 0,
+                directory_fingerprint_token: 0,
+                search_token: 0,
+                search_loading: false,
+                search_cache: None,
+                scheduler,
+                clipboard: None,
+                paste_token: 0,
+                paste_progress: None,
+                queued_pastes: VecDeque::new(),
+                paste_dest_dir: None,
+                trash_token: 0,
+                trash_progress: None,
+                trash_source_cwd: None,
+                restore_token: 0,
+                restore_progress: None,
+                restore_source_cwd: None,
+            },
+            input: InputRuntime {
+                frame_state: FrameState::default(),
+                last_click: None,
+                wheel_scroll: ScrollState {
+                    horizontal: ScrollLane::new(),
+                    vertical: ScrollLane::new(),
+                    preview: ScrollLane::new(),
+                    preview_horizontal: ScrollLane::new(),
+                    search: ScrollLane::new(),
+                },
+                wheel_profile: detect_wheel_profile(),
+                last_wheel_target: Some(WheelTarget::Entries),
+                hover_panel: None,
+                browser_wheel_post_burst_pending: false,
+                last_navigation_key: None,
+                last_selection_change_at: Instant::now(),
+                // Initialize to far past so the first keypress is always Immediate.
+                last_key_nav_at: Instant::now() - Duration::from_secs(1),
+            },
             status: String::new(),
-            help_open: false,
             should_quit: false,
-            navigation_history: NavigationHistory::default(),
-            preview_state: PreviewState {
-                scroll: 0,
-                horizontal_scroll: 0,
-                content: preview::PreviewContent::placeholder("No selection"),
-                token: 0,
-                metrics: PreviewMetrics::default(),
-                load_state: None,
-                directory_stats: None,
-                deferred_refresh_at: None,
-                prefetch_ready_at: None,
-                result_cache: HashMap::new(),
-                result_order: VecDeque::new(),
-                line_count_cache: HashMap::new(),
-                line_count_order: VecDeque::new(),
-                pending_line_counts: HashSet::new(),
-                incremental_render_in_flight: false,
-                incremental_render_path: None,
-            },
-            comic_preview: comic::ComicPreviewState::default(),
-            epub_preview: epub::EpubPreviewState::default(),
-            image_preview: images::ImagePreviewState::default(),
-            media_preview: MediaPreviewState::default(),
-            pdf_preview: pdf::PdfPreviewState::default(),
-            terminal_images: inline_image::TerminalImageState::default(),
-            frame_state: FrameState::default(),
-            selected_paths: HashSet::new(),
-            clipboard: None,
-            paste_token: 0,
-            paste_progress: None,
-            queued_pastes: VecDeque::new(),
-            paste_dest_dir: None,
-            trash_token: 0,
-            trash_progress: None,
-            trash_source_cwd: None,
-            trash: None,
-            restore_token: 0,
-            restore_progress: None,
-            restore_source_cwd: None,
-            restore: None,
-            create: None,
-            rename: None,
-            bulk_rename: None,
-            goto_overlay: None,
-            copy_overlay: None,
-            search: None,
-            search_cache: None,
-            search_loading: false,
-            search_token: 0,
-            directory_token: 0,
-            directory_fingerprint_token: 0,
-            scheduler,
-            directory_item_count_cache: HashMap::new(),
-            directory_item_count_order: VecDeque::new(),
-            directory_count_viewport: None,
-            directory_view_memory: HashMap::new(),
-            directory_runtime: DirectoryRuntime {
-                fingerprint: crate::fs::DirectoryFingerprint::default(),
-                watch_tx: directory_watch_tx,
-                watch_rx: directory_watch_rx,
-                watch: None,
-                pending_reload_at: None,
-                pending_fingerprint_scan: None,
-                pending_load: None,
-                use_polling_reload: true,
-                last_auto_reload_at: Instant::now(),
-            },
-            last_sidebar_refresh_at: Instant::now(),
-            last_click: None,
-            wheel_scroll: ScrollState {
-                horizontal: ScrollLane::new(),
-                vertical: ScrollLane::new(),
-                preview: ScrollLane::new(),
-                preview_horizontal: ScrollLane::new(),
-                search: ScrollLane::new(),
-            },
-            wheel_profile: detect_wheel_profile(),
-            last_wheel_target: Some(WheelTarget::Entries),
-            hover_panel: None,
-            browser_wheel_post_burst_pending: false,
-            last_navigation_key: None,
-            last_selection_change_at: Instant::now(),
-            // Initialize to far past so the first keypress is always Immediate.
-            last_key_nav_at: Instant::now() - Duration::from_secs(1),
         };
-        app.in_trash = App::path_is_trash(&app.cwd);
+        app.navigation.in_trash = App::path_is_trash(&app.navigation.cwd);
         let snapshot = crate::fs::load_directory_snapshot(
-            &app.cwd,
+            &app.navigation.cwd,
             app.effective_show_hidden(),
-            app.sort_mode,
+            app.navigation.sort_mode,
         )?;
-        app.sidebar = crate::fs::build_sidebar_rows();
-        app.last_sidebar_refresh_at = Instant::now();
-        app.entries = snapshot.entries;
-        app.directory_runtime.fingerprint = snapshot.fingerprint;
+        app.navigation.sidebar = crate::fs::build_sidebar_rows();
+        app.navigation.last_sidebar_refresh_at = Instant::now();
+        app.navigation.entries = snapshot.entries;
+        app.navigation.directory_runtime.fingerprint = snapshot.fingerprint;
         app.clamp_selection();
         app.remember_current_directory_view();
         app.refresh_preview();
@@ -658,26 +679,28 @@ impl App {
 
     pub(in crate::app) fn ffprobe_available(&mut self) -> bool {
         *self
-            .media_preview
+            .preview
+            .media
             .ffprobe_available
             .get_or_insert_with(|| inline_image::command_exists("ffprobe"))
     }
 
     pub(in crate::app) fn media_ffmpeg_available(&mut self) -> bool {
         *self
-            .media_preview
+            .preview
+            .media
             .ffmpeg_available
             .get_or_insert_with(|| inline_image::command_exists("ffmpeg"))
     }
 
     #[cfg(test)]
     pub(in crate::app) fn set_media_ffprobe_available_for_tests(&mut self, available: bool) {
-        self.media_preview.ffprobe_available = Some(available);
+        self.preview.media.ffprobe_available = Some(available);
     }
 
     #[cfg(test)]
     pub(in crate::app) fn set_media_ffmpeg_available_for_tests(&mut self, available: bool) {
-        self.media_preview.ffmpeg_available = Some(available);
+        self.preview.media.ffmpeg_available = Some(available);
     }
 }
 

--- a/src/ui/browser/entries.rs
+++ b/src/ui/browser/entries.rs
@@ -18,7 +18,8 @@ pub(super) fn render_entries(
     palette: Palette,
 ) {
     state.entries_panel = Some(area);
-    let path_text = helpers::stable_path_label(&app.cwd, area.width.saturating_sub(10) as usize);
+    let path_text =
+        helpers::stable_path_label(&app.navigation.cwd, area.width.saturating_sub(10) as usize);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -47,7 +48,7 @@ pub(super) fn render_entries(
     let inner = block.inner(area);
     helpers::fill_area(frame, inner, palette.panel_alt, palette.text);
 
-    if app.view_mode == crate::app::ViewMode::Grid {
+    if app.navigation.view_mode == crate::app::ViewMode::Grid {
         render_grid(frame, inner, app, state, palette);
     } else {
         render_list(frame, inner, app, state, palette);

--- a/src/ui/browser/grid.rs
+++ b/src/ui/browser/grid.rs
@@ -25,7 +25,7 @@ pub(super) fn render_grid(
         helpers::fill_area(frame, sb, palette.panel_alt, palette.border);
     }
 
-    let spec = helpers::grid_zoom_spec(app.zoom_level);
+    let spec = helpers::grid_zoom_spec(app.navigation.zoom_level);
     let gap_x = spec.gap_x;
     let gap_y = spec.gap_y;
     let cols = ((content_area.width + gap_x) / (spec.tile_width_hint + gap_x)).max(1) as usize;
@@ -35,15 +35,18 @@ pub(super) fn render_grid(
     let rows_visible = ((content_area.height + gap_y) / (spec.tile_height + gap_y)).max(1) as usize;
     state.metrics = ViewMetrics { cols, rows_visible };
 
-    if app.entries.is_empty() {
+    if app.navigation.entries.is_empty() {
         helpers::render_empty_state(frame, content_area, "This folder is empty", palette);
         return;
     }
 
-    let start = app.scroll_row * cols;
+    let start = app.navigation.scroll_row * cols;
     let limit = rows_visible * cols;
 
-    for (visible_index, entry_index) in (start..app.entries.len()).take(limit).enumerate() {
+    for (visible_index, entry_index) in (start..app.navigation.entries.len())
+        .take(limit)
+        .enumerate()
+    {
         let row = visible_index / cols;
         let col = visible_index % cols;
         let tile_x = content_area.x + col as u16 * (tile_width + gap_x);
@@ -61,9 +64,9 @@ pub(super) fn render_grid(
             width: actual_tile_width,
             height: spec.tile_height,
         };
-        let entry = &app.entries[entry_index];
+        let entry = &app.navigation.entries[entry_index];
         let tile_state = TileState {
-            selected: entry_index == app.selected,
+            selected: entry_index == app.navigation.selected,
             multi_selected: app.is_selected(&entry.path),
             clip_op: app.clipboard_op_for(&entry.path),
         };
@@ -75,8 +78,15 @@ pub(super) fn render_grid(
     }
 
     if let Some(sb) = scrollbar_area {
-        let total_rows = app.entries.len().div_ceil(cols);
-        render_browser_scrollbar(frame, sb, total_rows, rows_visible, app.scroll_row, palette);
+        let total_rows = app.navigation.entries.len().div_ceil(cols);
+        render_browser_scrollbar(
+            frame,
+            sb,
+            total_rows,
+            rows_visible,
+            app.navigation.scroll_row,
+            palette,
+        );
     }
 }
 

--- a/src/ui/browser/list.rs
+++ b/src/ui/browser/list.rs
@@ -34,23 +34,23 @@ pub(super) fn render_list(
         rows_visible: (content_area.height / row_height.max(1)).max(1) as usize,
     };
 
-    if app.entries.is_empty() {
+    if app.navigation.entries.is_empty() {
         helpers::render_empty_state(frame, content_area, "This folder is empty", palette);
         return;
     }
 
-    for (visible_index, entry_index) in (app.scroll_row..app.entries.len())
+    for (visible_index, entry_index) in (app.navigation.scroll_row..app.navigation.entries.len())
         .take(state.metrics.rows_visible)
         .enumerate()
     {
-        let entry = &app.entries[entry_index];
+        let entry = &app.navigation.entries[entry_index];
         let row = Rect {
             x: content_area.x,
             y: content_area.y + visible_index as u16 * row_height,
             width: content_area.width,
             height: row_height,
         };
-        let selected = entry_index == app.selected;
+        let selected = entry_index == app.navigation.selected;
         let multi_selected = app.is_selected(&entry.path);
         let clip_op = app.clipboard_op_for(&entry.path);
         let icon_color = theme::entry_color(entry, palette);
@@ -140,9 +140,9 @@ pub(super) fn render_list(
         render_browser_scrollbar(
             frame,
             sb,
-            app.entries.len(),
+            app.navigation.entries.len(),
             state.metrics.rows_visible,
-            app.scroll_row,
+            app.navigation.scroll_row,
             palette,
         );
     }

--- a/src/ui/browser/mod.rs
+++ b/src/ui/browser/mod.rs
@@ -49,6 +49,7 @@ mod tests {
         for _ in 0..100 {
             let _ = app.process_background_jobs();
             let all_visible_directory_counts_loaded = app
+                .navigation
                 .entries
                 .iter()
                 .filter(|entry| entry.is_dir())
@@ -200,13 +201,13 @@ mod tests {
         }
 
         let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-        app.view_mode = crate::app::ViewMode::List;
+        app.navigation.view_mode = crate::app::ViewMode::List;
         let mut terminal = Terminal::new(TestBackend::new(90, 24)).expect("terminal should init");
 
-        app.zoom_level = 0;
+        app.navigation.zoom_level = 0;
         let compact = draw_ui(&mut terminal, &mut app);
 
-        app.zoom_level = 2;
+        app.navigation.zoom_level = 2;
         let zoomed = draw_ui(&mut terminal, &mut app);
 
         assert_eq!(compact.metrics.rows_visible, zoomed.metrics.rows_visible);
@@ -438,7 +439,7 @@ mod tests {
         fs::create_dir_all(&root).expect("failed to create temp root");
 
         let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-        app.sidebar = vec![SidebarRow::Item(SidebarItem::new(
+        app.navigation.sidebar = vec![SidebarRow::Item(SidebarItem::new(
             SidebarItemKind::Downloads,
             "Downloads Directory",
             "D",
@@ -475,7 +476,7 @@ mod tests {
         fs::create_dir_all(&drive).expect("failed to create temp dirs");
 
         let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-        app.sidebar = vec![
+        app.navigation.sidebar = vec![
             SidebarRow::Section { title: "Devices" },
             SidebarRow::Item(SidebarItem::new(
                 SidebarItemKind::Device { removable: true },
@@ -548,7 +549,7 @@ mod tests {
         }
 
         let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-        app.view_mode = crate::app::ViewMode::Grid;
+        app.navigation.view_mode = crate::app::ViewMode::Grid;
         let mut terminal = Terminal::new(TestBackend::new(140, 30)).expect("terminal should init");
 
         let state = draw_ui(&mut terminal, &mut app);
@@ -673,7 +674,7 @@ mod tests {
         }
 
         let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-        app.view_mode = crate::app::ViewMode::List;
+        app.navigation.view_mode = crate::app::ViewMode::List;
         let mut terminal = Terminal::new(TestBackend::new(90, 24)).expect("terminal should init");
 
         for _ in 0..10 {
@@ -1049,7 +1050,7 @@ mod tests {
         fs::create_dir_all(&root).expect("failed to create temp root");
 
         let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-        app.help_open = true;
+        app.overlays.help = true;
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal should init");
 
         draw_ui(&mut terminal, &mut app);
@@ -1242,7 +1243,11 @@ mod tests {
         file.set_len(13_000_000).expect("failed to size test file");
 
         let app = App::new_at(root.clone()).expect("app should load temp directory");
-        let entry = app.entries.first().expect("entry should be present");
+        let entry = app
+            .navigation
+            .entries
+            .first()
+            .expect("entry should be present");
         let rendered = line_text(&render_compact_list_row(
             &app,
             entry,
@@ -1277,7 +1282,11 @@ mod tests {
         file.set_len(13_000_000).expect("failed to size test file");
 
         let app = App::new_at(root.clone()).expect("app should load temp directory");
-        let entry = app.entries.first().expect("entry should be present");
+        let entry = app
+            .navigation
+            .entries
+            .first()
+            .expect("entry should be present");
         let rendered = line_text(&render_compact_list_row(
             &app,
             entry,
@@ -1319,11 +1328,13 @@ mod tests {
 
         let app = App::new_at(root.clone()).expect("app should load temp directory");
         let small_entry = app
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.path == small)
             .expect("small entry should be present");
         let large_entry = app
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.path == large)
@@ -1375,11 +1386,13 @@ mod tests {
         wait_for_directory_counts(&mut app);
 
         let short_entry = app
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.path == short)
             .expect("short-count entry should be present");
         let long_entry = app
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.path == long)
@@ -1428,11 +1441,13 @@ mod tests {
         wait_for_directory_counts(&mut app);
 
         let folder_entry = app
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.path == folder)
             .expect("folder entry should be present");
         let file_entry = app
+            .navigation
             .entries
             .iter()
             .find(|entry| entry.path == file_path)

--- a/src/ui/browser/sidebar.rs
+++ b/src/ui/browser/sidebar.rs
@@ -21,7 +21,7 @@ pub(super) fn render_sidebar(
     helpers::fill_area(frame, inner, palette.panel, palette.text);
     let mut y = inner.y;
     let row_height = 1u16;
-    for item in &app.sidebar {
+    for item in &app.navigation.sidebar {
         if y.saturating_add(row_height) > inner.y.saturating_add(inner.height) {
             break;
         }
@@ -50,7 +50,7 @@ pub(super) fn render_sidebar(
                 );
             }
             SidebarRow::Item(item) => {
-                let active = helpers::path_is_active(&app.cwd, &item.path);
+                let active = helpers::path_is_active(&app.navigation.cwd, &item.path);
                 let bg = if active {
                     palette.sidebar_active
                 } else {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -78,7 +78,7 @@ pub(super) fn render_toolbar(
     helpers::render_button(frame, nav_buttons[2], "Up", "󰁝", true, palette);
     frame.render_widget(
         Paragraph::new(Line::from(vec![helpers::chip_span(
-            &format!("Sort: {}", app.sort_mode.label()),
+            &format!("Sort: {}", app.navigation.sort_mode.label()),
             palette.button_bg,
             palette.text,
             true,
@@ -90,7 +90,7 @@ pub(super) fn render_toolbar(
     helpers::render_button(
         frame,
         meta[1],
-        if app.show_hidden {
+        if app.navigation.show_hidden {
             "Hidden On"
         } else {
             "Hidden Off"
@@ -99,7 +99,14 @@ pub(super) fn render_toolbar(
         true,
         palette,
     );
-    helpers::render_button(frame, meta[2], app.view_mode.label(), "󰕮", true, palette);
+    helpers::render_button(
+        frame,
+        meta[2],
+        app.navigation.view_mode.label(),
+        "󰕮",
+        true,
+        palette,
+    );
 }
 
 const STATUS_MIN_LEFT_WIDTH: u16 = 24;
@@ -320,14 +327,14 @@ mod tests {
         let mut app = App::new_at(src_dir.clone()).expect("failed to create app");
         app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('y'))))
             .expect("yank shortcut should succeed");
-        app.cwd = dst_dir.clone();
+        app.navigation.cwd = dst_dir.clone();
         app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('p'))))
             .expect("paste shortcut should succeed");
-        app.cwd = src_dir.clone();
-        app.selected = 1;
+        app.navigation.cwd = src_dir.clone();
+        app.navigation.selected = 1;
         app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('y'))))
             .expect("second yank shortcut should succeed");
-        app.cwd = dst_dir.clone();
+        app.navigation.cwd = dst_dir.clone();
         app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('p'))))
             .expect("second paste should be queued");
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -98,7 +98,7 @@ pub fn render(frame: &mut Frame<'_>, app: &App, state: &mut FrameState) {
         overlay_manager::render_copy_overlay(frame, area, app, state, palette);
     } else if app.search_is_open() {
         overlay_manager::render_search_overlay(frame, area, app, state, palette);
-    } else if app.help_open {
+    } else if app.overlays.help {
         overlay_manager::render_help(frame, area, state, palette);
     }
 }

--- a/src/ui/overlay_manager/bulk_rename.rs
+++ b/src/ui/overlay_manager/bulk_rename.rs
@@ -84,7 +84,7 @@ pub(super) fn render_bulk_rename_overlay(
         let is_dir = app.bulk_rename_item_is_dir(line_idx);
         let is_cursor_line = line_idx == cursor_line;
 
-        let live_path = app.cwd.join(new_name);
+        let live_path = app.navigation.cwd.join(new_name);
         let (icon, icon_color) = (
             theme::path_symbol(&live_path, is_dir),
             theme::path_color(&live_path, is_dir, palette),

--- a/src/ui/overlay_manager/create.rs
+++ b/src/ui/overlay_manager/create.rs
@@ -117,7 +117,7 @@ pub(super) fn render_create_overlay(
                 ("󰈔", palette.muted)
             }
         } else {
-            let path = app.cwd.join(clean_name);
+            let path = app.navigation.cwd.join(clean_name);
             (
                 theme::path_symbol(&path, is_dir),
                 theme::path_color(&path, is_dir, palette),

--- a/src/ui/overlay_manager/rename.rs
+++ b/src/ui/overlay_manager/rename.rs
@@ -60,7 +60,7 @@ pub(super) fn render_rename_overlay(
     }
 
     let is_dir = app.rename_item_is_dir();
-    let live_path = app.cwd.join(app.rename_input());
+    let live_path = app.navigation.cwd.join(app.rename_input());
     let (icon, icon_color) = (
         theme::path_symbol(&live_path, is_dir),
         theme::path_color(&live_path, is_dir, palette),


### PR DESCRIPTION
## Summary

- split the `App` state surface into focused substates for navigation, preview, overlays, jobs, and input
- move existing fields under those grouped state structs without changing behavior
- update app, jobs, overlays, input, and UI call sites to use the new state layout

## Why

`src/app/state.rs` had become a large flat coordinator with many unrelated fields living directly on `App`. That made the state surface harder to reason about and made new changes more likely to land in the wrong place.

This refactor keeps behavior the same, but gives the application state a clearer shape:

- navigation-related state lives together
- preview-related state lives together
- overlay state is grouped separately
- background job state is grouped separately
- input/frame interaction state is grouped separately

That makes the `App` surface easier to navigate and gives later refactors a cleaner foundation. This is a structural refactor only. Behavior is unchanged.

## Testing

**Verified with:**

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

**Result:**

- **All checks passed; behavior remains unchanged.**