### PR TITLE
refactor(preview): extract cancellable process helpers

### DIFF
--- a/src/preview/audio.rs
+++ b/src/preview/audio.rs
@@ -1,6 +1,7 @@
 use super::{
     PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout,
     appearance as theme,
+    process::{run_command_capture_stdout_cancellable, run_command_status_cancellable},
 };
 use crate::core::Entry;
 use ratatui::{
@@ -13,18 +14,12 @@ use std::{
     env, fs,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
-    sync::atomic::{AtomicU64, Ordering},
-    thread,
-    time::{Duration, SystemTime},
+    process::Command,
+    time::SystemTime,
 };
 
 const AUDIO_ARTWORK_CACHE_VERSION: usize = 2;
 const NATIVE_ARTWORK_STREAM_INDEX: u32 = u32::MAX;
-const CANCELLABLE_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(5);
-
-static COMMAND_CAPTURE_ID: AtomicU64 = AtomicU64::new(0);
-
 #[derive(Clone, Debug, Default, PartialEq)]
 struct AudioMetadata {
     title: Option<String>,
@@ -434,97 +429,6 @@ fn finalize_audio_artwork(temp_path: &Path, cache_path: &Path) -> Option<()> {
     }
 }
 
-fn run_command_capture_stdout_cancellable<F>(
-    mut command: Command,
-    capture_label: &str,
-    canceled: &F,
-) -> Option<Vec<u8>>
-where
-    F: Fn() -> bool,
-{
-    if canceled() {
-        return None;
-    }
-
-    let capture_path = command_capture_path(capture_label);
-    let stdout = fs::File::create(&capture_path).ok()?;
-    let mut child = match command
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => {
-            let _ = fs::remove_file(&capture_path);
-            return None;
-        }
-    };
-
-    loop {
-        if canceled() {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = fs::remove_file(&capture_path);
-            return None;
-        }
-
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let output = status
-                    .success()
-                    .then(|| fs::read(&capture_path).ok())
-                    .flatten();
-                let _ = fs::remove_file(&capture_path);
-                return output;
-            }
-            Ok(None) => thread::sleep(CANCELLABLE_COMMAND_POLL_INTERVAL),
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = fs::remove_file(&capture_path);
-                return None;
-            }
-        }
-    }
-}
-
-fn run_command_status_cancellable<F>(mut command: Command, canceled: &F) -> Option<bool>
-where
-    F: Fn() -> bool,
-{
-    if canceled() {
-        return None;
-    }
-
-    let mut child = command
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-    loop {
-        if canceled() {
-            let _ = child.kill();
-            let _ = child.wait();
-            return None;
-        }
-
-        match child.try_wait() {
-            Ok(Some(status)) => return Some(status.success()),
-            Ok(None) => thread::sleep(CANCELLABLE_COMMAND_POLL_INTERVAL),
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return None;
-            }
-        }
-    }
-}
-
-fn command_capture_path(label: &str) -> PathBuf {
-    let id = COMMAND_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
-    env::temp_dir().join(format!("elio-{label}-{}-{id}.tmp", std::process::id()))
-}
-
 fn preview_visual_from_path(path: PathBuf) -> Option<PreviewVisual> {
     let metadata = fs::metadata(&path).ok()?;
     Some(PreviewVisual {
@@ -702,14 +606,7 @@ fn preview_field_line(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        path::Path,
-        sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
-        },
-        time::{Duration, Instant},
-    };
+    use std::{path::Path, time::Duration};
 
     #[test]
     fn artwork_detection_requires_attached_pic_disposition() {
@@ -806,35 +703,5 @@ mod tests {
 
         assert_eq!(current, same);
         assert_ne!(current, different);
-    }
-
-    #[test]
-    fn cancellable_command_helper_stops_long_running_process_promptly() {
-        let canceled = Arc::new(AtomicBool::new(false));
-        let cancel_flag = Arc::clone(&canceled);
-        let cancel_thread = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(25));
-            cancel_flag.store(true, Ordering::Relaxed);
-        });
-
-        let mut command = Command::new("bash");
-        command.arg("-lc").arg("sleep 1; printf late");
-        let started_at = Instant::now();
-        let output =
-            run_command_capture_stdout_cancellable(command, "audio-cancel-command", &|| {
-                canceled.load(Ordering::Relaxed)
-            });
-        cancel_thread
-            .join()
-            .expect("cancel thread should finish cleanly");
-
-        assert!(
-            output.is_none(),
-            "canceled command output should be discarded"
-        );
-        assert!(
-            started_at.elapsed() < Duration::from_millis(500),
-            "canceled command should stop promptly"
-        );
     }
 }

