### PR TITLE
fix(release): update Node 24 workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,13 +265,13 @@ jobs:
 
     steps:
       - name: Download release notes
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: release-notes
           path: release-notes
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: release-asset-*
           path: dist
@@ -358,7 +358,7 @@ jobs:
       - name: Authenticate with crates.io
         id: auth
         if: steps.crates.outputs.published != 'true'
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@v1.0.4
 
       - name: Publish to crates.io
         if: steps.crates.outputs.published != 'true'


### PR DESCRIPTION
## Summary

Update the release workflow actions that still run on Node 20 so the release pipeline stays compatible with GitHub's Node 24 migration.

## What Changed

- Updated `actions/download-artifact` from `v6` to `v7` in the GitHub release job.
- Pinned `rust-lang/crates-io-auth-action` to `v1.0.4` in the crates.io publish job.
- Kept the release workflow logic unchanged apart from the action version updates.

## User Impact

No user-visible behavior change.

## Notes

This only affects `.github/workflows/release.yml`.

The goal is to resolve the Node 20 deprecation warnings in the release workflow without changing release behavior.

## Testing

Verified with:

- [ ] `cargo fmt --check`
- [ ] `cargo test --locked --test architecture_guardrails`
- [ ] `cargo clippy --locked --all-targets -- -D warnings`
- [ ] `cargo test --locked`
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Reviewed the release workflow diff to confirm the change is limited to action version updates.
- Verified upstream action runtime support:
  - `actions/download-artifact@v7` uses Node 24.
  - `rust-lang/crates-io-auth-action@v1.0.4` is the Node 24 release.

Result:

- Diff is limited to `.github/workflows/release.yml`.
- No local code or docs changes were required.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed
