### PR TITLE
Fix trash display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved fuzzy search indexing and filtering responsiveness for large directory trees.
 - Documented fuzzy search scope, hidden-file handling, pruning, refresh behavior, and large-tree caps.
+- Documented Trash behavior across Linux, BSD, macOS, and Windows.
+- Prefer `gio trash` on Linux before falling back to the Freedesktop Trash layout for desktop-compatible trashing.
 
 ### Fixed
 
 - Fixed fuzzy search reusing stale indexes after directory reloads, so pasted, cut, deleted, or newly created entries are reflected after filesystem changes.
+- Fixed Freedesktop Trash entries with collision-suffixed storage names, such as `photo.jpg.2`, so they display, preview, open, and restore using their original `.trashinfo` names.
 
 ## [1.0.1] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ For `c`, elio copies file metadata to the clipboard using OSC52 on supported ter
 
 `g` opens a quick jump menu with shortcuts for the top of the current folder, Downloads, Home, the platform config folder, and Trash. The config destination is `~/.config` or `$XDG_CONFIG_HOME` on Linux and BSD, `~/Library/Application Support` on macOS, and `%APPDATA%` on Windows.
 
+### Trash
+
+`d` moves the selected item or selection to the operating system trash. In the Trash view, `d` permanently deletes items and `r` restores them.
+
+Trash uses the platform's native behavior where possible: Linux tries `gio trash` first, then falls back to the Freedesktop Trash layout; BSD uses Freedesktop Trash; macOS moves items to `~/.Trash` and records restore metadata for items trashed by elio.
+
+Windows can move items to the Recycle Bin through the platform trash backend, but elio does not expose the Recycle Bin as a browsable Trash view yet, so restore/permanent-delete-from-Trash workflows are not supported there.
+
+On Freedesktop Trash systems, the stored filename may be changed to avoid collisions, for example `photo.jpg.2`. elio reads the matching `.trashinfo` metadata, so the file is still shown, previewed, opened, and restored as the original `photo.jpg`.
+
 ### Fuzzy Search
 
 `f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, skips symlinks, prunes common generated folders such as `.git`, `node_modules`, and `target`, and refreshes when the directory changes. Very large trees are capped so search stays responsive.

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -113,9 +113,7 @@ impl App {
             return preview_mode;
         };
         let variant = self.preview_request_options_for_entry(&entry);
-        let builtin_class =
-            file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified)
-                .builtin_class;
+        let builtin_class = file_info::inspect_entry_cached(&entry).builtin_class;
         let cold_heavy_preview = matches!(builtin_class, FileClass::Audio | FileClass::Video)
             && preview_work_class(&entry, &variant) == PreviewWorkClass::Heavy
             && self.cached_preview_for(&entry, &variant).is_none();

--- a/src/app/actions/preview/prefetch.rs
+++ b/src/app/actions/preview/prefetch.rs
@@ -220,7 +220,5 @@ impl App {
 }
 
 fn is_audio_entry(entry: &Entry) -> bool {
-    file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified)
-        .builtin_class
-        == FileClass::Audio
+    file_info::inspect_entry_cached(entry).builtin_class == FileClass::Audio
 }

--- a/src/app/actions/preview/request.rs
+++ b/src/app/actions/preview/request.rs
@@ -110,12 +110,7 @@ impl App {
         entry: &Entry,
         preview_rows_visible: usize,
     ) -> usize {
-        let facts = crate::file_info::inspect_path_cached(
-            &entry.path,
-            entry.kind,
-            entry.size,
-            entry.modified,
-        );
+        let facts = crate::file_info::inspect_entry_cached(entry);
         if facts.preview.kind == crate::file_info::PreviewKind::Source
             && facts.preview.structured_format.is_none()
         {

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -11,11 +11,20 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(target_os = "linux")]
+use std::process::{Command, Stdio};
+
 /// Minimum time between intermediate progress results sent to the UI.
 /// Only applies to permanent delete, which processes files one at a time.
 /// Non-permanent trash is a single batched OS call with no intermediate
 /// progress.
 const PROGRESS_SEND_INTERVAL: Duration = Duration::from_millis(80);
+
+#[cfg(target_os = "linux")]
+const GIO_TRASH_ARG_BUDGET: usize = 128 * 1024;
+
+#[cfg(target_os = "linux")]
+const GIO_TRASH_COMMAND_OVERHEAD: usize = "gio".len() + 1 + "trash".len() + 1 + "--".len() + 1;
 
 pub(in crate::app::jobs) struct TrashPool {
     shared: Arc<TrashShared>,
@@ -461,13 +470,12 @@ fn pid_is_alive(_pid: u32) -> bool {
     true
 }
 
-/// Move all targets to the OS trash in a single batched call to
-/// `trash::delete_all`.
+/// Move all targets to the OS trash in a single batched operation.
 ///
-/// This is significantly faster than per-item trashing because the `trash`
-/// crate amortizes expensive setup work — reading `/proc/mounts`, resolving
-/// the trash directory, checking for name collisions — across the whole
-/// batch instead of repeating it for every file.
+/// On Linux, prefer `gio trash` so Elio uses the same Freedesktop/GVfs trash
+/// backend as GNOME Files and other desktop-aware tools.  The Rust `trash`
+/// crate remains the fallback for systems without GIO, unsupported mounts, or
+/// command failures that leave sources untouched.
 ///
 /// Cancellation is checked once before the batch starts.  The batch itself
 /// is treated as atomic from Elio's perspective: once the OS call is in
@@ -482,11 +490,11 @@ fn run_trash_batch(
         return (0, Vec::new(), true);
     }
 
-    let paths: Vec<_> = request.targets.iter().map(|t| &t.path).collect();
+    let paths: Vec<_> = request.targets.iter().map(|t| t.path.as_path()).collect();
     let total = paths.len();
 
-    match ::trash::delete_all(paths) {
-        Ok(()) => {
+    match trash_with_system_backend(&paths) {
+        TrashBatchBackendResult::Completed => {
             #[cfg(target_os = "macos")]
             {
                 let origins: Vec<(String, std::path::PathBuf)> = request
@@ -498,8 +506,219 @@ fn run_trash_batch(
             }
             (total, Vec::new(), false)
         }
-        Err(e) => (0, vec![e.to_string()], false),
+        TrashBatchBackendResult::Failed { completed, error } => (completed, vec![error], false),
     }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum TrashBatchBackendResult {
+    Completed,
+    Failed { completed: usize, error: String },
+}
+
+fn trash_with_system_backend(paths: &[&Path]) -> TrashBatchBackendResult {
+    #[cfg(target_os = "linux")]
+    {
+        trash_with_gio_first(paths)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    match trash_with_crate(paths) {
+        Ok(()) => TrashBatchBackendResult::Completed,
+        Err(error) => TrashBatchBackendResult::Failed {
+            completed: 0,
+            error,
+        },
+    }
+}
+
+fn trash_with_crate(paths: &[&Path]) -> Result<(), String> {
+    ::trash::delete_all(paths.iter().copied()).map_err(|e| e.to_string())
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Eq, PartialEq)]
+enum GioTrashCommandResult {
+    Completed,
+    Unavailable,
+    Failed(String),
+}
+
+#[cfg(target_os = "linux")]
+fn trash_with_gio_first(paths: &[&Path]) -> TrashBatchBackendResult {
+    trash_with_gio_runner(paths, run_gio_trash_command, trash_with_crate)
+}
+
+#[cfg(target_os = "linux")]
+fn trash_with_gio_runner<G, F>(
+    paths: &[&Path],
+    mut run_gio: G,
+    mut run_fallback: F,
+) -> TrashBatchBackendResult
+where
+    G: FnMut(&[&Path]) -> GioTrashCommandResult,
+    F: FnMut(&[&Path]) -> Result<(), String>,
+{
+    for range in gio_trash_chunks(paths) {
+        match run_gio(&paths[range.clone()]) {
+            GioTrashCommandResult::Completed => {}
+            GioTrashCommandResult::Unavailable => {
+                return finish_gio_unavailable_fallback(
+                    paths,
+                    range.start,
+                    "gio trash is not available",
+                    |p| run_fallback(p),
+                );
+            }
+            GioTrashCommandResult::Failed(error) => {
+                return finish_gio_failure_fallback(paths, range, &error, |p| run_fallback(p));
+            }
+        }
+    }
+
+    TrashBatchBackendResult::Completed
+}
+
+#[cfg(target_os = "linux")]
+fn finish_gio_unavailable_fallback<F>(
+    paths: &[&Path],
+    remaining_start: usize,
+    gio_error: &str,
+    mut run_fallback: F,
+) -> TrashBatchBackendResult
+where
+    F: FnMut(&[&Path]) -> Result<(), String>,
+{
+    finish_with_fallback(
+        paths[remaining_start..].to_vec(),
+        remaining_start,
+        gio_error,
+        |p| run_fallback(p),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn finish_gio_failure_fallback<F>(
+    paths: &[&Path],
+    failed_range: std::ops::Range<usize>,
+    gio_error: &str,
+    mut run_fallback: F,
+) -> TrashBatchBackendResult
+where
+    F: FnMut(&[&Path]) -> Result<(), String>,
+{
+    let mut completed = failed_range.start;
+    let mut remaining = Vec::new();
+
+    for path in &paths[failed_range.clone()] {
+        if path.exists() {
+            remaining.push(*path);
+        } else {
+            completed += 1;
+        }
+    }
+    remaining.extend_from_slice(&paths[failed_range.end..]);
+
+    finish_with_fallback(remaining, completed, gio_error, |p| run_fallback(p))
+}
+
+#[cfg(target_os = "linux")]
+fn finish_with_fallback<F>(
+    remaining: Vec<&Path>,
+    completed: usize,
+    gio_error: &str,
+    mut run_fallback: F,
+) -> TrashBatchBackendResult
+where
+    F: FnMut(&[&Path]) -> Result<(), String>,
+{
+    if remaining.is_empty() {
+        return TrashBatchBackendResult::Completed;
+    }
+
+    run_fallback(&remaining).map_or_else(
+        |fallback_error| TrashBatchBackendResult::Failed {
+            completed,
+            error: format!(
+                "Could not trash all items: {gio_error}; fallback failed: {fallback_error}"
+            ),
+        },
+        |()| TrashBatchBackendResult::Completed,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn run_gio_trash_command(paths: &[&Path]) -> GioTrashCommandResult {
+    if paths.is_empty() {
+        return GioTrashCommandResult::Completed;
+    }
+
+    let output = Command::new("gio")
+        .arg("trash")
+        .arg("--")
+        .args(paths)
+        .stdin(Stdio::null())
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => GioTrashCommandResult::Completed,
+        Ok(output) => GioTrashCommandResult::Failed(format!(
+            "gio trash failed{}",
+            command_output_message(&output.stderr, &output.stdout)
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            GioTrashCommandResult::Unavailable
+        }
+        Err(error) => GioTrashCommandResult::Failed(format!("could not start gio trash: {error}")),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn command_output_message(stderr: &[u8], stdout: &[u8]) -> String {
+    let bytes = if stderr.is_empty() { stdout } else { stderr };
+    let text = String::from_utf8_lossy(bytes).trim().to_string();
+    if text.is_empty() {
+        String::new()
+    } else {
+        format!(": {text}")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn gio_trash_chunks(paths: &[&Path]) -> Vec<std::ops::Range<usize>> {
+    gio_trash_chunks_with_budget(paths, GIO_TRASH_ARG_BUDGET)
+}
+
+#[cfg(target_os = "linux")]
+fn gio_trash_chunks_with_budget(paths: &[&Path], budget: usize) -> Vec<std::ops::Range<usize>> {
+    if paths.is_empty() {
+        return Vec::new();
+    }
+
+    let budget = budget.max(GIO_TRASH_COMMAND_OVERHEAD + 1);
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut used = GIO_TRASH_COMMAND_OVERHEAD;
+
+    for (index, path) in paths.iter().enumerate() {
+        let arg_len = gio_trash_arg_len(path);
+        if index > start && used + arg_len > budget {
+            ranges.push(start..index);
+            start = index;
+            used = GIO_TRASH_COMMAND_OVERHEAD;
+        }
+        used += arg_len;
+    }
+
+    ranges.push(start..paths.len());
+    ranges
+}
+
+#[cfg(target_os = "linux")]
+fn gio_trash_arg_len(path: &Path) -> usize {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().len() + 1
 }
 
 /// Send a throttled intermediate progress result for the permanent-delete
@@ -545,6 +764,138 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("elio-test-{tag}-{pid}-{nanos}"));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[cfg(target_os = "linux")]
+    fn path_refs(paths: &[PathBuf]) -> Vec<&Path> {
+        paths.iter().map(|path| path.as_path()).collect()
+    }
+
+    // ── GIO trash backend ─────────────────────────────────────────────────
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gio_trash_chunks_split_before_budget_is_exceeded() {
+        let paths = vec![
+            PathBuf::from("/home/user/a.jpg"),
+            PathBuf::from("/home/user/b.jpg"),
+            PathBuf::from("/home/user/c.jpg"),
+        ];
+        let refs = path_refs(&paths);
+        let budget = GIO_TRASH_COMMAND_OVERHEAD
+            + gio_trash_arg_len(&paths[0])
+            + gio_trash_arg_len(&paths[1])
+            - 1;
+
+        let chunks = gio_trash_chunks_with_budget(&refs, budget);
+
+        assert_eq!(chunks, vec![0..1, 1..2, 2..3]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gio_trash_chunks_keep_oversized_path_in_its_own_chunk() {
+        let paths = vec![PathBuf::from("/home/user/really-long-name.jpg")];
+        let refs = path_refs(&paths);
+
+        let chunks = gio_trash_chunks_with_budget(&refs, GIO_TRASH_COMMAND_OVERHEAD + 1);
+
+        assert_eq!(chunks, vec![0..1]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gio_first_falls_back_when_gio_is_unavailable() {
+        let root = make_tmp_dir("gio-unavailable-fallback");
+        let first = root.join("a.jpg");
+        let second = root.join("b.jpg");
+        fs::write(&first, b"a").unwrap();
+        fs::write(&second, b"b").unwrap();
+        let paths = vec![first, second];
+        let refs = path_refs(&paths);
+        let mut gio_calls = 0usize;
+        let mut fallback_paths = Vec::new();
+
+        let result = trash_with_gio_runner(
+            &refs,
+            |_| {
+                gio_calls += 1;
+                GioTrashCommandResult::Unavailable
+            },
+            |paths| {
+                fallback_paths = paths.iter().map(|path| path.to_path_buf()).collect();
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, TrashBatchBackendResult::Completed);
+        assert_eq!(gio_calls, 1);
+        assert_eq!(fallback_paths, paths);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gio_first_falls_back_for_remaining_paths_after_partial_failure() {
+        let root = make_tmp_dir("gio-partial-fallback");
+        let moved = root.join("moved.jpg");
+        let remaining = root.join("remaining.jpg");
+        fs::write(&moved, b"moved").unwrap();
+        fs::write(&remaining, b"remaining").unwrap();
+        let paths = vec![moved.clone(), remaining.clone()];
+        let refs = path_refs(&paths);
+        let mut fallback_paths = Vec::new();
+
+        let result = trash_with_gio_runner(
+            &refs,
+            |paths| {
+                fs::remove_file(paths[0]).unwrap();
+                GioTrashCommandResult::Failed("gio failed on this mount".to_string())
+            },
+            |paths| {
+                fallback_paths = paths.iter().map(|path| path.to_path_buf()).collect();
+                for path in paths {
+                    fs::remove_file(*path).unwrap();
+                }
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, TrashBatchBackendResult::Completed);
+        assert_eq!(fallback_paths, vec![remaining]);
+        assert!(!moved.exists());
+        assert!(!paths[1].exists());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gio_first_reports_completed_count_when_fallback_fails() {
+        let root = make_tmp_dir("gio-fallback-failure");
+        let moved = root.join("moved.jpg");
+        let remaining = root.join("remaining.jpg");
+        fs::write(&moved, b"moved").unwrap();
+        fs::write(&remaining, b"remaining").unwrap();
+        let paths = vec![moved.clone(), remaining];
+        let refs = path_refs(&paths);
+
+        let result = trash_with_gio_runner(
+            &refs,
+            |paths| {
+                fs::remove_file(paths[0]).unwrap();
+                GioTrashCommandResult::Failed("gio failed on this mount".to_string())
+            },
+            |_| Err("fallback failed too".to_string()),
+        );
+
+        assert_eq!(
+            result,
+            TrashBatchBackendResult::Failed {
+                completed: 1,
+                error: "Could not trash all items: gio failed on this mount; fallback failed: fallback failed too".to_string(),
+            }
+        );
+        let _ = fs::remove_dir_all(&root);
     }
 
     /// Simulates the startup logic: delete cleanup_root/{current_pid}/ if it

--- a/src/app/open_with/discovery/mime.rs
+++ b/src/app/open_with/discovery/mime.rs
@@ -5,12 +5,16 @@ use std::process::Command;
 
 use crate::preview::process::run_command_capture_stdout_cancellable;
 
-pub(super) fn detect_mime_type(path: &Path, canceled: &impl Fn() -> bool) -> Option<String> {
+pub(super) fn detect_mime_type_with_name(
+    path: &Path,
+    display_name: Option<&str>,
+    canceled: &impl Fn() -> bool,
+) -> Option<String> {
     // Fast path: look up the file extension in the XDG MIME globs database.
     // This is instant (pure file read), covers virtually all files with a
     // recognisable extension, and works correctly on both Linux and BSD because
     // it searches the full XDG data dir chain rather than a hardcoded path.
-    if let Some(mime) = mime_from_xdg_database(path) {
+    if let Some(mime) = mime_from_data_dirs_with_name(path, display_name, &super::xdg_data_dirs()) {
         return Some(mime);
     }
 
@@ -52,8 +56,14 @@ pub(super) fn detect_mime_type(path: &Path, canceled: &impl Fn() -> bool) -> Opt
 ///
 /// This correctly handles BSD systems where `shared-mime-info` installs to
 /// `/usr/local/share/mime/` rather than `/usr/share/mime/`.
-fn mime_from_xdg_database(path: &Path) -> Option<String> {
-    mime_from_data_dirs(path, &super::xdg_data_dirs())
+fn mime_from_data_dirs_with_name(
+    path: &Path,
+    display_name: Option<&str>,
+    data_dirs: &[PathBuf],
+) -> Option<String> {
+    display_name
+        .and_then(|name| mime_from_data_dirs(Path::new(name), data_dirs))
+        .or_else(|| mime_from_data_dirs(path, data_dirs))
 }
 
 /// Inner implementation that accepts an explicit data-dir list for testing.
@@ -261,6 +271,26 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[test]
+    fn display_name_extension_can_override_collision_suffixed_storage_path() {
+        let dir = unique_dir("display-name-extension");
+        write_globs2(&dir, "50:image/jpeg:*.jpeg\n");
+
+        let result = mime_from_data_dirs_with_name(
+            Path::new("/trash/files/photo.jpeg.2"),
+            Some("photo.jpeg"),
+            std::slice::from_ref(&dir),
+        );
+        let raw_storage_result = mime_from_data_dirs(
+            Path::new("/trash/files/photo.jpeg.2"),
+            std::slice::from_ref(&dir),
+        );
+        let _ = fs::remove_dir_all(&dir);
+
+        assert_eq!(result.as_deref(), Some("image/jpeg"));
+        assert!(raw_storage_result.is_none());
+    }
+
     // ── mime_from_xdg_database (system integration) ───────────────────────────
     // Uses the real XDG data dirs.  Skips gracefully if no MIME database is
     // present (e.g. minimal CI image).
@@ -274,7 +304,11 @@ mod tests {
             return;
         }
         // .png is universally registered as image/png.
-        let result = mime_from_xdg_database(Path::new("/any/path/image.png"));
+        let result = mime_from_data_dirs_with_name(
+            Path::new("/any/path/image.png"),
+            None,
+            &super::super::xdg_data_dirs(),
+        );
         assert_eq!(
             result.as_deref(),
             Some("image/png"),

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -14,21 +14,28 @@ mod scan;
 use std::path::Path;
 
 use super::super::state::OpenWithApp;
+use crate::core::Entry;
 
 // ── public entry point ────────────────────────────────────────────────────────
 
-pub(super) fn discover_open_with_apps(path: &Path) -> Vec<OpenWithApp> {
+pub(super) fn discover_open_with_apps_for_entry(entry: &Entry) -> Vec<OpenWithApp> {
+    discover_open_with_apps_inner(&entry.path, Some(entry.name.as_str()))
+}
+
+fn discover_open_with_apps_inner(path: &Path, display_name: Option<&str>) -> Vec<OpenWithApp> {
     #[cfg(target_os = "macos")]
     {
+        let _ = display_name;
         macos::discover_via_nsworkspace(path)
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        discover_xdg(path)
+        discover_xdg(path, display_name)
     }
     #[cfg(not(any(target_os = "macos", all(unix, not(target_os = "macos")))))]
     {
         let _ = path;
+        let _ = display_name;
         vec![]
     }
 }
@@ -80,7 +87,7 @@ pub(super) fn current_desktops() -> Vec<String> {
 // ── XDG discovery (Linux / BSD) ───────────────────────────────────────────────
 
 #[cfg(all(unix, not(target_os = "macos")))]
-fn discover_xdg(path: &Path) -> Vec<OpenWithApp> {
+fn discover_xdg(path: &Path, display_name: Option<&str>) -> Vec<OpenWithApp> {
     use std::time::{Duration, Instant};
 
     // 3-second budget for subprocess fallbacks; pure-Rust MIME lookup is
@@ -88,7 +95,7 @@ fn discover_xdg(path: &Path) -> Vec<OpenWithApp> {
     let deadline = Instant::now() + Duration::from_millis(3000);
     let canceled = || Instant::now() > deadline;
 
-    let Some(mime_type) = mime::detect_mime_type(path, &canceled) else {
+    let Some(mime_type) = mime::detect_mime_type_with_name(path, display_name, &canceled) else {
         return vec![];
     };
 

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -67,9 +67,10 @@ impl App {
             self.status = "Open With is for files".to_string();
             return;
         }
+        let entry = entry.clone();
         let path = entry.path.clone();
 
-        let apps = super::discovery::discover_open_with_apps(&path);
+        let apps = super::discovery::discover_open_with_apps_for_entry(&entry);
         self.handle_discovered_open_with_apps(&path, apps, open_with_fallback, |app| {
             detached_open_command(&app.program, &app.args)
         });

--- a/src/app/overlays/epub.rs
+++ b/src/app/overlays/epub.rs
@@ -331,7 +331,7 @@ impl App {
 }
 
 fn is_epub_entry(entry: &Entry) -> bool {
-    file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified)
+    file_info::inspect_entry_cached(entry)
         .preview
         .document_format
         == Some(DocumentFormat::Epub)

--- a/src/app/overlays/images/format.rs
+++ b/src/app/overlays/images/format.rs
@@ -44,7 +44,7 @@ pub(super) fn static_image_detail_label(entry: &Entry) -> Option<&'static str> {
 }
 
 fn static_image_format_for_entry(entry: &Entry) -> Option<StaticImageFormat> {
-    crate::file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified)
+    crate::file_info::inspect_entry_cached(entry)
         .specific_type_label
         .and_then(StaticImageFormat::from_label)
 }
@@ -60,6 +60,7 @@ pub(super) fn static_image_format_for_overlay_request(
     )
     .specific_type_label
     .and_then(StaticImageFormat::from_label)
+    .or_else(|| sniff_static_image_format(&request.path))
 }
 
 pub(super) fn static_image_format_for_prepare_request(
@@ -73,12 +74,41 @@ pub(super) fn static_image_format_for_prepare_request(
     )
     .specific_type_label
     .and_then(StaticImageFormat::from_label)
+    .or_else(|| sniff_static_image_format(&request.path))
 }
 
 pub(super) fn static_image_format_for_path(path: &Path) -> Option<StaticImageFormat> {
     crate::file_info::inspect_path(path, EntryKind::File)
         .specific_type_label
         .and_then(StaticImageFormat::from_label)
+        .or_else(|| sniff_static_image_format(path))
+}
+
+fn sniff_static_image_format(path: &Path) -> Option<StaticImageFormat> {
+    let mut file = File::open(path).ok()?;
+    let mut buffer = [0_u8; 512];
+    let bytes_read = file.read(&mut buffer).ok()?;
+    let prefix = &buffer[..bytes_read];
+    if prefix.starts_with(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]) {
+        return Some(StaticImageFormat::Png);
+    }
+    if prefix.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some(StaticImageFormat::Jpeg);
+    }
+    if prefix.starts_with(b"GIF87a") || prefix.starts_with(b"GIF89a") {
+        return Some(StaticImageFormat::Gif);
+    }
+    if prefix.len() >= 12 && &prefix[..4] == b"RIFF" && &prefix[8..12] == b"WEBP" {
+        return Some(StaticImageFormat::Webp);
+    }
+    if prefix.len() >= 4 && prefix[..4] == [0x00, 0x00, 0x01, 0x00] {
+        return Some(StaticImageFormat::Ico);
+    }
+
+    let text = std::str::from_utf8(prefix).ok()?;
+    let trimmed = text.trim_start_matches(|ch: char| ch.is_ascii_whitespace() || ch == '\u{feff}');
+    (trimmed.starts_with("<svg") || (trimmed.starts_with("<?xml") && trimmed.contains("<svg")))
+        .then_some(StaticImageFormat::Svg)
 }
 
 pub(super) fn read_raster_dimensions(path: &Path) -> Option<RenderedImageDimensions> {
@@ -249,4 +279,36 @@ fn parse_svg_view_box(value: &str) -> Option<(f32, f32)> {
     let width = parts.next()?.parse::<f32>().ok()?;
     let height = parts.next()?.parse::<f32>().ok()?;
     Some((width, height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-static-image-format-{label}-{unique}"))
+    }
+
+    #[test]
+    fn static_image_format_sniffs_collision_suffixed_jpeg_path() {
+        let root = temp_path("jpeg-collision-suffix");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("photo.jpeg.2");
+        fs::write(&path, [0xff, 0xd8, 0xff, 0xdb]).expect("failed to write jpeg signature");
+
+        assert_eq!(
+            static_image_format_for_path(&path),
+            Some(StaticImageFormat::Jpeg)
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
 }

--- a/src/app/overlays/pdf/session.rs
+++ b/src/app/overlays/pdf/session.rs
@@ -402,7 +402,7 @@ impl App {
 }
 
 fn is_pdf_entry(entry: &Entry) -> bool {
-    file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified)
+    file_info::inspect_entry_cached(entry)
         .preview
         .document_format
         == Some(DocumentFormat::Pdf)

--- a/src/file_info/classify.rs
+++ b/src/file_info/classify.rs
@@ -3,7 +3,7 @@ use super::{
     license::sniff_license_file_type, names::inspect_exact_name,
 };
 use crate::{
-    core::{EntryKind, FileClass},
+    core::{Entry, EntryKind, FileClass},
     preview::code::registry,
 };
 use std::collections::HashMap;
@@ -20,6 +20,10 @@ const STRONG_SHELL_THRESHOLD: u8 = 4;
 const SCORE_MARGIN: u8 = 2;
 
 pub(crate) fn inspect_path(path: &Path, kind: EntryKind) -> FileFacts {
+    inspect_path_with_name(path, None, kind)
+}
+
+fn inspect_path_with_name(path: &Path, display_name: Option<&str>, kind: EntryKind) -> FileFacts {
     if kind == EntryKind::Directory {
         return FileFacts {
             builtin_class: FileClass::Directory,
@@ -28,11 +32,15 @@ pub(crate) fn inspect_path(path: &Path, kind: EntryKind) -> FileFacts {
         };
     }
 
-    let name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(normalize_key)
+    let name_for_type = display_name
+        .map(str::to_owned)
+        .or_else(|| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_owned)
+        })
         .unwrap_or_default();
+    let name = normalize_key(&name_for_type);
     if let Some(facts) = inspect_exact_name(&name) {
         return facts;
     }
@@ -40,7 +48,7 @@ pub(crate) fn inspect_path(path: &Path, kind: EntryKind) -> FileFacts {
         return facts;
     }
 
-    let ext = path
+    let ext = Path::new(&name_for_type)
         .extension()
         .and_then(|ext| ext.to_str())
         .map(normalize_key)
@@ -63,9 +71,30 @@ pub(crate) fn inspect_path_cached(
     size: u64,
     modified: Option<SystemTime>,
 ) -> FileFacts {
+    inspect_path_with_name_cached(path, None, kind, size, modified)
+}
+
+pub(crate) fn inspect_entry_cached(entry: &Entry) -> FileFacts {
+    inspect_path_with_name_cached(
+        &entry.path,
+        Some(&entry.name),
+        entry.kind,
+        entry.size,
+        entry.modified,
+    )
+}
+
+fn inspect_path_with_name_cached(
+    path: &Path,
+    display_name: Option<&str>,
+    kind: EntryKind,
+    size: u64,
+    modified: Option<SystemTime>,
+) -> FileFacts {
     #[derive(Eq, Hash, PartialEq)]
     struct CacheKey {
         path: PathBuf,
+        display_name: Option<String>,
         is_dir: bool,
         size: u64,
         mtime: Option<(u64, u32)>,
@@ -81,6 +110,7 @@ pub(crate) fn inspect_path_cached(
         .map(|d| (d.as_secs(), d.subsec_nanos()));
     let key = CacheKey {
         path: path.to_path_buf(),
+        display_name: display_name.map(str::to_owned),
         is_dir: kind == EntryKind::Directory,
         size,
         mtime,
@@ -94,7 +124,7 @@ pub(crate) fn inspect_path_cached(
         return facts;
     }
 
-    let facts = inspect_path(path, kind);
+    let facts = inspect_path_with_name(path, display_name, kind);
     facts_cache()
         .lock()
         .expect("file facts cache lock")

--- a/src/file_info/mod.rs
+++ b/src/file_info/mod.rs
@@ -9,7 +9,7 @@ mod types;
 mod tests;
 
 pub(crate) use self::archives::inspect_compound_archive_name;
-pub(crate) use self::classify::{inspect_path, inspect_path_cached};
+pub(crate) use self::classify::{inspect_entry_cached, inspect_path, inspect_path_cached};
 pub(crate) use self::types::{
     CodeBackend, CompoundArchiveKind, CompressionKind, CustomCodeKind, DiskImageKind,
     DocumentFormat, FileFacts, PreviewKind, PreviewSpec, StructuredFormat,

--- a/src/file_info/tests/classify.rs
+++ b/src/file_info/tests/classify.rs
@@ -216,6 +216,31 @@ fn extensionless_png_is_detected_from_magic_bytes() {
 }
 
 #[test]
+fn entry_display_name_controls_classification_when_storage_name_has_collision_suffix() {
+    let root = temp_path("display-name-classification");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("photo.jpeg.2");
+    fs::write(&path, [0xff, 0xd8, 0xff, 0xdb]).expect("failed to write jpeg signature");
+    let metadata = fs::metadata(&path).expect("failed to stat temp file");
+    let entry = crate::core::Entry {
+        path: path.clone(),
+        name: "photo.jpeg".to_string(),
+        name_key: "photo.jpeg".to_string(),
+        kind: EntryKind::File,
+        size: metadata.len(),
+        modified: metadata.modified().ok(),
+        readonly: false,
+    };
+
+    let facts = inspect_entry_cached(&entry);
+
+    assert_eq!(facts.builtin_class, FileClass::Image);
+    assert_eq!(facts.specific_type_label, Some("JPEG image"));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn extensionless_svg_is_detected_from_contents() {
     let root = temp_path("extensionless-svg");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -4,15 +4,13 @@ use anyhow::{Context, Result};
 use std::cell::RefCell;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
-#[cfg(test)]
-use std::path::PathBuf;
 use std::{
     cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fs,
     hash::{Hash, Hasher},
     io,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -51,16 +49,37 @@ struct EntryDetails {
     readonly: bool,
 }
 
-/// Reads the `DeletionDate` from a `.trashinfo` file inside `info_dir` for the given file name.
-fn read_trash_deletion_date(info_dir: &Path, name: &str) -> Option<SystemTime> {
+#[derive(Clone, Debug, Default)]
+struct TrashInfoMetadata {
+    original_name: Option<String>,
+    deletion_date: Option<SystemTime>,
+}
+
+fn trash_info_dir_for_files_dir(dir: &Path) -> Option<PathBuf> {
+    (dir.file_name().is_some_and(|n| n == "files"))
+        .then(|| dir.parent().map(|p| p.join("info")).filter(|p| p.is_dir()))
+        .flatten()
+}
+
+/// Reads the display metadata from a `.trashinfo` file inside `info_dir` for
+/// the given stored trash file name.
+fn read_trash_info_metadata(info_dir: &Path, name: &str) -> Option<TrashInfoMetadata> {
     let info_path = info_dir.join(format!("{name}.trashinfo"));
     let content = fs::read_to_string(info_path).ok()?;
+
+    let mut metadata = TrashInfoMetadata::default();
     for line in content.lines() {
         if let Some(date_str) = line.trim().strip_prefix("DeletionDate=") {
-            return parse_trash_deletion_date(date_str);
+            metadata.deletion_date = parse_trash_deletion_date(date_str);
+        } else if let Some(path_str) = line.trim().strip_prefix("Path=") {
+            metadata.original_name = trash_original_name(path_str);
         }
     }
-    None
+    Some(metadata)
+}
+
+fn trash_original_name(encoded_path: &str) -> Option<String> {
+    super::trashinfo::original_basename_from_path_value(encoded_path)
 }
 
 /// Parses a `DeletionDate` value from a `.trashinfo` file into a `SystemTime`.
@@ -148,16 +167,20 @@ pub(crate) fn load_directory_snapshot(
 ) -> Result<DirectorySnapshot> {
     let mut entries = read_entries(dir, show_hidden)?;
 
-    // If this is a freedesktop trash `files/` directory (recognised by the presence of a
-    // sibling `info/` directory), replace each entry's modification time with the deletion
-    // date stored in the corresponding `.trashinfo` file so the listing shows "trashed X ago"
-    // rather than the file's own last-modified timestamp.
-    if dir.file_name().is_some_and(|n| n == "files")
-        && let Some(info_dir) = dir.parent().map(|p| p.join("info")).filter(|p| p.is_dir())
-    {
+    // If this is a freedesktop trash `files/` directory, keep the entry path
+    // pointing at the stored trash file but display the original basename from
+    // the matching `.trashinfo`. The stored name may be collision-renamed
+    // (`foo.txt.2`, `foo.2.txt`, etc.) and is an implementation detail.
+    if let Some(info_dir) = trash_info_dir_for_files_dir(dir) {
         for entry in &mut entries {
-            if let Some(date) = read_trash_deletion_date(&info_dir, &entry.name) {
-                entry.modified = Some(date);
+            if let Some(metadata) = read_trash_info_metadata(&info_dir, &entry.name) {
+                if let Some(date) = metadata.deletion_date {
+                    entry.modified = Some(date);
+                }
+                if let Some(original_name) = metadata.original_name {
+                    entry.name = original_name;
+                    entry.name_key = entry.name.to_lowercase();
+                }
             }
         }
     }
@@ -189,6 +212,7 @@ pub(crate) fn scan_directory_fingerprint(
     show_hidden: bool,
 ) -> Result<DirectoryFingerprint> {
     let mut parts = Vec::new();
+    let trash_info_dir = trash_info_dir_for_files_dir(dir);
     for item in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
         let item = match item {
             Ok(item) => item,
@@ -205,11 +229,23 @@ pub(crate) fn scan_directory_fingerprint(
             Err(_) => continue,
         };
         let details = entry_details(&item.path(), &metadata);
+        let mut name = file_name.to_string_lossy().to_string();
+        let mut modified = details.modified;
+        if let Some(info_dir) = trash_info_dir.as_deref()
+            && let Some(metadata) = read_trash_info_metadata(info_dir, &name)
+        {
+            if let Some(original_name) = metadata.original_name {
+                name = original_name;
+            }
+            if let Some(date) = metadata.deletion_date {
+                modified = Some(date);
+            }
+        }
         parts.push(FingerprintPart {
-            name: file_name.to_string_lossy().to_lowercase(),
+            name: name.to_lowercase(),
             kind: details.kind,
             size: details.size,
-            modified: fingerprint_time(details.modified),
+            modified: fingerprint_time(modified),
             readonly: details.readonly,
         });
     }
@@ -698,6 +734,91 @@ mod tests {
             .expect("should be after epoch")
             .as_secs();
         assert_eq!(secs, 1_710_498_600);
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn trash_snapshot_displays_original_name_from_trashinfo() {
+        let root = temp_path("trash-display-name");
+        let files_dir = root.join("files");
+        let info_dir = root.join("info");
+        fs::create_dir_all(&files_dir).expect("failed to create files dir");
+        fs::create_dir_all(&info_dir).expect("failed to create info dir");
+
+        fs::write(files_dir.join("report.pdf.2"), "dummy")
+            .expect("failed to write collision-renamed trashed file");
+        fs::write(
+            info_dir.join("report.pdf.2.trashinfo"),
+            "[Trash Info]\nPath=/home/user/Reports/report%20final.pdf\nDeletionDate=2024-03-15T10:30:00\n",
+        )
+        .expect("failed to write trashinfo");
+
+        let snapshot =
+            load_directory_snapshot(&files_dir, false, SortMode::Name).expect("should load");
+        let entry = snapshot.entries.first().expect("entry should be present");
+
+        assert_eq!(entry.name, "report final.pdf");
+        assert_eq!(entry.name_key, "report final.pdf");
+        assert_eq!(
+            entry.path.file_name().and_then(|n| n.to_str()),
+            Some("report.pdf.2")
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn trash_snapshot_keeps_stored_name_without_original_path_metadata() {
+        let root = temp_path("trash-display-name-fallback");
+        let files_dir = root.join("files");
+        let info_dir = root.join("info");
+        fs::create_dir_all(&files_dir).expect("failed to create files dir");
+        fs::create_dir_all(&info_dir).expect("failed to create info dir");
+
+        fs::write(files_dir.join("stored-name.txt.2"), "dummy")
+            .expect("failed to write trashed file");
+        fs::write(
+            info_dir.join("stored-name.txt.2.trashinfo"),
+            "[Trash Info]\nDeletionDate=2024-03-15T10:30:00\n",
+        )
+        .expect("failed to write trashinfo");
+
+        let snapshot =
+            load_directory_snapshot(&files_dir, false, SortMode::Name).expect("should load");
+        let entry = snapshot.entries.first().expect("entry should be present");
+
+        assert_eq!(entry.name, "stored-name.txt.2");
+        assert_eq!(entry.name_key, "stored-name.txt.2");
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn trash_fingerprint_tracks_original_name_from_trashinfo() {
+        let root = temp_path("trash-fingerprint-display-name");
+        let files_dir = root.join("files");
+        let info_dir = root.join("info");
+        fs::create_dir_all(&files_dir).expect("failed to create files dir");
+        fs::create_dir_all(&info_dir).expect("failed to create info dir");
+        fs::write(files_dir.join("photo.jpeg.2"), "dummy").expect("failed to write trashed file");
+        let info_path = info_dir.join("photo.jpeg.2.trashinfo");
+
+        fs::write(
+            &info_path,
+            "[Trash Info]\nPath=/home/user/photo.jpeg\nDeletionDate=2024-03-15T10:30:00\n",
+        )
+        .expect("failed to write initial trashinfo");
+        let first = scan_directory_fingerprint(&files_dir, false).expect("failed to fingerprint");
+
+        fs::write(
+            &info_path,
+            "[Trash Info]\nPath=/home/user/renamed-photo.jpeg\nDeletionDate=2024-03-15T10:30:00\n",
+        )
+        .expect("failed to update trashinfo");
+        let second = scan_directory_fingerprint(&files_dir, false).expect("failed to fingerprint");
+
+        assert_ne!(first, second);
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -8,6 +8,7 @@ mod directory;
 mod directory_stats;
 mod restore;
 mod sort;
+mod trashinfo;
 
 fn is_hidden(file_name: &std::ffi::OsStr) -> bool {
     file_name.to_string_lossy().starts_with('.')

--- a/src/fs/restore.rs
+++ b/src/fs/restore.rs
@@ -68,7 +68,7 @@ fn restore_trash_item_freedesktop(entry_path: &Path, info_dir: PathBuf) -> anyho
     let content =
         fs::read_to_string(&info_path).with_context(|| format!("cannot read {:?}", info_path))?;
 
-    let original = parse_trashinfo_original_path(&content)
+    let original = super::trashinfo::parse_original_path(&content)
         .ok_or_else(|| anyhow::anyhow!("cannot parse original path from {:?}", info_path))?;
 
     if original.exists() {
@@ -608,43 +608,6 @@ fn decode_utf16be(bytes: &[u8]) -> Option<String> {
         .map(|c| u16::from_be_bytes([c[0], c[1]]))
         .collect();
     String::from_utf16(&units).ok()
-}
-
-fn parse_trashinfo_original_path(content: &str) -> Option<PathBuf> {
-    for line in content.lines() {
-        if let Some(encoded) = line.trim().strip_prefix("Path=") {
-            return Some(PathBuf::from(percent_decode(encoded)));
-        }
-    }
-    None
-}
-
-fn percent_decode(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%'
-            && i + 2 < bytes.len()
-            && let (Some(hi), Some(lo)) = (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2]))
-        {
-            out.push(hi << 4 | lo);
-            i += 3;
-            continue;
-        }
-        out.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
-}
-
-fn hex_nibble(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/src/fs/trashinfo.rs
+++ b/src/fs/trashinfo.rs
@@ -1,0 +1,67 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn parse_original_path(content: &str) -> Option<PathBuf> {
+    for line in content.lines() {
+        if let Some(encoded) = line.trim().strip_prefix("Path=") {
+            return Some(PathBuf::from(percent_decode(encoded)));
+        }
+    }
+    None
+}
+
+pub(crate) fn original_basename_from_path_value(encoded_path: &str) -> Option<String> {
+    let decoded = percent_decode(encoded_path);
+    let name = Path::new(&decoded).file_name()?.to_string_lossy();
+    (!name.is_empty()).then(|| name.into_owned())
+}
+
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (hex_nibble(bytes[i + 1]), hex_nibble(bytes[i + 2]))
+        {
+            out.push(hi << 4 | lo);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_original_path_from_trashinfo_content() {
+        let path = parse_original_path(
+            "[Trash Info]\nPath=/home/user/Reports/report%20final.pdf\nDeletionDate=2024-03-15T10:30:00\n",
+        )
+        .expect("path should parse");
+
+        assert_eq!(path, PathBuf::from("/home/user/Reports/report final.pdf"));
+    }
+
+    #[test]
+    fn derives_basename_from_encoded_path_value() {
+        let name = original_basename_from_path_value("/home/user/Camera/photo%201.jpeg")
+            .expect("basename should parse");
+
+        assert_eq!(name, "photo 1.jpeg");
+    }
+}

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -19,7 +19,7 @@ pub(crate) fn preview_work_class(
     entry: &Entry,
     options: &PreviewRequestOptions,
 ) -> PreviewWorkClass {
-    let facts = file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified);
+    let facts = file_info::inspect_entry_cached(entry);
     if options.comic_page_index().is_some()
         || options.epub_section_index().is_some()
         || facts.builtin_class == FileClass::Audio
@@ -43,7 +43,7 @@ pub(crate) fn loading_preview_for(
     if entry.is_dir() {
         return PreviewContent::new(PreviewKind::Directory, Vec::new()).with_detail("Loading");
     }
-    let facts = file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified);
+    let facts = file_info::inspect_entry_cached(entry);
     let detail = facts
         .specific_type_label
         .or_else(|| {
@@ -164,7 +164,7 @@ where
         return directory::build_directory_preview(entry);
     }
 
-    let facts = file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified);
+    let facts = file_info::inspect_entry_cached(entry);
     let preview_spec = facts.preview;
     let type_detail = facts.specific_type_label;
     if preview_spec.kind == file_info::PreviewKind::Iso
@@ -250,8 +250,7 @@ where
     let mut preview_truncation_note = truncation_note(text_preview.bytes_truncated, line_truncated);
 
     if preview_spec.kind == file_info::PreviewKind::Csv {
-        let is_tsv = entry
-            .path
+        let is_tsv = std::path::Path::new(&entry.name)
             .extension()
             .and_then(|e| e.to_str())
             .is_some_and(|e| e.eq_ignore_ascii_case("tsv"));

--- a/src/ui/theme/appearance/resolve.rs
+++ b/src/ui/theme/appearance/resolve.rs
@@ -103,8 +103,7 @@ pub(super) fn builtin_classify_entry(entry: &Entry) -> FileClass {
         return class;
     }
 
-    let class = file_info::inspect_path_cached(&entry.path, entry.kind, entry.size, entry.modified)
-        .builtin_class;
+    let class = file_info::inspect_entry_cached(entry).builtin_class;
     entry_class_cache()
         .lock()
         .expect("entry class cache lock")


### PR DESCRIPTION
## Summary

 Fixes Linux/Freedesktop Trash handling so collision-suffixed stored names like `photo.jpg.2` still display, preview, open, and restore as the original file, and makes Linux trashing prefer the desktop `gio trash` backend before falling back to the direct Freedesktop implementation.

## What Changed

 - Read Freedesktop `.trashinfo` metadata when listing Trash entries.
 - Keep the physical Trash path for IO while using the original basename for display, classification, previews, icons, and open With.
 - Prefer `gio trash` on Linux, with chunking for large selections and fallback to the existing `trash` crate path.
 - Share `.trashinfo` parsing between listing and restore code.
 - Documented platform-specific Trash behavior in the README and changelog.

## User Impact

Linux users see trashed files with their original names even when the stored Trash filename has a collision suffix. A file stored as `photo.jpg.2` is still shown and handled as `photo.jpg`, including image preview, icon/type detection, Open With suggestions, and restore.

## Notes

On Linux, Elio now tries `gio trash` first to better match desktop file managers such as GNOME Files when GIO is available. If GIO is missing or fails, Elio falls back to the Freedesktop Trash implementation. macOS behavior is unchanged, and Windows still does not expose a browsable Trash view in Elio.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

 - Tested on Linux.
 - Trashed files whose Freedesktop Trash storage names were collision-suffixed.
 - Verified original names are shown from `.trashinfo`.
 - Verified image preview/type handling works for a JPEG stored as `*.jpeg.2`.
 - Verified Linux trashing uses the new GIO-first path with fallback coverage in tests.

Result: All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
