### PR TITLE
feat(preview): add Kindle ebook previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added RAR archive previews using the existing external archive listing backends, with `unrar` as an additional fallback when available.
 - Added non-image comic archive previews for CBZ and CBR files, using embedded XML/comment metadata or conservative structured-name fallbacks instead of showing an empty pane.
-- Added MOBI and AZW3 ebook classification, book icons, and native metadata previews for Kindle ebook files.
+- Added MOBI and AZW3 ebook classification, book icons, native metadata previews, and cover image previews for Kindle ebook files.
 
 ### Changed
 
 - Improved fuzzy search indexing and filtering responsiveness for large directory trees.
-- Simplified document metadata previews by keeping author, dates, application, and stats in the `Details` section.
+- Simplified document metadata previews by keeping author, dates, application, stats, and extra metadata fields in the `Details` section.
+- Made MOBI and AZW3 cover previews larger while preserving room for document details.
+- Made full-height EPUB image sections advance on preview scroll without first scrolling hidden context lines.
 - Kept RAR archive loading previews silent while archive contents are inspected in the background.
 - Documented fuzzy search scope, hidden-file handling, pruning, refresh behavior, and large-tree caps.
 - Documented Trash behavior across Linux, BSD, macOS, and Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added RAR archive previews using the existing external archive listing backends, with `unrar` as an additional fallback when available.
 - Added non-image comic archive previews for CBZ and CBR files, using embedded XML/comment metadata or conservative structured-name fallbacks instead of showing an empty pane.
+- Added MOBI and AZW3 ebook classification, book icons, and native metadata previews for Kindle ebook files.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 
 - **Text and code** — plain text, source code with syntax highlighting, and Markdown
 - **Structured data** — JSON, JSONC, JSON5, YAML, TOML, `.env`, logs, CSV/TSV, and SQLite
-- **Documents** — PDF, EPUB, DOC, DOCX, DOCM, ODT, Pages, XLSX, XLSM, ODS, PPTX, PPTM, and ODP
+- **Documents** — PDF, EPUB, MOBI, AZW3, DOC, DOCX, DOCM, ODT, Pages, XLSX, XLSM, ODS, PPTX, PPTM, and ODP
 - **Media** — image metadata and inline previews, audio metadata and covers, and video metadata and thumbnails
 - **Folders and archives** — directories, ZIP/TAR-family archives, comic archives, torrents, ISO images, and other disk-image-style containers
 - **Binary files** — metadata previews for non-text files

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -140,6 +140,16 @@ class = "document"
 icon = "󱗖"
 color = "#d3aa7c"
 
+[extensions.mobi]
+class = "document"
+icon = "󱗖"
+color = "#d3aa7c"
+
+[extensions.azw3]
+class = "document"
+icon = "󱗖"
+color = "#d3aa7c"
+
 [extensions.ico]
 class = "image"
 icon = "󰋩"

--- a/src/app/input/tests/preview_wheel.rs
+++ b/src/app/input/tests/preview_wheel.rs
@@ -254,7 +254,13 @@ fn preview_wheel_uses_last_focused_panel_when_coordinates_miss() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     app.navigation.view_mode = ViewMode::List;
-    app.select_index(0);
+    let file_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == file_path)
+        .expect("long file should be visible");
+    app.select_index(file_index);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
             x: 0,
@@ -308,7 +314,13 @@ fn preview_wheel_follows_hovered_panel_without_click() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     app.navigation.view_mode = ViewMode::List;
-    app.select_index(0);
+    let file_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == file_path)
+        .expect("long file should be visible");
+    app.select_index(file_index);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
             x: 0,
@@ -362,7 +374,13 @@ fn preview_wheel_uses_preview_column_when_row_is_unreliable() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     app.navigation.view_mode = ViewMode::List;
-    app.select_index(0);
+    let file_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == file_path)
+        .expect("long file should be visible");
+    app.select_index(file_index);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
             x: 0,
