### PR TITLE
Improve archive and document metadata previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified media and binary metadata previews by using `Details` instead of repeating `Video`, `Audio`, `Image`, or `Binary` as the first body section.
 - Clarified archive metadata previews by using `Details` instead of `Summary`, `Image`, or `Torrent` for the first body section.
 - Clarified SQLite database previews by using `Details` for the first metadata section.
+- Fixed comic archive previews so CBZ and CBR files show ComicInfo metadata and compact contents when image rendering is unavailable.
 
 ## [1.0.1] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved fuzzy search indexing and filtering responsiveness for large directory trees.
+- Simplified document metadata previews by keeping author, dates, application, and stats in the `Details` section.
+- Kept RAR archive loading previews silent while archive contents are inspected in the background.
 - Documented fuzzy search scope, hidden-file handling, pruning, refresh behavior, and large-tree caps.
 - Documented Trash behavior across Linux, BSD, macOS, and Windows.
 - Prefer `gio trash` on Linux before falling back to the Freedesktop Trash layout for desktop-compatible trashing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed fuzzy search reusing stale indexes after directory reloads, so pasted, cut, deleted, or newly created entries are reflected after filesystem changes.
 - Fixed Freedesktop Trash entries with collision-suffixed storage names, such as `photo.jpg.2`, so they display, preview, open, and restore using their original `.trashinfo` names.
 - Fixed stacked browser layouts so the Preview pane expands in tall narrow terminals and respects configured Files/Preview pane weights.
+- Fixed metadata previews for large ZIP-based office documents, including PPTX, PPTM, ODP, DOCX, XLSX, and Pages files.
+- Clarified document metadata preview sections by replacing the repeated `Document` body heading with `Details` and keeping `People` for author fields.
+- Fixed fixed-layout EPUB pages without extractable text so the preview shows page and book context instead of an empty pane.
+- Clarified media and binary metadata previews by using `Details` instead of repeating `Video`, `Audio`, `Image`, or `Binary` as the first body section.
+- Clarified archive metadata previews by using `Details` instead of `Summary`, `Image`, or `Torrent` for the first body section.
+- Clarified SQLite database previews by using `Details` for the first metadata section.
 
 ## [1.0.1] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added RAR archive previews using the existing external archive listing backends, with `unrar` as an additional fallback when available.
+- Added non-image comic archive previews for CBZ and CBR files, using embedded XML/comment metadata or conservative structured-name fallbacks instead of showing an empty pane.
+
 ### Changed
 
 - Improved fuzzy search indexing and filtering responsiveness for large directory trees.
@@ -25,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified media and binary metadata previews by using `Details` instead of repeating `Video`, `Audio`, `Image`, or `Binary` as the first body section.
 - Clarified archive metadata previews by using `Details` instead of `Summary`, `Image`, or `Torrent` for the first body section.
 - Clarified SQLite database previews by using `Details` for the first metadata section.
-- Fixed comic archive previews so CBZ and CBR files show ComicInfo metadata and compact contents when image rendering is unavailable.
 
 ## [1.0.1] - 2026-04-12
 

--- a/src/file_info/archives.rs
+++ b/src/file_info/archives.rs
@@ -9,6 +9,8 @@ pub(super) fn inspect_archive_name(name: &str) -> Option<FileFacts> {
         Some("Comic ZIP archive")
     } else if name.ends_with(".cbr") {
         Some("Comic RAR archive")
+    } else if name.ends_with(".rar") {
+        Some("RAR archive")
     } else if name.ends_with(".zip") {
         Some("ZIP archive")
     } else if name.ends_with(".7z") {

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -532,7 +532,7 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
         "flac" => plain(FileClass::Audio, Some("FLAC audio")),
         "ogg" => plain(FileClass::Audio, Some("Ogg audio")),
         "m4a" => plain(FileClass::Audio, Some("M4A audio")),
-        "zip" | "tar" | "gz" | "xz" | "bz2" | "7z" => plain(FileClass::Archive, None),
+        "zip" | "tar" | "gz" | "xz" | "bz2" | "7z" | "rar" => plain(FileClass::Archive, None),
         "ttf" | "otf" | "woff" | "woff2" => plain(FileClass::Font, None),
         _ => plain(FileClass::File, None),
     }

