### PR TITLE
feat(preview): add QML code preview and file icon support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added QML source file support with syntax-highlighted code previews.
+- Added a dedicated QML file icon in the built-in browser theme.
+
 ## [1.1.0] - 2026-04-18
 
 ### Added

--- a/assets/syntaxes/QML.sublime-syntax
+++ b/assets/syntaxes/QML.sublime-syntax
@@ -1,0 +1,149 @@
+%YAML 1.2
+---
+name: QML
+file_extensions:
+  - qml
+scope: source.qml
+version: 2
+variables:
+  identifier: '[A-Za-z_][A-Za-z0-9_]*'
+  dotted_identifier: '{{identifier}}(?:\.{{identifier}})*'
+  type_name: '[A-Z][A-Za-z0-9_]*'
+  dotted_type: '{{type_name}}(?:\.{{type_name}})*'
+  basic_type: '(?:bool|double|enum|int|list|real|string|url|variant|var|date|point|rect|size)'
+contexts:
+  prototype:
+    - include: comments
+  main:
+    - include: strings
+    - include: template-strings
+    - include: import-statements
+    - include: pragma-statements
+    - include: object-types
+    - include: group-attributes
+    - include: property-declarations
+    - include: signal-declarations
+    - include: function-declarations
+    - include: handler-keywords
+    - include: binding-targets
+    - include: js-keywords
+    - include: constants
+    - include: function-calls
+    - include: type-references
+    - include: operators
+  comments:
+    - match: '//.*$'
+      scope: comment.line.double-slash.qml
+    - match: '/\*'
+      push: block-comment
+  block-comment:
+    - meta_scope: comment.block.qml
+    - match: '/\*'
+      push: block-comment
+    - match: '\*/'
+      pop: true
+  strings:
+    - match: '"'
+      push: double-quoted-string
+    - match: "'"
+      push: single-quoted-string
+  double-quoted-string:
+    - meta_scope: string.quoted.double.qml
+    - meta_include_prototype: false
+    - match: '\\.'
+      scope: constant.character.escape.qml
+    - match: '"'
+      pop: true
+  single-quoted-string:
+    - meta_scope: string.quoted.single.qml
+    - meta_include_prototype: false
+    - match: '\\.'
+      scope: constant.character.escape.qml
+    - match: "'"
+      pop: true
+  template-strings:
+    - match: '`'
+      push: template-string
+  template-string:
+    - meta_scope: string.quoted.template.qml
+    - meta_include_prototype: false
+    - match: '\\.'
+      scope: constant.character.escape.qml
+    - match: '`'
+      pop: true
+  import-statements:
+    - match: '\b(import)\s+({{dotted_identifier}})\b'
+      captures:
+        1: keyword.control.import.qml
+        2: support.type.qml
+    - match: '\b(import)\b'
+      scope: keyword.control.import.qml
+    - match: '\b(as)\b'
+      scope: keyword.control.as.qml
+    - match: '\b\d+(?:\.\d+)+\b'
+      scope: constant.numeric.qml
+  pragma-statements:
+    - match: '\b(pragma)\s+({{identifier}})\b'
+      captures:
+        1: keyword.control.qml
+        2: support.type.qml
+  object-types:
+    - match: '\b({{dotted_type}})(?=\s*\{)'
+      captures:
+        1: entity.name.type.qml
+  group-attributes:
+    - match: '\b({{identifier}})(?=\s*\{)'
+      captures:
+        1: entity.other.attribute-name.qml
+  property-declarations:
+    - match: '\b(default|readonly|required|alias)\b'
+      scope: storage.modifier.qml
+    - match: '\b(property)\s+({{dotted_type}}|{{basic_type}}|alias)\s+({{identifier}})\b'
+      captures:
+        1: keyword.other.qml
+        2: support.type.qml
+        3: variable.parameter.qml
+    - match: '\b(id)(?=\s*:)'
+      scope: keyword.other.qml
+  signal-declarations:
+    - match: '\b(signal)\s+({{identifier}})\b'
+      captures:
+        1: storage.type.qml
+        2: entity.name.function.qml
+  function-declarations:
+    - match: '\b(function)\s+({{identifier}})\b'
+      captures:
+        1: storage.type.qml
+        2: entity.name.function.qml
+  handler-keywords:
+    - match: '\b(on[A-Z][A-Za-z0-9_]*(?:Changed)?)\b'
+      scope: keyword.control.qml
+  binding-targets:
+    - match: '\b({{dotted_identifier}})(?=\s*:)'
+      captures:
+        1: entity.other.attribute-name.qml
+  js-keywords:
+    - match: '\b(?:if|else|for|while|switch|case|break|continue|return|try|catch|finally|throw|new|const|let|var|typeof|instanceof|delete|in|of)\b'
+      scope: keyword.control.qml
+  constants:
+    - match: '\b(?:true|false|null|undefined)\b'
+      scope: constant.language.qml
+    - match: '\b(?:0x[0-9A-Fa-f_]+|\d[\d_]*(?:\.\d[\d_]*)?)\b'
+      scope: constant.numeric.qml
+  function-calls:
+    - match: '\b({{identifier}})(?=\s*\()'
+      captures:
+        1: support.function.qml
+  type-references:
+    - match: '\b({{dotted_type}})\b'
+      captures:
+        1: entity.name.type.qml
+    - match: '\b{{basic_type}}\b'
+      scope: support.type.qml
+  operators:
+    - match: ':'
+      scope: punctuation.separator.key-value.qml
+    - match: '\.'
+      scope: punctuation.accessor.qml
+    - match: '=>|\?\?|[-+*/%=&|<>!~^]+|\?'
+      scope: keyword.operator.qml

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -80,6 +80,11 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
             specific_type_label: Some("Less stylesheet"),
             preview: preview_for_extension(ext),
         },
