### PR TITLE
test(architecture): lock app ui boundary

### DIFF
--- a/tests/architecture_guardrails.rs
+++ b/tests/architecture_guardrails.rs
@@ -20,6 +20,18 @@ fn file_info_does_not_depend_on_app() {
     assert_tree_has_no_pattern("src/file_info", "app::", &[]);
 }
 
+#[test]
+fn app_ui_access_stays_confined_to_inline_image_theme_helpers() {
+    assert_tree_has_no_pattern(
+        "src/app",
+        "crate::ui::",
+        &[
+            "src/app/overlays/inline_image/iterm.rs",
+            "src/app/overlays/inline_image/kitty.rs",
+        ],
+    );
+}
+
 fn assert_tree_has_no_pattern(root: &str, forbidden: &str, allowed_files: &[&str]) {
     let mut files = Vec::new();
     collect_rust_files(


### PR DESCRIPTION
## Summary

- add an `app_ui_access_stays_confined_to_inline_image_theme_helpers` guardrail to `tests/architecture_guardrails.rs`
- lock `src/app` away from `crate::ui::` everywhere except the two current inline-image theme helper files
- keep the existing architecture guardrails unchanged otherwise

## Why

The codebase already avoids `app -> ui` dependencies almost everywhere, but that assumption was not enforced. 

A blanket `app_does_not_depend_on_ui()` rule is not yet possible because the inline-image helpers in `src/app/overlays/inline_image/kitty.rs` and `src/app/overlays/inline_image/iterm.rs` still read the panel background from `crate::ui::theme::palette()`.

This change adds an accurate guardrail for the current architecture: `app` may not depend on `crate::ui::` outside those two known exceptions. This prevents the boundary from drifting while staying aligned with the actual code.

## Testing

**Verified with:**

- [x] `cargo test --test architecture_guardrails`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`

**Result:**

- **All checks passed; architectural guardrails successfully updated and enforced.**