### PR TITLE
chore(architecture): add dependency guardrails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,6 +56,9 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --check
 
+      - name: cargo test --test architecture_guardrails
+        run: cargo test --test architecture_guardrails
+
       - name: cargo clippy --all-targets -- -D warnings
         run: cargo clippy --all-targets -- -D warnings
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,9 +10,14 @@ This crate is organized around a small set of layers.
 
 Current boundary rules:
 
-- Shared file-model types live in `src/core/`, not in `src/app/`.
-- Lower layers such as `fs` and `file_info` may depend on `core`, but should not depend on `app`.
-- `preview` is presentation code, but it should consume stable contracts from lower layers instead of reaching upward into unrelated subsystems.
-- `app` coordinates behavior; it should not be the home for generic data model types that other layers need.
+- Shared model types that multiple layers need, such as file-model and sidebar types, live in
+  `src/core/`, not in `src/app/`.
+- `fs` and `file_info` may depend on `core`, but should not depend on `app`.
+- `preview` is presentation code, but it should not depend on `app`.
+- `preview` should not reach into `ui::theme` directly. The explicit adapter boundary for theme
+  access is `src/preview/appearance.rs`.
+- `app` coordinates behavior; it should not be the home for generic data model types that other
+  layers need.
 
-This document is intentionally short. Keep it focused on real dependency rules, and update it as architectural seams become explicit in the code.
+These rules are enforced by the architecture guardrail test and CI. Keep this document focused on
+rules that the codebase actually follows and that tooling can check.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -37,9 +37,11 @@ pub(crate) use crate::fs::{
 pub(crate) use self::types::ClipOp;
 pub use self::types::{
     CopyHit, EntryHit, FrameState, GoToHit, PathHit, SearchHit, SearchRow, SearchScope,
-    SidebarItem, SidebarItemKind, SidebarRow, ViewMetrics, ViewMode,
+    ViewMetrics, ViewMode,
 };
-pub use crate::core::{Entry, EntryKind, SortMode};
+#[cfg(test)]
+pub use crate::core::SidebarItem;
+pub use crate::core::{Entry, EntryKind, SidebarItemKind, SidebarRow, SortMode};
 
 impl App {
     pub fn set_frame_state(&mut self, frame_state: FrameState) -> bool {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -13,7 +13,7 @@ use super::{
     overlays::{comic, epub, images, inline_image, pdf},
     types::*,
 };
-use crate::core::{Entry, SortMode};
+use crate::core::{Entry, SidebarRow, SortMode};
 use crate::fs::search::SearchCandidate;
 use crate::preview;
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -30,60 +30,6 @@ pub(crate) enum ClipOp {
     Cut,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SidebarItem {
-    pub kind: SidebarItemKind,
-    pub title: String,
-    pub icon: String,
-    pub path: PathBuf,
-}
-
-impl SidebarItem {
-    pub fn new(
-        kind: SidebarItemKind,
-        title: impl Into<String>,
-        icon: impl Into<String>,
-        path: PathBuf,
-    ) -> Self {
-        Self {
-            kind,
-            title: title.into(),
-            icon: icon.into(),
-            path,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SidebarItemKind {
-    Home,
-    Desktop,
-    Documents,
-    Downloads,
-    Pictures,
-    Music,
-    Videos,
-    Root,
-    Trash,
-    Custom,
-    Device { removable: bool },
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum SidebarRow {
-    Section { title: &'static str },
-    Item(SidebarItem),
-}
-
-impl SidebarRow {
-    pub fn item(&self) -> Option<&SidebarItem> {
-        match self {
-            Self::Item(item) => Some(item),
-            Self::Section { .. } => None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default)]
 pub struct FrameState {
     pub sidebar_hits: Vec<PathHit>,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,6 @@
 mod file_model;
+mod sidebar;
 
 pub(crate) use self::file_model::FileClass;
 pub use self::file_model::{Entry, EntryKind, SortMode};
+pub use self::sidebar::{SidebarItem, SidebarItemKind, SidebarRow};

--- a/src/core/sidebar.rs
+++ b/src/core/sidebar.rs
@@ -1,0 +1,55 @@
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SidebarItem {
+    pub kind: SidebarItemKind,
+    pub title: String,
+    pub icon: String,
+    pub path: PathBuf,
+}
+
+impl SidebarItem {
+    pub fn new(
+        kind: SidebarItemKind,
+        title: impl Into<String>,
+        icon: impl Into<String>,
+        path: PathBuf,
+    ) -> Self {
+        Self {
+            kind,
+            title: title.into(),
+            icon: icon.into(),
+            path,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SidebarItemKind {
+    Home,
+    Desktop,
+    Documents,
+    Downloads,
+    Pictures,
+    Music,
+    Videos,
+    Root,
+    Trash,
+    Custom,
+    Device { removable: bool },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SidebarRow {
+    Section { title: &'static str },
+    Item(SidebarItem),
+}
+
+impl SidebarRow {
+    pub fn item(&self) -> Option<&SidebarItem> {
+        match self {
+            Self::Item(item) => Some(item),
+            Self::Section { .. } => None,
+        }
+    }
+}

--- a/src/file_info/classify.rs
+++ b/src/file_info/classify.rs
@@ -3,7 +3,7 @@ use super::{
     license::sniff_license_file_type, names::inspect_exact_name,
 };
 use crate::{
-    app::{EntryKind, FileClass},
+    core::{EntryKind, FileClass},
     preview::code::registry,
 };
 use std::collections::HashMap;

--- a/src/file_info/names.rs
+++ b/src/file_info/names.rs
@@ -1,5 +1,5 @@
 use super::{FileFacts, PreviewSpec};
-use crate::{app::FileClass, preview::code::registry};
+use crate::{core::FileClass, preview::code::registry};
 
 fn preview_for_exact_name(name: &str) -> PreviewSpec {
     registry::language_for_exact_name(name)

--- a/src/fs/places/devices.rs
+++ b/src/fs/places/devices.rs
@@ -5,14 +5,14 @@
     target_os = "openbsd"
 ))]
 use super::resolution::path_identity_key;
-use crate::app::SidebarItem;
+use crate::core::SidebarItem;
 #[cfg(any(
     target_os = "macos",
     windows,
     target_os = "freebsd",
     target_os = "openbsd"
 ))]
-use crate::app::SidebarItemKind;
+use crate::core::SidebarItemKind;
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},

--- a/src/fs/places/linux.rs
+++ b/src/fs/places/linux.rs
@@ -1,5 +1,5 @@
 use super::resolution::path_identity_key;
-use crate::app::{SidebarItem, SidebarItemKind};
+use crate::core::{SidebarItem, SidebarItemKind};
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,

--- a/src/fs/places/resolution.rs
+++ b/src/fs/places/resolution.rs
@@ -1,7 +1,7 @@
 use super::devices::mounted_device_items;
 use crate::{
-    app::{SidebarItem, SidebarItemKind, SidebarRow},
     config::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
+    core::{SidebarItem, SidebarItemKind, SidebarRow},
 };
 use std::{
     collections::HashSet,

--- a/src/fs/places/tests.rs
+++ b/src/fs/places/tests.rs
@@ -1,7 +1,7 @@
 use super::resolution::{PlaceResolutionContext, build_sidebar_rows_with_context};
 use crate::{
-    app::{SidebarItemKind, SidebarRow},
     config::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
+    core::{SidebarItemKind, SidebarRow},
 };
 use std::{
     fs,

--- a/src/preview/audio.rs
+++ b/src/preview/audio.rs
@@ -520,7 +520,7 @@ fn render_audio_metadata_lines(
     if let Some(channels) = metadata.and_then(|metadata| metadata.channels) {
         fields.push(("Channels", format_channels(channels)));
     }
-    fields.push(("File Size", crate::app::format_size(byte_size)));
+    fields.push(("File Size", crate::fs::format_size(byte_size)));
 
     let label_width = fields
         .iter()

--- a/src/preview/container/archive/render.rs
+++ b/src/preview/container/archive/render.rs
@@ -23,15 +23,15 @@ pub(super) fn render_archive_preview(config: ArchiveRenderConfig) -> PreviewCont
         ("Files", (file_count > 0).then(|| file_count.to_string())),
         (
             "Packed",
-            config.metadata.compressed_size.map(crate::app::format_size),
+            config.metadata.compressed_size.map(crate::fs::format_size),
         ),
         (
             "Unpacked",
-            config.metadata.unpacked_size.map(crate::app::format_size),
+            config.metadata.unpacked_size.map(crate::fs::format_size),
         ),
         (
             "Archive Size",
-            config.metadata.physical_size.map(crate::app::format_size),
+            config.metadata.physical_size.map(crate::fs::format_size),
         ),
         ("Comment", config.metadata.comment),
     ];

--- a/src/preview/container/iso.rs
+++ b/src/preview/container/iso.rs
@@ -139,7 +139,7 @@ pub(in crate::preview) fn render_iso_preview(
         ("System", metadata.system_id.clone()),
         (
             "Image Size",
-            metadata.total_size.map(crate::app::format_size),
+            metadata.total_size.map(crate::fs::format_size),
         ),
         (
             "Bootable",

--- a/src/preview/container/torrent.rs
+++ b/src/preview/container/torrent.rs
@@ -69,10 +69,10 @@ pub(in crate::preview) fn build_torrent_preview(path: &Path) -> Option<PreviewCo
         ),
         ("Mode", metadata.mode.map(|mode| mode.label().to_string())),
         ("Files", Some(file_count.to_string())),
-        ("Size", metadata.total_size.map(crate::app::format_size)),
+        ("Size", metadata.total_size.map(crate::fs::format_size)),
         (
             "Piece Size",
-            metadata.piece_length.map(crate::app::format_size),
+            metadata.piece_length.map(crate::fs::format_size),
         ),
         (
             "Pieces",

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -420,7 +420,7 @@ fn image_metadata_preview(entry: &Entry, type_detail: Option<&'static str>) -> P
     let byte_size = std::fs::metadata(&entry.path)
         .map(|metadata| metadata.len())
         .unwrap_or(entry.size);
-    let mut fields = vec![("File Size", crate::app::format_size(byte_size))];
+    let mut fields = vec![("File Size", crate::fs::format_size(byte_size))];
     if let Ok((width_px, height_px)) = (|| {
         let reader = ImageReader::open(&entry.path)?;
         let reader = reader

--- a/src/preview/tests/audio.rs
+++ b/src/preview/tests/audio.rs
@@ -97,7 +97,7 @@ fn audio_preview_falls_back_to_file_metadata_without_tools() {
     assert_eq!(preview.detail.as_deref(), Some("FLAC audio"));
     assert!(preview.preview_visual.is_none());
     assert!(line_texts.iter().any(|line| line.contains("File Size")
-        && line.contains(&crate::app::format_size(contents.len() as u64))));
+        && line.contains(&crate::fs::format_size(contents.len() as u64))));
     assert!(line_texts.iter().all(|line| !line.contains("Title")));
     assert!(
         line_texts

--- a/src/preview/tests/videos.rs
+++ b/src/preview/tests/videos.rs
@@ -30,7 +30,7 @@ fn video_preview_falls_back_to_file_metadata_without_tools() {
     assert_eq!(preview.kind, PreviewKind::Video);
     assert_eq!(preview.detail.as_deref(), Some("Matroska video"));
     assert!(line_texts.iter().any(|line| line.contains("File Size")
-        && line.contains(&crate::app::format_size(contents.len() as u64))));
+        && line.contains(&crate::fs::format_size(contents.len() as u64))));
     assert!(preview.preview_visual.is_none());
     assert!(
         line_texts
@@ -125,7 +125,7 @@ fn video_preview_skips_thumbnail_without_ffprobe_even_if_ffmpeg_is_available() {
     assert_eq!(preview.detail.as_deref(), Some("AVI video"));
     assert!(preview.preview_visual.is_none());
     assert!(line_texts.iter().any(|line| line.contains("File Size")
-        && line.contains(&crate::app::format_size(contents.len() as u64))));
+        && line.contains(&crate::fs::format_size(contents.len() as u64))));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/preview/video.rs
+++ b/src/preview/video.rs
@@ -167,7 +167,7 @@ fn render_video_metadata_lines(
     byte_size: u64,
 ) -> Vec<Line<'static>> {
     let palette = theme::palette();
-    let mut fields = vec![("File Size", crate::app::format_size(byte_size))];
+    let mut fields = vec![("File Size", crate::fs::format_size(byte_size))];
     if let Some((width, height)) = metadata.and_then(|metadata| metadata.dimensions) {
         fields.insert(0, ("Dimensions", format!("{width}x{height}")));
     }

--- a/tests/architecture_guardrails.rs
+++ b/tests/architecture_guardrails.rs
@@ -1,0 +1,191 @@
+use std::{fs, path::Path, path::PathBuf};
+
+#[test]
+fn preview_does_not_depend_on_app() {
+    assert_tree_has_no_pattern("src/preview", "app::", &[]);
+}
+
+#[test]
+fn preview_theme_access_stays_behind_preview_appearance_adapter() {
+    assert_tree_has_no_pattern("src/preview", "ui::theme", &["src/preview/appearance.rs"]);
+}
+
+#[test]
+fn fs_does_not_depend_on_app() {
+    assert_tree_has_no_pattern("src/fs", "app::", &[]);
+}
+
+#[test]
+fn file_info_does_not_depend_on_app() {
+    assert_tree_has_no_pattern("src/file_info", "app::", &[]);
+}
+
+fn assert_tree_has_no_pattern(root: &str, forbidden: &str, allowed_files: &[&str]) {
+    let mut files = Vec::new();
+    collect_rust_files(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join(root),
+        &mut files,
+    );
+    files.sort();
+
+    let violations = files
+        .into_iter()
+        .filter_map(|path| {
+            let relative = relative_path(&path);
+            if allowed_files.contains(&relative.as_str()) {
+                return None;
+            }
+
+            let contents = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            strip_comments_and_strings(&contents)
+                .contains(forbidden)
+                .then_some(relative)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        violations.is_empty(),
+        "found forbidden `{forbidden}` references:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn collect_rust_files(root: &Path, files: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(root)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", root.display()));
+    let mut children = entries
+        .map(|entry| entry.expect("directory entry should be readable").path())
+        .collect::<Vec<_>>();
+    children.sort();
+
+    for child in children {
+        if child.is_dir() {
+            collect_rust_files(&child, files);
+        } else if child.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            files.push(child);
+        }
+    }
+}
+
+fn relative_path(path: &Path) -> String {
+    path.strip_prefix(env!("CARGO_MANIFEST_DIR"))
+        .expect("source path should live under workspace root")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn strip_comments_and_strings(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut output = String::with_capacity(source.len());
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if let Some((prefix_len, hash_count)) = raw_string_prefix(&bytes[index..]) {
+            output.push_str(&" ".repeat(prefix_len));
+            index += prefix_len;
+
+            while index < bytes.len() {
+                let byte = bytes[index];
+                output.push(if byte == b'\n' { '\n' } else { ' ' });
+                index += 1;
+
+                if byte == b'"' && has_n_hashes(bytes, index, hash_count) {
+                    output.push_str(&" ".repeat(hash_count));
+                    index += hash_count;
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if bytes[index..].starts_with(b"//") {
+            output.push_str("  ");
+            index += 2;
+            while index < bytes.len() && bytes[index] != b'\n' {
+                output.push(' ');
+                index += 1;
+            }
+            continue;
+        }
+
+        if bytes[index..].starts_with(b"/*") {
+            output.push_str("  ");
+            index += 2;
+            let mut depth = 1usize;
+            while index < bytes.len() && depth > 0 {
+                if bytes[index..].starts_with(b"/*") {
+                    output.push_str("  ");
+                    index += 2;
+                    depth += 1;
+                    continue;
+                }
+                if bytes[index..].starts_with(b"*/") {
+                    output.push_str("  ");
+                    index += 2;
+                    depth -= 1;
+                    continue;
+                }
+                output.push(if bytes[index] == b'\n' { '\n' } else { ' ' });
+                index += 1;
+            }
+            continue;
+        }
+
+        if bytes[index..].starts_with(b"b\"") || bytes[index] == b'"' {
+            let prefix_len = usize::from(bytes[index] == b'b') + 1;
+            output.push_str(&" ".repeat(prefix_len));
+            index += prefix_len;
+            let mut escaped = false;
+            while index < bytes.len() {
+                let byte = bytes[index];
+                output.push(if byte == b'\n' { '\n' } else { ' ' });
+                index += 1;
+
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if byte == b'\\' {
+                    escaped = true;
+                    continue;
+                }
+                if byte == b'"' {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        output.push(bytes[index] as char);
+        index += 1;
+    }
+
+    output
+}
+
+fn raw_string_prefix(bytes: &[u8]) -> Option<(usize, usize)> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let offset = if bytes.starts_with(b"br") || bytes.starts_with(b"rb") {
+        2
+    } else if bytes[0] == b'r' {
+        1
+    } else {
+        return None;
+    };
+
+    let mut index = offset;
+    while bytes.get(index) == Some(&b'#') {
+        index += 1;
+    }
+    (bytes.get(index) == Some(&b'"')).then_some((index + 1, index - offset))
+}
+
+fn has_n_hashes(bytes: &[u8], start: usize, count: usize) -> bool {
+    bytes
+        .get(start..start + count)
+        .is_some_and(|slice| slice.iter().all(|&byte| byte == b'#'))
+}


### PR DESCRIPTION
## Summary

- move shared sidebar types into `src/core/sidebar.rs`
- update `app`, `fs`, and related call sites to use the shared core sidebar types
- document the current layer boundaries in `docs/architecture.md`
- add `tests/architecture_guardrails.rs` to enforce the dependency rules
- run the architecture guardrail test in CI before clippy

## Why

This locks in the boundary work from the previous refactors. At this point the crate has clearer layering:

- shared model and sidebar types live in `core`
- `fs` and `file_info` no longer depend on `app`
- `preview` no longer depends on `app`
- preview theme access stays behind `src/preview/appearance.rs`

This PR adds lightweight enforcement so those boundaries do not regress over time. It also moves the remaining shared sidebar types out of `app`, which aligns the code with the documented architecture.

## Testing

**Verified with:**

- [x] `cargo test`
- [x] `cargo test --test architecture_guardrails`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

**Result:**

- **All checks passed; architectural boundaries enforced.**