+        "qml" => FileFacts {
+            builtin_class: FileClass::Code,
+            specific_type_label: Some("QML source file"),
+            preview: preview_for_extension(ext),
+        },
         "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "mts" | "cts" => FileFacts {
             builtin_class: FileClass::Code,
             specific_type_label: Some(match ext {

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -62,6 +62,16 @@ fn html_and_css_files_use_code_preview_support() {
 }
 
 #[test]
+fn qml_files_use_code_preview_support() {
+    let qml = inspect_path(Path::new("Main.qml"), EntryKind::File);
+
+    assert_eq!(qml.builtin_class, FileClass::Code);
+    assert_eq!(qml.specific_type_label, Some("QML source file"));
+    assert_eq!(qml.preview.language_hint, Some("qml"));
+    assert_code_spec(qml.preview, Some("qml"), CodeBackend::Syntect);
+}
+
+#[test]
 fn nix_and_cmake_files_use_code_preview_support() {
     let nix = inspect_path(Path::new("flake.nix"), EntryKind::File);
     let cmake = inspect_path(Path::new("toolchain.cmake"), EntryKind::File);

--- a/src/preview/code/backends/syntect/mod.rs
+++ b/src/preview/code/backends/syntect/mod.rs
@@ -297,6 +297,10 @@ mod tests {
                 "powershell",
                 "function Invoke-Greeting([string]$Name) {\n  Write-Host \"Hello $Name\"\n}\n",
             ),
+            (
+                "qml",
+                "import QtQuick\nItem {\n  id: root\n  property bool active: true\n  onActiveChanged: console.log(\"changed\")\n}\n",
+            ),
         ] {
             let rendered = render_syntect_code_preview(code_syntax, snippet, true, 20, &|| false)
                 .expect("vendored syntax should render through syntect");
@@ -394,6 +398,26 @@ mod tests {
         assert_ne!(span_color(&rendered[1], "Write-Host"), Some(palette.fg));
         assert_eq!(span_color(&rendered[1], "\"Hello "), Some(palette.string));
         assert_eq!(span_color(&rendered[1], "$Name"), Some(palette.parameter));
+    }
+
+    #[test]
+    fn qml_tokens_map_to_semantic_roles() {
+        let palette = theme::code_preview_palette();
+        let sample = "import QtQuick\nItem {\n  id: root\n  required property bool active: true\n  Component.onCompleted: {\n    if (active) {\n      console.log(\"hello\")\n    }\n  }\n}\n";
+        let rendered = render_syntect_code_preview("qml", sample, true, 20, &|| false)
+            .expect("qml syntax should render through syntect");
+
+        assert_eq!(span_color(&rendered[1], "Item"), Some(palette.r#type));
+        assert_eq!(span_color(&rendered[3], "required"), Some(palette.keyword));
+        assert_eq!(span_color(&rendered[3], "property"), Some(palette.keyword));
+        assert_eq!(span_color(&rendered[3], "active"), Some(palette.parameter));
+        assert_eq!(
+            span_color(&rendered[4], "Component.onCompleted"),
+            Some(palette.parameter)
+        );
+        assert_eq!(span_color(&rendered[5], "if"), Some(palette.keyword));
+        assert_eq!(span_color(&rendered[6], "log"), Some(palette.function));
+        assert_eq!(span_color(&rendered[6], "\"hello\""), Some(palette.string));
     }
 
     #[test]

--- a/src/preview/code/registry/data/web.rs
+++ b/src/preview/code/registry/data/web.rs
@@ -82,4 +82,12 @@ pub(super) const LANGUAGES: &[RegistryEntry] = &[
         &["tsx"],
         &["tsx"],
     ),
+    entry(
+        language("qml", "QML", CodeBackend::Syntect, None),
+        &["qml"],
+        &[],
+        &[],
+        &["qml"],
+        &["qml"],
+    ),
 ];

--- a/src/preview/code/registry/tests.rs
+++ b/src/preview/code/registry/tests.rs
@@ -76,6 +76,10 @@ fn extension_lookup_returns_canonical_language_ids() {
         language_for_extension("json5").map(|language| language.canonical_id),
         Some("json5")
     );
+    assert_eq!(
+        language_for_extension("qml").map(|language| language.canonical_id),
+        Some("qml")
+    );
 }
 
 #[test]
@@ -227,6 +231,10 @@ fn markdown_fence_lookup_supports_common_aliases() {
     assert_eq!(
         language_for_markdown_fence("rscript").map(|language| language.canonical_id),
         Some("r")
+    );
+    assert_eq!(
+        language_for_markdown_fence("qml").map(|language| language.canonical_id),
+        Some("qml")
     );
 }
 

--- a/src/preview/code/render.rs
+++ b/src/preview/code/render.rs
@@ -171,6 +171,10 @@ mod tests {
                 "cmake",
                 "cmake_minimum_required(VERSION 3.28)\nproject(elio)\n",
             ),
+            (
+                "qml",
+                "import QtQuick\nItem {\n  property bool active: true\n  onActiveChanged: console.log(\"changed\")\n}\n",
+            ),
         ] {
             let preview = render_code_preview(
                 PreviewSpec::code(code_syntax, CodeBackend::Syntect, None),

--- a/src/preview/code/syntax_manifest.rs
+++ b/src/preview/code/syntax_manifest.rs
@@ -63,6 +63,11 @@ pub(crate) const CURATED_SYNTAXES: &[CuratedSyntax] = &[
         source: SyntaxSource::Vendored,
     },
     CuratedSyntax {
+        canonical_id: "qml",
+        lookup_token: "qml",
+        source: SyntaxSource::Vendored,
+    },
+    CuratedSyntax {
         canonical_id: "sql",
         lookup_token: "sql",
         source: SyntaxSource::BundledDefault,

--- a/src/preview/tests/code/syntect.rs
+++ b/src/preview/tests/code/syntect.rs
@@ -269,6 +269,51 @@ fn typescript_preview_uses_code_renderer() {
 }
 
 #[test]
+fn qml_preview_uses_curated_syntect_support() {
+    let root = temp_path("qml");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("Main.qml");
+    fs::write(
+        &path,
+        "import QtQuick\nItem {\n  id: root\n  required property var model\n  readonly property bool active: true\n  Component.onCompleted: {\n    if (active) {\n      console.log(\"hello\")\n    }\n  }\n}\n",
+    )
+    .expect("failed to write qml source");
+
+    let preview = build_preview(&file_entry(path));
+    let code_palette = theme::code_preview_palette();
+
+    assert_eq!(preview.kind, PreviewKind::Code);
+    assert!(
+        preview
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("QML"))
+    );
+    assert_eq!(
+        span_color(&preview.lines[1], "Item"),
+        Some(code_palette.r#type)
+    );
+    assert_eq!(
+        span_color(&preview.lines[3], "property"),
+        Some(code_palette.keyword)
+    );
+    assert_ne!(
+        span_color(&preview.lines[4], "active"),
+        Some(code_palette.fg)
+    );
+    assert_eq!(
+        span_color(&preview.lines[6], "if"),
+        Some(code_palette.keyword)
+    );
+    assert_eq!(
+        span_color(&preview.lines[7], "\"hello\""),
+        Some(code_palette.string)
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn tsx_preview_uses_code_renderer() {
     let root = temp_path("tsx");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/ui/theme/appearance/rules/extensions.rs
+++ b/src/ui/theme/appearance/rules/extensions.rs
@@ -14,6 +14,14 @@ pub(super) fn default_extension_rules() -> HashMap<String, RuleOverride> {
         ("tsx".to_string(), rule_class(FileClass::Code)),
         ("jsx".to_string(), rule_class(FileClass::Code)),
         (
+            "qml".to_string(),
+            RuleOverride {
+                class: Some(FileClass::Code),
+                icon: Some("".to_string()),
+                color: Some(rgb(64, 205, 82)),
+            },
+        ),
+        (
             "sql".to_string(),
             RuleOverride {
                 class: Some(FileClass::Code),

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -314,6 +314,10 @@ fn default_theme_assigns_icons_for_new_language_support() {
     let cobol = theme.resolve(Path::new("ledger.cbl"), EntryKind::File);
     assert_eq!(cobol.class, FileClass::Code);
     assert_eq!(cobol.icon, "");
+
+    let qml = theme.resolve(Path::new("Main.qml"), EntryKind::File);
+    assert_eq!(qml.class, FileClass::Code);
+    assert_eq!(qml.icon, "");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add first-class QML support so `.qml` files classify as code, render with syntax-highlighted previews, and show a dedicated file icon in the browser.

## What Changed

- Added `.qml` file classification and language registry entries so QML routes through the existing code preview pipeline.
- Vendored a QML syntect grammar and registered it in the curated syntax bundle for syntax-highlighted previews.
- Added a dedicated QML file icon mapping in the built-in theme.
- Added coverage for classification, registry lookup, syntect rendering, preview output, theme resolution, and the `CHANGELOG.md` entry.

## User Impact

`.qml` files now show a dedicated QML icon in the file browser and render with syntax-highlighted code previews instead of falling back to generic file handling.

## Notes

QML uses a vendored `.sublime-syntax` grammar so it can participate in Elio’s curated syntect bundle.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified locally with real `.qml` files in Elio; the file browser shows the QML icon and the preview syntax highlighting looks correct.

Result:

- All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
