### PR TITLE
Fix/fuzzy search indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved fuzzy search indexing and filtering responsiveness for large directory trees.
+- Documented fuzzy search scope, hidden-file handling, pruning, refresh behavior, and large-tree caps.
+
+### Fixed
+
+- Fixed fuzzy search reusing stale indexes after directory reloads, so pasted, cut, deleted, or newly created entries are reflected after filesystem changes.
+
 ## [1.0.1] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ For `c`, elio copies file metadata to the clipboard using OSC52 on supported ter
 
 `g` opens a quick jump menu with shortcuts for the top of the current folder, Downloads, Home, the platform config folder, and Trash. The config destination is `~/.config` or `$XDG_CONFIG_HOME` on Linux and BSD, `~/Library/Application Support` on macOS, and `%APPDATA%` on Windows.
 
+### Fuzzy Search
+
+`f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, skips symlinks, prunes common generated folders such as `.git`, `node_modules`, and `target`, and refreshes when the directory changes. Very large trees are capped so search stays responsive.
+
 ---
 
 ## Preview Coverage

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -399,7 +399,10 @@ impl App {
         if let Some(search) = &mut self.overlays.search {
             search.candidates = Arc::new(Vec::new());
             search.matches.clear();
-            search.cached_matches = HashMap::from([(String::new(), Vec::new())]);
+            search.cached_matches = HashMap::from([(
+                String::new(),
+                super::super::search::build_base_search_cache_entry(Vec::new()),
+            )]);
             search.selected = 0;
             search.scroll = 0;
             search.loading = true;

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -110,6 +110,8 @@ impl App {
         load: PendingDirectoryLoad,
         snapshot: crate::fs::DirectorySnapshot,
     ) {
+        let should_refresh_open_search = self.overlays.search.is_some();
+        self.invalidate_search_index_for_directory_snapshot(&load.target_cwd);
         self.navigation.directory_runtime.pending_fingerprint_scan = None;
         let cwd_changed = load.target_cwd != self.navigation.cwd;
         let remembered_view = self.remembered_view_for(&load.target_cwd);
@@ -191,7 +193,7 @@ impl App {
             }
         }
 
-        if load.refresh_search {
+        if load.refresh_search || should_refresh_open_search {
             self.refresh_search_after_directory_reload();
         }
 
@@ -200,6 +202,20 @@ impl App {
             DirectoryLoadCompletion::Clear => self.status.clear(),
             DirectoryLoadCompletion::Status(status) => self.status = status,
         }
+    }
+
+    fn invalidate_search_index_for_directory_snapshot(&mut self, cwd: &Path) {
+        if self
+            .jobs
+            .search_cache
+            .as_ref()
+            .is_some_and(|cache| cache.cwd == cwd)
+        {
+            self.jobs.search_cache = None;
+        }
+
+        self.jobs.search_loading = false;
+        self.jobs.search_token = self.jobs.search_token.wrapping_add(1);
     }
 
     fn remembered_view_for(&self, cwd: &Path) -> Option<DirectoryViewMemory> {

--- a/src/app/jobs/pool/search.rs
+++ b/src/app/jobs/pool/search.rs
@@ -29,6 +29,7 @@ pub(in crate::app::jobs) struct SearchJobKey {
     pub(in crate::app::jobs) cwd: PathBuf,
     pub(in crate::app::jobs) scope: SearchScope,
     pub(in crate::app::jobs) show_hidden: bool,
+    pub(in crate::app::jobs) fingerprint: crate::fs::DirectoryFingerprint,
 }
 
 impl SearchPool {
@@ -70,6 +71,7 @@ impl SearchPool {
                             cwd: request.cwd,
                             scope: request.scope,
                             show_hidden: request.show_hidden,
+                            fingerprint: request.fingerprint,
                             result,
                         }))
                         .is_err()
@@ -164,6 +166,7 @@ impl SearchJobKey {
             cwd: request.cwd.clone(),
             scope: request.scope,
             show_hidden: request.show_hidden,
+            fingerprint: request.fingerprint,
         }
     }
 }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -151,6 +151,7 @@ impl App {
                     if build.token != self.jobs.search_token
                         || build.cwd != self.navigation.cwd
                         || build.show_hidden != self.navigation.show_hidden
+                        || build.fingerprint != self.navigation.directory_runtime.fingerprint
                     {
                         continue;
                     }
@@ -164,6 +165,7 @@ impl App {
                                 cwd: build.cwd,
                                 scope: build.scope,
                                 show_hidden: build.show_hidden,
+                                fingerprint: build.fingerprint,
                                 candidates: candidates.clone(),
                             });
                             if let Some(search) = &mut self.overlays.search

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -172,7 +172,9 @@ impl App {
                                 search.candidates = candidates;
                                 search.cached_matches = HashMap::from([(
                                     String::new(),
-                                    (0..search.candidates.len()).collect(),
+                                    crate::app::search::build_base_search_cache_entry(
+                                        (0..search.candidates.len()).collect(),
+                                    ),
                                 )]);
                                 search.loading = false;
                                 search.error = None;
@@ -186,8 +188,10 @@ impl App {
                             {
                                 search.candidates = Arc::new(Vec::new());
                                 search.matches.clear();
-                                search.cached_matches =
-                                    HashMap::from([(String::new(), Vec::new())]);
+                                search.cached_matches = HashMap::from([(
+                                    String::new(),
+                                    crate::app::search::build_base_search_cache_entry(Vec::new()),
+                                )]);
                                 search.selected = 0;
                                 search.scroll = 0;
                                 search.loading = false;

--- a/src/app/jobs/tests.rs
+++ b/src/app/jobs/tests.rs
@@ -76,12 +76,14 @@ fn search_pool_replaces_pending_request_with_latest_distinct_job() {
         cwd: PathBuf::from("/tmp/a"),
         scope: SearchScope::Files,
         show_hidden: false,
+        fingerprint: crate::fs::DirectoryFingerprint::default(),
     }));
     assert!(scheduler.submit_search(SearchRequest {
         token: 2,
         cwd: PathBuf::from("/tmp/b"),
         scope: SearchScope::Files,
         show_hidden: false,
+        fingerprint: crate::fs::DirectoryFingerprint::default(),
     }));
     assert_eq!(
         scheduler.snapshot().search_pending,
@@ -89,6 +91,7 @@ fn search_pool_replaces_pending_request_with_latest_distinct_job() {
             cwd: PathBuf::from("/tmp/b"),
             scope: SearchScope::Files,
             show_hidden: false,
+            fingerprint: crate::fs::DirectoryFingerprint::default(),
         })
     );
 }
@@ -374,6 +377,7 @@ fn scheduler_reports_pending_work_when_jobs_are_queued() {
         cwd: PathBuf::from("/tmp/a"),
         scope: SearchScope::Files,
         show_hidden: false,
+        fingerprint: crate::fs::DirectoryFingerprint::default(),
     }));
     assert!(scheduler.has_pending_work());
 }
@@ -386,6 +390,7 @@ fn scheduler_reports_pending_work_for_buffered_results() {
         cwd: PathBuf::from("/tmp/search"),
         scope: SearchScope::Files,
         show_hidden: false,
+        fingerprint: crate::fs::DirectoryFingerprint::default(),
         result: Ok(Arc::new(Vec::new())),
     }));
 

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -46,6 +46,7 @@ pub(in crate::app) struct SearchBuild {
     pub(in crate::app) cwd: PathBuf,
     pub(in crate::app) scope: SearchScope,
     pub(in crate::app) show_hidden: bool,
+    pub(in crate::app) fingerprint: crate::fs::DirectoryFingerprint,
     pub(in crate::app) result: Result<Arc<Vec<SearchCandidate>>, String>,
 }
 
@@ -55,6 +56,7 @@ pub(in crate::app) struct SearchRequest {
     pub(in crate::app) cwd: PathBuf,
     pub(in crate::app) scope: SearchScope,
     pub(in crate::app) show_hidden: bool,
+    pub(in crate::app) fingerprint: crate::fs::DirectoryFingerprint,
 }
 
 #[derive(Debug)]

--- a/src/app/search/index.rs
+++ b/src/app/search/index.rs
@@ -50,6 +50,7 @@ impl App {
             cwd: self.navigation.cwd.clone(),
             scope,
             show_hidden: self.effective_show_hidden(),
+            fingerprint: self.navigation.directory_runtime.fingerprint,
         };
         if !self.jobs.scheduler.submit_search(request) {
             self.jobs.search_loading = false;

--- a/src/app/search/index.rs
+++ b/src/app/search/index.rs
@@ -2,32 +2,33 @@ use super::super::*;
 use std::collections::HashMap;
 
 impl App {
-    pub(in crate::app) fn refresh_search_matches(&mut self, _previous_query: &str) {
+    pub(in crate::app) fn refresh_search_matches(&mut self, previous_query: &str) {
         let Some(search) = &mut self.overlays.search else {
             return;
         };
         search.query_cursor = search.query_cursor.min(search.query.chars().count());
 
         let next_query = search.query.clone();
-        if let Some(cached) = search.cached_matches.get(&next_query).cloned() {
-            search.matches = cached;
+        let next_query_key = super::search_cache_key(&next_query);
+        if let Some(cached) = search.cached_matches.get(&next_query_key).cloned() {
+            search.matches = cached.matches;
         } else {
-            let pool = search
-                .cached_matches
-                .get("")
-                .cloned()
-                .unwrap_or_else(|| (0..search.candidates.len()).collect::<Vec<_>>());
+            let result = {
+                let pool = select_search_pool(search, previous_query, &next_query);
+                crate::fs::search::filter_candidates_in(
+                    &search.candidates,
+                    pool.iter().copied(),
+                    &next_query,
+                    SEARCH_MATCH_LIMIT,
+                )
+            };
 
-            search.matches = crate::fs::search::filter_candidates_in(
-                &search.candidates,
-                pool,
-                &next_query,
-                SEARCH_MATCH_LIMIT,
+            search.matches = result.matches.clone();
+            prune_search_cache(&mut search.cached_matches, &next_query_key);
+            search.cached_matches.insert(
+                next_query_key,
+                super::build_search_cache_entry(result.pool, result.matches),
             );
-            prune_search_cache(&mut search.cached_matches, &next_query);
-            search
-                .cached_matches
-                .insert(next_query.clone(), search.matches.clone());
         }
 
         if search.matches.is_empty() {
@@ -62,7 +63,42 @@ impl App {
     }
 }
 
-fn prune_search_cache(cached_matches: &mut HashMap<String, Vec<usize>>, active_query: &str) {
+fn select_search_pool<'a>(
+    search: &'a SearchOverlay,
+    previous_query: &str,
+    next_query: &str,
+) -> &'a [usize] {
+    let next_query_key = super::search_cache_key(next_query);
+    let previous_query_key = super::search_cache_key(previous_query);
+
+    if !previous_query_key.is_empty()
+        && next_query_key.starts_with(&previous_query_key)
+        && let Some(entry) = search.cached_matches.get(&previous_query_key)
+    {
+        return &entry.pool;
+    }
+
+    if let Some(entry) = search
+        .cached_matches
+        .iter()
+        .filter(|(query, _)| !query.is_empty() && next_query_key.starts_with(query.as_str()))
+        .max_by_key(|(query, _)| query.len())
+        .map(|(_, entry)| entry)
+    {
+        return &entry.pool;
+    }
+
+    search
+        .cached_matches
+        .get("")
+        .map(|entry| entry.pool.as_slice())
+        .unwrap_or(&[])
+}
+
+fn prune_search_cache(
+    cached_matches: &mut HashMap<String, SearchMatchCacheEntry>,
+    active_query: &str,
+) {
     if cached_matches.len() < SEARCH_CACHE_LIMIT {
         return;
     }

--- a/src/app/search/mod.rs
+++ b/src/app/search/mod.rs
@@ -3,3 +3,21 @@ mod overlay;
 
 #[cfg(test)]
 mod tests;
+
+use super::{SEARCH_MATCH_LIMIT, SearchMatchCacheEntry};
+
+pub(in crate::app) fn search_cache_key(query: &str) -> String {
+    query.to_lowercase()
+}
+
+pub(in crate::app) fn build_search_cache_entry(
+    pool: Vec<usize>,
+    matches: Vec<usize>,
+) -> SearchMatchCacheEntry {
+    SearchMatchCacheEntry { pool, matches }
+}
+
+pub(in crate::app) fn build_base_search_cache_entry(pool: Vec<usize>) -> SearchMatchCacheEntry {
+    let matches = pool.iter().copied().take(SEARCH_MATCH_LIMIT).collect();
+    build_search_cache_entry(pool, matches)
+}

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -20,7 +20,14 @@ impl App {
         self.overlays
             .search
             .as_ref()
-            .map(|search| search.matches.len())
+            .map(|search| {
+                let query_key = super::search_cache_key(&search.query);
+                search
+                    .cached_matches
+                    .get(&query_key)
+                    .map(|entry| entry.pool.len())
+                    .unwrap_or(search.matches.len())
+            })
             .unwrap_or(0)
     }
 
@@ -28,7 +35,7 @@ impl App {
         self.overlays
             .search
             .as_ref()
-            .and_then(|search| search.cached_matches.get("").map(Vec::len))
+            .and_then(|search| search.cached_matches.get("").map(|entry| entry.pool.len()))
             .unwrap_or(0)
     }
 
@@ -101,7 +108,10 @@ impl App {
             query_cursor: 0,
             candidates,
             matches,
-            cached_matches: HashMap::from([(String::new(), base_matches)]),
+            cached_matches: HashMap::from([(
+                String::new(),
+                super::build_base_search_cache_entry(base_matches),
+            )]),
             selected: 0,
             scroll: 0,
             loading,

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -89,6 +89,7 @@ impl App {
                 cache.cwd == self.navigation.cwd
                     && cache.scope == scope
                     && cache.show_hidden == self.navigation.show_hidden
+                    && cache.fingerprint == self.navigation.directory_runtime.fingerprint
             })
             .map(|cache| cache.candidates.clone());
         let candidates = cached.clone().unwrap_or_else(|| Arc::new(Vec::new()));

--- a/src/app/search/tests.rs
+++ b/src/app/search/tests.rs
@@ -18,6 +18,10 @@ fn temp_path(label: &str) -> PathBuf {
     path.canonicalize().unwrap_or(path)
 }
 
+fn base_cache_entry(pool: Vec<usize>) -> SearchMatchCacheEntry {
+    super::build_base_search_cache_entry(pool)
+}
+
 #[test]
 fn opening_search_restarts_index_when_cache_missing_even_if_loading() {
     let root = temp_path("restarts-index");
@@ -99,7 +103,7 @@ fn refining_query_rechecks_full_candidate_set() {
         query_cursor: 1,
         candidates: Arc::new(candidates),
         matches: Vec::new(),
-        cached_matches: HashMap::from([(String::new(), (0..301).collect())]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry((0..301).collect()))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -149,7 +153,7 @@ fn search_query_cursor_inserts_and_deletes_in_place() {
         query_cursor: 2,
         candidates: Arc::new(Vec::new()),
         matches: Vec::new(),
-        cached_matches: HashMap::from([(String::new(), Vec::new())]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(Vec::new()))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -183,7 +187,7 @@ fn search_query_ctrl_arrows_move_across_word_boundaries() {
         query_cursor: "foo bar/baz".chars().count(),
         candidates: Arc::new(Vec::new()),
         matches: Vec::new(),
-        cached_matches: HashMap::from([(String::new(), Vec::new())]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(Vec::new()))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -229,7 +233,7 @@ fn search_query_ctrl_backspace_and_delete_remove_word_units() {
         query_cursor: 8,
         candidates: Arc::new(Vec::new()),
         matches: Vec::new(),
-        cached_matches: HashMap::from([(String::new(), Vec::new())]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(Vec::new()))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -266,7 +270,7 @@ fn search_query_terminal_fallback_word_delete_bindings_work() {
         query_cursor: 8,
         candidates: Arc::new(Vec::new()),
         matches: Vec::new(),
-        cached_matches: HashMap::from([(String::new(), Vec::new())]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(Vec::new()))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -318,7 +322,7 @@ fn search_rows_ignore_stale_match_indexes() {
         query_cursor: 0,
         candidates: Arc::new(Vec::new()),
         matches: vec![3],
-        cached_matches: HashMap::from([(String::new(), vec![3])]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(vec![3]))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -357,7 +361,7 @@ fn confirm_search_selection_selects_file_already_in_current_directory() {
             is_dir: false,
         }]),
         matches: vec![0],
-        cached_matches: HashMap::from([(String::new(), vec![0])]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(vec![0]))]),
         selected: 0,
         scroll: 0,
         loading: false,
@@ -398,7 +402,7 @@ fn confirm_search_selection_keeps_overlay_open_when_reveal_fails() {
             is_dir: false,
         }]),
         matches: vec![0],
-        cached_matches: HashMap::from([(String::new(), vec![0])]),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(vec![0]))]),
         selected: 0,
         scroll: 0,
         loading: false,

--- a/src/app/search/tests.rs
+++ b/src/app/search/tests.rs
@@ -5,7 +5,7 @@ use std::{
     fs,
     path::PathBuf,
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 fn temp_path(label: &str) -> PathBuf {
@@ -20,6 +20,25 @@ fn temp_path(label: &str) -> PathBuf {
 
 fn base_cache_entry(pool: Vec<usize>) -> SearchMatchCacheEntry {
     super::build_base_search_cache_entry(pool)
+}
+
+fn wait_for_search_candidates(app: &mut App, expected: usize) {
+    for _ in 0..300 {
+        let _ = app.process_background_jobs();
+        if app.search_is_open()
+            && !app.search_is_loading()
+            && app.search_candidate_count() == expected
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!(
+        "timed out waiting for search candidates: expected={}, actual={}, loading={}",
+        expected,
+        app.search_candidate_count(),
+        app.search_is_loading(),
+    );
 }
 
 #[test]
@@ -51,6 +70,7 @@ fn opening_search_ignores_hidden_cache_when_browser_hides_dotfiles() {
         cwd: root.clone(),
         scope: SearchScope::Folders,
         show_hidden: true,
+        fingerprint: app.navigation.directory_runtime.fingerprint,
         candidates: Arc::new(vec![crate::fs::search::SearchCandidate {
             path: root.join(".hidden-root/needle"),
             name: "needle".to_string(),
@@ -66,6 +86,46 @@ fn opening_search_ignores_hidden_cache_when_browser_hides_dotfiles() {
 
     assert_eq!(app.search_candidate_count(), 0);
     assert!(app.search_is_loading());
+
+    fs::remove_dir_all(root).expect("failed to remove temp tree");
+}
+
+#[test]
+fn directory_reload_invalidates_closed_search_cache() {
+    let root = temp_path("reload-invalidates-cache");
+    fs::create_dir_all(root.join("alpha")).expect("failed to create initial folder");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_fuzzy_finder(SearchScope::Folders)
+        .expect("failed to open search");
+    wait_for_search_candidates(&mut app, 1);
+    app.overlays.search = None;
+
+    fs::create_dir_all(root.join("beta")).expect("failed to create new folder");
+    let snapshot = crate::fs::load_directory_snapshot(&root, false, app.navigation.sort_mode)
+        .expect("failed to load directory snapshot");
+    app.apply_directory_snapshot(
+        PendingDirectoryLoad {
+            token: 0,
+            target_cwd: root.clone(),
+            previous_cwd: root.clone(),
+            previous_selected_path: None,
+            previous_selection_name: None,
+            reselect_path: None,
+            history_mode: DirectoryHistoryMode::None,
+            refresh_search: false,
+            completion: DirectoryLoadCompletion::Keep,
+        },
+        snapshot,
+    );
+
+    app.open_fuzzy_finder(SearchScope::Folders)
+        .expect("failed to reopen search");
+    assert!(
+        app.search_is_loading(),
+        "reopening search should rebuild instead of reusing the stale cache"
+    );
+    wait_for_search_candidates(&mut app, 2);
 
     fs::remove_dir_all(root).expect("failed to remove temp tree");
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -268,6 +268,7 @@ pub(super) struct SearchCache {
     pub(super) cwd: PathBuf,
     pub(super) scope: SearchScope,
     pub(super) show_hidden: bool,
+    pub(super) fingerprint: crate::fs::DirectoryFingerprint,
     pub(super) candidates: Arc<Vec<SearchCandidate>>,
 }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -189,11 +189,17 @@ pub(super) struct SearchOverlay {
     pub(super) query_cursor: usize,
     pub(super) candidates: Arc<Vec<SearchCandidate>>,
     pub(super) matches: Vec<usize>,
-    pub(super) cached_matches: HashMap<String, Vec<usize>>,
+    pub(super) cached_matches: HashMap<String, SearchMatchCacheEntry>,
     pub(super) selected: usize,
     pub(super) scroll: usize,
     pub(super) loading: bool,
     pub(super) error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SearchMatchCacheEntry {
+    pub(super) pool: Vec<usize>,
+    pub(super) matches: Vec<usize>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -22,7 +22,7 @@ thread_local! {
     static TEST_OPEN_IN_SYSTEM_CAPTURE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub(crate) struct DirectoryFingerprint {
     pub digest: u64,
     pub entries: usize,

--- a/src/fs/search.rs
+++ b/src/fs/search.rs
@@ -31,6 +31,31 @@ pub(crate) fn collect_candidates(
     collect_candidates_with_limits(cwd, show_hidden, scope, usize::MAX, SEARCH_NODE_VISIT_LIMIT)
 }
 
+struct PendingSearchNode {
+    path: PathBuf,
+    name: String,
+    name_key: String,
+    relative: Option<String>,
+    relative_key: Option<String>,
+    is_dir: bool,
+    enqueue_children: bool,
+}
+
+impl PendingSearchNode {
+    fn into_candidate(self) -> Option<SearchCandidate> {
+        let relative = self.relative?;
+        let relative_key = self.relative_key?;
+        Some(SearchCandidate {
+            path: self.path,
+            name: self.name,
+            name_key: self.name_key,
+            relative,
+            relative_key,
+            is_dir: self.is_dir,
+        })
+    }
+}
+
 fn collect_candidates_with_limits(
     cwd: &Path,
     show_hidden: bool,
@@ -69,11 +94,9 @@ fn collect_candidates_with_limits(
                 continue;
             }
 
-            let path = entry.path();
-            let Ok(metadata) = fs::symlink_metadata(&path) else {
+            let Ok(file_type) = entry.file_type() else {
                 continue;
             };
-            let file_type = metadata.file_type();
             if file_type.is_symlink() {
                 continue;
             }
@@ -86,35 +109,54 @@ fn collect_candidates_with_limits(
 
             visited_nodes += 1;
 
-            let Ok(relative_path) = path.strip_prefix(cwd) else {
+            let include_candidate = should_include_candidate(is_dir, scope);
+            if !is_dir && !include_candidate {
                 continue;
-            };
-            let relative = relative_path.to_string_lossy().replace('\\', "/");
+            }
+
             let name = file_name.to_string_lossy().to_string();
             let name_key = name.to_lowercase();
-            let relative_key = relative.to_lowercase();
-            nodes.push(SearchCandidate {
+            let enqueue_children = is_dir && !should_prune_dir(&name_key);
+            if !include_candidate && !enqueue_children {
+                continue;
+            }
+
+            let path = entry.path();
+            let (relative, relative_key) = if include_candidate {
+                let Ok(relative_path) = path.strip_prefix(cwd) else {
+                    continue;
+                };
+                let relative = relative_path.to_string_lossy().replace('\\', "/");
+                let relative_key = relative.to_lowercase();
+                (Some(relative), Some(relative_key))
+            } else {
+                (None, None)
+            };
+
+            nodes.push(PendingSearchNode {
                 path,
                 name,
                 name_key,
                 relative,
                 relative_key,
                 is_dir,
+                enqueue_children,
             });
         }
 
         nodes.sort_by(|left, right| {
+            // Siblings share the same parent prefix, so sorting by name preserves
+            // the same natural order as sorting by their relative paths.
             super::natural_cmp(&left.name_key, &right.name_key)
-                .then_with(|| super::natural_cmp(&left.relative_key, &right.relative_key))
-                .then_with(|| left.relative.cmp(&right.relative))
+                .then_with(|| left.name.cmp(&right.name))
         });
 
         for node in nodes {
-            if node.is_dir && !should_prune_dir(&node.name_key) {
+            if node.enqueue_children {
                 queue.push_back(node.path.clone());
             }
-            if should_include_candidate(node.is_dir, scope) {
-                candidates.push(node);
+            if let Some(candidate) = node.into_candidate() {
+                candidates.push(candidate);
             }
         }
     }
@@ -356,6 +398,51 @@ mod tests {
                 .iter()
                 .any(|candidate| candidate.relative == ".hidden-root/needle")
         );
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[test]
+    fn collect_candidates_prune_known_dirs_without_hiding_the_directory_itself() {
+        let root = temp_path("pruned-dirs");
+        fs::create_dir_all(root.join("node_modules/package"))
+            .expect("failed to create node_modules");
+        fs::create_dir_all(root.join("src/feature")).expect("failed to create src tree");
+
+        let candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
+                .expect("failed to collect candidates");
+        let names = candidates
+            .iter()
+            .map(|candidate| candidate.relative.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"node_modules"));
+        assert!(!names.contains(&"node_modules/package"));
+        assert!(names.contains(&"src"));
+        assert!(names.contains(&"src/feature"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[test]
+    fn collect_candidates_still_descends_directories_when_searching_files() {
+        let root = temp_path("file-search-descend");
+        fs::create_dir_all(root.join("alpha")).expect("failed to create alpha");
+        fs::write(root.join("alpha/needle.txt"), "needle").expect("failed to write needle");
+        fs::write(root.join("top.txt"), "top").expect("failed to write top");
+
+        let candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
+                .expect("failed to collect file candidates");
+        let names = candidates
+            .iter()
+            .map(|candidate| candidate.relative.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"top.txt"));
+        assert!(names.contains(&"alpha/needle.txt"));
+        assert!(!names.contains(&"alpha"));
 
         fs::remove_dir_all(root).expect("failed to remove temp tree");
     }

--- a/src/fs/search.rs
+++ b/src/fs/search.rs
@@ -172,16 +172,19 @@ pub(crate) fn filter_candidates_in<I>(
     pool: I,
     query: &str,
     limit: usize,
-) -> Vec<usize>
+) -> SearchFilterResult
 where
     I: IntoIterator<Item = usize>,
 {
     if query.trim().is_empty() {
-        return pool.into_iter().take(limit).collect();
+        let pool = pool.into_iter().collect::<Vec<_>>();
+        let matches = pool.iter().copied().take(limit).collect();
+        return SearchFilterResult { pool, matches };
     }
 
     let query_key = query.to_lowercase();
     let needle = query_key.as_bytes();
+    let mut filtered_pool = Vec::new();
     let mut top = Vec::<(usize, i64, usize)>::with_capacity(limit.min(64));
 
     for index in pool {
@@ -196,6 +199,8 @@ where
             (None, Some(path)) => path,
             (None, None) => continue,
         };
+
+        filtered_pool.push(index);
 
         let entry = (index, score, candidate.relative.len());
         let insert_at = top
@@ -212,7 +217,16 @@ where
         }
     }
 
-    top.into_iter().map(|(index, _, _)| index).collect()
+    let matches = top.into_iter().map(|(index, _, _)| index).collect();
+    SearchFilterResult {
+        pool: filtered_pool,
+        matches,
+    }
+}
+
+pub(crate) struct SearchFilterResult {
+    pub(crate) pool: Vec<usize>,
+    pub(crate) matches: Vec<usize>,
 }
 
 fn should_include_candidate(is_dir: bool, scope: SearchCandidateScope) -> bool {
@@ -336,8 +350,8 @@ mod tests {
             },
         ];
 
-        let matches = filter_candidates_in(&candidates, 0..candidates.len(), "mn", 10);
-        assert_eq!(matches.first().copied(), Some(0));
+        let result = filter_candidates_in(&candidates, 0..candidates.len(), "mn", 10);
+        assert_eq!(result.matches.first().copied(), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes stale fuzzy search indexes after the current directory changes, and documents the fuzzy search indexing behavior.

## What Changed

 - Invalidates cached fuzzy search candidates when a directory snapshot is reloaded.
 - Tags search jobs and cache entries with the directory fingerprint so stale in-flight results are ignored.
 - Refreshes an open fuzzy search overlay after directory reloads.
 - Adds a regression test for reopening fuzzy search after the directory contents change.
 - Documents fuzzy search scope, hidden-file behavior, pruning, refresh behavior, and large-tree caps in the workflow section.

## User Impact

Fuzzy search now reflects pasted, cut, deleted, or otherwise changed directory contents after reloads instead of reusing an old indexed count. Users also get a short README note explaining what fuzzy search indexes and why very large trees may be capped.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

 - Verified fuzzy search updates after pasting a large folder into a test directory.
 - Verified fuzzy search updates after cutting/removing that folder.

Result: All checks passed locally. 

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
