### PR TITLE
Improve stacked preview layout for narrow terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed fuzzy search reusing stale indexes after directory reloads, so pasted, cut, deleted, or newly created entries are reflected after filesystem changes.
 - Fixed Freedesktop Trash entries with collision-suffixed storage names, such as `photo.jpg.2`, so they display, preview, open, and restore using their original `.trashinfo` names.
+- Fixed stacked browser layouts so the Preview pane expands in tall narrow terminals and respects configured Files/Preview pane weights.
 
 ## [1.0.1] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Supported sections:
 
 - `[ui]`: startup UI options like top bar, hidden files, and initial grid view
 - `[places]`: pinned sidebar entries and the `Devices` section
-- `[layout.panes]`: relative pane widths for Places, Files, and Preview
+- `[layout.panes]`: relative pane weights for Places, Files, and Preview
 - `[keys]`: single-character key rebinding for browser actions
 
 Notes:
@@ -208,6 +208,7 @@ Notes:
 - `places = 0` hides the Places pane, and `preview = 0` hides the Preview pane.
 - `files` must be greater than `0`.
 - Pane weights are relative, so `10/45/45` and `20/90/90` produce the same split.
+- In narrow terminals where Preview stacks below Files, `files` and `preview` control the vertical split.
 - `places.entries` accepts built-in names, `{ builtin, icon? }`, or `{ title, path, icon? }`.
 - Custom `places` paths must be absolute or start with `~/`.
 - Invalid `places` entries are skipped with a warning.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -35,18 +35,22 @@ show_top_bar = false
 #   "trash",
 # ]
 #
-# Optional pane widths for the browser body. Values are relative weights across
-# the horizontal space. Set a pane to 0 to hide it.
+# Optional pane weights for the browser body. Values are relative: in
+# side-by-side layouts they control horizontal width, and when Preview stacks
+# below Files they control the Files / Preview vertical split.
+# Set a pane to 0 to hide it.
 #
 # If this table is omitted, Elio keeps the built-in responsive layout:
 # - horizontal layout: Places prefers 20 cols, Files / Preview use a 54 / 46
 #   split of the remaining width
 # - tighter windows: Places can shrink to 18 cols before Preview stacks
+# - stacked layout: Files / Preview use a 54 / 46 split of the available height
 # - height-constrained windows: Preview drops out instead of stacking too early
 #
 # Custom layouts keep visible panes side by side whenever they can still meet
 # minimum usable widths. If Preview can no longer fit horizontally but there is
-# enough height, it stacks below Files instead.
+# enough height, it stacks below Files using the configured Files / Preview
+# weights.
 #
 # [layout.panes]
 # places = 10

--- a/src/ui/browser/layout.rs
+++ b/src/ui/browser/layout.rs
@@ -10,15 +10,15 @@ use ratatui::{Frame, layout::Rect};
 
 const LEGACY_WIDE_SIDEBAR_WIDTH: u16 = 20;
 const LEGACY_NARROW_SIDEBAR_WIDTH: u16 = 22;
-const LEGACY_NARROW_PREVIEW_HEIGHT: u16 = 11;
 const LEGACY_HORIZONTAL_SIDEBAR_MIN_WIDTH: u16 = 18;
 const LEGACY_HORIZONTAL_ENTRIES_MIN_WIDTH: u16 = 26;
 const LEGACY_HORIZONTAL_PREVIEW_MIN_WIDTH: u16 = 22;
+const LEGACY_STACKED_ENTRIES_WEIGHT: u16 = 54;
+const LEGACY_STACKED_PREVIEW_WEIGHT: u16 = 46;
 const CUSTOM_SIDEBAR_MIN_WIDTH: u16 = 16;
 const CUSTOM_ENTRIES_MIN_WIDTH: u16 = 28;
 const CUSTOM_PREVIEW_MIN_WIDTH: u16 = 24;
 const CUSTOM_STACKED_ENTRIES_MIN_HEIGHT: u16 = 10;
-const CUSTOM_STACKED_PREVIEW_DESIRED_HEIGHT: u16 = LEGACY_NARROW_PREVIEW_HEIGHT;
 const CUSTOM_STACKED_PREVIEW_MIN_HEIGHT: u16 = 8;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -122,8 +122,11 @@ fn legacy_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
         LEGACY_NARROW_SIDEBAR_WIDTH,
         CUSTOM_ENTRIES_MIN_WIDTH.max(CUSTOM_PREVIEW_MIN_WIDTH),
     )?;