@@ -412,7 +430,13 @@ fn preview_wheel_steps_comic_pages_instead_of_scrolling_summary_text() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     app.navigation.view_mode = ViewMode::List;
-    app.select_index(0);
+    let archive_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == archive)
+        .expect("archive should be visible");
+    app.select_index(archive_index);
     wait_for_background_preview(&mut app);
     app.set_frame_state(FrameState {
         entries_panel: Some(Rect {
@@ -682,6 +706,79 @@ fn preview_wheel_scrolls_epub_section_before_advancing_to_next_section() {
             .any(|line| line.to_string().contains("Second chapter text."))
     );
     assert_eq!(app.preview.state.scroll, 0);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn preview_wheel_advances_full_height_epub_image_without_hidden_scroll() {
+    let root = temp_path("preview-wheel-epub-full-height-image");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let archive = root.join("story.epub");
+    fs::write(&archive, b"epub placeholder").expect("failed to write epub placeholder");
+    let page = root.join("cover.png");
+    fs::write(&page, b"image placeholder").expect("failed to write image placeholder");
+    let page_size = fs::metadata(&page)
+        .expect("page metadata should exist")
+        .len();
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    let epub_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == archive)
+        .expect("epub should be visible");
+    app.select_index(epub_index);
+    app.sync_epub_preview_selection();
+    app.preview.state.content = crate::preview::PreviewContent::new(
+        crate::preview::PreviewKind::Document,
+        vec![ratatui::text::Line::from("Hidden cover context")],
+    )
+    .with_ebook_section(0, 2, Some("Cover".to_string()))
+    .with_preview_visual(crate::preview::PreviewVisual {
+        kind: crate::preview::PreviewVisualKind::PageImage,
+        layout: crate::preview::PreviewVisualLayout::FullHeight,
+        path: page,
+        size: page_size,
+        modified: None,
+    });
+    app.apply_current_epub_preview_metadata();
+    app.set_frame_state(FrameState {
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 8,
+        }),
+        preview_panel: Some(Rect {
+            x: 21,
+            y: 0,
+            width: 24,
+            height: 8,
+        }),
+        preview_rows_visible: 0,
+        preview_cols_visible: 24,
+        ..FrameState::default()
+    });
+
+    app.handle_event(Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 22,
+        row: 1,
+        modifiers: KeyModifiers::NONE,
+    }))
+    .expect("preview wheel should be handled");
+
+    assert_eq!(app.preview.state.scroll, 0);
+    assert_eq!(app.preview.state.content.ebook_section_index, Some(1));
+    assert_eq!(app.preview.state.content.ebook_section_count, Some(2));
+    assert!(
+        app.preview_header_detail(10)
+            .as_deref()
+            .is_some_and(|detail| detail.contains("Section 2/2"))
+    );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/wheel.rs
+++ b/src/app/input/wheel.rs
@@ -583,6 +583,9 @@ impl App {
         if delta == 0 || !self.epub_preview_wheel_capture_active() {
             return false;
         }
+        if self.current_epub_section_uses_full_height_image() {
+            return true;
+        }
 
         let visible_cols = self.input.frame_state.preview_cols_visible.max(1);
         let visible_rows = self.input.frame_state.preview_rows_visible.max(1);
@@ -597,6 +600,18 @@ impl App {
         } else {
             self.preview.state.scroll >= max_scroll
         }
+    }
+
+    fn current_epub_section_uses_full_height_image(&self) -> bool {
+        self.preview
+            .state
+            .content
+            .preview_visual
+            .as_ref()
+            .is_some_and(|visual| {
+                visual.kind == preview::PreviewVisualKind::PageImage
+                    && visual.layout == preview::PreviewVisualLayout::FullHeight
+            })
     }
 
     fn preview_has_vertical_overflow(&self) -> bool {

--- a/src/app/overlays/preview_visual.rs
+++ b/src/app/overlays/preview_visual.rs
@@ -5,6 +5,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 const PREVIEW_INLINE_COVER_MIN_HEIGHT: u16 = 6;
 const PREVIEW_INLINE_COVER_MAX_HEIGHT: u16 = 12;
+const PREVIEW_LARGE_INLINE_COVER_MAX_HEIGHT: u16 = 18;
 const PREVIEW_INLINE_VIDEO_COVER_MAX_HEIGHT: u16 = 18;
 const PREVIEW_INLINE_MIN_TEXT_HEIGHT: u16 = 6;
 const PREVIEW_INLINE_PAGE_MIN_HEIGHT: u16 = 8;
@@ -17,12 +18,13 @@ impl App {
         {
             return None;
         }
-        match self.current_preview_visual_layout()? {
+        let layout = self.current_preview_visual_layout()?;
+        match layout {
             preview::PreviewVisualLayout::FullHeight => {
                 let rows = (area.width >= 12 && area.height > 0).then_some(area.height)?;
                 return (!self.preview_visual_failed_for_rows(area, rows)).then_some(rows);
             }
-            preview::PreviewVisualLayout::Inline => {}
+            preview::PreviewVisualLayout::Inline | preview::PreviewVisualLayout::LargeInline => {}
         }
         if self.current_preview_visual_kind() == Some(preview::PreviewVisualKind::PageImage) {
             if area.width < 12
@@ -42,21 +44,19 @@ impl App {
             return None;
         }
 
-        let rows = if self.preview.state.content.kind == preview::PreviewKind::Video {
-            (area.height / 2)
-                .clamp(
-                    PREVIEW_INLINE_COVER_MIN_HEIGHT,
-                    PREVIEW_INLINE_VIDEO_COVER_MAX_HEIGHT,
-                )
-                .min(area.height.saturating_sub(PREVIEW_INLINE_MIN_TEXT_HEIGHT))
-        } else {
-            (area.height / 3)
-                .clamp(
-                    PREVIEW_INLINE_COVER_MIN_HEIGHT,
-                    PREVIEW_INLINE_COVER_MAX_HEIGHT,
-                )
-                .min(area.height.saturating_sub(PREVIEW_INLINE_MIN_TEXT_HEIGHT))
+        let (height_divisor, max_height) = match layout {
+            preview::PreviewVisualLayout::LargeInline => (2, PREVIEW_LARGE_INLINE_COVER_MAX_HEIGHT),
+            preview::PreviewVisualLayout::Inline
+                if self.preview.state.content.kind == preview::PreviewKind::Video =>
+            {
+                (2, PREVIEW_INLINE_VIDEO_COVER_MAX_HEIGHT)
+            }
+            preview::PreviewVisualLayout::Inline => (3, PREVIEW_INLINE_COVER_MAX_HEIGHT),
+            preview::PreviewVisualLayout::FullHeight => unreachable!(),
         };
+        let rows = (area.height / height_divisor)
+            .clamp(PREVIEW_INLINE_COVER_MIN_HEIGHT, max_height)
+            .min(area.height.saturating_sub(PREVIEW_INLINE_MIN_TEXT_HEIGHT));
         (!self.preview_visual_failed_for_rows(area, rows)).then_some(rows)
     }
 

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -221,6 +221,35 @@ fn document_page_image_prepares_in_background_before_display() {
 }
 
 #[test]
+fn large_inline_cover_uses_more_height_without_hiding_details() {
+    let root = temp_root("large-inline-cover-document");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("app should initialize");
+    configure_terminal_image_support(&mut app);
+    app.preview.state.content = PreviewContent::new(PreviewKind::Document, Vec::new())
+        .with_preview_visual(PreviewVisual {
+            kind: PreviewVisualKind::Cover,
+            layout: PreviewVisualLayout::LargeInline,
+            path: root.join("cover.png"),
+            size: 11 * 1024,
+            modified: None,
+        });
+
+    assert_eq!(
+        app.preview_visual_rows(Rect {
+            x: 0,
+            y: 0,
+            width: 48,
+            height: 20,
+        }),
+        Some(10)
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn iterm_inline_page_image_clear_area_covers_preview_body_without_header() {
     let root = temp_root("iterm-inline-clear-area");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -509,6 +509,16 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
             specific_type_label: Some("EPUB ebook"),
             preview: PreviewSpec::document(DocumentFormat::Epub),
         },
+        "mobi" => FileFacts {
+            builtin_class: FileClass::Document,
+            specific_type_label: Some("MOBI ebook"),
+            preview: PreviewSpec::document(DocumentFormat::Mobi),
+        },
+        "azw3" => FileFacts {
+            builtin_class: FileClass::Document,
+            specific_type_label: Some("AZW3 ebook"),
+            preview: PreviewSpec::document(DocumentFormat::Azw3),
+        },
         "cbz" => plain(FileClass::Archive, Some("Comic ZIP archive")),
         "cbr" => plain(FileClass::Archive, Some("Comic RAR archive")),
         "pdf" => FileFacts {

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -371,6 +371,8 @@ fn office_and_pages_documents_use_metadata_preview() {
     let xlsx = inspect_path(Path::new("budget.xlsx"), EntryKind::File);
     let pages = inspect_path(Path::new("proposal.pages"), EntryKind::File);
     let epub = inspect_path(Path::new("novel.epub"), EntryKind::File);
+    let mobi = inspect_path(Path::new("novel.mobi"), EntryKind::File);
+    let azw3 = inspect_path(Path::new("novel.azw3"), EntryKind::File);
     let pdf = inspect_path(Path::new("manual.pdf"), EntryKind::File);
 
     assert_eq!(doc.builtin_class, FileClass::Document);
@@ -412,6 +414,14 @@ fn office_and_pages_documents_use_metadata_preview() {
     assert_eq!(epub.builtin_class, FileClass::Document);
     assert_eq!(epub.preview.document_format, Some(DocumentFormat::Epub));
     assert_eq!(epub.specific_type_label, Some("EPUB ebook"));
+
+    assert_eq!(mobi.builtin_class, FileClass::Document);
+    assert_eq!(mobi.preview.document_format, Some(DocumentFormat::Mobi));
+    assert_eq!(mobi.specific_type_label, Some("MOBI ebook"));
+
+    assert_eq!(azw3.builtin_class, FileClass::Document);
+    assert_eq!(azw3.preview.document_format, Some(DocumentFormat::Azw3));
+    assert_eq!(azw3.specific_type_label, Some("AZW3 ebook"));
 
     assert_eq!(pdf.builtin_class, FileClass::Document);
     assert_eq!(pdf.preview.document_format, Some(DocumentFormat::Pdf));

--- a/src/file_info/types.rs
+++ b/src/file_info/types.rs
@@ -28,6 +28,8 @@ pub(crate) enum DocumentFormat {
     Xlsm,
     Pages,
     Epub,
+    Mobi,
+    Azw3,
     Pdf,
 }
 
@@ -46,6 +48,8 @@ impl DocumentFormat {
             Self::Xlsm => "XLSM spreadsheet",
             Self::Pages => "Pages document",
             Self::Epub => "EPUB ebook",
+            Self::Mobi => "MOBI ebook",
+            Self::Azw3 => "AZW3 ebook",
             Self::Pdf => "PDF document",
         }
     }

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -64,6 +64,10 @@ pub(crate) fn loading_preview_for(
         (facts.preview.document_format, options.epub_section_index()),
         (Some(file_info::DocumentFormat::Epub), Some(_))
     );
+    let is_silent_kindle_loading = matches!(
+        facts.preview.document_format,
+        Some(file_info::DocumentFormat::Mobi | file_info::DocumentFormat::Azw3)
+    );
     let is_silent_archive_loading = matches!(facts.specific_type_label, Some("RAR archive"));
     let kind = if is_comic_page_preview {
         PreviewKind::Comic
@@ -75,6 +79,7 @@ pub(crate) fn loading_preview_for(
     let lines = if is_comic_page_preview
         || is_epub_section_preview
         || facts.builtin_class == FileClass::Audio
+        || is_silent_kindle_loading
         || is_silent_archive_loading
     {
         Vec::new()

--- a/src/preview/document/formats/kindle.rs
+++ b/src/preview/document/formats/kindle.rs
@@ -1,0 +1,428 @@
+use super::super::{
+    common::{present_str, push_metadata_field},
+    metadata::DocumentMetadata,
+};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::Path,
+};
+
+const PDB_HEADER_LEN: usize = 78;
+const PDB_RECORD_ENTRY_LEN: usize = 8;
+const PALMDOC_HEADER_LEN: usize = 16;
+const MOBI_MAGIC: &[u8; 4] = b"MOBI";
+const EXTH_MAGIC: &[u8; 4] = b"EXTH";
+const MAX_KINDLE_RECORD0_BYTES: usize = 2 * 1024 * 1024;
+const MOBI_TEXT_ENCODING_CP1252: u32 = 1252;
+const MOBI_TEXT_ENCODING_UTF8: u32 = 65001;
+const MOBI_EXTH_FLAG_PRESENT: u32 = 0x40;
+
+#[derive(Clone, Copy, Debug)]
+enum KindleTextEncoding {
+    Utf8,
+    Windows1252,
+}
+
+#[derive(Debug)]
+struct KindleRecord0 {
+    pdb_title: Option<String>,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+struct KindleHeader {
+    encryption: Option<String>,
+    full_name: Option<String>,
+    exth_records: BTreeMap<u32, Vec<Vec<u8>>>,
+    encoding: Option<KindleTextEncoding>,
+}
+
+pub(super) fn extract_kindle_metadata(path: &Path) -> Option<DocumentMetadata> {
+    File::open(path).ok()?;
+    Some(
+        parse_kindle_metadata(path)
+            .map(render_kindle_metadata)
+            .unwrap_or_default(),
+    )
+}
+
+fn parse_kindle_metadata(path: &Path) -> Option<KindleRecord0> {
+    let mut file = File::open(path).ok()?;
+    let file_len = file.metadata().ok()?.len();
+    if file_len < PDB_HEADER_LEN as u64 {
+        return None;
+    }
+
+    let mut header = [0_u8; PDB_HEADER_LEN];
+    file.read_exact(&mut header).ok()?;
+    let record_count = read_u16(&header, 76)?;
+    if record_count == 0 {
+        return None;
+    }
+
+    let pdb_title = decode_pdb_name(&header[..32]);
+
+    let mut first_record = [0_u8; PDB_RECORD_ENTRY_LEN];
+    file.read_exact(&mut first_record).ok()?;
+    let record0_offset = read_u32(&first_record, 0)? as u64;
+    let record1_offset = if record_count > 1 {
+        let mut second_record = [0_u8; PDB_RECORD_ENTRY_LEN];
+        file.read_exact(&mut second_record).ok()?;
+        Some(read_u32(&second_record, 0)? as u64)
+    } else {
+        None
+    };
+
+    let record0_end = record1_offset.unwrap_or(file_len);
+    if record0_offset >= file_len || record0_end <= record0_offset {
+        return None;
+    }
+
+    let size = (record0_end - record0_offset).min(MAX_KINDLE_RECORD0_BYTES as u64) as usize;
+    let mut bytes = vec![0_u8; size];
+    file.seek(SeekFrom::Start(record0_offset)).ok()?;
+    file.read_exact(&mut bytes).ok()?;
+
+    Some(KindleRecord0 { pdb_title, bytes })
+}
+
+fn render_kindle_metadata(record0: KindleRecord0) -> DocumentMetadata {
+    let header = parse_kindle_header(&record0.bytes).unwrap_or_default();
+    let encoding = header.encoding.unwrap_or(KindleTextEncoding::Windows1252);
+    let mut metadata = DocumentMetadata {
+        title: first_exth_text(&header, encoding, &[503])
+            .or_else(|| header.full_name.clone())
+            .or_else(|| record0.pdb_title.clone()),
+        author: joined_exth_text(&header, encoding, 100, ", "),
+        subject: joined_exth_text(&header, encoding, 105, ", "),
+        modified: first_exth_text(&header, encoding, &[502])
+            .map(|updated| normalize_kindle_date(&updated)),
+        application: creator_application(&header),
+        ..DocumentMetadata::default()
+    };
+
+    push_metadata_field(
+        &mut metadata,
+        "Publisher",
+        first_exth_text(&header, encoding, &[101]),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "Language",
+        first_exth_text(&header, encoding, &[524]),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "Published",
+        first_exth_text(&header, encoding, &[106]).map(|value| normalize_kindle_date(&value)),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "ISBN",
+        first_exth_text(&header, encoding, &[104]),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "ASIN",
+        first_exth_text(&header, encoding, &[113, 504]),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "Description",
+        first_exth_text(&header, encoding, &[103]),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "Rights",
+        first_exth_text(&header, encoding, &[109]),
+    );
+    push_metadata_field(
+        &mut metadata,
+        "Kindle Type",
+        first_exth_text(&header, encoding, &[501]),
+    );
+    push_metadata_field(&mut metadata, "Encryption", header.encryption);
+
+    metadata
+}
+
+fn parse_kindle_header(record0: &[u8]) -> Option<KindleHeader> {
+    if record0.len() < PALMDOC_HEADER_LEN + 8
+        || record0.get(PALMDOC_HEADER_LEN..PALMDOC_HEADER_LEN + 4)? != MOBI_MAGIC
+    {
+        return None;
+    }
+
+    let mut header = KindleHeader {
+        encryption: read_u16(record0, 12).and_then(encryption_label),
+        ..KindleHeader::default()
+    };
+
+    let mobi_header_len = read_u32(record0, 20)? as usize;
+    if mobi_header_len < 24 {
+        return Some(header);
+    }
+    let mobi_header_end = PALMDOC_HEADER_LEN.checked_add(mobi_header_len)?;
+    if mobi_header_end > record0.len() {
+        return Some(header);
+    }
+
+    header.encoding = read_u32(record0, 28).map(kindle_text_encoding);
+    let encoding = header.encoding.unwrap_or(KindleTextEncoding::Windows1252);
+
+    if let (Some(offset), Some(length)) = (read_u32(record0, 84), read_u32(record0, 88)) {
+        header.full_name = decode_record0_text(record0, offset as usize, length as usize, encoding);
+    }
+
+    let exth_flags = read_u32(record0, 128).unwrap_or(0);
+    if exth_flags & MOBI_EXTH_FLAG_PRESENT != 0 {
+        header.exth_records = parse_exth_records(record0, mobi_header_end);
+    }
+
+    Some(header)
+}
+
+fn parse_exth_records(record0: &[u8], exth_offset: usize) -> BTreeMap<u32, Vec<Vec<u8>>> {
+    let mut records = BTreeMap::<u32, Vec<Vec<u8>>>::new();
+    if exth_offset
+        .checked_add(12)
+        .is_none_or(|end| end > record0.len())
+        || record0.get(exth_offset..exth_offset + 4) != Some(EXTH_MAGIC)
+    {
+        return records;
+    }
+
+    let Some(exth_len) = read_u32(record0, exth_offset + 4).map(|value| value as usize) else {
+        return records;
+    };
+    let Some(record_count) = read_u32(record0, exth_offset + 8).map(|value| value as usize) else {
+        return records;
+    };
+    let Some(exth_end) = exth_offset.checked_add(exth_len) else {
+        return records;
+    };
+    if exth_len < 12 || exth_end > record0.len() {
+        return records;
+    }
+
+    let mut cursor = exth_offset + 12;
+    for _ in 0..record_count {
+        if cursor.checked_add(8).is_none_or(|end| end > exth_end) {
+            break;
+        }
+        let Some(kind) = read_u32(record0, cursor) else {
+            break;
+        };
+        let Some(len) = read_u32(record0, cursor + 4).map(|value| value as usize) else {
+            break;
+        };
+        if len < 8 || cursor.checked_add(len).is_none_or(|end| end > exth_end) {
+            break;
+        }
+        let value = record0[cursor + 8..cursor + len].to_vec();
+        records.entry(kind).or_default().push(value);
+        cursor += len;
+    }
+
+    records
+}
+
+fn first_exth_text(
+    header: &KindleHeader,
+    encoding: KindleTextEncoding,
+    kinds: &[u32],
+) -> Option<String> {
+    kinds
+        .iter()
+        .filter_map(|kind| header.exth_records.get(kind))
+        .flat_map(|values| values.iter())
+        .find_map(|value| decode_metadata_text(value, encoding))
+}
+
+fn joined_exth_text(
+    header: &KindleHeader,
+    encoding: KindleTextEncoding,
+    kind: u32,
+    separator: &str,
+) -> Option<String> {
+    let values = header.exth_records.get(&kind)?;
+    let mut decoded = Vec::<String>::new();
+    for value in values {
+        let Some(value) = decode_metadata_text(value, encoding) else {
+            continue;
+        };
+        if decoded.iter().all(|existing| existing != &value) {
+            decoded.push(value);
+        }
+    }
+    (!decoded.is_empty()).then(|| decoded.join(separator))
+}
+
+fn creator_application(header: &KindleHeader) -> Option<String> {
+    let software = header
+        .exth_records
+        .get(&204)
+        .and_then(|values| values.first())
+        .and_then(|value| exth_integer(value))
+        .and_then(creator_software_label);
+    let major = header
+        .exth_records
+        .get(&205)
+        .and_then(|values| values.first())
+        .and_then(|value| exth_integer(value));
+    let minor = header
+        .exth_records
+        .get(&206)
+        .and_then(|values| values.first())
+        .and_then(|value| exth_integer(value));
+    let build = header
+        .exth_records
+        .get(&207)
+        .and_then(|values| values.first())
+        .and_then(|value| exth_integer(value));
+
+    let software = software?;
+    let mut label = software.to_string();
+    if let (Some(major), Some(minor)) = (major, minor) {
+        label.push_str(&format!(" {major}.{minor}"));
+    }
+    if let Some(build) = build {
+        label.push_str(&format!(" build {build}"));
+    }
+    Some(label)
+}
+
+fn creator_software_label(value: u32) -> Option<&'static str> {
+    match value {
+        1 => Some("mobigen"),
+        2 => Some("Mobipocket Creator"),
+        200..=202 => Some("KindleGen"),
+        _ => None,
+    }
+}
+
+fn exth_integer(bytes: &[u8]) -> Option<u32> {
+    if bytes.len() == 1 {
+        return Some(bytes[0] as u32);
+    }
+    if bytes.len() == 2 {
+        return Some(u16::from_be_bytes([bytes[0], bytes[1]]) as u32);
+    }
+    if bytes.len() == 4 {
+        return Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+    }
+    None
+}
+
+fn normalize_kindle_date(value: &str) -> String {
+    present_str(value.trim(), "Created").unwrap_or_else(|| value.trim().to_string())
+}
+
+fn encryption_label(value: u16) -> Option<String> {
+    match value {
+        0 => None,
+        1 => Some("Old Mobipocket encryption".to_string()),
+        2 => Some("Mobipocket encryption".to_string()),
+        _ => Some(format!("Unknown ({value})")),
+    }
+}
+
+fn kindle_text_encoding(value: u32) -> KindleTextEncoding {
+    match value {
+        MOBI_TEXT_ENCODING_UTF8 => KindleTextEncoding::Utf8,
+        MOBI_TEXT_ENCODING_CP1252 => KindleTextEncoding::Windows1252,
+        _ => KindleTextEncoding::Windows1252,
+    }
+}
+
+fn decode_record0_text(
+    record0: &[u8],
+    offset: usize,
+    length: usize,
+    encoding: KindleTextEncoding,
+) -> Option<String> {
+    let end = offset.checked_add(length)?;
+    let bytes = record0.get(offset..end)?;
+    decode_metadata_text(bytes, encoding)
+}
+
+fn decode_metadata_text(bytes: &[u8], encoding: KindleTextEncoding) -> Option<String> {
+    let bytes = trim_metadata_bytes(bytes);
+    if bytes.is_empty() {
+        return None;
+    }
+    let value = match encoding {
+        KindleTextEncoding::Utf8 => String::from_utf8_lossy(bytes).into_owned(),
+        KindleTextEncoding::Windows1252 => decode_windows_1252(bytes),
+    };
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn decode_pdb_name(bytes: &[u8]) -> Option<String> {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    decode_metadata_text(&bytes[..end], KindleTextEncoding::Windows1252)
+}
+
+fn trim_metadata_bytes(bytes: &[u8]) -> &[u8] {
+    let mut start = 0;
+    let mut end = bytes.len();
+    while start < end && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    while end > start && (bytes[end - 1].is_ascii_whitespace() || bytes[end - 1] == 0) {
+        end -= 1;
+    }
+    &bytes[start..end]
+}
+
+fn decode_windows_1252(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| match *byte {
+            0x80 => '\u{20AC}',
+            0x82 => '\u{201A}',
+            0x83 => '\u{0192}',
+            0x84 => '\u{201E}',
+            0x85 => '\u{2026}',
+            0x86 => '\u{2020}',
+            0x87 => '\u{2021}',
+            0x88 => '\u{02C6}',
+            0x89 => '\u{2030}',
+            0x8A => '\u{0160}',
+            0x8B => '\u{2039}',
+            0x8C => '\u{0152}',
+            0x8E => '\u{017D}',
+            0x91 => '\u{2018}',
+            0x92 => '\u{2019}',
+            0x93 => '\u{201C}',
+            0x94 => '\u{201D}',
+            0x95 => '\u{2022}',
+            0x96 => '\u{2013}',
+            0x97 => '\u{2014}',
+            0x98 => '\u{02DC}',
+            0x99 => '\u{2122}',
+            0x9A => '\u{0161}',
+            0x9B => '\u{203A}',
+            0x9C => '\u{0153}',
+            0x9E => '\u{017E}',
+            0x9F => '\u{0178}',
+            value => char::from(value),
+        })
+        .collect()
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    let bytes = bytes.get(offset..offset + 2)?;
+    Some(u16::from_be_bytes([bytes[0], bytes[1]]))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+    let bytes = bytes.get(offset..offset + 4)?;
+    Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}

--- a/src/preview/document/formats/kindle.rs
+++ b/src/preview/document/formats/kindle.rs
@@ -1,12 +1,20 @@
 use super::super::{
     common::{present_str, push_metadata_field},
-    metadata::DocumentMetadata,
+    metadata::{DocumentMetadata, render_document_preview},
+};
+use crate::{
+    file_info::DocumentFormat,
+    preview::{PreviewContent, PreviewVisual, PreviewVisualKind, PreviewVisualLayout},
 };
 use std::{
     collections::BTreeMap,
+    collections::hash_map::DefaultHasher,
+    env, fs,
     fs::File,
-    io::{Read, Seek, SeekFrom},
-    path::Path,
+    hash::{Hash, Hasher},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    time::SystemTime,
 };
 
 const PDB_HEADER_LEN: usize = 78;
@@ -15,9 +23,13 @@ const PALMDOC_HEADER_LEN: usize = 16;
 const MOBI_MAGIC: &[u8; 4] = b"MOBI";
 const EXTH_MAGIC: &[u8; 4] = b"EXTH";
 const MAX_KINDLE_RECORD0_BYTES: usize = 2 * 1024 * 1024;
+const MAX_KINDLE_COVER_RECORD_BYTES: usize = 8 * 1024 * 1024;
+const KINDLE_COVER_CACHE_VERSION: usize = 1;
 const MOBI_TEXT_ENCODING_CP1252: u32 = 1252;
 const MOBI_TEXT_ENCODING_UTF8: u32 = 65001;
 const MOBI_EXTH_FLAG_PRESENT: u32 = 0x40;
+const EXTH_COVER_OFFSET: u32 = 201;
+const EXTH_THUMB_OFFSET: u32 = 202;
 
 #[derive(Clone, Copy, Debug)]
 enum KindleTextEncoding {
@@ -26,126 +38,278 @@ enum KindleTextEncoding {
 }
 
 #[derive(Debug)]
-struct KindleRecord0 {
+struct KindleDatabase {
     pdb_title: Option<String>,
-    bytes: Vec<u8>,
+    file_len: u64,
+    modified: Option<SystemTime>,
+    record_offsets: Vec<u64>,
+}
+
+#[derive(Debug, Default)]
+struct KindlePreviewData {
+    metadata: DocumentMetadata,
+    visual: Option<PreviewVisual>,
 }
 
 #[derive(Debug, Default)]
 struct KindleHeader {
+    encrypted: bool,
     encryption: Option<String>,
     full_name: Option<String>,
+    first_image_record_index: Option<u32>,
     exth_records: BTreeMap<u32, Vec<Vec<u8>>>,
     encoding: Option<KindleTextEncoding>,
 }
 
-pub(super) fn extract_kindle_metadata(path: &Path) -> Option<DocumentMetadata> {
-    File::open(path).ok()?;
-    Some(
-        parse_kindle_metadata(path)
-            .map(render_kindle_metadata)
-            .unwrap_or_default(),
-    )
+#[derive(Clone, Copy, Debug)]
+enum KindleCoverFormat {
+    Gif,
+    Jpeg,
+    Png,
+    Webp,
 }
 
-fn parse_kindle_metadata(path: &Path) -> Option<KindleRecord0> {
+impl KindleCoverFormat {
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Gif => "gif",
+            Self::Jpeg => "jpg",
+            Self::Png => "png",
+            Self::Webp => "webp",
+        }
+    }
+}
+
+pub(super) fn build_kindle_preview(path: &Path, format: DocumentFormat) -> Option<PreviewContent> {
+    File::open(path).ok()?;
+    let preview = parse_kindle_preview_data(path).unwrap_or_default();
+    let mut content = render_document_preview(format, preview.metadata);
+    if let Some(visual) = preview.visual {
+        content = content.with_preview_visual(visual);
+    }
+    Some(content)
+}
+
+fn parse_kindle_preview_data(path: &Path) -> Option<KindlePreviewData> {
     let mut file = File::open(path).ok()?;
-    let file_len = file.metadata().ok()?.len();
+    let database = parse_kindle_database(&mut file)?;
+    let record0 = read_record_bytes(&mut file, &database, 0, MAX_KINDLE_RECORD0_BYTES, true)?;
+    let header = parse_kindle_header(&record0).unwrap_or_default();
+    let metadata = render_kindle_metadata(&database, &header);
+    let visual = extract_kindle_cover_visual(path, &mut file, &database, &header);
+
+    Some(KindlePreviewData { metadata, visual })
+}
+
+fn parse_kindle_database(file: &mut File) -> Option<KindleDatabase> {
+    let file_metadata = file.metadata().ok()?;
+    let file_len = file_metadata.len();
     if file_len < PDB_HEADER_LEN as u64 {
         return None;
     }
 
     let mut header = [0_u8; PDB_HEADER_LEN];
+    file.seek(SeekFrom::Start(0)).ok()?;
     file.read_exact(&mut header).ok()?;
-    let record_count = read_u16(&header, 76)?;
+    let record_count = usize::from(read_u16(&header, 76)?);
     if record_count == 0 {
+        return None;
+    }
+    if (PDB_HEADER_LEN + record_count * PDB_RECORD_ENTRY_LEN) as u64 > file_len {
         return None;
     }
 
     let pdb_title = decode_pdb_name(&header[..32]);
+    let mut record_offsets = Vec::with_capacity(record_count);
+    for _ in 0..record_count {
+        let mut record = [0_u8; PDB_RECORD_ENTRY_LEN];
+        file.read_exact(&mut record).ok()?;
+        let offset = read_u32(&record, 0)? as u64;
+        if offset >= file_len {
+            return None;
+        }
+        record_offsets.push(offset);
+    }
 
-    let mut first_record = [0_u8; PDB_RECORD_ENTRY_LEN];
-    file.read_exact(&mut first_record).ok()?;
-    let record0_offset = read_u32(&first_record, 0)? as u64;
-    let record1_offset = if record_count > 1 {
-        let mut second_record = [0_u8; PDB_RECORD_ENTRY_LEN];
-        file.read_exact(&mut second_record).ok()?;
-        Some(read_u32(&second_record, 0)? as u64)
-    } else {
-        None
-    };
+    Some(KindleDatabase {
+        pdb_title,
+        file_len,
+        modified: file_metadata.modified().ok(),
+        record_offsets,
+    })
+}
 
-    let record0_end = record1_offset.unwrap_or(file_len);
-    if record0_offset >= file_len || record0_end <= record0_offset {
+fn read_record_bytes(
+    file: &mut File,
+    database: &KindleDatabase,
+    index: usize,
+    limit_bytes: usize,
+    allow_truncation: bool,
+) -> Option<Vec<u8>> {
+    let start = *database.record_offsets.get(index)?;
+    let end = database
+        .record_offsets
+        .get(index + 1)
+        .copied()
+        .unwrap_or(database.file_len);
+    if end <= start || end > database.file_len {
         return None;
     }
 
-    let size = (record0_end - record0_offset).min(MAX_KINDLE_RECORD0_BYTES as u64) as usize;
+    let record_len = end - start;
+    if !allow_truncation && record_len > limit_bytes as u64 {
+        return None;
+    }
+    let size = record_len.min(limit_bytes as u64) as usize;
     let mut bytes = vec![0_u8; size];
-    file.seek(SeekFrom::Start(record0_offset)).ok()?;
+    file.seek(SeekFrom::Start(start)).ok()?;
     file.read_exact(&mut bytes).ok()?;
-
-    Some(KindleRecord0 { pdb_title, bytes })
+    (!bytes.is_empty()).then_some(bytes)
 }
 
-fn render_kindle_metadata(record0: KindleRecord0) -> DocumentMetadata {
-    let header = parse_kindle_header(&record0.bytes).unwrap_or_default();
+fn render_kindle_metadata(database: &KindleDatabase, header: &KindleHeader) -> DocumentMetadata {
     let encoding = header.encoding.unwrap_or(KindleTextEncoding::Windows1252);
     let mut metadata = DocumentMetadata {
-        title: first_exth_text(&header, encoding, &[503])
+        title: first_exth_text(header, encoding, &[503])
             .or_else(|| header.full_name.clone())
-            .or_else(|| record0.pdb_title.clone()),
-        author: joined_exth_text(&header, encoding, 100, ", "),
-        subject: joined_exth_text(&header, encoding, 105, ", "),
-        modified: first_exth_text(&header, encoding, &[502])
+            .or_else(|| database.pdb_title.clone()),
+        author: joined_exth_text(header, encoding, 100, ", "),
+        subject: joined_exth_text(header, encoding, 105, ", "),
+        modified: first_exth_text(header, encoding, &[502])
             .map(|updated| normalize_kindle_date(&updated)),
-        application: creator_application(&header),
+        application: creator_application(header),
         ..DocumentMetadata::default()
     };
 
     push_metadata_field(
         &mut metadata,
         "Publisher",
-        first_exth_text(&header, encoding, &[101]),
+        first_exth_text(header, encoding, &[101]),
     );
     push_metadata_field(
         &mut metadata,
         "Language",
-        first_exth_text(&header, encoding, &[524]),
+        first_exth_text(header, encoding, &[524]),
     );
     push_metadata_field(
         &mut metadata,
         "Published",
-        first_exth_text(&header, encoding, &[106]).map(|value| normalize_kindle_date(&value)),
+        first_exth_text(header, encoding, &[106]).map(|value| normalize_kindle_date(&value)),
     );
     push_metadata_field(
         &mut metadata,
         "ISBN",
-        first_exth_text(&header, encoding, &[104]),
+        first_exth_text(header, encoding, &[104]),
     );
     push_metadata_field(
         &mut metadata,
         "ASIN",
-        first_exth_text(&header, encoding, &[113, 504]),
+        first_exth_text(header, encoding, &[113, 504]),
     );
     push_metadata_field(
         &mut metadata,
         "Description",
-        first_exth_text(&header, encoding, &[103]),
+        first_exth_text(header, encoding, &[103]),
     );
     push_metadata_field(
         &mut metadata,
         "Rights",
-        first_exth_text(&header, encoding, &[109]),
+        first_exth_text(header, encoding, &[109]),
     );
     push_metadata_field(
         &mut metadata,
         "Kindle Type",
-        first_exth_text(&header, encoding, &[501]),
+        first_exth_text(header, encoding, &[501]),
     );
-    push_metadata_field(&mut metadata, "Encryption", header.encryption);
+    push_metadata_field(&mut metadata, "Encryption", header.encryption.clone());
 
     metadata
+}
+
+fn extract_kindle_cover_visual(
+    path: &Path,
+    file: &mut File,
+    database: &KindleDatabase,
+    header: &KindleHeader,
+) -> Option<PreviewVisual> {
+    if header.encrypted {
+        return None;
+    }
+
+    let first_image_record_index = usize::try_from(header.first_image_record_index?).ok()?;
+    for relative_cover_index in kindle_cover_record_offsets(header) {
+        let Some(cover_record_index) = usize::try_from(relative_cover_index)
+            .ok()
+            .and_then(|index| first_image_record_index.checked_add(index))
+        else {
+            continue;
+        };
+        if cover_record_index >= database.record_offsets.len() {
+            continue;
+        }
+        if let Some(visual) =
+            extract_kindle_cover_record_visual(path, file, database, cover_record_index)
+        {
+            return Some(visual);
+        }
+    }
+
+    None
+}
+
+fn extract_kindle_cover_record_visual(
+    path: &Path,
+    file: &mut File,
+    database: &KindleDatabase,
+    cover_record_index: usize,
+) -> Option<PreviewVisual> {
+    let cache_path =
+        if let Some(cache_path) = cached_kindle_cover_path(path, database, cover_record_index) {
+            cache_path
+        } else {
+            let bytes = read_record_bytes(
+                file,
+                database,
+                cover_record_index,
+                MAX_KINDLE_COVER_RECORD_BYTES,
+                false,
+            )?;
+            let format = sniff_kindle_cover_format(&bytes)?;
+            let cache_path =
+                kindle_cover_cache_path(path, database, cover_record_index, format.extension())?;
+            if !cache_path.exists() {
+                write_bytes_atomically(&cache_path, &bytes)?;
+            }
+            cache_path
+        };
+
+    kindle_cover_visual_from_path(cache_path)
+}
+
+fn cached_kindle_cover_path(
+    path: &Path,
+    database: &KindleDatabase,
+    record_index: usize,
+) -> Option<PathBuf> {
+    for extension in ["jpg", "png", "gif", "webp"] {
+        let cache_path = kindle_cover_cache_path(path, database, record_index, extension)?;
+        if cache_path.exists() {
+            return Some(cache_path);
+        }
+    }
+    None
+}
+
+fn kindle_cover_record_offsets(header: &KindleHeader) -> Vec<u32> {
+    let mut offsets = Vec::new();
+    for kind in [EXTH_COVER_OFFSET, EXTH_THUMB_OFFSET] {
+        if let Some(offset) = first_exth_integer(header, &[kind])
+            && !offsets.contains(&offset)
+        {
+            offsets.push(offset);
+        }
+    }
+    offsets
 }
 
 fn parse_kindle_header(record0: &[u8]) -> Option<KindleHeader> {
@@ -155,8 +319,10 @@ fn parse_kindle_header(record0: &[u8]) -> Option<KindleHeader> {
         return None;
     }
 
+    let encryption = read_u16(record0, 12).unwrap_or(0);
     let mut header = KindleHeader {
-        encryption: read_u16(record0, 12).and_then(encryption_label),
+        encrypted: encryption != 0,
+        encryption: encryption_label(encryption),
         ..KindleHeader::default()
     };
 
@@ -170,13 +336,22 @@ fn parse_kindle_header(record0: &[u8]) -> Option<KindleHeader> {
     }
 
     header.encoding = read_u32(record0, 28).map(kindle_text_encoding);
+    if mobi_header_len >= 96 {
+        header.first_image_record_index = read_u32(record0, 108);
+    }
     let encoding = header.encoding.unwrap_or(KindleTextEncoding::Windows1252);
 
-    if let (Some(offset), Some(length)) = (read_u32(record0, 84), read_u32(record0, 88)) {
+    if mobi_header_len >= 76
+        && let (Some(offset), Some(length)) = (read_u32(record0, 84), read_u32(record0, 88))
+    {
         header.full_name = decode_record0_text(record0, offset as usize, length as usize, encoding);
     }
 
-    let exth_flags = read_u32(record0, 128).unwrap_or(0);
+    let exth_flags = if mobi_header_len >= 116 {
+        read_u32(record0, 128).unwrap_or(0)
+    } else {
+        0
+    };
     if exth_flags & MOBI_EXTH_FLAG_PRESENT != 0 {
         header.exth_records = parse_exth_records(record0, mobi_header_end);
     }
@@ -258,6 +433,14 @@ fn joined_exth_text(
         }
     }
     (!decoded.is_empty()).then(|| decoded.join(separator))
+}
+
+fn first_exth_integer(header: &KindleHeader, kinds: &[u32]) -> Option<u32> {
+    kinds
+        .iter()
+        .filter_map(|kind| header.exth_records.get(kind))
+        .flat_map(|values| values.iter())
+        .find_map(|value| exth_integer(value))
 }
 
 fn creator_application(header: &KindleHeader) -> Option<String> {
@@ -415,6 +598,98 @@ fn decode_windows_1252(bytes: &[u8]) -> String {
             value => char::from(value),
         })
         .collect()
+}
+
+fn sniff_kindle_cover_format(bytes: &[u8]) -> Option<KindleCoverFormat> {
+    if bytes.starts_with(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]) {
+        return Some(KindleCoverFormat::Png);
+    }
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some(KindleCoverFormat::Jpeg);
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some(KindleCoverFormat::Gif);
+    }
+    if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        return Some(KindleCoverFormat::Webp);
+    }
+    None
+}
+
+fn kindle_cover_visual_from_path(path: PathBuf) -> Option<PreviewVisual> {
+    let metadata = fs::metadata(&path).ok()?;
+    Some(PreviewVisual {
+        kind: PreviewVisualKind::Cover,
+        layout: PreviewVisualLayout::LargeInline,
+        path,
+        size: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn kindle_cover_cache_path(
+    path: &Path,
+    database: &KindleDatabase,
+    record_index: usize,
+    extension: &str,
+) -> Option<PathBuf> {
+    let mut hasher = DefaultHasher::new();
+    KINDLE_COVER_CACHE_VERSION.hash(&mut hasher);
+    path.hash(&mut hasher);
+    database.file_len.hash(&mut hasher);
+    database
+        .modified
+        .and_then(system_time_key)
+        .hash(&mut hasher);
+    record_index.hash(&mut hasher);
+    let cache_dir = kindle_cover_cache_dir()?;
+    Some(cache_dir.join(format!("cover-{:016x}.{extension}", hasher.finish())))
+}
+
+fn kindle_cover_cache_dir() -> Option<PathBuf> {
+    let cache_dir =
+        env::temp_dir().join(format!("elio-kindle-cover-v{KINDLE_COVER_CACHE_VERSION}"));
+    fs::create_dir_all(&cache_dir).ok()?;
+    Some(cache_dir)
+}
+
+fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> Option<()> {
+    let parent = path.parent()?;
+    fs::create_dir_all(parent).ok()?;
+
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let temp_name = format!(
+        ".{}.tmp-{}-{}",
+        path.file_name()?.to_string_lossy(),
+        std::process::id(),
+        unique
+    );
+    let temp_path = parent.join(temp_name);
+
+    let mut file = File::create(&temp_path).ok()?;
+    file.write_all(bytes).ok()?;
+    file.sync_all().ok()?;
+    match fs::rename(&temp_path, path) {
+        Ok(()) => Some(()),
+        Err(_) if path.exists() => {
+            let _ = fs::remove_file(&temp_path);
+            Some(())
+        }
+        Err(_) => {
+            let _ = fs::remove_file(&temp_path);
+            None
+        }
+    }
+}
+
+fn system_time_key(time: SystemTime) -> Option<(u64, u32)> {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|duration| (duration.as_secs(), duration.subsec_nanos()))
 }
 
 fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {

--- a/src/preview/document/formats/mod.rs
+++ b/src/preview/document/formats/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod doc;
+pub(super) mod kindle;
 pub(super) mod ooxml;
 pub(super) mod open_document;
 pub(super) mod pages;
@@ -11,6 +12,10 @@ use zip::ZipArchive;
 
 pub(super) fn extract_doc_metadata(path: &Path) -> Option<DocumentMetadata> {
     doc::extract_doc_metadata(path)
+}
+
+pub(super) fn extract_kindle_metadata(path: &Path) -> Option<DocumentMetadata> {
+    kindle::extract_kindle_metadata(path)
 }
 
 pub(super) fn extract_ooxml_metadata<R: Read + std::io::Seek>(

--- a/src/preview/document/formats/mod.rs
+++ b/src/preview/document/formats/mod.rs
@@ -14,8 +14,11 @@ pub(super) fn extract_doc_metadata(path: &Path) -> Option<DocumentMetadata> {
     doc::extract_doc_metadata(path)
 }
 
-pub(super) fn extract_kindle_metadata(path: &Path) -> Option<DocumentMetadata> {
-    kindle::extract_kindle_metadata(path)
+pub(super) fn build_kindle_preview(
+    path: &Path,
+    format: DocumentFormat,
+) -> Option<crate::preview::PreviewContent> {
+    kindle::build_kindle_preview(path, format)
 }
 
 pub(super) fn extract_ooxml_metadata<R: Read + std::io::Seek>(

--- a/src/preview/document/metadata.rs
+++ b/src/preview/document/metadata.rs
@@ -56,18 +56,13 @@ pub(super) fn render_document_preview_lines(metadata: &DocumentMetadata) -> Vec<
         .max(owned_section_label_width(&metadata.metadata))
         .max(6);
 
+    let mut owned_details = metadata.stats.clone();
+    owned_details.extend(metadata.metadata.iter().cloned());
     push_combined_section(
         &mut lines,
         "Details",
         &details,
-        &metadata.stats,
-        label_width,
-        palette,
-    );
-    push_owned_section(
-        &mut lines,
-        "Metadata",
-        &metadata.metadata,
+        &owned_details,
         label_width,
         palette,
     );
@@ -106,25 +101,6 @@ fn push_combined_section(
         lines.push(document_line(label, value, label_width, palette));
     }
     for (label, value) in owned_fields {
-        lines.push(document_line(label, value, label_width, palette));
-    }
-}
-
-fn push_owned_section(
-    lines: &mut Vec<Line<'static>>,
-    title: &str,
-    fields: &[(String, String)],
-    label_width: usize,
-    palette: theme::Palette,
-) {
-    if fields.is_empty() {
-        return;
-    }
-    if !lines.is_empty() {
-        lines.push(Line::from(""));
-    }
-    lines.push(section_line(title, palette));
-    for (label, value) in fields {
         lines.push(document_line(label, value, label_width, palette));
     }
 }

--- a/src/preview/document/mod.rs
+++ b/src/preview/document/mod.rs
@@ -6,7 +6,7 @@ mod metadata;
 use self::{
     common::extract_zip_document_metadata,
     formats::{
-        extract_doc_metadata, extract_kindle_metadata, extract_ooxml_metadata,
+        build_kindle_preview, extract_doc_metadata, extract_ooxml_metadata,
         extract_open_document_metadata, extract_pages_metadata, extract_pdf_metadata,
     },
     metadata::render_document_preview,
@@ -40,7 +40,7 @@ pub(super) fn build_document_preview(
         DocumentFormat::Epub => {
             return epub::build_epub_preview(path, epub_section_index.unwrap_or(0));
         }
-        DocumentFormat::Mobi | DocumentFormat::Azw3 => extract_kindle_metadata(path),
+        DocumentFormat::Mobi | DocumentFormat::Azw3 => return build_kindle_preview(path, format),
         DocumentFormat::Pdf => extract_pdf_metadata(path),
     }?;
 

--- a/src/preview/document/mod.rs
+++ b/src/preview/document/mod.rs
@@ -6,8 +6,8 @@ mod metadata;
 use self::{
     common::extract_zip_document_metadata,
     formats::{
-        extract_doc_metadata, extract_ooxml_metadata, extract_open_document_metadata,
-        extract_pages_metadata, extract_pdf_metadata,
+        extract_doc_metadata, extract_kindle_metadata, extract_ooxml_metadata,
+        extract_open_document_metadata, extract_pages_metadata, extract_pdf_metadata,
     },
     metadata::render_document_preview,
 };
@@ -40,6 +40,7 @@ pub(super) fn build_document_preview(
         DocumentFormat::Epub => {
             return epub::build_epub_preview(path, epub_section_index.unwrap_or(0));
         }
+        DocumentFormat::Mobi | DocumentFormat::Azw3 => extract_kindle_metadata(path),
         DocumentFormat::Pdf => extract_pdf_metadata(path),
     }?;
 

--- a/src/preview/tests/documents/kindle.rs
+++ b/src/preview/tests/documents/kindle.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+#[test]
+fn mobi_and_azw3_previews_use_document_headers() {
+    for (file_name, detail) in [("novel.mobi", "MOBI ebook"), ("novel.azw3", "AZW3 ebook")] {
+        let root = temp_path(&format!("kindle-{}", file_name.replace('.', "-")));
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join(file_name);
+        fs::write(&path, b"synthetic kindle ebook bytes").expect("failed to write ebook fixture");
+
+        let preview = build_preview(&file_entry(path));
+        let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+        assert_eq!(preview.kind, PreviewKind::Document);
+        assert_eq!(preview.section_label(), "Document");
+        assert_eq!(preview.detail.as_deref(), Some(detail));
+        assert!(
+            line_texts
+                .iter()
+                .any(|text| text.contains("No document metadata available"))
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+}
+
+#[test]
+fn mobi_preview_reads_exth_metadata() {
+    let root = temp_path("mobi-exth-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("handbook.mobi");
+    write_synthetic_kindle(
+        &path,
+        "Fallback Handbook",
+        &[
+            (100, b"Avery Quill".as_slice()),
+            (100, b"Morgan Line".as_slice()),
+            (101, b"Elio Press".as_slice()),
+            (103, b"Synthetic metadata fixture".as_slice()),
+            (105, b"Reference".as_slice()),
+            (106, b"2026-03-12T08:00:00Z".as_slice()),
+            (113, b"B012345678".as_slice()),
+            (204, &201_u32.to_be_bytes()),
+            (205, &2_u32.to_be_bytes()),
+            (206, &9_u32.to_be_bytes()),
+            (207, &1029_u32.to_be_bytes()),
+            (501, b"EBOK".as_slice()),
+            (503, b"Signal Handbook".as_slice()),
+            (524, b"en".as_slice()),
+        ],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert_eq!(preview.detail.as_deref(), Some("MOBI ebook"));
+    assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("Signal Handbook"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Author") && text.contains("Avery Quill, Morgan Line"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Subject") && text.contains("Reference"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Application") && text.contains("KindleGen 2.9 build 1029"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Publisher") && text.contains("Elio Press"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Language") && text.contains("en"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Published") && text.contains("2026"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("ASIN") && text.contains("B012345678"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Kindle Type") && text.contains("EBOK"))
+    );
+    assert!(line_texts.iter().all(|text| !text.contains("Binary")));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn azw3_preview_uses_mobi_full_name_when_exth_title_is_missing() {
+    let root = temp_path("azw3-full-name-metadata");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("handbook.azw3");
+    write_synthetic_kindle(
+        &path,
+        "Fallback Handbook",
+        &[(100, b"Avery Quill".as_slice()), (524, b"en".as_slice())],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert_eq!(preview.detail.as_deref(), Some("AZW3 ebook"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Title") && text.contains("Fallback Handbook"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Author") && text.contains("Avery Quill"))
+    );
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Language") && text.contains("en"))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+fn write_synthetic_kindle(path: &std::path::Path, full_name: &str, exth_records: &[(u32, &[u8])]) {
+    let mut record0 = vec![0_u8; 16];
+    write_be_u16(&mut record0, 0, 2);
+    write_be_u32(&mut record0, 4, 12_345);
+    write_be_u16(&mut record0, 8, 2);
+    write_be_u16(&mut record0, 10, 4096);
+
+    let mut mobi_header = vec![0_u8; 256];
+    mobi_header[0..4].copy_from_slice(b"MOBI");
+    write_be_u32(&mut mobi_header, 4, 256);
+    write_be_u32(&mut mobi_header, 8, 2);
+    write_be_u32(&mut mobi_header, 12, 65_001);
+    write_be_u32(&mut mobi_header, 20, 6);
+
+    let exth = build_exth(exth_records);
+    let full_name_offset = 16 + mobi_header.len() + exth.len();
+    write_be_u32(&mut mobi_header, 68, full_name_offset as u32);
+    write_be_u32(&mut mobi_header, 72, full_name.len() as u32);
+    if !exth_records.is_empty() {
+        write_be_u32(&mut mobi_header, 112, 0x40);
+    }
+
+    record0.extend_from_slice(&mobi_header);
+    record0.extend_from_slice(&exth);
+    record0.extend_from_slice(full_name.as_bytes());
+    record0.extend_from_slice(&[0, 0]);
+    while !record0.len().is_multiple_of(4) {
+        record0.push(0);
+    }
+
+    let record_count = 2_u16;
+    let record0_offset = 78 + usize::from(record_count) * 8;
+    let record1_offset = record0_offset + record0.len();
+    let mut bytes = vec![0_u8; 78];
+    bytes[..13].copy_from_slice(b"Fixture Book\0");
+    bytes[60..64].copy_from_slice(b"BOOK");
+    bytes[64..68].copy_from_slice(b"MOBI");
+    write_be_u16(&mut bytes, 76, record_count);
+    write_record_entry(&mut bytes, record0_offset as u32);
+    write_record_entry(&mut bytes, record1_offset as u32);
+    bytes.extend_from_slice(&record0);
+    bytes.extend_from_slice(b"EOF");
+
+    fs::write(path, bytes).expect("failed to write synthetic kindle file");
+}
+
+fn build_exth(records: &[(u32, &[u8])]) -> Vec<u8> {
+    if records.is_empty() {
+        return Vec::new();
+    }
+
+    let mut exth = Vec::new();
+    exth.extend_from_slice(b"EXTH");
+    exth.extend_from_slice(&[0; 4]);
+    exth.extend_from_slice(&(records.len() as u32).to_be_bytes());
+    for (kind, value) in records {
+        exth.extend_from_slice(&kind.to_be_bytes());
+        exth.extend_from_slice(&((8 + value.len()) as u32).to_be_bytes());
+        exth.extend_from_slice(value);
+    }
+    let exth_len = exth.len() as u32;
+    exth[4..8].copy_from_slice(&exth_len.to_be_bytes());
+    while !exth.len().is_multiple_of(4) {
+        exth.push(0);
+    }
+    exth
+}
+
+fn write_record_entry(bytes: &mut Vec<u8>, offset: u32) {
+    bytes.extend_from_slice(&offset.to_be_bytes());
+    bytes.extend_from_slice(&[0, 0, 0, 0]);
+}
+
+fn write_be_u16(bytes: &mut [u8], offset: usize, value: u16) {
+    bytes[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
+}
+
+fn write_be_u32(bytes: &mut [u8], offset: usize, value: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&value.to_be_bytes());
+}

--- a/src/preview/tests/documents/kindle.rs
+++ b/src/preview/tests/documents/kindle.rs
@@ -25,6 +25,24 @@ fn mobi_and_azw3_previews_use_document_headers() {
 }
 
 #[test]
+fn kindle_loading_preview_uses_empty_body() {
+    for (file_name, detail) in [("novel.mobi", "MOBI ebook"), ("novel.azw3", "AZW3 ebook")] {
+        let root = temp_path(&format!("kindle-loading-{}", file_name.replace('.', "-")));
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join(file_name);
+        fs::write(&path, b"still-loading").expect("failed to write ebook fixture");
+
+        let preview = loading_preview_for(&file_entry(path), &PreviewRequestOptions::Default);
+
+        assert_eq!(preview.kind, PreviewKind::Document);
+        assert_eq!(preview.detail.as_deref(), Some(detail));
+        assert!(preview.lines.is_empty());
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+}
+
+#[test]
 fn mobi_preview_reads_exth_metadata() {
     let root = temp_path("mobi-exth-metadata");
     fs::create_dir_all(&root).expect("failed to create temp root");
@@ -56,6 +74,7 @@ fn mobi_preview_reads_exth_metadata() {
     assert_eq!(preview.kind, PreviewKind::Document);
     assert_eq!(preview.detail.as_deref(), Some("MOBI ebook"));
     assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+    assert!(line_texts.iter().all(|text| text != "Metadata"));
     assert!(
         line_texts
             .iter()
@@ -107,6 +126,146 @@ fn mobi_preview_reads_exth_metadata() {
 }
 
 #[test]
+fn mobi_and_azw3_previews_attach_exth_cover_visual() {
+    for (file_name, detail) in [
+        ("covered.mobi", "MOBI ebook"),
+        ("covered.azw3", "AZW3 ebook"),
+    ] {
+        let root = temp_path(&format!("kindle-cover-{}", file_name.replace('.', "-")));
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join(file_name);
+        let cover_bytes = raster_image_bytes(&root, ImageFormat::Png, 24, 36);
+        let cover_offset = 0_u32.to_be_bytes();
+        write_synthetic_kindle_with_resources(
+            &path,
+            "Covered Handbook",
+            &[
+                (201, cover_offset.as_slice()),
+                (503, b"Covered Handbook".as_slice()),
+            ],
+            &[cover_bytes.as_slice()],
+        );
+
+        let preview = build_preview(&file_entry(path));
+        let visual = preview
+            .preview_visual
+            .clone()
+            .expect("kindle preview should attach the cover image");
+        let dimensions = image::ImageReader::open(&visual.path)
+            .expect("cover cache should open")
+            .with_guessed_format()
+            .expect("cover cache format should be detected")
+            .into_dimensions()
+            .expect("cover cache dimensions should decode");
+
+        assert_eq!(preview.kind, PreviewKind::Document);
+        assert_eq!(preview.detail.as_deref(), Some(detail));
+        assert_eq!(visual.kind, PreviewVisualKind::Cover);
+        assert_eq!(visual.layout, PreviewVisualLayout::LargeInline);
+        assert_eq!(visual.size, cover_bytes.len() as u64);
+        assert_eq!(dimensions, (24, 36));
+        assert!(visual.path.extension().is_some_and(|ext| ext == "png"));
+
+        let _ = fs::remove_file(visual.path);
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+}
+
+#[test]
+fn kindle_preview_does_not_guess_cover_without_exth_pointer() {
+    let root = temp_path("kindle-cover-no-pointer");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("covered.mobi");
+    let cover_bytes = raster_image_bytes(&root, ImageFormat::Jpeg, 24, 36);
+    write_synthetic_kindle_with_resources(
+        &path,
+        "Covered Handbook",
+        &[(503, b"Covered Handbook".as_slice())],
+        &[cover_bytes.as_slice()],
+    );
+
+    let preview = build_preview(&file_entry(path));
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert!(preview.preview_visual.is_none());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn kindle_preview_falls_back_to_thumbnail_when_cover_record_is_not_an_image() {
+    let root = temp_path("kindle-cover-thumbnail-fallback");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("covered.azw3");
+    let thumbnail_bytes = raster_image_bytes(&root, ImageFormat::Png, 12, 18);
+    let cover_offset = 0_u32.to_be_bytes();
+    let thumb_offset = 1_u32.to_be_bytes();
+    write_synthetic_kindle_with_resources(
+        &path,
+        "Covered Handbook",
+        &[
+            (201, cover_offset.as_slice()),
+            (202, thumb_offset.as_slice()),
+            (503, b"Covered Handbook".as_slice()),
+        ],
+        &[b"not an image".as_slice(), thumbnail_bytes.as_slice()],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let visual = preview
+        .preview_visual
+        .clone()
+        .expect("kindle preview should fall back to thumbnail image");
+    let dimensions = image::ImageReader::open(&visual.path)
+        .expect("thumbnail cache should open")
+        .with_guessed_format()
+        .expect("thumbnail cache format should be detected")
+        .into_dimensions()
+        .expect("thumbnail cache dimensions should decode");
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert_eq!(visual.kind, PreviewVisualKind::Cover);
+    assert_eq!(visual.layout, PreviewVisualLayout::LargeInline);
+    assert_eq!(visual.size, thumbnail_bytes.len() as u64);
+    assert_eq!(dimensions, (12, 18));
+
+    let _ = fs::remove_file(visual.path);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn kindle_preview_skips_cover_for_encrypted_books() {
+    let root = temp_path("kindle-cover-encrypted");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("encrypted.azw3");
+    let cover_bytes = raster_image_bytes(&root, ImageFormat::Png, 24, 36);
+    let cover_offset = 0_u32.to_be_bytes();
+    write_synthetic_kindle_with_options(
+        &path,
+        "Encrypted Handbook",
+        &[
+            (201, cover_offset.as_slice()),
+            (503, b"Encrypted Handbook".as_slice()),
+        ],
+        &[cover_bytes.as_slice()],
+        2,
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Document);
+    assert!(preview.preview_visual.is_none());
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Encryption") && text.contains("Mobipocket encryption"))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn azw3_preview_uses_mobi_full_name_when_exth_title_is_missing() {
     let root = temp_path("azw3-full-name-metadata");
     fs::create_dir_all(&root).expect("failed to create temp root");
@@ -142,11 +301,31 @@ fn azw3_preview_uses_mobi_full_name_when_exth_title_is_missing() {
 }
 
 fn write_synthetic_kindle(path: &std::path::Path, full_name: &str, exth_records: &[(u32, &[u8])]) {
+    write_synthetic_kindle_with_resources(path, full_name, exth_records, &[]);
+}
+
+fn write_synthetic_kindle_with_resources(
+    path: &std::path::Path,
+    full_name: &str,
+    exth_records: &[(u32, &[u8])],
+    resource_records: &[&[u8]],
+) {
+    write_synthetic_kindle_with_options(path, full_name, exth_records, resource_records, 0);
+}
+
+fn write_synthetic_kindle_with_options(
+    path: &std::path::Path,
+    full_name: &str,
+    exth_records: &[(u32, &[u8])],
+    resource_records: &[&[u8]],
+    encryption: u16,
+) {
     let mut record0 = vec![0_u8; 16];
     write_be_u16(&mut record0, 0, 2);
     write_be_u32(&mut record0, 4, 12_345);
     write_be_u16(&mut record0, 8, 2);
     write_be_u16(&mut record0, 10, 4096);
+    write_be_u16(&mut record0, 12, encryption);
 
     let mut mobi_header = vec![0_u8; 256];
     mobi_header[0..4].copy_from_slice(b"MOBI");
@@ -159,6 +338,9 @@ fn write_synthetic_kindle(path: &std::path::Path, full_name: &str, exth_records:
     let full_name_offset = 16 + mobi_header.len() + exth.len();
     write_be_u32(&mut mobi_header, 68, full_name_offset as u32);
     write_be_u32(&mut mobi_header, 72, full_name.len() as u32);
+    if !resource_records.is_empty() {
+        write_be_u32(&mut mobi_header, 92, 1);
+    }
     if !exth_records.is_empty() {
         write_be_u32(&mut mobi_header, 112, 0x40);
     }
@@ -171,20 +353,43 @@ fn write_synthetic_kindle(path: &std::path::Path, full_name: &str, exth_records:
         record0.push(0);
     }
 
-    let record_count = 2_u16;
+    let mut records = vec![record0];
+    records.extend(resource_records.iter().map(|record| record.to_vec()));
+    records.push(b"EOF".to_vec());
+
+    let record_count = records.len() as u16;
     let record0_offset = 78 + usize::from(record_count) * 8;
-    let record1_offset = record0_offset + record0.len();
     let mut bytes = vec![0_u8; 78];
     bytes[..13].copy_from_slice(b"Fixture Book\0");
     bytes[60..64].copy_from_slice(b"BOOK");
     bytes[64..68].copy_from_slice(b"MOBI");
     write_be_u16(&mut bytes, 76, record_count);
-    write_record_entry(&mut bytes, record0_offset as u32);
-    write_record_entry(&mut bytes, record1_offset as u32);
-    bytes.extend_from_slice(&record0);
-    bytes.extend_from_slice(b"EOF");
+    let mut offset = record0_offset;
+    for record in &records {
+        write_record_entry(&mut bytes, offset as u32);
+        offset += record.len();
+    }
+    for record in records {
+        bytes.extend_from_slice(&record);
+    }
 
     fs::write(path, bytes).expect("failed to write synthetic kindle file");
+}
+
+fn raster_image_bytes(
+    root: &std::path::Path,
+    format: ImageFormat,
+    width_px: u32,
+    height_px: u32,
+) -> Vec<u8> {
+    let extension = match format {
+        ImageFormat::Png => "png",
+        ImageFormat::Jpeg => "jpg",
+        _ => "img",
+    };
+    let path = root.join(format!("cover.{extension}"));
+    write_test_raster_image(&path, format, width_px, height_px);
+    fs::read(path).expect("failed to read raster test image")
 }
 
 fn build_exth(records: &[(u32, &[u8])]) -> Vec<u8> {

--- a/src/preview/tests/documents/mod.rs
+++ b/src/preview/tests/documents/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
 mod epub;
+mod kindle;
 mod office;
 mod pdf;

--- a/src/preview/types.rs
+++ b/src/preview/types.rs
@@ -114,6 +114,7 @@ pub(crate) enum PreviewVisualKind {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum PreviewVisualLayout {
     Inline,
+    LargeInline,
     FullHeight,
 }
 

--- a/src/ui/browser/preview.rs
+++ b/src/ui/browser/preview.rs
@@ -202,7 +202,9 @@ fn render_preview_body(
         frame.render_widget(paragraph, text_area);
     }
 
-    if let Some(scrollbar_area) = scrollbar_area {
+    if let Some(scrollbar_area) = scrollbar_area
+        && text_area.height > 0
+    {
         render_preview_scrollbar(
             frame,
             scrollbar_area,

--- a/src/ui/theme/appearance/rules/extensions.rs
+++ b/src/ui/theme/appearance/rules/extensions.rs
@@ -1,6 +1,7 @@
 use super::super::types::RuleOverride;
 use super::shared::{
-    rgb, rule_class, rule_document_file, rule_presentation_file, rule_spreadsheet_file,
+    rgb, rule_class, rule_document_file, rule_ebook_file, rule_presentation_file,
+    rule_spreadsheet_file,
 };
 use crate::core::FileClass;
 use std::collections::HashMap;
@@ -538,14 +539,9 @@ pub(super) fn default_extension_rules() -> HashMap<String, RuleOverride> {
             },
         ),
         ("pdf".to_string(), rule_class(FileClass::Document)),
-        (
-            "epub".to_string(),
-            RuleOverride {
-                class: Some(FileClass::Document),
-                icon: Some("󱗖".to_string()),
-                color: Some(rgb(211, 170, 124)),
-            },
-        ),
+        ("epub".to_string(), rule_ebook_file()),
+        ("mobi".to_string(), rule_ebook_file()),
+        ("azw3".to_string(), rule_ebook_file()),
         (
             "cbz".to_string(),
             RuleOverride {

--- a/src/ui/theme/appearance/rules/shared.rs
+++ b/src/ui/theme/appearance/rules/shared.rs
@@ -17,6 +17,14 @@ pub(super) fn rule_document_file() -> RuleOverride {
     }
 }
 
+pub(super) fn rule_ebook_file() -> RuleOverride {
+    RuleOverride {
+        class: Some(FileClass::Document),
+        icon: Some("󱗖".to_string()),
+        color: Some(rgb(211, 170, 124)),
+    }
+}
+
 pub(super) fn rule_spreadsheet_file() -> RuleOverride {
     RuleOverride {
         class: Some(FileClass::Document),

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -375,6 +375,16 @@ fn word_processing_documents_get_blue_document_icons() {
     assert_eq!(epub.icon, "󱗖");
     assert_eq!(epub.color, rgb(211, 170, 124));
 
+    let mobi = theme.resolve(Path::new("novel.mobi"), EntryKind::File);
+    assert_eq!(mobi.class, FileClass::Document);
+    assert_eq!(mobi.icon, "󱗖");
+    assert_eq!(mobi.color, rgb(211, 170, 124));
+
+    let azw3 = theme.resolve(Path::new("novel.azw3"), EntryKind::File);
+    assert_eq!(azw3.class, FileClass::Document);
+    assert_eq!(azw3.icon, "󱗖");
+    assert_eq!(azw3.color, rgb(211, 170, 124));
+
     let comic = theme.resolve(Path::new("issue.cbz"), EntryKind::File);
     assert_eq!(comic.class, FileClass::Archive);
     assert_eq!(comic.icon, "󱗖");


### PR DESCRIPTION
## Summary

Adds first-class MOBI and AZW3 preview support so Kindle ebooks are classified as books and can show native metadata plus embedded cover art when available.

## What Changed

- Added native MOBI/AZW3 metadata previews using PalmDB/MOBI EXTH fields.
- Extracted declared Kindle cover or thumbnail image records into the existing preview visual pipeline.
- Kept Kindle loading previews silent and rendered Kindle covers larger while preserving room for details.
- Collapsed document metadata into a single `Details` section for compact, consistent document previews.
- Made full-height EPUB image sections advance on preview scroll without first scrolling hidden context lines.
- Updated preview coverage docs, changelog entries, and focused tests.

## User Impact

MOBI and AZW3 files no longer appear as generic binary files. They now use book classification, show useful ebook details, and display embedded covers in image-capable terminals when the file exposes a cover record. EPUB image sections also feel more direct to scroll through.

## Notes

Cover extraction only reads declared EXTH cover or thumbnail records and skips encrypted books instead of attempting DRM bypass. No new runtime dependencies were added.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- User verified the MOBI/AZW3 preview behavior, larger cover sizing, EPUB image scroll behavior, and single `Details` layout locally.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