--- a/src/preview/container/archive/comic.rs
+++ b/src/preview/container/archive/comic.rs
@@ -4,6 +4,7 @@ use super::common::{
 use super::format::archive_default_label;
 use super::*;
 use crate::fs::natural_cmp;
+use crate::preview::process::run_command_capture_stdout_cancellable;
 use std::{
     collections::{HashMap, VecDeque, hash_map::DefaultHasher},
     env,
@@ -11,22 +12,13 @@ use std::{
     hash::{Hash, Hasher},
     io::Read,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
-    sync::{
-        Arc, Mutex, OnceLock,
-        atomic::{AtomicU64, Ordering},
-    },
-    thread,
-    time::Duration,
+    process::Command,
+    sync::{Arc, Mutex, OnceLock},
 };
 use zip::ZipArchive;
 
 const COMIC_ARCHIVE_IMAGE_ENTRY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 const COMIC_ARCHIVE_CACHE_LIMIT: usize = 16;
-const CANCELLABLE_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(5);
-
-static COMMAND_CAPTURE_ID: AtomicU64 = AtomicU64::new(0);
-
 fn has_unrar() -> bool {
     static RESULT: OnceLock<bool> = OnceLock::new();
     *RESULT.get_or_init(|| Command::new("unrar").output().is_ok())
@@ -585,67 +577,13 @@ fn archive_asset_cache_path(
     Some(cache_dir.join(format!("comic-{:016x}.{extension}", hasher.finish())))
 }
 
-fn run_command_capture_stdout_cancellable<F>(
-    mut command: Command,
-    capture_label: &str,
-    canceled: &F,
-) -> Option<Vec<u8>>
-where
-    F: Fn() -> bool,
-{
-    if canceled() {
-        return None;
-    }
-
-    let capture_path = command_capture_path(capture_label);
-    let stdout = File::create(&capture_path).ok()?;
-    let mut child = match command
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => {
-            let _ = fs::remove_file(&capture_path);
-            return None;
-        }
-    };
-
-    loop {
-        if canceled() {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = fs::remove_file(&capture_path);
-            return None;
-        }
-
-        match child.try_wait().ok()? {
-            Some(status) => {
-                let output = status
-                    .success()
-                    .then(|| fs::read(&capture_path).ok())
-                    .flatten();
-                let _ = fs::remove_file(&capture_path);
-                return output;
-            }
-            None => thread::sleep(CANCELLABLE_COMMAND_POLL_INTERVAL),
-        }
-    }
-}
-
-fn command_capture_path(label: &str) -> PathBuf {
-    let id = COMMAND_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
-    env::temp_dir().join(format!("elio-{label}-{}-{id}.tmp", std::process::id()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::ArchiveFormat;
     use super::super::build_archive_preview;
     use super::{
         ComicArchiveBackend, ComicArchiveSignature, build_comic_archive_preview,
-        parse_comic_archive_from_7z_output, parse_zip_comic_archive,
-        run_command_capture_stdout_cancellable, sniff_comic_archive_signature,
+        parse_comic_archive_from_7z_output, parse_zip_comic_archive, sniff_comic_archive_signature,
     };
     use crate::preview::PreviewKind;
     use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
@@ -655,12 +593,8 @@ mod tests {
         io::Write,
         path::PathBuf,
         process::Command,
-        sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
-        },
-        thread,
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+        sync::atomic::{AtomicBool, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
     };
 
     fn temp_path(label: &str) -> PathBuf {
@@ -771,36 +705,6 @@ Packed Size = 40
 
         fs::remove_dir_all(&root).expect("failed to remove temp root");
     }
-
-    #[test]
-    fn cancellable_command_helper_stops_long_running_process_promptly() {
-        let canceled = Arc::new(AtomicBool::new(false));
-        let cancel_flag = Arc::clone(&canceled);
-        let cancel_thread = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(25));
-            cancel_flag.store(true, Ordering::Relaxed);
-        });
-
-        let mut command = Command::new("bash");
-        command.arg("-lc").arg("sleep 1; printf late");
-        let started_at = Instant::now();
-        let output = run_command_capture_stdout_cancellable(command, "cancel-command", &|| {
-            canceled.load(Ordering::Relaxed)
-        });
-        cancel_thread
-            .join()
-            .expect("cancel thread should finish cleanly");
-
-        assert!(
-            output.is_none(),
-            "canceled command output should be discarded"
-        );
-        assert!(
-            started_at.elapsed() < Duration::from_millis(500),
-            "canceled command should stop promptly"
-        );
-    }
-
     #[test]
     fn build_comic_archive_preview_falls_back_to_7z_for_mislabeled_cbz() {
         let root = temp_path("mislabeled-cbz");

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -8,6 +8,7 @@ mod directory;
 mod dispatch;
 mod document;
 mod markdown;
+mod process;
 mod structured;
 mod text;
 mod types;

--- a/src/preview/process.rs
+++ b/src/preview/process.rs
@@ -1,0 +1,162 @@
+use std::{
+    env, fs,
+    path::PathBuf,
+    process::{Child, Command, ExitStatus, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
+    thread,
+    time::Duration,
+};
+
+const CANCELLABLE_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+static COMMAND_CAPTURE_ID: AtomicU64 = AtomicU64::new(0);
+
+pub(in crate::preview) fn run_command_capture_stdout_cancellable<F>(
+    mut command: Command,
+    capture_label: &str,
+    canceled: &F,
+) -> Option<Vec<u8>>
+where
+    F: Fn() -> bool,
+{
+    if canceled() {
+        return None;
+    }
+
+    // Use a temp file instead of a pipe so long-running tools can write freely
+    // while we keep polling for cancellation.
+    let capture_path = command_capture_path(capture_label);
+    let stdout = fs::File::create(&capture_path).ok()?;
+    let mut child = match command
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => {
+            let _ = fs::remove_file(&capture_path);
+            return None;
+        }
+    };
+
+    let status = wait_for_child_cancellable(&mut child, canceled);
+    let output = status
+        .filter(|status| status.success())
+        .and_then(|_| fs::read(&capture_path).ok());
+    let _ = fs::remove_file(&capture_path);
+    output
+}
+
+pub(in crate::preview) fn run_command_status_cancellable<F>(
+    mut command: Command,
+    canceled: &F,
+) -> Option<bool>
+where
+    F: Fn() -> bool,
+{
+    if canceled() {
+        return None;
+    }
+
+    let mut child = command
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    wait_for_child_cancellable(&mut child, canceled).map(|status| status.success())
+}
+
+fn wait_for_child_cancellable<F>(child: &mut Child, canceled: &F) -> Option<ExitStatus>
+where
+    F: Fn() -> bool,
+{
+    loop {
+        if canceled() {
+            kill_and_wait(child);
+            return None;
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => thread::sleep(CANCELLABLE_COMMAND_POLL_INTERVAL),
+            Err(_) => {
+                kill_and_wait(child);
+                return None;
+            }
+        }
+    }
+}
+
+fn kill_and_wait(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn command_capture_path(label: &str) -> PathBuf {
+    let id = COMMAND_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
+    env::temp_dir().join(format!("elio-{label}-{}-{id}.tmp", std::process::id()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_command_capture_stdout_cancellable, run_command_status_cancellable};
+    use std::{
+        process::Command,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    #[test]
+    fn capture_helper_stops_long_running_process_promptly() {
+        let canceled = Arc::new(AtomicBool::new(false));
+        let cancel_flag = Arc::clone(&canceled);
+        let cancel_thread = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(25));
+            cancel_flag.store(true, Ordering::Relaxed);
+        });
+
+        let mut command = Command::new("bash");
+        command.arg("-lc").arg("sleep 1; printf late");
+        let started_at = Instant::now();
+        let output =
+            run_command_capture_stdout_cancellable(command, "preview-process-test", &|| {
+                canceled.load(Ordering::Relaxed)
+            });
+        cancel_thread
+            .join()
+            .expect("cancel thread should finish cleanly");
+
+        assert!(
+            output.is_none(),
+            "canceled command output should be discarded"
+        );
+        assert!(
+            started_at.elapsed() < Duration::from_millis(500),
+            "canceled command should stop promptly"
+        );
+    }
+
+    #[test]
+    fn status_helper_reports_command_success() {
+        let mut command = Command::new("bash");
+        command.arg("-lc").arg("exit 0");
+
+        let result = run_command_status_cancellable(command, &|| false);
+
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn status_helper_reports_command_failure() {
+        let mut command = Command::new("bash");
+        command.arg("-lc").arg("exit 7");
+
+        let result = run_command_status_cancellable(command, &|| false);
+
+        assert_eq!(result, Some(false));
+    }
+}

--- a/src/preview/process.rs
+++ b/src/preview/process.rs
@@ -110,6 +110,20 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    #[cfg(not(windows))]
+    fn shell_command(script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(script);
+        command
+    }
+
+    #[cfg(windows)]
+    fn shell_command(script: &str) -> Command {
+        let mut command = Command::new("cmd");
+        command.arg("/C").arg(script);
+        command
+    }
+
     #[test]
     fn capture_helper_stops_long_running_process_promptly() {
         let canceled = Arc::new(AtomicBool::new(false));
@@ -119,8 +133,10 @@ mod tests {
             cancel_flag.store(true, Ordering::Relaxed);
         });
 
-        let mut command = Command::new("bash");
-        command.arg("-lc").arg("sleep 1; printf late");
+        #[cfg(not(windows))]
+        let command = shell_command("sleep 1; printf late");
+        #[cfg(windows)]
+        let command = shell_command("ping -n 3 127.0.0.1 >NUL && echo late");
         let started_at = Instant::now();
         let output =
             run_command_capture_stdout_cancellable(command, "preview-process-test", &|| {
@@ -142,8 +158,7 @@ mod tests {
 
     #[test]
     fn status_helper_reports_command_success() {
-        let mut command = Command::new("bash");
-        command.arg("-lc").arg("exit 0");
+        let command = shell_command("exit 0");
 
         let result = run_command_status_cancellable(command, &|| false);
 
@@ -152,8 +167,7 @@ mod tests {
 
     #[test]
     fn status_helper_reports_command_failure() {
-        let mut command = Command::new("bash");
-        command.arg("-lc").arg("exit 7");
+        let command = shell_command("exit 7");
 
         let result = run_command_status_cancellable(command, &|| false);
 

--- a/src/preview/video.rs
+++ b/src/preview/video.rs
@@ -1,6 +1,7 @@
 use super::{
     PreviewContent, PreviewKind, PreviewVisual, PreviewVisualKind, PreviewVisualLayout,
     appearance as theme,
+    process::{run_command_capture_stdout_cancellable, run_command_status_cancellable},
 };
 use crate::core::Entry;
 use ratatui::{
@@ -13,18 +14,12 @@ use std::{
     env, fs,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
-    sync::atomic::{AtomicU64, Ordering},
-    thread,
-    time::{Duration, SystemTime},
+    process::Command,
+    time::SystemTime,
 };
 
 const VIDEO_THUMBNAIL_CACHE_VERSION: usize = 1;
 const VIDEO_FALLBACK_THUMBNAIL_TIMESTAMP_MS: [u64; 2] = [1_000, 0];
-const CANCELLABLE_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(5);
-
-static COMMAND_CAPTURE_ID: AtomicU64 = AtomicU64::new(0);
-
 #[derive(Clone, Debug, Default, PartialEq)]
 struct VideoMetadata {
     dimensions: Option<(u32, u32)>,
@@ -375,86 +370,6 @@ fn finalize_video_thumbnail(temp_path: &Path, cache_path: &Path) -> Option<()> {
     }
 }
 
-fn run_command_capture_stdout_cancellable<F>(
-    mut command: Command,
-    capture_label: &str,
-    canceled: &F,
-) -> Option<Vec<u8>>
-where
-    F: Fn() -> bool,
-{
-    if canceled() {
-        return None;
-    }
-
-    let capture_path = command_capture_path(capture_label);
-    let stdout = fs::File::create(&capture_path).ok()?;
-    let mut child = match command
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => {
-            let _ = fs::remove_file(&capture_path);
-            return None;
-        }
-    };
-
-    loop {
-        if canceled() {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = fs::remove_file(&capture_path);
-            return None;
-        }
-
-        match child.try_wait().ok()? {
-            Some(status) => {
-                let output = status
-                    .success()
-                    .then(|| fs::read(&capture_path).ok())
-                    .flatten();
-                let _ = fs::remove_file(&capture_path);
-                return output;
-            }
-            None => thread::sleep(CANCELLABLE_COMMAND_POLL_INTERVAL),
-        }
-    }
-}
-
-fn run_command_status_cancellable<F>(mut command: Command, canceled: &F) -> Option<bool>
-where
-    F: Fn() -> bool,
-{
-    if canceled() {
-        return None;
-    }
-
-    let mut child = command
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-    loop {
-        if canceled() {
-            let _ = child.kill();
-            let _ = child.wait();
-            return None;
-        }
-
-        match child.try_wait().ok()? {
-            Some(status) => return Some(status.success()),
-            None => thread::sleep(CANCELLABLE_COMMAND_POLL_INTERVAL),
-        }
-    }
-}
-
-fn command_capture_path(label: &str) -> PathBuf {
-    let id = COMMAND_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
-    env::temp_dir().join(format!("elio-{label}-{}-{id}.tmp", std::process::id()))
-}
-
 fn system_time_key(time: SystemTime) -> Option<(u64, u32)> {
     time.duration_since(SystemTime::UNIX_EPOCH)
         .ok()
@@ -507,14 +422,7 @@ fn preview_field_line(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        path::Path,
-        sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
-        },
-        time::{Duration, Instant},
-    };
+    use std::{path::Path, time::Duration};
 
     #[test]
     fn thumbnail_timestamp_clamps_to_supported_range() {
@@ -572,36 +480,6 @@ mod tests {
         assert_eq!(
             thumbnail_candidate_timestamps_ms(Some(120.0)),
             vec![12_000, 1_000, 0]
-        );
-    }
-
-    #[test]
-    fn cancellable_command_helper_stops_long_running_process_promptly() {
-        let canceled = Arc::new(AtomicBool::new(false));
-        let cancel_flag = Arc::clone(&canceled);
-        let cancel_thread = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(25));
-            cancel_flag.store(true, Ordering::Relaxed);
-        });
-
-        let mut command = Command::new("bash");
-        command.arg("-lc").arg("sleep 1; printf late");
-        let started_at = Instant::now();
-        let output =
-            run_command_capture_stdout_cancellable(command, "video-cancel-command", &|| {
-                canceled.load(Ordering::Relaxed)
-            });
-        cancel_thread
-            .join()
-            .expect("cancel thread should finish cleanly");
-
-        assert!(
-            output.is_none(),
-            "canceled command output should be discarded"
-        );
-        assert!(
-            started_at.elapsed() < Duration::from_millis(500),
-            "canceled command should stop promptly"
         );
     }
 }


### PR DESCRIPTION
## Summary

- add `src/preview/process.rs` for shared cancellable subprocess helpers
- move the duplicated cancellable command logic out of audio, video, and comic preview code
- update preview modules to use the shared helper instead of local copies

## Why

Audio, video, and comic preview paths each carried near-identical logic for spawning long-running tools, polling for cancellation, capturing stdout, and cleaning up subprocess state.

This refactor keeps the behavior the same, but removes that duplication by centralizing the preview-scoped helpers in one module. That makes the cancellation behavior easier to reason about and reduces the chance of the implementations drifting apart later.

This is a structural refactor only. Behavior is unchanged.

## Testing

**Verified with:**

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

**Result:**

- **All checks passed; behavior remains unchanged.**