-    let (entries, preview) =
-        split_stacked_content_with_height(content, LEGACY_NARROW_PREVIEW_HEIGHT)?;
+    let (entries, preview) = split_stacked_content_weighted(
+        content,
+        LEGACY_STACKED_ENTRIES_WEIGHT,
+        LEGACY_STACKED_PREVIEW_WEIGHT,
+    )?;
 
     Some(BodyLayout {
         sidebar: non_empty(sidebar),
@@ -283,7 +286,7 @@ fn stacked_body_layout_with_mins(area: Rect, weights: PaneWeights) -> Option<Bod
     };
 
     let (entries, preview) =
-        split_stacked_content_with_height(content, CUSTOM_STACKED_PREVIEW_DESIRED_HEIGHT)?;
+        split_stacked_content_weighted(content, weights.files, weights.preview)?;
     Some(BodyLayout {
         sidebar,
         entries: non_empty(entries),
@@ -322,27 +325,20 @@ fn split_sidebar_and_content(
     Some((sidebar, content))
 }
 
-fn split_stacked_content_with_height(
+fn split_stacked_content_weighted(
     area: Rect,
-    desired_preview_height: u16,
+    entries_weight: u16,
+    preview_weight: u16,
 ) -> Option<(Rect, Rect)> {
-    if area.height
-        < CUSTOM_STACKED_ENTRIES_MIN_HEIGHT.saturating_add(CUSTOM_STACKED_PREVIEW_MIN_HEIGHT)
-    {
-        return None;
-    }
-
-    let preview_height = area
-        .height
-        .saturating_sub(CUSTOM_STACKED_ENTRIES_MIN_HEIGHT)
-        .min(desired_preview_height);
-    if preview_height < CUSTOM_STACKED_PREVIEW_MIN_HEIGHT {
-        return None;
-    }
-    let entries_height = area.height.saturating_sub(preview_height);
-    if entries_height < CUSTOM_STACKED_ENTRIES_MIN_HEIGHT {
-        return None;
-    }
+    let heights = allocate_weighted_lengths_with_mins(
+        area.height,
+        vec![entries_weight, preview_weight],
+        vec![
+            CUSTOM_STACKED_ENTRIES_MIN_HEIGHT,
+            CUSTOM_STACKED_PREVIEW_MIN_HEIGHT,
+        ],
+    )?;
+    let [entries_height, preview_height]: [u16; 2] = heights.try_into().ok()?;
 
     let entries = Rect {
         x: area.x,

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -235,8 +235,31 @@ fn narrow_browser_layout_stacks_preview_below_entries() {
     assert_eq!(sidebar.width, 22);
     assert_eq!(entries.x, preview.x);
     assert_eq!(entries.width, preview.width);
-    assert_eq!(entries.height, 10);
-    assert_eq!(preview.height, 10);
+    assert_eq!(entries.height, 11);
+    assert_eq!(preview.height, 9);
+}
+
+#[test]
+fn narrow_tall_browser_layout_gives_preview_more_vertical_space() {
+    let layout = resolve_body_layout(
+        Rect {
+            x: 0,
+            y: 0,
+            width: 65,
+            height: 60,
+        },
+        None,
+    );
+
+    let sidebar = layout.sidebar.expect("sidebar should be visible");
+    let entries = layout.entries.expect("entries should be visible");
+    let preview = layout.preview.expect("preview should be visible");
+
+    assert_eq!(sidebar.width, 22);
+    assert_eq!(entries.x, preview.x);
+    assert_eq!(entries.width, preview.width);
+    assert_eq!(entries.height, 33);
+    assert_eq!(preview.height, 27);
 }
 
 #[test]
@@ -411,8 +434,60 @@ fn weighted_layout_stacks_preview_when_width_is_tight_and_height_is_sufficient()
     assert!(sidebar.width >= 16);
     assert_eq!(entries.x, preview.x);
     assert_eq!(entries.width, preview.width);
-    assert_eq!(entries.height, 10);
-    assert_eq!(preview.height, 10);
+    assert_eq!(entries.height, 11);
+    assert_eq!(preview.height, 9);
+}
+
+#[test]
+fn weighted_stacked_layout_respects_file_and_preview_height_weights() {
+    let layout = resolve_body_layout(
+        Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 60,
+        },
+        Some(PaneWeights {
+            places: 10,
+            files: 30,
+            preview: 70,
+        }),
+    );
+
+    let sidebar = layout.sidebar.expect("sidebar should be visible");
+    let entries = layout.entries.expect("entries should be visible");
+    let preview = layout.preview.expect("preview should be visible");
+
+    assert!(sidebar.width >= 16);
+    assert_eq!(entries.x, preview.x);
+    assert_eq!(entries.width, preview.width);
+    assert_eq!(entries.height, 23);
+    assert_eq!(preview.height, 37);
+}
+
+#[test]
+fn weighted_stacked_layout_can_favor_files_over_preview() {
+    let layout = resolve_body_layout(
+        Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 60,
+        },
+        Some(PaneWeights {
+            places: 10,
+            files: 70,
+            preview: 30,
+        }),
+    );
+
+    let entries = layout.entries.expect("entries should be visible");
+    let preview = layout.preview.expect("preview should be visible");
+
+    assert_eq!(entries.x, preview.x);
+    assert_eq!(entries.width, preview.width);
+    assert_eq!(entries.height, 39);
+    assert_eq!(preview.height, 21);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix the stacked browser layout so the Preview pane uses available height in tall narrow terminals while preserving the existing normal-width layout behavior.

## What Changed

- Replaced the fixed stacked Preview height with weighted vertical allocation.
- Kept the built-in responsive layout behavior for normal side-by-side terminals.
- Made custom `files` / `preview` pane weights control the vertical split when Preview stacks below Files.
- Added regression tests for tall narrow layouts and custom stacked pane weights.
- Updated README, example config documentation, and changelog.

## User Impact

In narrow tall terminals, such as phone SSH sessions or narrow desktop terminal columns, the Preview pane now expands instead of staying capped at a small height. Custom pane weights now also apply when Preview is stacked below Files.

## Notes

Preview still drops out when the terminal height is too constrained to keep both Files and Preview usable.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Not manually validated in a live terminal in this pass; automated layout regression tests cover tall narrow layouts and custom stacked pane weights.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