--- a/src/file_info/tests/classify.rs
+++ b/src/file_info/tests/classify.rs
@@ -4,8 +4,8 @@ use super::*;
 fn extensionless_shebang_scripts_are_classified_as_shell_code() {
     let (root, path) = write_temp_file(
         "extensionless-bash-script",
-        "apksigner",
-        "#!/bin/bash\n#\n# Copyright (C) 2016 The Android Open Source Project\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n\nexec java -jar apksigner.jar \"$@\"\n",
+        "tool-wrapper",
+        "#!/bin/bash\n#\n# Copyright (C) 2026 Example Project\n# SPDX-License-Identifier: Apache-2.0\n\nexec java -jar fixture.jar \"$@\"\n",
     );
 
     let facts = inspect_path(&path, EntryKind::File);

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -426,6 +426,7 @@ fn archive_suffixes_keep_specific_labels_for_common_multi_part_formats() {
     let zip = inspect_path(Path::new("release.zip"), EntryKind::File);
     let cbz = inspect_path(Path::new("issue.cbz"), EntryKind::File);
     let cbr = inspect_path(Path::new("issue.cbr"), EntryKind::File);
+    let rar = inspect_path(Path::new("release.rar"), EntryKind::File);
     let seven_zip = inspect_path(Path::new("release.7z"), EntryKind::File);
 
     assert_eq!(tgz.builtin_class, FileClass::Archive);
@@ -435,6 +436,7 @@ fn archive_suffixes_keep_specific_labels_for_common_multi_part_formats() {
     assert_eq!(zip.specific_type_label, Some("ZIP archive"));
     assert_eq!(cbz.specific_type_label, Some("Comic ZIP archive"));
     assert_eq!(cbr.specific_type_label, Some("Comic RAR archive"));
+    assert_eq!(rar.specific_type_label, Some("RAR archive"));
     assert_eq!(seven_zip.specific_type_label, Some("7z archive"));
 }
 

--- a/src/file_info/tests/license.rs
+++ b/src/file_info/tests/license.rs
@@ -5,7 +5,7 @@ fn license_like_files_detect_specific_and_generic_licenses() {
     let (mit_root, mit_path) = write_temp_file(
         "mit-license",
         "LICENSE",
-        "MIT License\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND.\n",
+        "SPDX-License-Identifier: MIT\n\nFixture grant notes.\n",
     );
     let mit = inspect_path(&mit_path, EntryKind::File);
     assert_eq!(mit.builtin_class, FileClass::License);
@@ -16,7 +16,7 @@ fn license_like_files_detect_specific_and_generic_licenses() {
     let (apache_root, apache_path) = write_temp_file(
         "apache-license",
         "LICENSE.md",
-        "# SPDX-License-Identifier: Apache-2.0\n\nLicensed under the Apache License, Version 2.0.\n",
+        "# SPDX-License-Identifier: Apache-2.0\n\nFixture license notes.\n",
     );
     let apache = inspect_path(&apache_path, EntryKind::File);
     assert_eq!(apache.builtin_class, FileClass::License);
@@ -37,7 +37,7 @@ fn license_like_files_detect_specific_and_generic_licenses() {
     let (copying_root, copying_path) = write_temp_file(
         "copying-lesser",
         "COPYING.LESSER",
-        "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 2.1, February 1999\n\nThis library is free software; you can redistribute it and/or\nmodify it under the terms of the GNU Lesser General Public\nLicense as published by the Free Software Foundation; either\nversion 2.1 of the License, or (at your option) any later version.\n",
+        "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 2.1\nor any later version\n",
     );
     let copying = inspect_path(&copying_path, EntryKind::File);
     assert_eq!(copying.builtin_class, FileClass::License);
@@ -47,7 +47,7 @@ fn license_like_files_detect_specific_and_generic_licenses() {
     let (hyphen_root, hyphen_path) = write_temp_file(
         "license-prefix",
         "license-mit",
-        "MIT License\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND.\n",
+        "SPDX-License-Identifier: MIT\n\nFixture grant notes.\n",
     );
     let hyphen = inspect_path(&hyphen_path, EntryKind::File);
     assert_eq!(hyphen.builtin_class, FileClass::License);
@@ -148,13 +148,13 @@ fn high_signal_license_texts_are_detected_without_canonical_filenames() {
         (
             "cc-by-at-text",
             "third-party.txt",
-            "CREATIVE COMMONS IST KEINE RECHTSANWALTSKANZLEI UND LEISTET KEINE RECHTSBERATUNG.\n\nLizenz\n\nDER GEGENSTAND DIESER LIZENZ WIRD UNTER DEN BEDINGUNGEN DIESER CREATIVE COMMONS PUBLIC LICENSE ZUR VERFÜGUNG GESTELLT.\n\nSofern zwischen Ihnen und dem Lizenzgeber keine anderweitige Vereinbarung getroffen wurde und soweit Wahlfreiheit besteht, findet auf diesen Lizenzvertrag das Recht der Republik Österreich Anwendung.\n",
+            "CREATIVE COMMONS IST KEINE RECHTSANWALTSKANZLEI UND LEISTET KEINE RECHTSBERATUNG.\nCREATIVE COMMONS PUBLIC LICENSE.\nRECHT DER REPUBLIK ÖSTERREICH ANWENDUNG.\n",
             "Creative Commons Attribution 3.0 Austria",
         ),
         (
             "cc-by-sa-at-text",
             "third-party.txt",
-            "CREATIVE COMMONS IST KEINE RECHTSANWALTSKANZLEI UND LEISTET KEINE RECHTSBERATUNG.\n\nLizenz\n\nUnter \"Lizenzelementen\" werden im Sinne dieser Lizenz die folgenden übergeordneten Lizenzcharakteristika verstanden: \"Namensnennung\", \"Weitergabe unter gleichen Bedingungen\".\n\nSofern zwischen Ihnen und dem Lizenzgeber keine anderweitige Vereinbarung getroffen wurde und soweit Wahlfreiheit besteht, findet auf diesen Lizenzvertrag das Recht der Republik Österreich Anwendung.\n",
+            "CREATIVE COMMONS IST KEINE RECHTSANWALTSKANZLEI UND LEISTET KEINE RECHTSBERATUNG.\nWEITERGABE UNTER GLEICHEN BEDINGUNGEN.\nRECHT DER REPUBLIK ÖSTERREICH ANWENDUNG.\n",
             "Creative Commons Attribution-ShareAlike 3.0 Austria",
         ),
         (
@@ -166,13 +166,13 @@ fn high_signal_license_texts_are_detected_without_canonical_filenames() {
         (
             "w3c-text",
             "third-party.txt",
-            "W3C SOFTWARE NOTICE AND LICENSE\n\nBy obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.\n",
+            "W3C SOFTWARE NOTICE AND LICENSE\nBy obtaining, using and/or copying this work.\n",
             "W3C Software Notice and License",
         ),
         (
             "wtfpl-text",
             "third-party.txt",
-            "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE\nVersion 2, December 2004\n\nEveryone is permitted to copy and distribute verbatim or modified copies of this license document, and changing it is allowed as long as the name is changed.\n",
+            "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE\nEveryone is permitted to copy and distribute verbatim or modified copies.\n",
             "WTFPL",
         ),
     ];
@@ -240,9 +240,9 @@ fn diff_like_numeric_text_does_not_trigger_japanese_cc_license_detection() {
 #[test]
 fn embedded_license_headers_do_not_turn_shell_wrappers_into_license_files() {
     let (root, path) = write_temp_file(
-        "android-shell-wrapper",
-        "lld",
-        "#!/bin/bash\n#\n# Copyright (C) 2020 The Android Open Source Project\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\n$(dirname \"$0\")/lld-bin/lld \"$@\"\n",
+        "shell-wrapper",
+        "tool",
+        "#!/bin/bash\n#\n# Copyright (C) 2026 Example Project\n# SPDX-License-Identifier: Apache-2.0\n\n$(dirname \"$0\")/fixture-bin/tool \"$@\"\n",
     );
 
     let facts = inspect_path(&path, EntryKind::File);
@@ -256,9 +256,9 @@ fn embedded_license_headers_do_not_turn_shell_wrappers_into_license_files() {
 #[test]
 fn notice_files_with_embedded_license_text_are_not_classified_as_licenses() {
     let (root, path) = write_temp_file(
-        "android-notice",
+        "notice-bundle",
         "NOTICE.txt",
-        "==============================================================================\nAndroid used by:\n  sdk-repo-linux-build-tools.zip\n\nApache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n",
+        "==============================================================================\nExample component used by:\n  fixture-package.zip\n\nApache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n",
     );
 
     let facts = inspect_path(&path, EntryKind::File);

--- a/src/preview/audio.rs
+++ b/src/preview/audio.rs
@@ -527,7 +527,7 @@ fn render_audio_metadata_lines(
         .map(|(label, _)| label.len())
         .max()
         .unwrap_or(8);
-    let mut lines = vec![preview_section_line("Audio", palette)];
+    let mut lines = vec![preview_section_line("Details", palette)];
     for (label, value) in fields {
         lines.push(preview_field_line(label, &value, label_width, palette));
     }

--- a/src/preview/binary/mod.rs
+++ b/src/preview/binary/mod.rs
@@ -95,7 +95,7 @@ fn parse_binary_metadata(bytes: &[u8]) -> Option<BinaryMetadata> {
 fn render_binary_preview(detail: &str, metadata: BinaryMetadata) -> PreviewContent {
     let palette = theme::palette();
     let mut lines = Vec::new();
-    push_section(&mut lines, "Binary", &metadata.fields(), palette);
+    push_section(&mut lines, "Details", &metadata.fields(), palette);
     push_section(&mut lines, "Metadata", &metadata.extra_fields(), palette);
 
     PreviewContent::new(PreviewKind::Binary, lines).with_detail(detail)

--- a/src/preview/container/archive/comic.rs
+++ b/src/preview/container/archive/comic.rs
@@ -6,8 +6,9 @@ use super::*;
 use crate::fs::natural_cmp;
 use crate::preview::process::run_command_capture_stdout_cancellable;
 use quick_xml::{Reader, events::Event};
+use serde_json::Value as JsonValue;
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque, hash_map::DefaultHasher},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque, hash_map::DefaultHasher},
     env,
     fs::{self, File},
     hash::{Hash, Hasher},
@@ -21,7 +22,6 @@ use zip::ZipArchive;
 const COMIC_ARCHIVE_IMAGE_ENTRY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 const COMIC_INFO_ENTRY_LIMIT_BYTES: usize = 256 * 1024;
 const COMIC_ARCHIVE_CACHE_LIMIT: usize = 16;
-const COMIC_EXTRA_PREVIEW_LIMIT: usize = 3;
 fn has_unrar() -> bool {
     static RESULT: OnceLock<bool> = OnceLock::new();
     *RESULT.get_or_init(|| Command::new("unrar").output().is_ok())
@@ -70,8 +70,30 @@ struct ComicArchivePage {
 struct CachedComicArchive {
     backend: ComicArchiveBackend,
     page_entries: Vec<ComicArchivePage>,
-    extra_entries: Vec<String>,
     comic_info: Option<ComicInfoMetadata>,
+    derived_info: Option<ComicDerivedMetadata>,
+}
+
+#[derive(Clone, Debug)]
+struct ComicArchiveListing {
+    backend: ComicArchiveBackend,
+    page_entries: Vec<ComicArchivePage>,
+    metadata_entry: Option<ComicMetadataEntry>,
+    archive_comment: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug)]
+struct ComicMetadataEntry {
+    name: String,
+    kind: ComicMetadataFileKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ComicMetadataFileKind {
+    ComicInfo,
+    MetronInfo,
+    CoMet,
+    Acbf,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -85,6 +107,17 @@ struct ComicInfoMetadata {
     writer: Option<String>,
     penciller: Option<String>,
     genre: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ComicDerivedMetadata {
+    series: Option<String>,
+    volume: Option<String>,
+    number: Option<String>,
+    year: Option<String>,
+    publisher: Option<String>,
+    source: Option<String>,
+    chapters: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -142,7 +175,7 @@ where
     let detail = type_detail
         .unwrap_or(archive_default_label(format))
         .to_string();
-    let lines = comic_archive_details_lines(&comic, current_index);
+    let lines = comic_archive_details_lines(&comic);
     let mut preview = PreviewContent::new(PreviewKind::Comic, lines)
         .with_detail(detail)
         .with_navigation_position("Page", current_index, comic.page_entries.len(), None);
@@ -165,162 +198,899 @@ where
     Some(preview)
 }
 
-fn comic_archive_details_lines(
-    comic: &CachedComicArchive,
-    _current_index: usize,
-) -> Vec<Line<'static>> {
-    let palette = theme::palette();
+fn comic_archive_details_lines(comic: &CachedComicArchive) -> Vec<Line<'static>> {
     let info = comic.comic_info.as_ref();
+    let derived = comic.derived_info.as_ref();
+    if info.is_none() && derived.is_none() {
+        return Vec::new();
+    }
+    let palette = theme::palette();
     let fields = vec![
         ("Title", info.and_then(|info| info.title.clone())),
-        ("Series", info.and_then(|info| info.series.clone())),
-        ("Number", info.and_then(|info| info.number.clone())),
-        ("Volume", info.and_then(|info| info.volume.clone())),
-        ("Year", info.and_then(|info| info.year.clone())),
-        ("Publisher", info.and_then(|info| info.publisher.clone())),
+        (
+            "Series",
+            info.and_then(|info| info.series.clone())
+                .or_else(|| derived.and_then(|info| info.series.clone())),
+        ),
+        (
+            "Number",
+            info.and_then(|info| info.number.clone())
+                .or_else(|| derived.and_then(|info| info.number.clone())),
+        ),
+        (
+            "Volume",
+            info.and_then(|info| info.volume.clone())
+                .or_else(|| derived.and_then(|info| info.volume.clone())),
+        ),
+        (
+            "Year",
+            info.and_then(|info| info.year.clone())
+                .or_else(|| derived.and_then(|info| info.year.clone())),
+        ),
+        (
+            "Publisher",
+            info.and_then(|info| info.publisher.clone())
+                .or_else(|| derived.and_then(|info| info.publisher.clone())),
+        ),
         ("Writer", info.and_then(|info| info.writer.clone())),
         ("Penciller", info.and_then(|info| info.penciller.clone())),
         ("Genre", info.and_then(|info| info.genre.clone())),
-        ("Pages", Some(format!("{}", comic.page_entries.len()))),
-        (
-            "Root",
-            info.is_none().then(|| common_root_folder(comic)).flatten(),
-        ),
+        ("Source", derived.and_then(|info| info.source.clone())),
+        ("Chapters", derived.and_then(|info| info.chapters.clone())),
     ];
     let mut lines = Vec::new();
     push_preview_section(&mut lines, "Details", &fields, palette);
-    let content_fields = comic_archive_content_fields(comic);
-    push_preview_values_section(&mut lines, "Contents", &content_fields, palette);
     lines
 }
 
-fn comic_archive_content_fields(comic: &CachedComicArchive) -> Vec<(&'static str, String)> {
-    let mut fields = Vec::new();
-    if !comic.extra_entries.is_empty() {
-        fields.push((
-            "Extras",
-            summarize_comic_extra_entries(&comic.extra_entries),
-        ));
-    }
-    fields
-}
-
-fn summarize_comic_extra_entries(entries: &[String]) -> String {
-    let count = entries.len();
-    let noun = if count == 1 { "file" } else { "files" };
-    let names = entries
-        .iter()
-        .take(COMIC_EXTRA_PREVIEW_LIMIT)
-        .map(|entry| entry.as_str())
-        .collect::<Vec<_>>()
-        .join(", ");
-    if count > COMIC_EXTRA_PREVIEW_LIMIT {
-        format!("{count} {noun}: {names}, ...")
-    } else {
-        format!("{count} {noun}: {names}")
-    }
-}
-
-fn common_root_folder(comic: &CachedComicArchive) -> Option<String> {
-    let mut root: Option<String> = None;
-    for entry_name in comic
-        .page_entries
-        .iter()
-        .map(|entry| entry.entry_name.as_str())
-        .chain(comic.extra_entries.iter().map(String::as_str))
+fn capture_comic_metadata_entry(metadata_entry: &mut Option<ComicMetadataEntry>, entry_name: &str) {
+    let Some(kind) = comic_metadata_file_kind(entry_name) else {
+        return;
+    };
+    if metadata_entry
+        .as_ref()
+        .is_some_and(|entry| entry.kind.priority() <= kind.priority())
     {
-        let normalized = normalize_archive_path(entry_name, false)?;
-        let (candidate, _) = normalized.split_once('/')?;
-        match root.as_deref() {
-            Some(existing) if existing != candidate => return None,
-            Some(_) => {}
-            None => root = Some(candidate.to_string()),
-        }
-    }
-    root
-}
-
-fn push_comic_extra_entry(entries: &mut Vec<String>, entry_name: &str) {
-    if entry_name.trim().is_empty() {
         return;
     }
-    entries.push(entry_name.to_string());
+    *metadata_entry = Some(ComicMetadataEntry {
+        name: entry_name.to_string(),
+        kind,
+    });
 }
 
-fn sort_comic_extra_entries(entries: &mut [String]) {
-    entries.sort_by(|left, right| natural_cmp(&left.to_lowercase(), &right.to_lowercase()));
+fn comic_metadata_file_kind(entry_name: &str) -> Option<ComicMetadataFileKind> {
+    let name = entry_name
+        .replace('\\', "/")
+        .rsplit('/')
+        .next()
+        .map(|name| name.to_ascii_lowercase())?;
+    match name.as_str() {
+        "comicinfo.xml" => Some(ComicMetadataFileKind::ComicInfo),
+        "metroninfo.xml" => Some(ComicMetadataFileKind::MetronInfo),
+        "comet.xml" | "cometinfo.xml" => Some(ComicMetadataFileKind::CoMet),
+        _ if name.ends_with(".acbf") => Some(ComicMetadataFileKind::Acbf),
+        _ => None,
+    }
 }
 
-fn find_comic_info_entry(entries: &[String]) -> Option<&str> {
-    entries
-        .iter()
-        .find(|entry| {
-            entry
-                .replace('\\', "/")
-                .rsplit('/')
-                .next()
-                .is_some_and(|name| name.eq_ignore_ascii_case("ComicInfo.xml"))
-        })
-        .map(String::as_str)
+impl ComicMetadataFileKind {
+    fn priority(self) -> u8 {
+        match self {
+            Self::ComicInfo => 0,
+            Self::MetronInfo => 1,
+            Self::CoMet => 2,
+            Self::Acbf => 3,
+        }
+    }
 }
 
-fn parse_comic_info_xml(xml: &str) -> Option<ComicInfoMetadata> {
+fn derive_comic_archive_metadata(
+    path: &Path,
+    page_entries: &[ComicArchivePage],
+) -> Option<ComicDerivedMetadata> {
+    let mut metadata = ComicDerivedMetadata::default();
+    if let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) {
+        apply_archive_name_metadata(&mut metadata, stem);
+    }
+    if metadata.series.is_none()
+        && (metadata.volume.is_some() || metadata.number.is_some())
+        && let Some(parent_series) = path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .and_then(series_from_collection_folder)
+    {
+        metadata.series = Some(parent_series);
+    }
+    apply_page_entry_metadata(&mut metadata, page_entries);
+    metadata.has_visible_fields().then_some(metadata)
+}
+
+fn apply_archive_name_metadata(metadata: &mut ComicDerivedMetadata, stem: &str) {
+    let annotations = bracketed_tokens(stem, '(', ')')
+        .into_iter()
+        .chain(bracketed_tokens(stem, '[', ']'));
+    for token in annotations {
+        if metadata.year.is_none() && is_year_token(&token) {
+            metadata.year = Some(token);
+        } else if metadata.source.is_none() && is_source_token(&token) {
+            metadata.source = Some(normalize_source_token(&token));
+        } else if metadata.publisher.is_none() && looks_like_publisher_tag(&token) {
+            metadata.publisher = Some(token.trim().to_string());
+        }
+    }
+
+    let main = clean_archive_name_main(stem);
+    if main.is_empty() {
+        return;
+    }
+
+    if let Some((series, volume)) = split_series_and_prefixed_number(main, 'v')
+        .or_else(|| split_series_and_prefixed_number(main, 't'))
+    {
+        set_derived_series(metadata, series);
+        metadata.volume.get_or_insert(volume);
+    } else if let Some((series, volume)) = split_series_and_volume_label(main) {
+        if let Some(series) = series {
+            set_derived_series(metadata, series);
+        }
+        metadata.volume.get_or_insert(volume);
+    } else if let Some((series, number)) = split_series_and_issue_number(main) {
+        set_derived_series(metadata, series);
+        metadata.number.get_or_insert(number);
+    } else if (metadata.year.is_some() || metadata.source.is_some() || metadata.publisher.is_some())
+        && is_meaningful_series_candidate(main)
+    {
+        metadata.series.get_or_insert_with(|| main.to_string());
+    }
+}
+
+fn clean_archive_name_main(stem: &str) -> &str {
+    let mut main = stem.trim();
+    while let Some(stripped) = strip_leading_bracketed_token(main) {
+        main = stripped.trim_start();
+    }
+    main.split(" (")
+        .next()
+        .unwrap_or(main)
+        .split(" [")
+        .next()
+        .unwrap_or(main)
+        .trim()
+}
+
+fn set_derived_series(metadata: &mut ComicDerivedMetadata, series: String) {
+    if is_meaningful_series_candidate(&series) {
+        metadata.series.get_or_insert(series);
+    }
+}
+
+fn apply_page_entry_metadata(
+    metadata: &mut ComicDerivedMetadata,
+    page_entries: &[ComicArchivePage],
+) {
+    let mut chapters = BTreeSet::new();
+    let mut page_series: Option<String> = None;
+
+    for page in page_entries {
+        let stem = archive_entry_stem(&page.entry_name);
+        if let Some(chapter) = extract_prefixed_number(stem, 'c') {
+            chapters.insert(chapter);
+        }
+        if metadata.volume.is_none()
+            && let Some(volume) = extract_prefixed_number(stem, 'v')
+        {
+            metadata.volume = Some(format_number_without_padding(volume));
+        }
+        if page_series.is_none()
+            && let Some(series) = series_from_page_entry_stem(stem)
+        {
+            page_series = Some(series);
+        }
+
+        let tags = bracketed_tokens(stem, '[', ']');
+        if metadata.source.is_none()
+            && let Some(source) = tags.iter().find(|tag| is_source_token(tag))
+        {
+            metadata.source = Some(normalize_source_token(source));
+        }
+        if metadata.publisher.is_none()
+            && let Some(publisher) = tags.iter().find(|tag| looks_like_publisher_tag(tag))
+        {
+            metadata.publisher = Some(publisher.trim().to_string());
+        }
+    }
+
+    if metadata.series.is_none() {
+        metadata.series = page_series;
+    }
+    metadata.chapters = summarize_number_set(&chapters);
+}
+
+fn split_series_and_prefixed_number(value: &str, prefix: char) -> Option<(String, String)> {
+    let (series, suffix) = value.rsplit_once(' ')?;
+    let mut chars = suffix.chars();
+    let first = chars.next()?;
+    if !first.eq_ignore_ascii_case(&prefix) {
+        return None;
+    }
+    let number = chars.as_str();
+    if number.is_empty() || !number.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    let series = series.trim();
+    (!series.is_empty()).then(|| (series.to_string(), strip_numeric_padding(number)))
+}
+
+fn split_series_and_volume_label(value: &str) -> Option<(Option<String>, String)> {
+    let (prefix, number) = value.rsplit_once(' ')?;
+    if number.is_empty() || !number.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    let (series, label) = prefix
+        .rsplit_once(' ')
+        .map(|(series, label)| (series.trim(), label.trim()))
+        .unwrap_or(("", prefix.trim()));
+    if !matches!(
+        label.to_ascii_lowercase().as_str(),
+        "volume" | "vol" | "vol."
+    ) {
+        return None;
+    }
+
+    let series = (!series.is_empty()).then(|| series.to_string());
+    Some((series, strip_numeric_padding(number)))
+}
+
+fn split_series_and_issue_number(value: &str) -> Option<(String, String)> {
+    let (series, suffix) = value.rsplit_once(" #")?;
+    if suffix.is_empty() || !suffix.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    let series = series.trim();
+    (!series.is_empty()).then(|| (series.to_string(), strip_numeric_padding(suffix)))
+}
+
+fn series_from_collection_folder(value: &str) -> Option<String> {
+    let mut name = value.trim();
+    while let Some(stripped) = strip_leading_bracketed_token(name) {
+        name = stripped.trim_start();
+    }
+    let name = name
+        .split(" (")
+        .next()
+        .unwrap_or(name)
+        .split(" [")
+        .next()
+        .unwrap_or(name)
+        .trim();
+    is_meaningful_series_candidate(name).then(|| name.to_string())
+}
+
+fn strip_leading_bracketed_token(value: &str) -> Option<&str> {
+    let value = value.strip_prefix('[')?;
+    let (_, rest) = value.split_once(']')?;
+    Some(rest)
+}
+
+fn is_meaningful_series_candidate(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() || value.chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    if value.len() >= 12 && value.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return false;
+    }
+    !matches!(
+        value.to_ascii_lowercase().as_str(),
+        "archive"
+            | "archives"
+            | "book"
+            | "books"
+            | "cbz"
+            | "chapter"
+            | "comic"
+            | "comics"
+            | "digital"
+            | "download"
+            | "downloads"
+            | "issue"
+            | "manga"
+            | "pages"
+            | "scan"
+            | "scans"
+            | "volume"
+    )
+}
+
+fn archive_entry_stem(entry_name: &str) -> &str {
+    let name = entry_name.rsplit(['/', '\\']).next().unwrap_or(entry_name);
+    name.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(name)
+}
+
+fn series_from_page_entry_stem(stem: &str) -> Option<String> {
+    let lower = stem.to_lowercase();
+    let bytes = lower.as_bytes();
+    for index in 0..bytes.len().saturating_sub(4) {
+        if bytes.get(index..index + 4) == Some(b" - c")
+            && bytes.get(index + 4).is_some_and(u8::is_ascii_digit)
+        {
+            let series = stem[..index].trim();
+            return (!series.is_empty()).then(|| series.to_string());
+        }
+    }
+    None
+}
+
+fn extract_prefixed_number(value: &str, prefix: char) -> Option<u32> {
+    let bytes = value.as_bytes();
+    let prefix = prefix.to_ascii_lowercase() as u8;
+    for index in 0..bytes.len().saturating_sub(1) {
+        if bytes[index].to_ascii_lowercase() != prefix
+            || !bytes[index + 1].is_ascii_digit()
+            || (index > 0 && bytes[index - 1].is_ascii_alphanumeric())
+        {
+            continue;
+        }
+
+        let start = index + 1;
+        let mut end = start;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if let Ok(number) = value[start..end].parse::<u32>() {
+            return Some(number);
+        }
+    }
+    None
+}
+
+fn bracketed_tokens(value: &str, open: char, close: char) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_token = false;
+    for ch in value.chars() {
+        if ch == open {
+            current.clear();
+            in_token = true;
+        } else if ch == close && in_token {
+            let token = current.trim();
+            if !token.is_empty() {
+                tokens.push(token.to_string());
+            }
+            current.clear();
+            in_token = false;
+        } else if in_token {
+            current.push(ch);
+        }
+    }
+    tokens
+}
+
+fn summarize_number_set(numbers: &BTreeSet<u32>) -> Option<String> {
+    let first = numbers.first()?;
+    let last = numbers.last()?;
+    Some(if first == last {
+        format_number_without_padding(*first)
+    } else {
+        format!(
+            "{}-{}",
+            format_number_without_padding(*first),
+            format_number_without_padding(*last)
+        )
+    })
+}
+
+fn is_year_token(value: &str) -> bool {
+    value.len() == 4
+        && value.chars().all(|ch| ch.is_ascii_digit())
+        && value
+            .parse::<u16>()
+            .is_ok_and(|year| (1900..=2100).contains(&year))
+}
+
+fn is_source_token(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "digital" | "digital edition" | "web" | "web-dl" | "print"
+    ) || lower.starts_with("digital-")
+        || lower.starts_with("digital ")
+}
+
+fn normalize_source_token(value: &str) -> String {
+    let lower = value.trim().to_ascii_lowercase();
+    if lower.starts_with("digital-") || lower.starts_with("digital ") {
+        return "Digital".to_string();
+    }
+    match lower.as_str() {
+        "digital" | "digital edition" => "Digital".to_string(),
+        "web" | "web-dl" => "Web".to_string(),
+        "print" => "Print".to_string(),
+        _ => value.trim().to_string(),
+    }
+}
+
+fn looks_like_publisher_tag(value: &str) -> bool {
+    let words: Vec<String> = value
+        .trim()
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .map(|word| word.to_ascii_lowercase())
+        .collect();
+    let Some(last) = words.last().map(String::as_str) else {
+        return false;
+    };
+    matches!(
+        last,
+        "press"
+            | "publisher"
+            | "publishers"
+            | "publishing"
+            | "comic"
+            | "comics"
+            | "studio"
+            | "studios"
+            | "books"
+    )
+}
+
+fn strip_numeric_padding(value: &str) -> String {
+    let stripped = value.trim_start_matches('0');
+    if stripped.is_empty() {
+        "0".to_string()
+    } else {
+        stripped.to_string()
+    }
+}
+
+fn format_number_without_padding(value: u32) -> String {
+    value.to_string()
+}
+
+impl ComicDerivedMetadata {
+    fn has_visible_fields(&self) -> bool {
+        self.series.is_some()
+            && (self.volume.is_some()
+                || self.number.is_some()
+                || self.year.is_some()
+                || self.publisher.is_some()
+                || self.source.is_some()
+                || self.chapters.is_some())
+    }
+}
+
+#[derive(Debug, Default)]
+struct ComicXmlParseState {
+    metadata: ComicInfoMetadata,
+    path: Vec<String>,
+    current_credit: Option<ComicCreditDraft>,
+    current_acbf_author: Option<AcbfAuthorDraft>,
+}
+
+#[derive(Debug, Default)]
+struct ComicCreditDraft {
+    creator: Option<String>,
+    roles: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct AcbfAuthorDraft {
+    activity: Option<String>,
+    first_name: Option<String>,
+    middle_name: Option<String>,
+    last_name: Option<String>,
+    nickname: Option<String>,
+}
+
+fn parse_comic_metadata_xml(xml: &str) -> Option<ComicInfoMetadata> {
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
-    let mut metadata = ComicInfoMetadata::default();
-    let mut current_tag: Option<String> = None;
+    let mut state = ComicXmlParseState::default();
 
     loop {
         match reader.read_event() {
             Ok(Event::Start(event)) => {
-                current_tag = Some(xml_local_name(event.name().as_ref()));
+                let tag = xml_local_name(event.name().as_ref()).to_ascii_lowercase();
+                if tag == "credit" {
+                    state.current_credit = Some(ComicCreditDraft::default());
+                }
+                if tag == "author"
+                    && state
+                        .path
+                        .last()
+                        .is_some_and(|parent| parent == "book-info")
+                {
+                    state.current_acbf_author = Some(AcbfAuthorDraft {
+                        activity: xml_attribute_value(&event, reader.decoder(), "activity"),
+                        ..Default::default()
+                    });
+                }
+                if tag == "sequence"
+                    && state
+                        .path
+                        .last()
+                        .is_some_and(|parent| parent == "book-info")
+                {
+                    set_comic_info_field(
+                        &mut state.metadata.series,
+                        xml_attribute_value(&event, reader.decoder(), "title").as_deref(),
+                    );
+                    set_comic_info_field(
+                        &mut state.metadata.volume,
+                        xml_attribute_value(&event, reader.decoder(), "volume").as_deref(),
+                    );
+                }
+                if tag == "publish-date"
+                    && state
+                        .path
+                        .last()
+                        .is_some_and(|parent| parent == "publish-info")
+                    && let Some(value) = xml_attribute_value(&event, reader.decoder(), "value")
+                {
+                    set_comic_info_year_from_date(&mut state.metadata.year, &value);
+                }
+                state.path.push(tag);
             }
             Ok(Event::Text(text)) => {
-                if let Some(tag) = current_tag.as_deref()
-                    && let Ok(value) = text.decode()
-                {
-                    assign_comic_info_text(&mut metadata, tag, value.as_ref());
+                if let Ok(value) = text.decode() {
+                    assign_comic_xml_text(&mut state, value.as_ref());
                 }
             }
             Ok(Event::CData(text)) => {
-                if let Some(tag) = current_tag.as_deref()
-                    && let Ok(value) = text.decode()
-                {
-                    assign_comic_info_text(&mut metadata, tag, value.as_ref());
+                if let Ok(value) = text.decode() {
+                    assign_comic_xml_text(&mut state, value.as_ref());
                 }
             }
-            Ok(Event::End(_)) | Ok(Event::Empty(_)) => current_tag = None,
+            Ok(Event::End(event)) => {
+                let tag = xml_local_name(event.name().as_ref()).to_ascii_lowercase();
+                if tag == "credit" {
+                    apply_comic_xml_credit(&mut state);
+                }
+                if tag == "author" {
+                    apply_acbf_author(&mut state);
+                }
+                state.path.pop();
+            }
+            Ok(Event::Empty(_)) => {}
             Ok(Event::Eof) | Err(_) => break,
             _ => {}
+        }
+    }
+
+    state
+        .metadata
+        .has_visible_fields()
+        .then_some(state.metadata)
+}
+
+fn parse_comic_book_info_comment(comment: &[u8]) -> Option<ComicInfoMetadata> {
+    let text = std::str::from_utf8(comment).ok()?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let root = parse_comic_book_info_json(text)?;
+    let info = root.get("ComicBookInfo/1.0")?;
+    let mut metadata = ComicInfoMetadata::default();
+    set_comic_info_field(
+        &mut metadata.title,
+        json_metadata_value(info.get("title")).as_deref(),
+    );
+    set_comic_info_field(
+        &mut metadata.series,
+        json_metadata_value(info.get("series")).as_deref(),
+    );
+    set_comic_info_field(
+        &mut metadata.number,
+        json_metadata_value(info.get("issue")).as_deref(),
+    );
+    set_comic_info_field(
+        &mut metadata.volume,
+        json_metadata_value(info.get("volume")).as_deref(),
+    );
+    set_comic_info_field(
+        &mut metadata.year,
+        json_metadata_value(info.get("publicationYear")).as_deref(),
+    );
+    set_comic_info_field(
+        &mut metadata.publisher,
+        json_metadata_value(info.get("publisher")).as_deref(),
+    );
+    set_comic_info_field(
+        &mut metadata.genre,
+        json_metadata_value(info.get("genre")).as_deref(),
+    );
+
+    if let Some(credits) = info.get("credits").and_then(JsonValue::as_array) {
+        for credit in credits {
+            let role = json_metadata_value(credit.get("role")).unwrap_or_default();
+            let person = json_metadata_value(credit.get("person")).unwrap_or_default();
+            match role.to_ascii_lowercase().as_str() {
+                "writer" | "author" => set_comic_info_field(&mut metadata.writer, Some(&person)),
+                "penciller" | "artist" => {
+                    set_comic_info_field(&mut metadata.penciller, Some(&person));
+                }
+                _ => {}
+            }
         }
     }
 
     metadata.has_visible_fields().then_some(metadata)
 }
 
-fn assign_comic_info_text(metadata: &mut ComicInfoMetadata, tag: &str, value: &str) {
-    match tag {
-        "Title" => set_comic_info_field(&mut metadata.title, value),
-        "Series" => set_comic_info_field(&mut metadata.series, value),
-        "Number" => set_comic_info_field(&mut metadata.number, value),
-        "Volume" => set_comic_info_field(&mut metadata.volume, value),
-        "Year" => set_comic_info_field(&mut metadata.year, value),
-        "Publisher" => set_comic_info_field(&mut metadata.publisher, value),
-        "Writer" => set_comic_info_field(&mut metadata.writer, value),
-        "Penciller" => set_comic_info_field(&mut metadata.penciller, value),
-        "Genre" => set_comic_info_field(&mut metadata.genre, value),
+fn parse_comic_book_info_json(text: &str) -> Option<JsonValue> {
+    if let Ok(root) = serde_json::from_str::<JsonValue>(text)
+        && root.get("ComicBookInfo/1.0").is_some()
+    {
+        return Some(root);
+    }
+
+    let marker_index = text.find("\"ComicBookInfo/1.0\"")?;
+    let mut starts = text[..marker_index]
+        .match_indices('{')
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    starts.reverse();
+    starts.into_iter().find_map(|start| {
+        balanced_json_object_from(text, start)
+            .and_then(|json| serde_json::from_str::<JsonValue>(json).ok())
+            .filter(|root| root.get("ComicBookInfo/1.0").is_some())
+    })
+}
+
+fn balanced_json_object_from(text: &str, start: usize) -> Option<&str> {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (offset, ch) in text[start..].char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    let end = start + offset + ch.len_utf8();
+                    return Some(&text[start..end]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn json_metadata_value(value: Option<&JsonValue>) -> Option<String> {
+    match value? {
+        JsonValue::String(value) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        }
+        JsonValue::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn assign_comic_xml_text(state: &mut ComicXmlParseState, value: &str) {
+    let value = value.trim();
+    if value.is_empty() {
+        return;
+    }
+    let Some(tag) = state.path.last().cloned() else {
+        return;
+    };
+
+    if capture_comic_xml_credit_text(state, &tag, value) {
+        return;
+    }
+    if capture_acbf_author_text(state, &tag, value) {
+        return;
+    }
+
+    let parent = state
+        .path
+        .len()
+        .checked_sub(2)
+        .and_then(|index| state.path.get(index))
+        .map(String::as_str);
+    if state.path.len() <= 2 {
+        assign_flat_comic_xml_text(&mut state.metadata, &tag, value);
+        return;
+    }
+
+    match (parent, tag.as_str()) {
+        (Some("series"), "name") => set_comic_info_field(&mut state.metadata.series, Some(value)),
+        (Some("publisher"), "name") => {
+            set_comic_info_field(&mut state.metadata.publisher, Some(value));
+        }
+        (Some("genres"), "genre") => set_comic_info_field(&mut state.metadata.genre, Some(value)),
+        (Some("stories"), "story") => set_comic_info_field(&mut state.metadata.title, Some(value)),
+        (Some("book-info"), "book-title") => {
+            set_comic_info_field(&mut state.metadata.title, Some(value));
+        }
+        (Some("book-info"), "genre") => {
+            set_comic_info_field(&mut state.metadata.genre, Some(value));
+        }
+        (Some("book-info"), "sequence") => {
+            set_comic_info_field(&mut state.metadata.number, Some(value));
+        }
+        (Some("publish-info"), "publisher") => {
+            set_comic_info_field(&mut state.metadata.publisher, Some(value));
+        }
+        (Some("publish-info"), "publish-date") => {
+            set_comic_info_year_from_date(&mut state.metadata.year, value);
+        }
+        (Some("series"), "volume") | (_, "mangavolume") => {
+            set_comic_info_field(&mut state.metadata.volume, Some(value));
+        }
+        (_, "coverdate") | (_, "storedate") => {
+            set_comic_info_year_from_date(&mut state.metadata.year, value);
+        }
         _ => {}
     }
 }
 
-fn set_comic_info_field(field: &mut Option<String>, value: &str) {
+fn assign_flat_comic_xml_text(metadata: &mut ComicInfoMetadata, tag: &str, value: &str) {
+    match tag {
+        "title" | "collectiontitle" => set_comic_info_field(&mut metadata.title, Some(value)),
+        "series" => set_comic_info_field(&mut metadata.series, Some(value)),
+        "number" | "issue" => set_comic_info_field(&mut metadata.number, Some(value)),
+        "volume" | "mangavolume" => set_comic_info_field(&mut metadata.volume, Some(value)),
+        "year" => set_comic_info_field(&mut metadata.year, Some(value)),
+        "date" | "coverdate" | "storedate" => {
+            set_comic_info_year_from_date(&mut metadata.year, value)
+        }
+        "publisher" => set_comic_info_field(&mut metadata.publisher, Some(value)),
+        "writer" | "author" => set_comic_info_field(&mut metadata.writer, Some(value)),
+        "penciller" | "artist" => set_comic_info_field(&mut metadata.penciller, Some(value)),
+        "genre" => set_comic_info_field(&mut metadata.genre, Some(value)),
+        _ => {}
+    }
+}
+
+fn capture_acbf_author_text(state: &mut ComicXmlParseState, tag: &str, value: &str) -> bool {
+    if state.current_acbf_author.is_none() {
+        return false;
+    }
+    let parent = state
+        .path
+        .len()
+        .checked_sub(2)
+        .and_then(|index| state.path.get(index))
+        .map(String::as_str);
+    if parent != Some("author") {
+        return false;
+    }
+    let Some(author) = state.current_acbf_author.as_mut() else {
+        return false;
+    };
+    match tag {
+        "first-name" => set_comic_info_field(&mut author.first_name, Some(value)),
+        "middle-name" => set_comic_info_field(&mut author.middle_name, Some(value)),
+        "last-name" => set_comic_info_field(&mut author.last_name, Some(value)),
+        "nickname" => set_comic_info_field(&mut author.nickname, Some(value)),
+        _ => return false,
+    }
+    true
+}
+
+fn capture_comic_xml_credit_text(state: &mut ComicXmlParseState, tag: &str, value: &str) -> bool {
+    if state.current_credit.is_none() {
+        return false;
+    }
+    let parent = state
+        .path
+        .len()
+        .checked_sub(2)
+        .and_then(|index| state.path.get(index))
+        .map(String::as_str);
+    match (parent, tag) {
+        (Some("credit"), "creator") => {
+            if let Some(credit) = state.current_credit.as_mut() {
+                set_comic_info_field(&mut credit.creator, Some(value));
+            }
+            true
+        }
+        (Some("roles"), "role") => {
+            if let Some(credit) = state.current_credit.as_mut() {
+                credit.roles.push(value.to_string());
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+fn apply_comic_xml_credit(state: &mut ComicXmlParseState) {
+    let Some(credit) = state.current_credit.take() else {
+        return;
+    };
+    let Some(creator) = credit.creator else {
+        return;
+    };
+    for role in credit.roles {
+        match role.to_ascii_lowercase().as_str() {
+            "writer" | "author" | "script" | "story" | "plot" => {
+                set_comic_info_field(&mut state.metadata.writer, Some(&creator));
+            }
+            "artist" | "penciller" | "illustrator" => {
+                set_comic_info_field(&mut state.metadata.penciller, Some(&creator));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn apply_acbf_author(state: &mut ComicXmlParseState) {
+    let Some(author) = state.current_acbf_author.take() else {
+        return;
+    };
+    let name = author
+        .nickname
+        .filter(|name| !name.trim().is_empty())
+        .or_else(|| {
+            let parts = [
+                author.first_name.as_deref(),
+                author.middle_name.as_deref(),
+                author.last_name.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+            (!parts.is_empty()).then(|| parts.join(" "))
+        });
+    let Some(name) = name else {
+        return;
+    };
+    match author
+        .activity
+        .as_deref()
+        .unwrap_or("Writer")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "writer" | "adapter" => set_comic_info_field(&mut state.metadata.writer, Some(&name)),
+        "artist" | "penciller" => {
+            set_comic_info_field(&mut state.metadata.penciller, Some(&name));
+        }
+        _ => {}
+    }
+}
+
+fn set_comic_info_field(field: &mut Option<String>, value: Option<&str>) {
     if field.is_some() {
         return;
     }
+    let Some(value) = value else {
+        return;
+    };
     let value = value.trim();
     if !value.is_empty() {
         *field = Some(value.to_string());
     }
+}
+
+fn set_comic_info_year_from_date(field: &mut Option<String>, value: &str) {
+    if field.is_some() {
+        return;
+    }
+    let year = value.trim().get(..4).filter(|year| is_year_token(year));
+    set_comic_info_field(field, year);
 }
 
 impl ComicInfoMetadata {
@@ -344,6 +1114,20 @@ fn xml_local_name(name: &[u8]) -> String {
         .map(|index| &name[index + 1..])
         .unwrap_or(name);
     String::from_utf8_lossy(local).to_string()
+}
+
+fn xml_attribute_value(
+    event: &quick_xml::events::BytesStart<'_>,
+    decoder: quick_xml::encoding::Decoder,
+    name: &str,
+) -> Option<String> {
+    event.attributes().flatten().find_map(|attribute| {
+        (xml_local_name(attribute.key.as_ref()).eq_ignore_ascii_case(name))
+            .then(|| attribute.decode_and_unescape_value(decoder).ok())
+            .flatten()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
 }
 
 fn load_comic_archive<F>(path: &Path, canceled: &F) -> Option<Arc<CachedComicArchive>>
@@ -445,7 +1229,7 @@ where
     let file = File::open(path).ok()?;
     let mut archive = ZipArchive::new(file).ok()?;
     let mut page_entries = Vec::new();
-    let mut extra_entries = Vec::new();
+    let mut metadata_entry = None;
 
     // Use file_names() to iterate the central directory without seeking to each
     // entry — much faster for archives with many pages.
@@ -459,7 +1243,7 @@ where
             continue;
         }
         let Some(extension) = archive_image_extension(name) else {
-            push_comic_extra_entry(&mut extra_entries, name);
+            capture_comic_metadata_entry(&mut metadata_entry, name);
             continue;
         };
         let sort_key = normalize_archive_path(name, false)
@@ -476,22 +1260,23 @@ where
         return None;
     }
     page_entries.sort_by(|left, right| natural_cmp(&left.sort_key, &right.sort_key));
-    sort_comic_extra_entries(&mut extra_entries);
-    let comic_info = find_comic_info_entry(&extra_entries).and_then(|entry_name| {
+    let embedded_info = metadata_entry.as_ref().and_then(|entry| {
         read_zip_entry_bytes_limited(
             &mut archive,
-            entry_name,
+            &entry.name,
             COMIC_INFO_ENTRY_LIMIT_BYTES,
             canceled,
         )
-        .and_then(|bytes| parse_comic_info_xml(&String::from_utf8_lossy(&bytes)))
+        .and_then(|bytes| parse_comic_metadata_xml(&String::from_utf8_lossy(&bytes)))
     });
+    let comic_info = embedded_info.or_else(|| parse_comic_book_info_comment(archive.comment()));
+    let derived_info = derive_comic_archive_metadata(path, &page_entries);
 
     Some(CachedComicArchive {
         backend: ComicArchiveBackend::Zip,
         page_entries,
-        extra_entries,
         comic_info,
+        derived_info,
     })
 }
 
@@ -503,21 +1288,32 @@ where
     command.arg("l").arg("-slt").arg(path);
     let output = run_command_capture_stdout_cancellable(command, "comic-list", canceled)?;
 
-    let mut comic =
-        parse_comic_archive_from_7z_output(&String::from_utf8_lossy(&output), canceled)?;
-    comic.comic_info = find_comic_info_entry(&comic.extra_entries).and_then(|entry_name| {
-        read_7z_entry_bytes_limited(path, entry_name, COMIC_INFO_ENTRY_LIMIT_BYTES, canceled)
-            .and_then(|bytes| parse_comic_info_xml(&String::from_utf8_lossy(&bytes)))
+    let listing = parse_comic_archive_from_7z_output(&String::from_utf8_lossy(&output), canceled)?;
+    let embedded_info = listing.metadata_entry.as_ref().and_then(|entry| {
+        read_7z_entry_bytes_limited(path, &entry.name, COMIC_INFO_ENTRY_LIMIT_BYTES, canceled)
+            .and_then(|bytes| parse_comic_metadata_xml(&String::from_utf8_lossy(&bytes)))
     });
-    Some(comic)
+    let comment_info = listing
+        .archive_comment
+        .as_deref()
+        .and_then(parse_comic_book_info_comment);
+    let comic_info = embedded_info.or(comment_info);
+    let derived_info = derive_comic_archive_metadata(path, &listing.page_entries);
+    Some(CachedComicArchive {
+        backend: listing.backend,
+        page_entries: listing.page_entries,
+        comic_info,
+        derived_info,
+    })
 }
 
-fn parse_comic_archive_from_7z_output<F>(output: &str, canceled: &F) -> Option<CachedComicArchive>
+fn parse_comic_archive_from_7z_output<F>(output: &str, canceled: &F) -> Option<ComicArchiveListing>
 where
     F: Fn() -> bool,
 {
     let mut page_entries = Vec::new();
-    let mut extra_entries = Vec::new();
+    let mut metadata_entry = None;
+    let archive_comment = parse_7z_archive_comment(output);
     let mut in_entries = false;
     let mut current = BTreeMap::<String, String>::new();
 
@@ -536,7 +1332,7 @@ where
         }
 
         if line.is_empty() {
-            push_7z_comic_entry(&mut current, &mut page_entries, &mut extra_entries);
+            push_7z_comic_entry(&mut current, &mut page_entries, &mut metadata_entry);
             continue;
         }
 
@@ -544,26 +1340,62 @@ where
             current.insert(field.to_string(), value.to_string());
         }
     }
-    push_7z_comic_entry(&mut current, &mut page_entries, &mut extra_entries);
+    push_7z_comic_entry(&mut current, &mut page_entries, &mut metadata_entry);
 
     if canceled() || page_entries.is_empty() {
         return None;
     }
 
     page_entries.sort_by(|left, right| natural_cmp(&left.sort_key, &right.sort_key));
-    sort_comic_extra_entries(&mut extra_entries);
-    Some(CachedComicArchive {
+    Some(ComicArchiveListing {
         backend: ComicArchiveBackend::SevenZip,
         page_entries,
-        extra_entries,
-        comic_info: None,
+        metadata_entry,
+        archive_comment,
     })
+}
+
+fn parse_7z_archive_comment(output: &str) -> Option<Vec<u8>> {
+    let mut lines = output.lines().map(str::trim_end);
+    while let Some(line) = lines.next() {
+        if line == "----------" {
+            return None;
+        }
+        let Some((field, value)) = parse_key_value_line(line) else {
+            continue;
+        };
+        if field != "Comment" {
+            continue;
+        }
+        let value = value.trim();
+        if !value.is_empty() {
+            return Some(value.as_bytes().to_vec());
+        }
+
+        let mut comment_lines = Vec::new();
+        for line in lines.by_ref() {
+            if line == "----------" || parse_key_value_line(line).is_some() {
+                break;
+            }
+            comment_lines.push(line.to_string());
+        }
+        return normalize_7z_multiline_comment(comment_lines);
+    }
+    None
+}
+
+fn normalize_7z_multiline_comment(lines: Vec<String>) -> Option<Vec<u8>> {
+    let start = lines.iter().position(|line| !line.trim().is_empty())?;
+    let end = lines.iter().rposition(|line| !line.trim().is_empty())?;
+    let comment = lines[start..=end].join("\n");
+    let comment = comment.trim();
+    (!comment.is_empty()).then(|| comment.as_bytes().to_vec())
 }
 
 fn push_7z_comic_entry(
     current: &mut BTreeMap<String, String>,
     page_entries: &mut Vec<ComicArchivePage>,
-    extra_entries: &mut Vec<String>,
+    metadata_entry: &mut Option<ComicMetadataEntry>,
 ) {
     if current.is_empty() {
         return;
@@ -586,7 +1418,7 @@ fn push_7z_comic_entry(
                 extension: extension.to_string(),
             });
         } else {
-            push_comic_extra_entry(extra_entries, &entry_name);
+            capture_comic_metadata_entry(metadata_entry, &entry_name);
         }
     }
 
@@ -602,7 +1434,7 @@ where
     let output = run_command_capture_stdout_cancellable(command, "comic-list", canceled)?;
     let listing = String::from_utf8_lossy(&output);
     let mut page_entries = Vec::new();
-    let mut extra_entries = Vec::new();
+    let mut metadata_entry = None;
 
     for line in listing.lines() {
         if canceled() {
@@ -613,7 +1445,7 @@ where
             continue;
         }
         let Some(extension) = archive_image_extension(name) else {
-            push_comic_extra_entry(&mut extra_entries, name);
+            capture_comic_metadata_entry(&mut metadata_entry, name);
             continue;
         };
         let sort_key = normalize_archive_path(name, false)
@@ -631,17 +1463,68 @@ where
     }
 
     page_entries.sort_by(|a, b| natural_cmp(&a.sort_key, &b.sort_key));
-    sort_comic_extra_entries(&mut extra_entries);
-    let comic_info = find_comic_info_entry(&extra_entries).and_then(|entry_name| {
-        read_unrar_entry_bytes_limited(path, entry_name, COMIC_INFO_ENTRY_LIMIT_BYTES, canceled)
-            .and_then(|bytes| parse_comic_info_xml(&String::from_utf8_lossy(&bytes)))
+    let embedded_info = metadata_entry.as_ref().and_then(|entry| {
+        read_unrar_entry_bytes_limited(path, &entry.name, COMIC_INFO_ENTRY_LIMIT_BYTES, canceled)
+            .and_then(|bytes| parse_comic_metadata_xml(&String::from_utf8_lossy(&bytes)))
     });
+    let comment_info = embedded_info
+        .is_none()
+        .then(|| {
+            read_unrar_archive_comment(path, canceled)
+                .and_then(|comment| parse_comic_book_info_comment(&comment))
+        })
+        .flatten();
+    let comic_info = embedded_info.or(comment_info);
+    let derived_info = derive_comic_archive_metadata(path, &page_entries);
     Some(CachedComicArchive {
         backend: ComicArchiveBackend::Unrar,
         page_entries,
-        extra_entries,
         comic_info,
+        derived_info,
     })
+}
+
+fn read_unrar_archive_comment<F>(path: &Path, canceled: &F) -> Option<Vec<u8>>
+where
+    F: Fn() -> bool,
+{
+    if canceled() {
+        return None;
+    }
+    let mut command = Command::new("unrar");
+    command.arg("l").arg(path);
+    let output = run_command_capture_stdout_cancellable(command, "comic-comment", canceled)?;
+    parse_unrar_archive_comment(&String::from_utf8_lossy(&output))
+}
+
+fn parse_unrar_archive_comment(output: &str) -> Option<Vec<u8>> {
+    let mut in_archive = false;
+    let mut comment_lines = Vec::new();
+
+    for line in output.lines().map(str::trim_end) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Archive:") {
+            in_archive = true;
+            continue;
+        }
+        if !in_archive {
+            continue;
+        }
+        if trimmed.starts_with("Details:")
+            || trimmed.starts_with("Attributes")
+            || trimmed.starts_with("-----------")
+        {
+            break;
+        }
+        if trimmed.is_empty() && comment_lines.is_empty() {
+            continue;
+        }
+        comment_lines.push(line.to_string());
+    }
+
+    let comment = comment_lines.join("\n");
+    let comment = comment.trim();
+    (!comment.is_empty()).then(|| comment.as_bytes().to_vec())
 }
 
 fn comic_archive_cache() -> &'static Mutex<ComicArchiveCache> {

--- a/src/preview/container/archive/comic.rs
+++ b/src/preview/container/archive/comic.rs
@@ -5,8 +5,9 @@ use super::format::archive_default_label;
 use super::*;
 use crate::fs::natural_cmp;
 use crate::preview::process::run_command_capture_stdout_cancellable;
+use quick_xml::{Reader, events::Event};
 use std::{
-    collections::{HashMap, VecDeque, hash_map::DefaultHasher},
+    collections::{BTreeMap, HashMap, VecDeque, hash_map::DefaultHasher},
     env,
     fs::{self, File},
     hash::{Hash, Hasher},
@@ -18,7 +19,9 @@ use std::{
 use zip::ZipArchive;
 
 const COMIC_ARCHIVE_IMAGE_ENTRY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
+const COMIC_INFO_ENTRY_LIMIT_BYTES: usize = 256 * 1024;
 const COMIC_ARCHIVE_CACHE_LIMIT: usize = 16;
+const COMIC_EXTRA_PREVIEW_LIMIT: usize = 3;
 fn has_unrar() -> bool {
     static RESULT: OnceLock<bool> = OnceLock::new();
     *RESULT.get_or_init(|| Command::new("unrar").output().is_ok())
@@ -67,6 +70,21 @@ struct ComicArchivePage {
 struct CachedComicArchive {
     backend: ComicArchiveBackend,
     page_entries: Vec<ComicArchivePage>,
+    extra_entries: Vec<String>,
+    comic_info: Option<ComicInfoMetadata>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ComicInfoMetadata {
+    title: Option<String>,
+    series: Option<String>,
+    number: Option<String>,
+    volume: Option<String>,
+    year: Option<String>,
+    publisher: Option<String>,
+    writer: Option<String>,
+    penciller: Option<String>,
+    genre: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -124,7 +142,8 @@ where
     let detail = type_detail
         .unwrap_or(archive_default_label(format))
         .to_string();
-    let mut preview = PreviewContent::new(PreviewKind::Comic, Vec::new())
+    let lines = comic_archive_details_lines(&comic, current_index);
+    let mut preview = PreviewContent::new(PreviewKind::Comic, lines)
         .with_detail(detail)
         .with_navigation_position("Page", current_index, comic.page_entries.len(), None);
 
@@ -144,6 +163,187 @@ where
     }
 
     Some(preview)
+}
+
+fn comic_archive_details_lines(
+    comic: &CachedComicArchive,
+    _current_index: usize,
+) -> Vec<Line<'static>> {
+    let palette = theme::palette();
+    let info = comic.comic_info.as_ref();
+    let fields = vec![
+        ("Title", info.and_then(|info| info.title.clone())),
+        ("Series", info.and_then(|info| info.series.clone())),
+        ("Number", info.and_then(|info| info.number.clone())),
+        ("Volume", info.and_then(|info| info.volume.clone())),
+        ("Year", info.and_then(|info| info.year.clone())),
+        ("Publisher", info.and_then(|info| info.publisher.clone())),
+        ("Writer", info.and_then(|info| info.writer.clone())),
+        ("Penciller", info.and_then(|info| info.penciller.clone())),
+        ("Genre", info.and_then(|info| info.genre.clone())),
+        ("Pages", Some(format!("{}", comic.page_entries.len()))),
+        (
+            "Root",
+            info.is_none().then(|| common_root_folder(comic)).flatten(),
+        ),
+    ];
+    let mut lines = Vec::new();
+    push_preview_section(&mut lines, "Details", &fields, palette);
+    let content_fields = comic_archive_content_fields(comic);
+    push_preview_values_section(&mut lines, "Contents", &content_fields, palette);
+    lines
+}
+
+fn comic_archive_content_fields(comic: &CachedComicArchive) -> Vec<(&'static str, String)> {
+    let mut fields = Vec::new();
+    if !comic.extra_entries.is_empty() {
+        fields.push((
+            "Extras",
+            summarize_comic_extra_entries(&comic.extra_entries),
+        ));
+    }
+    fields
+}
+
+fn summarize_comic_extra_entries(entries: &[String]) -> String {
+    let count = entries.len();
+    let noun = if count == 1 { "file" } else { "files" };
+    let names = entries
+        .iter()
+        .take(COMIC_EXTRA_PREVIEW_LIMIT)
+        .map(|entry| entry.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if count > COMIC_EXTRA_PREVIEW_LIMIT {
+        format!("{count} {noun}: {names}, ...")
+    } else {
+        format!("{count} {noun}: {names}")
+    }
+}
+
+fn common_root_folder(comic: &CachedComicArchive) -> Option<String> {
+    let mut root: Option<String> = None;
+    for entry_name in comic
+        .page_entries
+        .iter()
+        .map(|entry| entry.entry_name.as_str())
+        .chain(comic.extra_entries.iter().map(String::as_str))
+    {
+        let normalized = normalize_archive_path(entry_name, false)?;
+        let (candidate, _) = normalized.split_once('/')?;
+        match root.as_deref() {
+            Some(existing) if existing != candidate => return None,
+            Some(_) => {}
+            None => root = Some(candidate.to_string()),
+        }
+    }
+    root
+}
+
+fn push_comic_extra_entry(entries: &mut Vec<String>, entry_name: &str) {
+    if entry_name.trim().is_empty() {
+        return;
+    }
+    entries.push(entry_name.to_string());
+}
+
+fn sort_comic_extra_entries(entries: &mut [String]) {
+    entries.sort_by(|left, right| natural_cmp(&left.to_lowercase(), &right.to_lowercase()));
+}
+
+fn find_comic_info_entry(entries: &[String]) -> Option<&str> {
+    entries
+        .iter()
+        .find(|entry| {
+            entry
+                .replace('\\', "/")
+                .rsplit('/')
+                .next()
+                .is_some_and(|name| name.eq_ignore_ascii_case("ComicInfo.xml"))
+        })
+        .map(String::as_str)
+}
+
+fn parse_comic_info_xml(xml: &str) -> Option<ComicInfoMetadata> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut metadata = ComicInfoMetadata::default();
+    let mut current_tag: Option<String> = None;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(event)) => {
+                current_tag = Some(xml_local_name(event.name().as_ref()));
+            }
+            Ok(Event::Text(text)) => {
+                if let Some(tag) = current_tag.as_deref()
+                    && let Ok(value) = text.decode()
+                {
+                    assign_comic_info_text(&mut metadata, tag, value.as_ref());
+                }
+            }
+            Ok(Event::CData(text)) => {
+                if let Some(tag) = current_tag.as_deref()
+                    && let Ok(value) = text.decode()
+                {
+                    assign_comic_info_text(&mut metadata, tag, value.as_ref());
+                }
+            }
+            Ok(Event::End(_)) | Ok(Event::Empty(_)) => current_tag = None,
+            Ok(Event::Eof) | Err(_) => break,
+            _ => {}
+        }
+    }
+
+    metadata.has_visible_fields().then_some(metadata)
+}
+
+fn assign_comic_info_text(metadata: &mut ComicInfoMetadata, tag: &str, value: &str) {
+    match tag {
+        "Title" => set_comic_info_field(&mut metadata.title, value),
+        "Series" => set_comic_info_field(&mut metadata.series, value),
+        "Number" => set_comic_info_field(&mut metadata.number, value),
+        "Volume" => set_comic_info_field(&mut metadata.volume, value),
+        "Year" => set_comic_info_field(&mut metadata.year, value),
+        "Publisher" => set_comic_info_field(&mut metadata.publisher, value),
+        "Writer" => set_comic_info_field(&mut metadata.writer, value),
+        "Penciller" => set_comic_info_field(&mut metadata.penciller, value),
+        "Genre" => set_comic_info_field(&mut metadata.genre, value),
+        _ => {}
+    }
+}
+
+fn set_comic_info_field(field: &mut Option<String>, value: &str) {
+    if field.is_some() {
+        return;
+    }
+    let value = value.trim();
+    if !value.is_empty() {
+        *field = Some(value.to_string());
+    }
+}
+
+impl ComicInfoMetadata {
+    fn has_visible_fields(&self) -> bool {
+        self.title.is_some()
+            || self.series.is_some()
+            || self.number.is_some()
+            || self.volume.is_some()
+            || self.year.is_some()
+            || self.publisher.is_some()
+            || self.writer.is_some()
+            || self.penciller.is_some()
+            || self.genre.is_some()
+    }
+}
+
+fn xml_local_name(name: &[u8]) -> String {
+    let local = name
+        .iter()
+        .position(|byte| *byte == b':')
+        .map(|index| &name[index + 1..])
+        .unwrap_or(name);
+    String::from_utf8_lossy(local).to_string()
 }
 
 fn load_comic_archive<F>(path: &Path, canceled: &F) -> Option<Arc<CachedComicArchive>>
@@ -243,13 +443,14 @@ where
     F: Fn() -> bool,
 {
     let file = File::open(path).ok()?;
-    let archive = ZipArchive::new(file).ok()?;
+    let mut archive = ZipArchive::new(file).ok()?;
     let mut page_entries = Vec::new();
+    let mut extra_entries = Vec::new();
 
     // Use file_names() to iterate the central directory without seeking to each
     // entry — much faster for archives with many pages.
     let names: Vec<String> = archive.file_names().map(|n| n.to_string()).collect();
-    for name in names {
+    for name in &names {
         if canceled() {
             return None;
         }
@@ -257,14 +458,15 @@ where
         if name.ends_with('/') {
             continue;
         }
-        let Some(extension) = archive_image_extension(&name) else {
+        let Some(extension) = archive_image_extension(name) else {
+            push_comic_extra_entry(&mut extra_entries, name);
             continue;
         };
-        let sort_key = normalize_archive_path(&name, false)
+        let sort_key = normalize_archive_path(name, false)
             .unwrap_or_else(|| name.clone())
             .to_lowercase();
         page_entries.push(ComicArchivePage {
-            entry_name: name,
+            entry_name: name.clone(),
             sort_key,
             extension: extension.to_string(),
         });
@@ -274,10 +476,22 @@ where
         return None;
     }
     page_entries.sort_by(|left, right| natural_cmp(&left.sort_key, &right.sort_key));
+    sort_comic_extra_entries(&mut extra_entries);
+    let comic_info = find_comic_info_entry(&extra_entries).and_then(|entry_name| {
+        read_zip_entry_bytes_limited(
+            &mut archive,
+            entry_name,
+            COMIC_INFO_ENTRY_LIMIT_BYTES,
+            canceled,
+        )
+        .and_then(|bytes| parse_comic_info_xml(&String::from_utf8_lossy(&bytes)))
+    });
 
     Some(CachedComicArchive {
         backend: ComicArchiveBackend::Zip,
         page_entries,
+        extra_entries,
+        comic_info,
     })
 }
 
@@ -289,7 +503,13 @@ where
     command.arg("l").arg("-slt").arg(path);
     let output = run_command_capture_stdout_cancellable(command, "comic-list", canceled)?;
 
-    parse_comic_archive_from_7z_output(&String::from_utf8_lossy(&output), canceled)
+    let mut comic =
+        parse_comic_archive_from_7z_output(&String::from_utf8_lossy(&output), canceled)?;
+    comic.comic_info = find_comic_info_entry(&comic.extra_entries).and_then(|entry_name| {
+        read_7z_entry_bytes_limited(path, entry_name, COMIC_INFO_ENTRY_LIMIT_BYTES, canceled)
+            .and_then(|bytes| parse_comic_info_xml(&String::from_utf8_lossy(&bytes)))
+    });
+    Some(comic)
 }
 
 fn parse_comic_archive_from_7z_output<F>(output: &str, canceled: &F) -> Option<CachedComicArchive>
@@ -297,6 +517,7 @@ where
     F: Fn() -> bool,
 {
     let mut page_entries = Vec::new();
+    let mut extra_entries = Vec::new();
     let mut in_entries = false;
     let mut current = BTreeMap::<String, String>::new();
 
@@ -315,7 +536,7 @@ where
         }
 
         if line.is_empty() {
-            push_7z_comic_page_entry(&mut current, &mut page_entries);
+            push_7z_comic_entry(&mut current, &mut page_entries, &mut extra_entries);
             continue;
         }
 
@@ -323,22 +544,26 @@ where
             current.insert(field.to_string(), value.to_string());
         }
     }
-    push_7z_comic_page_entry(&mut current, &mut page_entries);
+    push_7z_comic_entry(&mut current, &mut page_entries, &mut extra_entries);
 
     if canceled() || page_entries.is_empty() {
         return None;
     }
 
     page_entries.sort_by(|left, right| natural_cmp(&left.sort_key, &right.sort_key));
+    sort_comic_extra_entries(&mut extra_entries);
     Some(CachedComicArchive {
         backend: ComicArchiveBackend::SevenZip,
         page_entries,
+        extra_entries,
+        comic_info: None,
     })
 }
 
-fn push_7z_comic_page_entry(
+fn push_7z_comic_entry(
     current: &mut BTreeMap<String, String>,
     page_entries: &mut Vec<ComicArchivePage>,
+    extra_entries: &mut Vec<String>,
 ) {
     if current.is_empty() {
         return;
@@ -350,18 +575,19 @@ fn push_7z_comic_page_entry(
             .get("Attributes")
             .is_some_and(|value| value.starts_with('D'));
 
-    if !is_dir
-        && let Some(entry_name) = entry_name
-        && let Some(extension) = archive_image_extension(&entry_name)
-    {
-        let sort_key = normalize_archive_path(&entry_name, false)
-            .unwrap_or_else(|| entry_name.clone())
-            .to_lowercase();
-        page_entries.push(ComicArchivePage {
-            entry_name,
-            sort_key,
-            extension: extension.to_string(),
-        });
+    if !is_dir && let Some(entry_name) = entry_name {
+        if let Some(extension) = archive_image_extension(&entry_name) {
+            let sort_key = normalize_archive_path(&entry_name, false)
+                .unwrap_or_else(|| entry_name.clone())
+                .to_lowercase();
+            page_entries.push(ComicArchivePage {
+                entry_name,
+                sort_key,
+                extension: extension.to_string(),
+            });
+        } else {
+            push_comic_extra_entry(extra_entries, &entry_name);
+        }
     }
 
     current.clear();
@@ -376,6 +602,7 @@ where
     let output = run_command_capture_stdout_cancellable(command, "comic-list", canceled)?;
     let listing = String::from_utf8_lossy(&output);
     let mut page_entries = Vec::new();
+    let mut extra_entries = Vec::new();
 
     for line in listing.lines() {
         if canceled() {
@@ -386,6 +613,7 @@ where
             continue;
         }
         let Some(extension) = archive_image_extension(name) else {
+            push_comic_extra_entry(&mut extra_entries, name);
             continue;
         };
         let sort_key = normalize_archive_path(name, false)
@@ -403,9 +631,16 @@ where
     }
 
     page_entries.sort_by(|a, b| natural_cmp(&a.sort_key, &b.sort_key));
+    sort_comic_extra_entries(&mut extra_entries);
+    let comic_info = find_comic_info_entry(&extra_entries).and_then(|entry_name| {
+        read_unrar_entry_bytes_limited(path, entry_name, COMIC_INFO_ENTRY_LIMIT_BYTES, canceled)
+            .and_then(|bytes| parse_comic_info_xml(&String::from_utf8_lossy(&bytes)))
+    });
     Some(CachedComicArchive {
         backend: ComicArchiveBackend::Unrar,
         page_entries,
+        extra_entries,
+        comic_info,
     })
 }
 

--- a/src/preview/container/archive/comic/tests.rs
+++ b/src/preview/container/archive/comic/tests.rs
@@ -2,7 +2,8 @@ use super::super::ArchiveFormat;
 use super::super::build_archive_preview;
 use super::{
     ComicArchiveBackend, ComicArchiveSignature, build_comic_archive_preview,
-    parse_comic_archive_from_7z_output, parse_zip_comic_archive, sniff_comic_archive_signature,
+    parse_comic_archive_from_7z_output, parse_comic_book_info_comment, parse_unrar_archive_comment,
+    parse_zip_comic_archive, sniff_comic_archive_signature,
 };
 use crate::preview::PreviewKind;
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
@@ -64,7 +65,7 @@ fn sniff_comic_archive_signature_detects_common_formats() {
 #[test]
 fn parses_comic_pages_from_7z_listing_output() {
     let output = r#"
-Path = /tmp/berserk.cbz
+Path = /tmp/orbital.cbz
 Type = Rar
 Physical Size = 1024
 
@@ -98,6 +99,131 @@ Packed Size = 40
     assert_eq!(comic.page_entries[0].entry_name, "001.jpg");
     assert_eq!(comic.page_entries[1].entry_name, "002.jpg");
     assert_eq!(comic.page_entries[2].entry_name, "010.jpg");
+    assert!(comic.archive_comment.is_none());
+}
+
+#[test]
+fn parses_comic_book_info_from_7z_archive_comment() {
+    let output = r#"
+Path = /tmp/commented.cbr
+Type = Rar
+Physical Size = 1024
+Comment = {"ComicBookInfo/1.0":{"series":"Aurora Riders","title":"First Light","issue":"1","publisher":"Elio Press","publicationYear":1958,"genre":"Sci-Fi","credits":[{"role":"Writer","person":"Lee Maven"}]}}
+
+----------
+Path = 001.jpg
+Folder = -
+Size = 10
+Packed Size = 10
+"#;
+
+    let comic = parse_comic_archive_from_7z_output(output, &|| false)
+        .expect("7z output should yield comic pages");
+    let metadata = comic
+        .archive_comment
+        .as_deref()
+        .and_then(parse_comic_book_info_comment)
+        .expect("7z archive comment should contain ComicBookInfo metadata");
+
+    assert_eq!(metadata.series.as_deref(), Some("Aurora Riders"));
+    assert_eq!(metadata.title.as_deref(), Some("First Light"));
+    assert_eq!(metadata.number.as_deref(), Some("1"));
+    assert_eq!(metadata.publisher.as_deref(), Some("Elio Press"));
+    assert_eq!(metadata.year.as_deref(), Some("1958"));
+    assert_eq!(metadata.writer.as_deref(), Some("Lee Maven"));
+    assert_eq!(metadata.genre.as_deref(), Some("Sci-Fi"));
+}
+
+#[test]
+fn parses_multiline_comic_book_info_from_7z_archive_comment() {
+    let output = r#"
+Path = /tmp/commented.cbr
+Type = Rar
+Physical Size = 1024
+Comment =
+{
+{
+  "appMetadata": {},
+  "ComicBookInfo/1.0": {
+    "series": "Orbital Stories",
+    "issue": 4
+  }
+}
+}
+
+----------
+Path = 001.jpg
+Folder = -
+Size = 10
+Packed Size = 10
+"#;
+
+    let comic = parse_comic_archive_from_7z_output(output, &|| false)
+        .expect("7z output should yield comic pages");
+    let metadata = comic
+        .archive_comment
+        .as_deref()
+        .and_then(parse_comic_book_info_comment)
+        .expect("7z multiline archive comment should contain ComicBookInfo metadata");
+
+    assert_eq!(metadata.series.as_deref(), Some("Orbital Stories"));
+    assert_eq!(metadata.number.as_deref(), Some("4"));
+}
+
+#[test]
+fn parses_plain_multiline_comic_book_info_from_7z_archive_comment() {
+    let output = r#"
+Path = /tmp/commented.cbr
+Type = Rar
+Physical Size = 1024
+Comment =
+{
+  "ComicBookInfo/1.0": {
+    "series": "Plain Comment",
+    "issue": 7
+  }
+}
+
+----------
+Path = 001.jpg
+Folder = -
+Size = 10
+Packed Size = 10
+"#;
+
+    let comic = parse_comic_archive_from_7z_output(output, &|| false)
+        .expect("7z output should yield comic pages");
+    let metadata = comic
+        .archive_comment
+        .as_deref()
+        .and_then(parse_comic_book_info_comment)
+        .expect("plain 7z archive comment should contain ComicBookInfo metadata");
+
+    assert_eq!(metadata.series.as_deref(), Some("Plain Comment"));
+    assert_eq!(metadata.number.as_deref(), Some("7"));
+}
+
+#[test]
+fn parses_comic_book_info_from_unrar_archive_comment() {
+    let output = r#"
+UNRAR 7.21
+
+Archive: /tmp/commented.cbr
+{"ComicBookInfo/1.0":{"series":"Orbital Stories","issue":4}}
+Details: RAR 5
+
+ Attributes       Size     Date    Time   Name
+----------- ----------  ---------- -----  ----
+    ..A....         10  2026-01-01 00:00  001.jpg
+"#;
+
+    let metadata = parse_unrar_archive_comment(output)
+        .as_deref()
+        .and_then(parse_comic_book_info_comment)
+        .expect("unrar archive comment should contain ComicBookInfo metadata");
+
+    assert_eq!(metadata.series.as_deref(), Some("Orbital Stories"));
+    assert_eq!(metadata.number.as_deref(), Some("4"));
 }
 
 #[test]

--- a/src/preview/container/archive/common.rs
+++ b/src/preview/container/archive/common.rs
@@ -52,8 +52,10 @@ pub(super) fn system_time_key(time: SystemTime) -> Option<(u64, u32)> {
 }
 
 pub(super) fn parse_key_value_line(line: &str) -> Option<(&str, &str)> {
-    let (key, value) = line.split_once(" = ")?;
-    Some((key.trim(), value.trim()))
+    if let Some((key, value)) = line.split_once(" = ") {
+        return Some((key.trim(), value.trim()));
+    }
+    line.strip_suffix(" =").map(|key| (key.trim(), ""))
 }
 
 pub(super) fn parse_u64(value: &str) -> Option<u64> {

--- a/src/preview/container/archive/external.rs
+++ b/src/preview/container/archive/external.rs
@@ -32,6 +32,16 @@ pub(super) fn collect_archive_entries_with_bsdtar(path: &Path) -> Option<Vec<Arc
     ))
 }
 
+pub(super) fn collect_archive_entries_with_unrar(path: &Path) -> Option<Vec<ArchiveEntry>> {
+    let output = Command::new("unrar").arg("lb").arg(path).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(parse_unrar_bare_listing(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
 pub(super) fn collect_archive_listing_with_7z(
     path: &Path,
 ) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>)> {
@@ -125,9 +135,13 @@ fn push_7z_entry(
     current.clear();
 }
 
+fn parse_unrar_bare_listing(output: &str) -> Vec<ArchiveEntry> {
+    normalize_archive_entries(output.lines(), false)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_7z_listing;
+    use super::{parse_7z_listing, parse_unrar_bare_listing};
 
     #[test]
     fn parse_7z_listing_collects_external_fallback_metadata_and_entries() {
@@ -178,5 +192,34 @@ Packed Size = 0
                 .iter()
                 .any(|entry| entry.path == "usr/share/icons" && entry.is_dir)
         );
+    }
+
+    #[test]
+    fn parse_unrar_bare_listing_normalizes_nested_entries() {
+        let output = r#"
+./docs/readme.txt
+src\main.rs
+../ignored.txt
+images/
+"#;
+
+        let entries = parse_unrar_bare_listing(output);
+
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "docs/readme.txt" && !entry.is_dir)
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "src/main.rs" && !entry.is_dir)
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "images" && entry.is_dir)
+        );
+        assert!(!entries.iter().any(|entry| entry.path.contains("ignored")));
     }
 }

--- a/src/preview/container/archive/format.rs
+++ b/src/preview/container/archive/format.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 pub(in crate::preview) enum ArchiveFormat {
     ComicZip,
     ComicRar,
+    Rar,
     Zip,
     SevenZip,
     Tar,
@@ -61,6 +62,7 @@ pub(super) fn detect_archive_format(path: &Path) -> ArchiveFormat {
     {
         Some("cbz") => ArchiveFormat::ComicZip,
         Some("cbr") => ArchiveFormat::ComicRar,
+        Some("rar") => ArchiveFormat::Rar,
         Some("zip" | "jar" | "apk" | "aab" | "apkg") => ArchiveFormat::Zip,
         Some("7z") => ArchiveFormat::SevenZip,
         Some("tar") => ArchiveFormat::Tar,
@@ -79,6 +81,7 @@ pub(super) fn archive_default_label(format: ArchiveFormat) -> &'static str {
     match format {
         ArchiveFormat::ComicZip => "Comic ZIP archive",
         ArchiveFormat::ComicRar => "Comic RAR archive",
+        ArchiveFormat::Rar => "RAR archive",
         ArchiveFormat::Zip => "ZIP archive",
         ArchiveFormat::SevenZip => "7z archive",
         ArchiveFormat::Tar => "TAR archive",
@@ -101,6 +104,7 @@ pub(super) fn archive_format_name(format: ArchiveFormat) -> &'static str {
     match format {
         ArchiveFormat::ComicZip => "ZIP",
         ArchiveFormat::ComicRar => "RAR",
+        ArchiveFormat::Rar => "RAR",
         ArchiveFormat::Zip => "ZIP",
         ArchiveFormat::SevenZip => "7z",
         ArchiveFormat::Tar => "TAR",

--- a/src/preview/container/archive/mod.rs
+++ b/src/preview/container/archive/mod.rs
@@ -16,8 +16,8 @@ use self::comic::build_comic_archive_preview;
 use self::common::ArchiveMetadata;
 use self::common::normalize_archive_path;
 use self::external::{
-    collect_archive_entries_with_bsdtar, collect_archive_listing_with_7z,
-    fallback_single_file_archive_entry,
+    collect_archive_entries_with_bsdtar, collect_archive_entries_with_unrar,
+    collect_archive_listing_with_7z, fallback_single_file_archive_entry,
 };
 use self::format::{archive_default_label, archive_format_name, detect_archive_format};
 use self::internal::{collect_internal_archive_listing, collect_preferred_archive_entries};
@@ -198,6 +198,25 @@ fn build_external_archive_preview(
         return Some(render_archive_preview(ArchiveRenderConfig {
             detail: detail.to_string(),
             metadata,
+            entries: Some(entries),
+            total_entries_hint: None,
+            empty_label: ARCHIVE_EMPTY_LABEL,
+            unavailable_label: "Unable to read archive contents",
+            extra_sections: Vec::new(),
+            scan_truncated: false,
+        }));
+    }
+
+    if matches!(format, ArchiveFormat::Rar)
+        && let Some(entries) = collect_archive_entries_with_unrar(path)
+    {
+        return Some(render_archive_preview(ArchiveRenderConfig {
+            detail: detail.to_string(),
+            metadata: ArchiveMetadata {
+                format_label: Some(archive_format_name(format).to_string()),
+                physical_size: fs::metadata(path).ok().map(|metadata| metadata.len()),
+                ..ArchiveMetadata::default()
+            },
             entries: Some(entries),
             total_entries_hint: None,
             empty_label: ARCHIVE_EMPTY_LABEL,

--- a/src/preview/container/archive/render.rs
+++ b/src/preview/container/archive/render.rs
@@ -35,7 +35,7 @@ pub(super) fn render_archive_preview(config: ArchiveRenderConfig) -> PreviewCont
         ),
         ("Comment", config.metadata.comment),
     ];
-    push_preview_section(&mut lines, "Summary", &summary, palette);
+    push_preview_section(&mut lines, "Details", &summary, palette);
 
     for (title, fields) in config.extra_sections {
         push_preview_values_section(&mut lines, title, &fields, palette);

--- a/src/preview/container/iso.rs
+++ b/src/preview/container/iso.rs
@@ -165,7 +165,7 @@ pub(in crate::preview) fn render_iso_preview(
         ("Effective", metadata.effective_at.clone()),
     ];
 
-    push_preview_section(&mut lines, "Image", &summary, palette);
+    push_preview_section(&mut lines, "Details", &summary, palette);
 
     let mut rendered_items = 0usize;
     let mut tree_truncated = false;

--- a/src/preview/container/torrent.rs
+++ b/src/preview/container/torrent.rs
@@ -97,7 +97,7 @@ pub(in crate::preview) fn build_torrent_preview(path: &Path) -> Option<PreviewCo
             }),
         ),
     ];
-    push_preview_section(&mut lines, "Torrent", &summary, palette);
+    push_preview_section(&mut lines, "Details", &summary, palette);
 
     let metadata_fields = vec![
         ("Created By", metadata.created_by.clone()),

--- a/src/preview/data/sqlite.rs
+++ b/src/preview/data/sqlite.rs
@@ -52,7 +52,7 @@ pub(in crate::preview) fn build_sqlite_preview(path: &Path) -> Option<PreviewCon
         ("Encoding", Some(header.encoding_label().to_string())),
         ("Journal", Some(header.journal_label().to_string())),
     ];
-    push_data_section(&mut lines, "SQLite 3", &summary, palette);
+    push_data_section(&mut lines, "Details", &summary, palette);
 
     let objects = query_schema_objects(&conn).unwrap_or_default();
     let tables: Vec<_> = objects.iter().filter(|o| o.kind == "table").collect();

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -64,6 +64,7 @@ pub(crate) fn loading_preview_for(
         (facts.preview.document_format, options.epub_section_index()),
         (Some(file_info::DocumentFormat::Epub), Some(_))
     );
+    let is_silent_archive_loading = matches!(facts.specific_type_label, Some("RAR archive"));
     let kind = if is_comic_page_preview {
         PreviewKind::Comic
     } else if is_epub_section_preview {
@@ -74,6 +75,7 @@ pub(crate) fn loading_preview_for(
     let lines = if is_comic_page_preview
         || is_epub_section_preview
         || facts.builtin_class == FileClass::Audio
+        || is_silent_archive_loading
     {
         Vec::new()
     } else if facts.builtin_class == FileClass::Archive {

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -434,7 +434,7 @@ fn image_metadata_preview(entry: &Entry, type_detail: Option<&'static str>) -> P
         .map(|(label, _)| label.len())
         .max()
         .unwrap_or(8);
-    let mut lines = vec![preview_section_line("Image", palette)];
+    let mut lines = vec![preview_section_line("Details", palette)];
     for (label, value) in fields {
         lines.push(preview_field_line(label, &value, label_width, palette));
     }

--- a/src/preview/document/common.rs
+++ b/src/preview/document/common.rs
@@ -3,27 +3,19 @@ use quick_xml::{Reader, events::Event};
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{Cursor, Read},
+    io::Read,
     path::{Component, Path},
 };
 use zip::ZipArchive;
 
-pub(super) const DOCUMENT_PREVIEW_LIMIT_BYTES: u64 = 512 * 1024;
 pub(super) const DOCUMENT_XML_ENTRY_LIMIT_BYTES: usize = 64 * 1024;
 
 pub(super) fn extract_zip_document_metadata(
     path: &Path,
-    extract: impl FnOnce(&mut ZipArchive<Cursor<Vec<u8>>>) -> DocumentMetadata,
+    extract: impl FnOnce(&mut ZipArchive<File>) -> DocumentMetadata,
 ) -> Option<DocumentMetadata> {
-    let mut bytes = Vec::with_capacity(DOCUMENT_PREVIEW_LIMIT_BYTES as usize);
-    File::open(path)
-        .ok()?
-        .take(DOCUMENT_PREVIEW_LIMIT_BYTES)
-        .read_to_end(&mut bytes)
-        .ok()?;
-
-    let cursor = Cursor::new(bytes);
-    let metadata = match ZipArchive::new(cursor) {
+    let file = File::open(path).ok()?;
+    let metadata = match ZipArchive::new(file) {
         Ok(mut archive) => extract(&mut archive),
         Err(_) => DocumentMetadata::default(),
     };

--- a/src/preview/document/epub/render.rs
+++ b/src/preview/document/epub/render.rs
@@ -1,6 +1,9 @@
 use super::super::{
     common::{local_name, read_zip_entry_limited, resolve_zip_entry_path, xml_attribute_value},
-    metadata::{DocumentMetadata, render_document_preview, render_document_preview_lines},
+    metadata::{
+        DocumentMetadata, render_document_field_lines, render_document_preview,
+        render_document_preview_lines,
+    },
 };
 use super::{
     EPUB_CONTENT_ENTRY_LIMIT_BYTES, EPUB_COVER_ENTRY_LIMIT_BYTES,
@@ -68,7 +71,7 @@ fn render_epub_preview(preview: EpubPreviewData) -> PreviewContent {
             .as_ref()
             .is_some_and(|visual| visual.kind == PreviewVisualKind::PageImage)
         {
-            Vec::new()
+            epub_page_context_lines(&preview)
         } else {
             vec![Line::from("No readable content in this section")]
         }
@@ -109,6 +112,44 @@ fn render_epub_preview(preview: EpubPreviewData) -> PreviewContent {
         content = content.with_truncation(note);
     }
     content
+}
+
+fn epub_page_context_lines(preview: &EpubPreviewData) -> Vec<Line<'static>> {
+    let mut fields = Vec::new();
+    let page = preview
+        .section_title
+        .as_deref()
+        .map(epub_page_label)
+        .unwrap_or_else(|| format!("{} of {}", preview.section_index + 1, preview.section_count));
+    fields.push(("Page".to_string(), page));
+    push_epub_context_field(&mut fields, "Title", preview.metadata.title.as_deref());
+    push_epub_context_field(&mut fields, "Author", preview.metadata.author.as_deref());
+    push_epub_context_field(&mut fields, "Subject", preview.metadata.subject.as_deref());
+    push_epub_context_field(&mut fields, "Created", preview.metadata.created.as_deref());
+    push_epub_context_field(
+        &mut fields,
+        "Modified",
+        preview.metadata.modified.as_deref(),
+    );
+    fields.extend(preview.metadata.metadata.iter().cloned());
+    fields.extend(preview.metadata.stats.iter().cloned());
+    render_document_field_lines(&fields)
+}
+
+fn epub_page_label(title: &str) -> String {
+    let title = title.trim();
+    title
+        .strip_prefix("Page ")
+        .map(str::trim)
+        .filter(|page| !page.is_empty())
+        .unwrap_or(title)
+        .to_string()
+}
+
+fn push_epub_context_field(fields: &mut Vec<(String, String)>, label: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        fields.push((label.to_string(), value.to_string()));
+    }
 }
 
 fn extract_epub_preview_data<R: Read + std::io::Seek>(

--- a/src/preview/document/formats/ooxml.rs
+++ b/src/preview/document/formats/ooxml.rs
@@ -5,7 +5,7 @@ use super::super::{
     metadata::DocumentMetadata,
 };
 use crate::file_info::DocumentFormat;
-use std::io::Read;
+use std::io::{Read, Seek};
 use zip::ZipArchive;
 
 pub(super) fn extract_ooxml_metadata<R: Read + std::io::Seek>(
@@ -43,8 +43,18 @@ pub(super) fn extract_ooxml_metadata<R: Read + std::io::Seek>(
             );
         }
         DocumentFormat::Pptx | DocumentFormat::Pptm => {
-            push_count_stat(&mut metadata, "Slides", present_count(app.get("Slides")));
-            push_count_stat(&mut metadata, "Notes", present_count(app.get("Notes")));
+            let slide_count = archive_part_count(archive, "ppt/slides/slide", ".xml");
+            let notes_count = archive_part_count(archive, "ppt/notesSlides/notesSlide", ".xml");
+            push_count_stat(
+                &mut metadata,
+                "Slides",
+                count_with_archive_fallback(present_count(app.get("Slides")), slide_count),
+            );
+            push_count_stat(
+                &mut metadata,
+                "Notes",
+                count_with_archive_fallback(present_count(app.get("Notes")), notes_count),
+            );
             push_count_stat(
                 &mut metadata,
                 "Hidden Slides",
@@ -65,4 +75,30 @@ pub(super) fn extract_ooxml_metadata<R: Read + std::io::Seek>(
     }
 
     metadata
+}
+
+fn archive_part_count<R: Read + Seek>(
+    archive: &ZipArchive<R>,
+    prefix: &str,
+    suffix: &str,
+) -> Option<u64> {
+    let count = archive
+        .file_names()
+        .filter(|name| {
+            name.strip_prefix(prefix)
+                .and_then(|rest| rest.strip_suffix(suffix))
+                .is_some_and(|part_number| {
+                    !part_number.is_empty() && part_number.bytes().all(|byte| byte.is_ascii_digit())
+                })
+        })
+        .count();
+    (count > 0).then_some(count as u64)
+}
+
+fn count_with_archive_fallback(app_count: Option<u64>, archive_count: Option<u64>) -> Option<u64> {
+    match (app_count, archive_count) {
+        (Some(0), Some(count)) if count > 0 => Some(count),
+        (Some(count), _) => Some(count),
+        (None, count) => count,
+    }
 }

--- a/src/preview/document/metadata.rs
+++ b/src/preview/document/metadata.rs
@@ -36,21 +36,21 @@ pub(super) fn render_document_preview(
 pub(super) fn render_document_preview_lines(metadata: &DocumentMetadata) -> Vec<Line<'static>> {
     let palette = theme::palette();
     let mut lines = Vec::new();
-    let document = [
+    let details = [
         ("Variant", metadata.variant.as_deref()),
         ("Title", metadata.title.as_deref()),
         ("Subject", metadata.subject.as_deref()),
+        ("Application", metadata.application.as_deref()),
     ];
     let people = [
         ("Author", metadata.author.as_deref()),
         ("Modified By", metadata.modified_by.as_deref()),
-        ("Application", metadata.application.as_deref()),
     ];
     let dates = [
         ("Created", metadata.created.as_deref()),
         ("Modified", metadata.modified.as_deref()),
     ];
-    let label_width = document
+    let label_width = details
         .iter()
         .chain(people.iter())
         .chain(dates.iter())
@@ -62,7 +62,7 @@ pub(super) fn render_document_preview_lines(metadata: &DocumentMetadata) -> Vec<
         .max(owned_section_label_width(&metadata.metadata))
         .max(6);
 
-    push_section(&mut lines, "Document", &document, label_width, palette);
+    push_section(&mut lines, "Details", &details, label_width, palette);
     push_section(&mut lines, "People", &people, label_width, palette);
     push_section(&mut lines, "Dates", &dates, label_width, palette);
     push_owned_section(&mut lines, "Stats", &metadata.stats, label_width, palette);
@@ -74,6 +74,15 @@ pub(super) fn render_document_preview_lines(metadata: &DocumentMetadata) -> Vec<
         palette,
     );
     lines
+}
+
+pub(super) fn render_document_field_lines(fields: &[(String, String)]) -> Vec<Line<'static>> {
+    let palette = theme::palette();
+    let label_width = owned_section_label_width(fields);
+    fields
+        .iter()
+        .map(|(label, value)| compact_document_line(label, value, label_width, palette))
+        .collect()
 }
 
 fn push_section(
@@ -142,6 +151,21 @@ fn document_line(
     Line::from(vec![
         Span::styled(
             format!("{label:<width$} ", width = label_width + 1),
+            Style::default().fg(palette.muted),
+        ),
+        Span::styled(value.to_string(), Style::default().fg(palette.text)),
+    ])
+}
+
+fn compact_document_line(
+    label: &str,
+    value: &str,
+    label_width: usize,
+    palette: theme::Palette,
+) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<label_width$} "),
             Style::default().fg(palette.muted),
         ),
         Span::styled(value.to_string(), Style::default().fg(palette.text)),

--- a/src/preview/document/metadata.rs
+++ b/src/preview/document/metadata.rs
@@ -40,20 +40,14 @@ pub(super) fn render_document_preview_lines(metadata: &DocumentMetadata) -> Vec<
         ("Variant", metadata.variant.as_deref()),
         ("Title", metadata.title.as_deref()),
         ("Subject", metadata.subject.as_deref()),
-        ("Application", metadata.application.as_deref()),
-    ];
-    let people = [
         ("Author", metadata.author.as_deref()),
         ("Modified By", metadata.modified_by.as_deref()),
-    ];
-    let dates = [
+        ("Application", metadata.application.as_deref()),
         ("Created", metadata.created.as_deref()),
         ("Modified", metadata.modified.as_deref()),
     ];
     let label_width = details
         .iter()
-        .chain(people.iter())
-        .chain(dates.iter())
         .filter(|(_, value)| value.is_some())
         .map(|(label, _)| label.len())
         .max()
@@ -62,10 +56,14 @@ pub(super) fn render_document_preview_lines(metadata: &DocumentMetadata) -> Vec<
         .max(owned_section_label_width(&metadata.metadata))
         .max(6);
 
-    push_section(&mut lines, "Details", &details, label_width, palette);
-    push_section(&mut lines, "People", &people, label_width, palette);
-    push_section(&mut lines, "Dates", &dates, label_width, palette);
-    push_owned_section(&mut lines, "Stats", &metadata.stats, label_width, palette);
+    push_combined_section(
+        &mut lines,
+        "Details",
+        &details,
+        &metadata.stats,
+        label_width,
+        palette,
+    );
     push_owned_section(
         &mut lines,
         "Metadata",
@@ -85,10 +83,11 @@ pub(super) fn render_document_field_lines(fields: &[(String, String)]) -> Vec<Li
         .collect()
 }
 
-fn push_section(
+fn push_combined_section(
     lines: &mut Vec<Line<'static>>,
     title: &str,
     fields: &[(&str, Option<&str>)],
+    owned_fields: &[(String, String)],
     label_width: usize,
     palette: theme::Palette,
 ) {
@@ -96,7 +95,7 @@ fn push_section(
         .iter()
         .filter_map(|(label, value)| value.map(|value| (*label, value)))
         .collect();
-    if visible_fields.is_empty() {
+    if visible_fields.is_empty() && owned_fields.is_empty() {
         return;
     }
     if !lines.is_empty() {
@@ -104,6 +103,9 @@ fn push_section(
     }
     lines.push(section_line(title, palette));
     for (label, value) in visible_fields {
+        lines.push(document_line(label, value, label_width, palette));
+    }
+    for (label, value) in owned_fields {
         lines.push(document_line(label, value, label_width, palette));
     }
 }

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -366,7 +366,48 @@ fn zip_preview_renders_archive_details_and_tree() {
 }
 
 #[test]
-fn comic_zip_preview_uses_comic_info_and_compact_contents() {
+fn rar_preview_uses_external_listing_when_available() {
+    let root = temp_path("rar-preview");
+    fs::create_dir_all(root.join("docs")).expect("failed to create docs dir");
+    fs::create_dir_all(root.join("src")).expect("failed to create src dir");
+    fs::write(root.join("docs/readme.txt"), "hello").expect("failed to write readme");
+    fs::write(root.join("src/main.rs"), "fn main() {}\n").expect("failed to write source");
+
+    let path = root.join("bundle.rar");
+    let status = Command::new("7z")
+        .current_dir(&root)
+        .arg("a")
+        .arg("-t7z")
+        .arg(&path)
+        .arg("docs")
+        .arg("src")
+        .status();
+    let Ok(status) = status else {
+        fs::remove_dir_all(&root).expect("failed to remove temp root");
+        return;
+    };
+    if !status.success() {
+        fs::remove_dir_all(&root).expect("failed to remove temp root");
+        return;
+    }
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("RAR archive"));
+    assert!(line_texts.iter().any(|text| text == "Details"));
+    assert!(line_texts.iter().any(|text| text == "Contents"));
+    assert!(line_texts.iter().any(|text| text.contains("docs/")));
+    assert!(line_texts.iter().any(|text| text.contains("src/")));
+    assert!(line_texts.iter().any(|text| text.contains("readme.txt")));
+    assert!(line_texts.iter().any(|text| text.contains("main.rs")));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_uses_comic_info_without_archive_noise() {
     let root = temp_path("comic-zip-preview");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let path = root.join("issue.cbz");
@@ -455,22 +496,10 @@ fn comic_zip_preview_uses_comic_info_and_compact_contents() {
             .iter()
             .any(|text| text.contains("Genre") && text.contains("Science Fiction"))
     );
-    assert!(
-        line_texts
-            .iter()
-            .any(|text| text.contains("Pages") && text.contains("2"))
-    );
-    assert!(line_texts.iter().any(|text| text.trim() == "Contents"));
-    assert!(
-        line_texts
-            .iter()
-            .any(|text| text.contains("Extras") && text.contains("ComicInfo.xml"))
-    );
-    assert!(
-        line_texts
-            .iter()
-            .any(|text| text.contains("Extras") && text.contains("notes/readme.txt"))
-    );
+    assert!(!line_texts.iter().any(|text| text.contains("Pages")));
+    assert!(!line_texts.iter().any(|text| text.contains("Root")));
+    assert!(!line_texts.iter().any(|text| text.trim() == "Contents"));
+    assert!(!line_texts.iter().any(|text| text.contains("Extras")));
     assert!(
         !line_texts
             .iter()
@@ -480,6 +509,564 @@ fn comic_zip_preview_uses_comic_info_and_compact_contents() {
     assert!(!line_texts.iter().any(|text| text.contains("Archive Size")));
     assert!(!line_texts.iter().any(|text| text.contains("001-cover.jpg")));
     assert!(!line_texts.iter().any(|text| text.contains("002-page.jpg")));
+    assert!(
+        !line_texts
+            .iter()
+            .any(|text| text.contains("notes/readme.txt"))
+    );
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_reads_comic_book_info_zip_comment() {
+    let root = temp_path("comic-zip-comment-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("comment.cbz");
+    let file = File::create(&path).expect("failed to create comic zip");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("001.jpg", options)
+        .expect("failed to start page entry");
+    zip.write_all(b"page").expect("failed to write page entry");
+    zip.set_comment(
+        r#"{"appID":"FixtureReader/1","ComicBookInfo/1.0":{"series":"Aurora Riders","title":"First Light","issue":"1","publisher":"Elio Press","publicationYear":1958,"genre":"Sci-Fi","credits":[{"role":"Writer","person":"Lee Maven"}]}}"#,
+    );
+    zip.finish().expect("failed to finish comic zip");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("First Light"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Aurora Riders"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Number") && text.contains("1"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Year") && text.contains("1958"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Publisher") && text.contains("Elio Press"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Writer") && text.contains("Lee Maven"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Genre") && text.contains("Sci-Fi"))
+    );
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_reads_comet_xml_metadata() {
+    let root = temp_path("comic-zip-comet-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("comet.cbz");
+    let file = File::create(&path).expect("failed to create comic zip");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("001.jpg", options)
+        .expect("failed to start page entry");
+    zip.write_all(b"page").expect("failed to write page entry");
+    zip.start_file("CoMet.xml", options)
+        .expect("failed to start comet entry");
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="utf-8"?>
+            <comet>
+              <title>Moon Orbit</title>
+              <series>Orbital Stories</series>
+              <issue>5</issue>
+              <volume>2</volume>
+              <publisher>Elio Press</publisher>
+              <date>1994-11-05</date>
+              <genre>Science Fiction</genre>
+            </comet>"#,
+    )
+    .expect("failed to write comet entry");
+    zip.finish().expect("failed to finish comic zip");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("Moon Orbit"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Orbital Stories"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Number") && text.contains("5"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("2"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Year") && text.contains("1994"))
+    );
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_reads_metron_info_metadata() {
+    let root = temp_path("comic-zip-metron-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("metron.cbz");
+    let file = File::create(&path).expect("failed to create comic zip");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("001.jpg", options)
+        .expect("failed to start page entry");
+    zip.write_all(b"page").expect("failed to write page entry");
+    zip.start_file("MetronInfo.xml", options)
+        .expect("failed to start metron info entry");
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="utf-8"?>
+            <MetronInfo>
+              <Publisher>
+                <Name>Elio Press</Name>
+              </Publisher>
+              <Series>
+                <Name>Signal Hammer</Name>
+                <Volume>1</Volume>
+              </Series>
+              <Number>12</Number>
+              <Stories>
+                <Story>The End</Story>
+              </Stories>
+              <CoverDate>2017-06-21</CoverDate>
+              <Genres>
+                <Genre>Superhero</Genre>
+              </Genres>
+              <Credits>
+                <Credit>
+                  <Creator>Avery Quill</Creator>
+                  <Roles>
+                    <Role>Writer</Role>
+                  </Roles>
+                </Credit>
+                <Credit>
+                  <Creator>Morgan Line</Creator>
+                  <Roles>
+                    <Role>Artist</Role>
+                  </Roles>
+                </Credit>
+              </Credits>
+            </MetronInfo>"#,
+    )
+    .expect("failed to write metron info entry");
+    zip.finish().expect("failed to finish comic zip");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("The End"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Signal Hammer"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Number") && text.contains("12"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("1"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Year") && text.contains("2017"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Publisher") && text.contains("Elio Press"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Writer") && text.contains("Avery Quill"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Penciller") && text.contains("Morgan Line"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Genre") && text.contains("Superhero"))
+    );
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_reads_acbf_metadata() {
+    let root = temp_path("comic-zip-acbf-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("acbf.cbz");
+    let file = File::create(&path).expect("failed to create comic zip");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("page01.jpg", options)
+        .expect("failed to start page entry");
+    zip.write_all(b"page").expect("failed to write page entry");
+    zip.start_file("metadata/book.acbf", options)
+        .expect("failed to start acbf entry");
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="utf-8"?>
+            <ACBF xmlns="http://www.acbf.info/xml/acbf/1.1">
+              <meta-data>
+                <book-info>
+                  <author activity="Writer">
+                    <first-name>Rhea</first-name>
+                    <last-name>Quinn</last-name>
+                  </author>
+                  <author activity="Artist">
+                    <nickname>Northline Studio</nickname>
+                  </author>
+                  <book-title>Northline Relay</book-title>
+                  <genre>Science Fiction</genre>
+                  <sequence title="Futuristic Tales" volume="1">3</sequence>
+                </book-info>
+                <publish-info>
+                  <publisher>Elio Press</publisher>
+                  <publish-date value="2007-02-01">February 2007</publish-date>
+                </publish-info>
+              </meta-data>
+            </ACBF>"#,
+    )
+    .expect("failed to write acbf entry");
+    zip.finish().expect("failed to finish comic zip");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("Northline Relay"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Futuristic Tales"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Number") && text.contains("3"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("1"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Year") && text.contains("2007"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Publisher") && text.contains("Elio Press"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Writer") && text.contains("Rhea Quinn"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Penciller") && text.contains("Northline Studio"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Genre") && text.contains("Science Fiction"))
+    );
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_derives_metadata_from_structured_names() {
+    let root = temp_path("comic-zip-derived-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("Moon Ledger v01 (2005) (Digital) (Fixture Group) (ED).cbz");
+    write_zip_binary_entries(
+        &path,
+        &[
+            (
+                "Moon Ledger - c001 (v01) - p000 [Elio Press] [Digital] [Fixture Group].jpg",
+                b"chapter-one",
+            ),
+            (
+                "Moon Ledger - c007 (v01) - p195 [Elio Press] [Digital] [Fixture Group].png",
+                b"chapter-seven",
+            ),
+        ],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(preview.kind, PreviewKind::Comic);
+    assert_eq!(preview.detail.as_deref(), Some("Comic ZIP archive"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Moon Ledger"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("1"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Year") && text.contains("2005"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Publisher") && text.contains("Elio Press"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Source") && text.contains("Digital"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Chapters") && text.contains("1-7"))
+    );
+    assert!(!line_texts.iter().any(|text| text.contains("Pages")));
+    assert!(!line_texts.iter().any(|text| text.contains("Root")));
+    assert!(!line_texts.iter().any(|text| text.trim() == "Contents"));
+    assert!(!line_texts.iter().any(|text| text.contains("Extras")));
+    assert!(!line_texts.iter().any(|text| text.contains("p000")));
+    assert!(!line_texts.iter().any(|text| text.contains("Fixture Group")));
+    assert!(!line_texts.iter().any(|text| text.contains("ED")));
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_derives_tome_volume_and_digital_source_from_filenames() {
+    let root = temp_path("comic-zip-tome-derived-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("Skyline Saga T01 (Mira) (2018) [Digital-1699] [Fixture FR].cbz");
+    write_zip_binary_entries(
+        &path,
+        &[("0001_0000.jpg", b"cover"), ("0002_0001.jpg", b"page")],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Skyline Saga"))
+    );
+    assert!(
+        !line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("T01"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("1"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Year") && text.contains("2018"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Source") && text.contains("Digital"))
+    );
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_derives_metadata_from_bracketed_names_without_group_noise() {
+    let root = temp_path("comic-zip-bracketed-derived-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("[ScanGroup] Harbor Case v01 [Digital].cbz");
+    write_zip_binary_entries(&path, &[("001.jpg", b"cover"), ("002.jpg", b"page-one")]);
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Harbor Case"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("1"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Source") && text.contains("Digital"))
+    );
+    assert!(!line_texts.iter().any(|text| text.contains("ScanGroup")));
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_derives_series_from_collection_folder() {
+    let root = temp_path("comic-zip-folder-metadata");
+    let collection = root.join("[FixtureGroup] Harbor Case");
+    fs::create_dir_all(&collection).expect("failed to create collection folder");
+    let path = collection.join("Volume 01.cbz");
+    write_zip_binary_entries(&path, &[("000.jpg", b"cover"), ("001.png", b"page-one")]);
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert_eq!(preview.kind, PreviewKind::Comic);
+    assert_eq!(preview.detail.as_deref(), Some("Comic ZIP archive"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Harbor Case"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Volume") && text.contains("1"))
+    );
+    assert!(!line_texts.iter().any(|text| text.contains("FixtureGroup")));
+    assert!(!line_texts.iter().any(|text| text.contains("Pages")));
+    assert!(!line_texts.iter().any(|text| text.contains("Root")));
+    assert!(!line_texts.iter().any(|text| text.contains("000.jpg")));
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn comic_zip_preview_avoids_generic_derived_metadata() {
+    let root = temp_path("comic-zip-generic-derived-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("issue.cbz");
+    write_zip_binary_entries(
+        &path,
+        &[
+            ("c001-p001 [Digital].jpg", b"cover"),
+            ("c001-p002.jpg", b"page-one"),
+        ],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("comic zip should expose a page visual");
+
+    assert!(line_texts.is_empty());
 
     let _ = fs::remove_file(visual.path);
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -493,9 +1080,9 @@ fn comic_zip_preview_uses_natural_page_order_and_page_selection() {
     write_zip_binary_entries(
         &path,
         &[
-            ("10.jpg", b"page-ten"),
-            ("2.jpg", b"page-two"),
-            ("1.jpg", b"page-one"),
+            ("18376941278364981273/10.jpg", b"page-ten"),
+            ("18376941278364981273/2.jpg", b"page-two"),
+            ("18376941278364981273/1.jpg", b"page-one"),
         ],
     );
 
@@ -548,12 +1135,13 @@ fn comic_zip_preview_uses_natural_page_order_and_page_selection() {
         Some(3)
     );
     let second_line_texts: Vec<_> = second_preview.lines.iter().map(line_text).collect();
-    assert!(
-        second_line_texts
-            .iter()
-            .any(|text| text.contains("Pages") && text.contains("3"))
-    );
+    assert!(second_line_texts.is_empty());
     assert!(!second_line_texts.iter().any(|text| text.contains("2.jpg")));
+    assert!(
+        !second_line_texts
+            .iter()
+            .any(|text| text.contains("18376941278364981273"))
+    );
 
     let _ = fs::remove_file(first_visual.path.clone());
     let _ = fs::remove_file(second_visual.path.clone());
@@ -597,12 +1185,7 @@ fn cbr_file_with_zip_content_renders_as_comic_preview() {
         Some(("Page", 0, 2))
     );
     assert!(visual.path.exists());
-    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
-    assert!(
-        line_texts
-            .iter()
-            .any(|text| text.contains("Pages") && text.contains("2"))
-    );
+    assert!(line_texts.is_empty());
 
     let _ = fs::remove_file(visual.path);
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -407,6 +407,22 @@ fn rar_preview_uses_external_listing_when_available() {
 }
 
 #[test]
+fn rar_loading_preview_is_silent() {
+    let root = temp_path("rar-loading-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("bundle.rar");
+    fs::write(&path, b"not-a-real-rar").expect("failed to write rar fixture");
+
+    let preview = loading_preview_for(&file_entry(path), &PreviewRequestOptions::Default);
+
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("RAR archive"));
+    assert!(preview.lines.is_empty());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn comic_zip_preview_uses_comic_info_without_archive_noise() {
     let root = temp_path("comic-zip-preview");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -366,7 +366,7 @@ fn zip_preview_renders_archive_details_and_tree() {
 }
 
 #[test]
-fn comic_zip_preview_renders_first_page_without_summary() {
+fn comic_zip_preview_uses_comic_info_and_compact_contents() {
     let root = temp_path("comic-zip-preview");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let path = root.join("issue.cbz");
@@ -388,6 +388,21 @@ fn comic_zip_preview_renders_first_page_without_summary() {
     zip.start_file("notes/readme.txt", options)
         .expect("failed to start text entry");
     zip.write_all(b"hello").expect("failed to write text entry");
+    zip.start_file("ComicInfo.xml", options)
+        .expect("failed to start comic info entry");
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="utf-8"?>
+            <ComicInfo>
+              <Title>Bright Landing</Title>
+              <Series>Orbital Stories</Series>
+              <Number>4</Number>
+              <Year>2026</Year>
+              <Writer>Regueiro</Writer>
+              <Publisher>Elio Press</Publisher>
+              <Genre>Science Fiction</Genre>
+            </ComicInfo>"#,
+    )
+    .expect("failed to write comic info entry");
     zip.finish().expect("failed to finish comic zip");
 
     let preview = build_preview(&file_entry(path));
@@ -409,7 +424,53 @@ fn comic_zip_preview_renders_first_page_without_summary() {
     assert_eq!(position.index, 0);
     assert_eq!(position.count, 2);
     assert!(visual.path.exists());
-    assert!(line_texts.is_empty());
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("Bright Landing"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Series") && text.contains("Orbital Stories"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Number") && text.contains("4"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Writer") && text.contains("Regueiro"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Publisher") && text.contains("Elio Press"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Genre") && text.contains("Science Fiction"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Pages") && text.contains("2"))
+    );
+    assert!(line_texts.iter().any(|text| text.trim() == "Contents"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Extras") && text.contains("ComicInfo.xml"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Extras") && text.contains("notes/readme.txt"))
+    );
     assert!(
         !line_texts
             .iter()
@@ -417,10 +478,8 @@ fn comic_zip_preview_renders_first_page_without_summary() {
     );
     assert!(!line_texts.iter().any(|text| text.contains("Packed")));
     assert!(!line_texts.iter().any(|text| text.contains("Archive Size")));
-    assert!(!line_texts.iter().any(|text| text.trim() == "Contents"));
     assert!(!line_texts.iter().any(|text| text.contains("001-cover.jpg")));
     assert!(!line_texts.iter().any(|text| text.contains("002-page.jpg")));
-    assert!(!line_texts.iter().any(|text| text.contains("notes/")));
 
     let _ = fs::remove_file(visual.path);
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -488,6 +547,13 @@ fn comic_zip_preview_uses_natural_page_order_and_page_selection() {
             .map(|position| position.count),
         Some(3)
     );
+    let second_line_texts: Vec<_> = second_preview.lines.iter().map(line_text).collect();
+    assert!(
+        second_line_texts
+            .iter()
+            .any(|text| text.contains("Pages") && text.contains("3"))
+    );
+    assert!(!second_line_texts.iter().any(|text| text.contains("2.jpg")));
 
     let _ = fs::remove_file(first_visual.path.clone());
     let _ = fs::remove_file(second_visual.path.clone());
@@ -531,7 +597,12 @@ fn cbr_file_with_zip_content_renders_as_comic_preview() {
         Some(("Page", 0, 2))
     );
     assert!(visual.path.exists());
-    assert!(line_texts.is_empty());
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Pages") && text.contains("2"))
+    );
 
     let _ = fs::remove_file(visual.path);
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -34,7 +34,7 @@ fn torrent_preview_shows_single_file_metadata_and_trackers() {
 
     assert_eq!(preview.kind, PreviewKind::Text);
     assert_eq!(preview.detail.as_deref(), Some("BitTorrent file"));
-    assert_eq!(line_texts.first().map(String::as_str), Some("Torrent"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
     assert!(
         line_texts
             .iter()
@@ -250,7 +250,7 @@ fn iso_preview_renders_metadata_and_tree() {
     assert_eq!(preview.kind, PreviewKind::Archive);
     assert_eq!(preview.detail.as_deref(), Some("ISO disk image"));
     assert!(header.contains("ISO disk image"));
-    assert_eq!(line_texts.first().map(String::as_str), Some("Image"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
     assert!(
         line_texts
             .iter()
@@ -329,7 +329,7 @@ fn iso_preview_lists_contents_when_bsdtar_can_read_image() {
 }
 
 #[test]
-fn zip_preview_renders_archive_summary_and_tree() {
+fn zip_preview_renders_archive_details_and_tree() {
     let root = temp_path("zip-preview");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let path = root.join("bundle.zip");
@@ -350,7 +350,7 @@ fn zip_preview_renders_archive_summary_and_tree() {
     assert_eq!(preview.kind, PreviewKind::Archive);
     assert_eq!(preview.detail.as_deref(), Some("ZIP archive"));
     assert!(header.contains("ZIP archive"));
-    assert!(line_texts.iter().any(|text| text.trim() == "Summary"));
+    assert!(line_texts.iter().any(|text| text.trim() == "Details"));
     assert!(!line_texts.iter().any(|text| text.trim() == "Archive"));
     assert!(
         line_texts

--- a/src/preview/tests/audio.rs
+++ b/src/preview/tests/audio.rs
@@ -95,6 +95,7 @@ fn audio_preview_falls_back_to_file_metadata_without_tools() {
 
     assert_eq!(preview.kind, PreviewKind::Audio);
     assert_eq!(preview.detail.as_deref(), Some("FLAC audio"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
     assert!(preview.preview_visual.is_none());
     assert!(line_texts.iter().any(|line| line.contains("File Size")
         && line.contains(&crate::fs::format_size(contents.len() as u64))));

--- a/src/preview/tests/binaries.rs
+++ b/src/preview/tests/binaries.rs
@@ -12,6 +12,7 @@ fn pe_preview_shows_windows_executable_metadata() {
 
     assert_eq!(preview.kind, PreviewKind::Binary);
     assert_eq!(preview.detail.as_deref(), Some("Windows executable"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
     assert!(
         line_texts
             .iter()

--- a/src/preview/tests/data.rs
+++ b/src/preview/tests/data.rs
@@ -41,10 +41,10 @@ fn sqlite_preview_shows_header_and_tables() {
     assert_eq!(preview.kind, PreviewKind::Data);
     assert_eq!(preview.detail.as_deref(), Some("SQLite database"));
 
-    // Summary section header
+    // Details section header
     assert!(
-        text.iter().any(|l| l.contains("SQLite 3")),
-        "expected 'SQLite 3' section header; got: {text:?}"
+        text.iter().any(|l| l == "Details"),
+        "expected 'Details' section header; got: {text:?}"
     );
     // Page size field
     assert!(

--- a/src/preview/tests/documents/epub/fixed_layout.rs
+++ b/src/preview/tests/documents/epub/fixed_layout.rs
@@ -28,6 +28,7 @@ fn epub_preview_uses_section_image_for_fixed_layout_pages() {
                 <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
                   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
                     <dc:title>Fixed Layout Story</dc:title>
+                    <dc:creator>Elio</dc:creator>
                   </metadata>
                   <manifest>
                     <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
@@ -88,7 +89,10 @@ fn epub_preview_uses_section_image_for_fixed_layout_pages() {
     assert_eq!(preview.ebook_section_title.as_deref(), Some("Page 1"));
     assert_eq!(visual.kind, PreviewVisualKind::PageImage);
     assert_eq!(visual.layout, PreviewVisualLayout::FullHeight);
-    assert!(line_texts.is_empty());
+    assert_eq!(
+        line_texts,
+        vec!["Page   1", "Title  Fixed Layout Story", "Author Elio"]
+    );
     assert!(visual.path.exists());
     assert!(
         visual

--- a/src/preview/tests/documents/office.rs
+++ b/src/preview/tests/documents/office.rs
@@ -23,9 +23,9 @@ fn doc_preview_shows_legacy_document_metadata() {
     assert_eq!(preview.kind, PreviewKind::Document);
     assert_eq!(preview.detail.as_deref(), Some("DOC document"));
     assert_eq!(line_texts[0], "Details");
-    assert!(line_texts.iter().any(|text| text == "People"));
-    assert!(line_texts.iter().any(|text| text == "Dates"));
-    assert!(line_texts.iter().any(|text| text == "Stats"));
+    assert!(line_texts.iter().all(|text| text != "People"));
+    assert!(line_texts.iter().all(|text| text != "Dates"));
+    assert!(line_texts.iter().all(|text| text != "Stats"));
     assert!(
         line_texts
             .iter()
@@ -96,9 +96,9 @@ fn docx_preview_shows_document_metadata() {
             .iter()
             .all(|text| !text.contains("Format") || !text.contains("DOCX document"))
     );
-    assert!(line_texts.iter().any(|text| text == "People"));
-    assert!(line_texts.iter().any(|text| text == "Dates"));
-    assert!(line_texts.iter().any(|text| text == "Stats"));
+    assert!(line_texts.iter().all(|text| text != "People"));
+    assert!(line_texts.iter().all(|text| text != "Dates"));
+    assert!(line_texts.iter().all(|text| text != "Stats"));
     assert!(
         line_texts
             .iter()
@@ -128,20 +128,9 @@ fn docx_preview_shows_document_metadata() {
             .iter()
             .all(|text| !text.contains("ApplicationLibreOffice"))
     );
-    assert!(
-        line_texts
-            .iter()
-            .position(|text| text == "Details")
-            .unwrap()
-            < line_texts.iter().position(|text| text == "People").unwrap()
-    );
-    assert!(
-        line_texts.iter().position(|text| text == "People").unwrap()
-            < line_texts.iter().position(|text| text == "Dates").unwrap()
-    );
-    assert!(
-        line_texts.iter().position(|text| text == "Dates").unwrap()
-            < line_texts.iter().position(|text| text == "Stats").unwrap()
+    assert_eq!(
+        line_texts.iter().filter(|text| *text == "Details").count(),
+        1
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -177,9 +166,9 @@ fn odt_preview_shows_document_metadata() {
     assert_eq!(preview.kind, PreviewKind::Document);
     assert_eq!(preview.detail.as_deref(), Some("ODT document"));
     assert_eq!(line_texts[0], "Details");
-    assert!(line_texts.iter().any(|text| text == "People"));
-    assert!(line_texts.iter().any(|text| text == "Dates"));
-    assert!(line_texts.iter().any(|text| text == "Stats"));
+    assert!(line_texts.iter().all(|text| text != "People"));
+    assert!(line_texts.iter().all(|text| text != "Dates"));
+    assert!(line_texts.iter().all(|text| text != "Stats"));
     assert!(line_texts.iter().any(|text| text.contains("Project Notes")));
     assert!(line_texts.iter().any(|text| text.contains("LibreOffice")));
     assert!(line_texts.iter().any(|text| text.contains("980")));
@@ -236,6 +225,8 @@ fn pptx_preview_with_no_people_metadata_does_not_show_people_section() {
     assert_eq!(preview.detail.as_deref(), Some("PPTX presentation"));
     assert!(line_texts.iter().any(|text| text == "Details"));
     assert!(line_texts.iter().all(|text| text != "People"));
+    assert!(line_texts.iter().all(|text| text != "Dates"));
+    assert!(line_texts.iter().all(|text| text != "Stats"));
     assert!(
         line_texts
             .iter()

--- a/src/preview/tests/documents/office.rs
+++ b/src/preview/tests/documents/office.rs
@@ -22,7 +22,7 @@ fn doc_preview_shows_legacy_document_metadata() {
 
     assert_eq!(preview.kind, PreviewKind::Document);
     assert_eq!(preview.detail.as_deref(), Some("DOC document"));
-    assert_eq!(line_texts[0], "Document");
+    assert_eq!(line_texts[0], "Details");
     assert!(line_texts.iter().any(|text| text == "People"));
     assert!(line_texts.iter().any(|text| text == "Dates"));
     assert!(line_texts.iter().any(|text| text == "Stats"));
@@ -90,7 +90,7 @@ fn docx_preview_shows_document_metadata() {
 
     assert_eq!(preview.kind, PreviewKind::Document);
     assert_eq!(preview.detail.as_deref(), Some("DOCX document"));
-    assert_eq!(line_texts[0], "Document");
+    assert_eq!(line_texts[0], "Details");
     assert!(
         line_texts
             .iter()
@@ -131,7 +131,7 @@ fn docx_preview_shows_document_metadata() {
     assert!(
         line_texts
             .iter()
-            .position(|text| text == "Document")
+            .position(|text| text == "Details")
             .unwrap()
             < line_texts.iter().position(|text| text == "People").unwrap()
     );
@@ -176,7 +176,7 @@ fn odt_preview_shows_document_metadata() {
 
     assert_eq!(preview.kind, PreviewKind::Document);
     assert_eq!(preview.detail.as_deref(), Some("ODT document"));
-    assert_eq!(line_texts[0], "Document");
+    assert_eq!(line_texts[0], "Details");
     assert!(line_texts.iter().any(|text| text == "People"));
     assert!(line_texts.iter().any(|text| text == "Dates"));
     assert!(line_texts.iter().any(|text| text == "Stats"));
@@ -195,6 +195,56 @@ fn odt_preview_shows_document_metadata() {
         line_texts
             .iter()
             .all(|text| !text.contains("2026-03-10T18:00:00Z"))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn pptx_preview_with_no_people_metadata_does_not_show_people_section() {
+    let root = temp_path("pptx-no-people");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("deck.pptx");
+    write_zip_entries(
+        &path,
+        &[
+            (
+                "docProps/core.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+                    <cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+                        xmlns:dcterms="http://purl.org/dc/terms/">
+                      <dcterms:created>2006-08-16T00:00:00Z</dcterms:created>
+                      <dcterms:modified>2011-08-01T06:04:30Z</dcterms:modified>
+                    </cp:coreProperties>"#,
+            ),
+            (
+                "docProps/app.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+                    <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">
+                      <Application>Microsoft Office PowerPoint</Application>
+                      <Slides>0</Slides>
+                    </Properties>"#,
+            ),
+            ("ppt/slides/slide1.xml", r#"<?xml version="1.0"?><p:sld/>"#),
+        ],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert_eq!(preview.detail.as_deref(), Some("PPTX presentation"));
+    assert!(line_texts.iter().any(|text| text == "Details"));
+    assert!(line_texts.iter().all(|text| text != "People"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Application") && text.contains("Microsoft Office"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Slides") && text.contains("1"))
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -256,6 +306,95 @@ fn pptx_preview_shows_presentation_metadata() {
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn large_pptx_preview_reads_metadata_from_full_zip_archive() {
+    let root = temp_path("large-pptx");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("large-deck.pptx");
+    let core_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>Large Launch Deck</dc:title>
+          <dc:creator>Elio</dc:creator>
+        </cp:coreProperties>"#;
+    let app_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">
+          <Application>PowerPoint</Application>
+          <Slides>0</Slides>
+          <Notes>0</Notes>
+        </Properties>"#;
+    write_large_pptx_with_stale_counts(&path, core_xml, app_xml, 13, 2);
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert_eq!(preview.detail.as_deref(), Some("PPTX presentation"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Large Launch Deck"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Slides") && text.contains("13"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Notes") && text.contains("2"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .all(|text| !text.contains("No document metadata available"))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+fn write_large_pptx_with_stale_counts(
+    path: &std::path::Path,
+    core_xml: &str,
+    app_xml: &str,
+    slides: u16,
+    notes: u16,
+) {
+    let file = File::create(path).expect("failed to create pptx");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+
+    zip.start_file("ppt/media/image1.bin", options)
+        .expect("failed to start media entry");
+    zip.write_all(&vec![b'x'; 600 * 1024])
+        .expect("failed to write media entry");
+
+    for slide in 1..=slides {
+        zip.start_file(format!("ppt/slides/slide{slide}.xml"), options)
+            .expect("failed to start slide entry");
+        zip.write_all(br#"<?xml version="1.0"?><p:sld/>"#)
+            .expect("failed to write slide entry");
+    }
+
+    for note in 1..=notes {
+        zip.start_file(format!("ppt/notesSlides/notesSlide{note}.xml"), options)
+            .expect("failed to start notes entry");
+        zip.write_all(br#"<?xml version="1.0"?><p:notes/>"#)
+            .expect("failed to write notes entry");
+    }
+
+    zip.start_file("docProps/core.xml", options)
+        .expect("failed to start core metadata entry");
+    zip.write_all(core_xml.as_bytes())
+        .expect("failed to write core metadata");
+    zip.start_file("docProps/app.xml", options)
+        .expect("failed to start app metadata entry");
+    zip.write_all(app_xml.as_bytes())
+        .expect("failed to write app metadata");
+    zip.finish().expect("failed to finish pptx");
 }
 
 #[test]
@@ -413,6 +552,54 @@ fn odp_preview_shows_presentation_statistics() {
         line_texts
             .iter()
             .any(|text| text.contains("Objects") && text.contains("3"))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn large_odp_preview_reads_metadata_from_full_zip_archive() {
+    let root = temp_path("large-odp");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("large-deck.odp");
+    let filler = vec![b'x'; 600 * 1024];
+    let meta_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <office:document-meta xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0">
+          <office:meta>
+            <dc:title>Large Impress Deck</dc:title>
+            <meta:generator>LibreOffice Impress</meta:generator>
+            <meta:document-statistic meta:page-count="18" meta:object-count="5"/>
+          </office:meta>
+        </office:document-meta>"#;
+    write_zip_binary_entries(
+        &path,
+        &[
+            ("Pictures/image1.bin", filler.as_slice()),
+            ("meta.xml", meta_xml.as_bytes()),
+        ],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert_eq!(preview.detail.as_deref(), Some("ODP presentation"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Large Impress Deck"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Slides") && text.contains("18"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .all(|text| !text.contains("No document metadata available"))
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/preview/tests/images.rs
+++ b/src/preview/tests/images.rs
@@ -12,6 +12,7 @@ fn raster_image_preview_uses_image_metadata_fallback() {
 
     assert_eq!(preview.kind, PreviewKind::Image);
     assert_eq!(preview.detail.as_deref(), Some("PNG image"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
     assert!(
         line_texts
             .iter()

--- a/src/preview/tests/markdown.rs
+++ b/src/preview/tests/markdown.rs
@@ -419,7 +419,7 @@ fn markdown_license_preview_keeps_detected_detail() {
     let path = root.join("LICENSE.md");
     fs::write(
         &path,
-        "# SPDX-License-Identifier: Apache-2.0\n\nLicensed under the Apache License, Version 2.0.\n",
+        "# SPDX-License-Identifier: Apache-2.0\n\nFixture license notes.\n",
     )
     .expect("failed to write markdown license");
 

--- a/src/preview/tests/text.rs
+++ b/src/preview/tests/text.rs
@@ -7,7 +7,7 @@ fn plain_text_license_preview_shows_specific_license_detail() {
     let path = root.join("LICENSE");
     fs::write(
         &path,
-        "MIT License\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND.\n",
+        "SPDX-License-Identifier: MIT\n\nFixture grant notes.\n",
     )
     .expect("failed to write license");
 
@@ -283,22 +283,18 @@ fn license_file_with_hard_line_breaks_is_reflowed_into_paragraphs() {
     fs::create_dir_all(&root).expect("failed to create temp root");
     let path = root.join("LICENSE");
 
-    // Simulate a hard-wrapped license (lines at ~76 chars, traditional terminal format).
+    // Simulate hard-wrapped license text.
     // Each paragraph is a block of consecutive lines, separated by blank lines.
     let contents = "\
 MIT License
 
 Copyright (c) 2024 Example Author
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the \"Software\"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+All rights reserved for this fixture. No warranty or liability is accepted
+for the generated test text. The synthetic grant should stay together after
+reflowing.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The fixture notice should stay in the same paragraph after reflowing.
 ";
     fs::write(&path, contents).expect("failed to write license");
 
@@ -306,17 +302,17 @@ copies or substantial portions of the Software.
 
     assert_eq!(preview.kind, PreviewKind::Text);
 
-    // After reflowing: the five-line permission-grant block should be ONE long line.
-    let permission_line = preview
+    // After reflowing: the wrapped synthetic grant block should be ONE long line.
+    let grant_line = preview
         .lines
         .iter()
-        .find(|line| line_text(line).contains("Permission is hereby granted"))
-        .expect("permission grant line should exist");
-    let text = line_text(permission_line);
+        .find(|line| line_text(line).contains("synthetic grant"))
+        .expect("synthetic grant line should exist");
+    let text = line_text(grant_line);
     // The reflowed line must contain the last part that was originally on a separate line.
     assert!(
-        text.contains("furnished to do so"),
-        "permission grant should be reflowed into a single line, got: {text:?}"
+        text.contains("after reflowing"),
+        "synthetic grant should be reflowed into a single line, got: {text:?}"
     );
 
     // Blank-line paragraph separators must be preserved.

--- a/src/preview/tests/videos.rs
+++ b/src/preview/tests/videos.rs
@@ -29,6 +29,7 @@ fn video_preview_falls_back_to_file_metadata_without_tools() {
 
     assert_eq!(preview.kind, PreviewKind::Video);
     assert_eq!(preview.detail.as_deref(), Some("Matroska video"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
     assert!(line_texts.iter().any(|line| line.contains("File Size")
         && line.contains(&crate::fs::format_size(contents.len() as u64))));
     assert!(preview.preview_visual.is_none());

--- a/src/preview/video.rs
+++ b/src/preview/video.rs
@@ -186,7 +186,7 @@ fn render_video_metadata_lines(
         .map(|(label, _)| label.len())
         .max()
         .unwrap_or(8);
-    let mut lines = vec![preview_section_line("Video", palette)];
+    let mut lines = vec![preview_section_line("Details", palette)];
     for (label, value) in fields {
         lines.push(preview_field_line(label, &value, label_width, palette));
     }

--- a/src/ui/theme/appearance/tests/classification.rs
+++ b/src/ui/theme/appearance/tests/classification.rs
@@ -33,7 +33,7 @@ fn detected_license_files_use_license_class_appearance() {
     let (root, path) = write_temp_file(
         "license-appearance",
         "LICENSE.md",
-        "# SPDX-License-Identifier: Apache-2.0\n\nLicensed under the Apache License, Version 2.0.\n",
+        "# SPDX-License-Identifier: Apache-2.0\n\nFixture license notes.\n",
     );
 
     let resolved = theme.resolve(&path, EntryKind::File);
@@ -72,7 +72,7 @@ fn resolve_entry_cache_respects_entry_metadata_when_builtin_class_changes() {
     let (root, path) = write_temp_file(
         "appearance-cache",
         "third-party.txt",
-        "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n",
+        "SPDX-License-Identifier: Apache-2.0\n",
     );
 
     let metadata = fs::metadata(&path).expect("metadata should exist");


### PR DESCRIPTION
## Summary

Improves metadata previews for document and archive formats, adds RAR archive preview support, and makes comic archive previews useful in terminals without image rendering.

## What Changed

- Added RAR archive previews using existing external archive listing backends, with `unrar` as an additional fallback when available.
- Improved CBZ/CBR previews so non-image terminals show useful comic metadata from embedded XML/comment metadata or conservative filename/folder fallbacks.
- Expanded comic metadata support for ComicInfo, MetronInfo, CoMet, ACBF, and ComicBookInfo archive comments.
- Improved ZIP-based office document metadata extraction for large PPTX/PPTM/ODP/DOCX/XLSX/Pages files.
- Cleaned up metadata preview headings by using `Details` instead of repeated or noisy section names.
- Simplified document metadata previews so author, dates, application, and stats appear under `Details`.
- Kept RAR loading previews quiet while archive contents are inspected in the background.
- Sanitized test fixtures to avoid copyrighted sample names and long copied license bodies.

## User Impact

RAR files now show archive previews when supported tools are available. Comic archives now show useful metadata in terminals without image rendering instead of an empty or noisy preview. Document and archive metadata previews are cleaner and more consistent.

## Notes

RAR preview support uses optional external tools already used by the archive preview path, with `unrar` as an additional fallback when installed. No new required runtime dependency or configuration change is introduced.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested document metadata previews for PPTX/Office-style files.
- Tested CBZ/CBR comic archive previews in non-image preview paths.
- Tested RAR archive preview behavior and loading state.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
