### PR TITLE
 test(clipboard): tolerate queued paste completion timing

### DIFF
--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -545,9 +545,11 @@ fn queued_same_destination_pastes_defer_reload_until_queue_drains() {
         let _ = app.process_background_jobs();
         if app.jobs.paste_token != first_token {
             queued_started = true;
+            let reload_queued = app.navigation.directory_runtime.pending_load.is_some();
+            let queue_drained = app.paste_progress().is_none() && app.jobs.queued_pastes.is_empty();
             assert!(
-                app.navigation.directory_runtime.pending_load.is_none(),
-                "reload should stay deferred while a queued paste to the same destination starts"
+                !reload_queued || queue_drained,
+                "reload should stay deferred until the queued paste to the same destination has finished"
             );
             break;
         }


### PR DESCRIPTION
## Summary

- relax the queued same-destination paste timing assertion
- allow the test to observe either:
  - reload still deferred while the second paste is active
  - or reload already queued because the second paste already finished

## Why

The previous assertion depended on a narrow intermediate state and was flaky on faster CI runners after merge to `main`. 

The real invariant is that reload should not happen before the queued paste is done. If the queued paste has already finished by the time the test observes the token change, a pending reload is valid.

## Testing

**Verified with:**

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`

**Result:**

- **All checks passed; flaky test assertion stabilized.**