### PR TITLE
feat(preview): add font metadata previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added QML source file support with syntax-highlighted code previews.
 - Added a dedicated QML file icon in the built-in browser theme.
+- Added metadata previews for TrueType, OpenType, WOFF, and WOFF2 font files, replacing the generic binary fallback.
 
 ## [1.1.0] - 2026-04-18
 

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -548,7 +548,10 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
         "ogg" => plain(FileClass::Audio, Some("Ogg audio")),
         "m4a" => plain(FileClass::Audio, Some("M4A audio")),
         "zip" | "tar" | "gz" | "xz" | "bz2" | "7z" | "rar" => plain(FileClass::Archive, None),
-        "ttf" | "otf" | "woff" | "woff2" => plain(FileClass::Font, None),
+        "ttf" => plain(FileClass::Font, Some("TrueType font")),
+        "otf" => plain(FileClass::Font, Some("OpenType font")),
+        "woff" => plain(FileClass::Font, Some("WOFF font")),
+        "woff2" => plain(FileClass::Font, Some("WOFF2 font")),
         _ => plain(FileClass::File, None),
     }
 }

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -32,6 +32,22 @@ fn supported_video_extensions_keep_specific_video_labels() {
         assert_eq!(facts.specific_type_label, Some(label));
     }
 }
+
+#[test]
+fn font_files_keep_specific_labels() {
+    let cases = [
+        ("JetBrainsMono.ttf", "TrueType font"),
+        ("RedHatText.otf", "OpenType font"),
+        ("KaTeX_Main.woff", "WOFF font"),
+        ("FiraSans.woff2", "WOFF2 font"),
+    ];
+
+    for (path, label) in cases {
+        let facts = inspect_path(Path::new(path), EntryKind::File);
+        assert_eq!(facts.builtin_class, FileClass::Font);
+        assert_eq!(facts.specific_type_label, Some(label));
+    }
+}
 #[test]
 fn html_and_css_files_use_code_preview_support() {
     let html = inspect_path(Path::new("index.html"), EntryKind::File);

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -79,6 +79,7 @@ pub(crate) fn loading_preview_for(
     let lines = if is_comic_page_preview
         || is_epub_section_preview
         || facts.builtin_class == FileClass::Audio
+        || facts.builtin_class == FileClass::Font
         || is_silent_kindle_loading
         || is_silent_archive_loading
     {
@@ -110,6 +111,9 @@ fn loading_preview_kind(facts: &file_info::FileFacts) -> PreviewKind {
     }
     if facts.preview.document_format.is_some() {
         return PreviewKind::Document;
+    }
+    if facts.builtin_class == FileClass::Font {
+        return PreviewKind::Font;
     }
     if facts.builtin_class == FileClass::Audio {
         return PreviewKind::Audio;
@@ -228,6 +232,12 @@ where
             ffmpeg_available,
             canceled,
         );
+    }
+    if facts.builtin_class == FileClass::Font {
+        return match font::build_font_preview(entry, type_detail, canceled) {
+            Ok(preview) => preview,
+            Err(error) => apply_type_detail(unavailable_file_preview(&error), type_detail),
+        };
     }
 
     if matches!(

--- a/src/preview/font.rs
+++ b/src/preview/font.rs
@@ -16,7 +16,8 @@ use std::{
     sync::OnceLock,
 };
 
-const FC_SCAN_FORMAT: &str = "%{family}\n%{style}\n%{postscriptname}\n%{fontformat}\n%{fontwrapper}\n%{spacing}\n%{variable}\n";
+const FC_SCAN_FORMAT: &str =
+    "%{family}\n%{style}\n%{fontformat}\n%{fontwrapper}\n%{spacing}\n%{variable}\n";
 const WOFF_MAGIC: &[u8; 4] = b"wOFF";
 const WOFF2_MAGIC: &[u8; 4] = b"wOF2";
 const OTTO_MAGIC: &[u8; 4] = b"OTTO";
@@ -28,7 +29,6 @@ const TYPE_1_MAGIC: &[u8; 4] = b"typ1";
 struct FontMetadata {
     family: Option<String>,
     style: Option<String>,
-    postscript: Option<String>,
     format: String,
     monospace: bool,
     variable: bool,
@@ -39,7 +39,6 @@ struct FontMetadata {
 struct FcScanMetadata {
     family: Option<String>,
     style: Option<String>,
-    postscript: Option<String>,
     font_format: Option<String>,
     wrapper: Option<String>,
     monospace: bool,
@@ -66,9 +65,6 @@ where
     let preview_metadata = FontMetadata {
         family: scan_metadata.as_ref().and_then(|scan| scan.family.clone()),
         style: scan_metadata.as_ref().and_then(|scan| scan.style.clone()),
-        postscript: scan_metadata
-            .as_ref()
-            .and_then(|scan| scan.postscript.clone()),
         format: scan_metadata
             .as_ref()
             .and_then(|scan| {
@@ -117,7 +113,6 @@ fn parse_fc_scan_output(output: &str) -> Option<FcScanMetadata> {
     let mut lines = output.lines();
     let family = primary_name_value(lines.next().unwrap_or_default());
     let style = primary_name_value(lines.next().unwrap_or_default());
-    let postscript = clean_fc_scan_value(lines.next().unwrap_or_default());
     let font_format = clean_fc_scan_value(lines.next().unwrap_or_default());
     let wrapper = clean_fc_scan_value(lines.next().unwrap_or_default());
     let monospace = is_monospace_spacing(lines.next().unwrap_or_default());
@@ -127,7 +122,6 @@ fn parse_fc_scan_output(output: &str) -> Option<FcScanMetadata> {
     let metadata = FcScanMetadata {
         family,
         style,
-        postscript,
         font_format,
         wrapper,
         monospace,
@@ -135,7 +129,6 @@ fn parse_fc_scan_output(output: &str) -> Option<FcScanMetadata> {
     };
     if metadata.family.is_none()
         && metadata.style.is_none()
-        && metadata.postscript.is_none()
         && metadata.font_format.is_none()
         && metadata.wrapper.is_none()
         && !metadata.monospace
@@ -262,9 +255,6 @@ fn render_font_preview(detail: &str, metadata: FontMetadata) -> PreviewContent {
     if let Some(style) = metadata.style {
         fields.push(("Style", style));
     }
-    if let Some(postscript) = metadata.postscript {
-        fields.push(("PostScript", postscript));
-    }
     fields.push(("Format", metadata.format));
     if metadata.monospace {
         fields.push(("Monospace", "Yes".to_string()));
@@ -318,7 +308,6 @@ mod tests {
         let output = "\
 JetBrainsMono Nerd Font,JetBrainsMono NF
 Regular
-JetBrainsMonoNF-Regular
 TrueType
 SFNT
 100
@@ -329,10 +318,6 @@ True
 
         assert_eq!(metadata.family.as_deref(), Some("JetBrainsMono Nerd Font"));
         assert_eq!(metadata.style.as_deref(), Some("Regular"));
-        assert_eq!(
-            metadata.postscript.as_deref(),
-            Some("JetBrainsMonoNF-Regular")
-        );
         assert_eq!(metadata.font_format.as_deref(), Some("TrueType"));
         assert_eq!(metadata.wrapper.as_deref(), Some("SFNT"));
         assert!(metadata.monospace);
@@ -360,7 +345,6 @@ True
         let output = "\
 TypoGraphica
 Regular ,Normal, obyéejné, Standard, Kavov ika, Normaali
-TypoGraphica
 TrueType
 SFNT
 

--- a/src/preview/font.rs
+++ b/src/preview/font.rs
@@ -1,0 +1,394 @@
+use super::PreviewContent;
+use super::PreviewKind;
+use super::appearance as theme;
+use super::process::run_command_capture_stdout_cancellable;
+use crate::core::Entry;
+use anyhow::{Context, Result};
+use ratatui::{
+    style::Style,
+    text::{Line, Span},
+};
+use std::{
+    fs,
+    io::Read,
+    path::Path,
+    process::{Command, Stdio},
+    sync::OnceLock,
+};
+
+const FC_SCAN_FORMAT: &str = "%{family}\n%{style}\n%{postscriptname}\n%{fontformat}\n%{fontwrapper}\n%{spacing}\n%{variable}\n";
+const WOFF_MAGIC: &[u8; 4] = b"wOFF";
+const WOFF2_MAGIC: &[u8; 4] = b"wOF2";
+const OTTO_MAGIC: &[u8; 4] = b"OTTO";
+const TRUE_TYPE_MAGIC: [u8; 4] = [0x00, 0x01, 0x00, 0x00];
+const APPLE_TRUE_TYPE_MAGIC: &[u8; 4] = b"true";
+const TYPE_1_MAGIC: &[u8; 4] = b"typ1";
+
+#[derive(Debug, Eq, PartialEq)]
+struct FontMetadata {
+    family: Option<String>,
+    style: Option<String>,
+    postscript: Option<String>,
+    format: String,
+    monospace: bool,
+    variable: bool,
+    file_size: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct FcScanMetadata {
+    family: Option<String>,
+    style: Option<String>,
+    postscript: Option<String>,
+    font_format: Option<String>,
+    wrapper: Option<String>,
+    monospace: bool,
+    variable: bool,
+}
+
+pub(super) fn build_font_preview<F>(
+    entry: &Entry,
+    type_detail: Option<&'static str>,
+    canceled: &F,
+) -> Result<PreviewContent>
+where
+    F: Fn() -> bool,
+{
+    let detail = type_detail.unwrap_or("Font");
+    let metadata = fs::metadata(&entry.path)
+        .with_context(|| format!("failed to read metadata for {}", entry.path.display()))?;
+    let byte_size = metadata.len();
+    let header = read_font_header(&entry.path)?;
+    let fallback_format = detect_font_format_from_header(&header, type_detail);
+    let scan_metadata = (byte_size >= 12)
+        .then(|| fc_scan_metadata(&entry.path, canceled))
+        .flatten();
+    let preview_metadata = FontMetadata {
+        family: scan_metadata.as_ref().and_then(|scan| scan.family.clone()),
+        style: scan_metadata.as_ref().and_then(|scan| scan.style.clone()),
+        postscript: scan_metadata
+            .as_ref()
+            .and_then(|scan| scan.postscript.clone()),
+        format: scan_metadata
+            .as_ref()
+            .and_then(|scan| {
+                normalize_format(
+                    scan.wrapper.as_deref(),
+                    scan.font_format.as_deref(),
+                    type_detail,
+                )
+            })
+            .unwrap_or(fallback_format),
+        monospace: scan_metadata.as_ref().is_some_and(|scan| scan.monospace),
+        variable: scan_metadata.as_ref().is_some_and(|scan| scan.variable),
+        file_size: crate::fs::format_size(byte_size),
+    };
+
+    Ok(render_font_preview(detail, preview_metadata))
+}
+
+fn fc_scan_metadata<F>(path: &Path, canceled: &F) -> Option<FcScanMetadata>
+where
+    F: Fn() -> bool,
+{
+    if canceled() || !fc_scan_available() {
+        return None;
+    }
+
+    let mut command = Command::new("fc-scan");
+    command.arg("--format").arg(FC_SCAN_FORMAT).arg(path);
+    let output = run_command_capture_stdout_cancellable(command, "preview-font-fc-scan", canceled)?;
+    parse_fc_scan_output(&String::from_utf8_lossy(&output))
+}
+
+fn fc_scan_available() -> bool {
+    static FC_SCAN_AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *FC_SCAN_AVAILABLE.get_or_init(|| {
+        Command::new("fc-scan")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
+fn parse_fc_scan_output(output: &str) -> Option<FcScanMetadata> {
+    let mut lines = output.lines();
+    let family = primary_name_value(lines.next().unwrap_or_default());
+    let style = primary_name_value(lines.next().unwrap_or_default());
+    let postscript = clean_fc_scan_value(lines.next().unwrap_or_default());
+    let font_format = clean_fc_scan_value(lines.next().unwrap_or_default());
+    let wrapper = clean_fc_scan_value(lines.next().unwrap_or_default());
+    let monospace = is_monospace_spacing(lines.next().unwrap_or_default());
+    let variable = clean_fc_scan_value(lines.next().unwrap_or_default())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+
+    let metadata = FcScanMetadata {
+        family,
+        style,
+        postscript,
+        font_format,
+        wrapper,
+        monospace,
+        variable,
+    };
+    if metadata.family.is_none()
+        && metadata.style.is_none()
+        && metadata.postscript.is_none()
+        && metadata.font_format.is_none()
+        && metadata.wrapper.is_none()
+        && !metadata.monospace
+        && !metadata.variable
+    {
+        None
+    } else {
+        Some(metadata)
+    }
+}
+
+fn clean_fc_scan_value(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() || value == "(null)" {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn primary_name_value(value: &str) -> Option<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .find(|family| !family.is_empty())
+        .map(str::to_string)
+}
+
+fn is_monospace_spacing(value: &str) -> bool {
+    matches!(value.trim(), "100" | "110")
+}
+
+fn read_font_header(path: &Path) -> Result<Vec<u8>> {
+    let mut file =
+        fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut header = [0u8; 8];
+    let read = file
+        .read(&mut header)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    Ok(header[..read].to_vec())
+}
+
+fn detect_font_format_from_header(header: &[u8], type_detail: Option<&'static str>) -> String {
+    if header.starts_with(WOFF_MAGIC) {
+        return woff_wrapper_format("WOFF", header.get(4..8));
+    }
+    if header.starts_with(WOFF2_MAGIC) {
+        return woff_wrapper_format("WOFF2", header.get(4..8));
+    }
+    if header.starts_with(OTTO_MAGIC) {
+        return "OpenType (CFF)".to_string();
+    }
+    if is_true_type_flavor(header) {
+        return true_type_outline_format(type_detail).to_string();
+    }
+    format_from_type_detail(type_detail).to_string()
+}
+
+fn woff_wrapper_format(wrapper: &str, flavor: Option<&[u8]>) -> String {
+    match flavor {
+        Some(flavor) if flavor == OTTO_MAGIC => format!("{wrapper} (CFF)"),
+        Some(flavor) if is_true_type_flavor(flavor) => format!("{wrapper} (TrueType)"),
+        _ => wrapper.to_string(),
+    }
+}
+
+fn normalize_format(
+    wrapper: Option<&str>,
+    font_format: Option<&str>,
+    type_detail: Option<&'static str>,
+) -> Option<String> {
+    let wrapper = wrapper.map(str::trim).filter(|value| !value.is_empty());
+    let font_format = font_format.map(str::trim).filter(|value| !value.is_empty());
+
+    match (wrapper, font_format) {
+        (Some("WOFF"), Some("CFF")) => Some("WOFF (CFF)".to_string()),
+        (Some("WOFF"), Some("TrueType")) => Some("WOFF (TrueType)".to_string()),
+        (Some("WOFF2"), Some("CFF")) => Some("WOFF2 (CFF)".to_string()),
+        (Some("WOFF2"), Some("TrueType")) => Some("WOFF2 (TrueType)".to_string()),
+        (Some("WOFF"), _) => Some("WOFF".to_string()),
+        (Some("WOFF2"), _) => Some("WOFF2".to_string()),
+        (Some("SFNT"), Some("CFF")) => Some("OpenType (CFF)".to_string()),
+        (Some("SFNT"), Some("TrueType")) => Some(true_type_outline_format(type_detail).to_string()),
+        (Some("SFNT"), _) => Some(format_from_type_detail(type_detail).to_string()),
+        (Some(wrapper), Some(format)) if wrapper.eq_ignore_ascii_case(format) => {
+            Some(wrapper.to_string())
+        }
+        (Some(wrapper), Some(format)) => Some(format!("{wrapper} ({format})")),
+        (Some(wrapper), None) => Some(wrapper.to_string()),
+        (None, Some("CFF")) => Some("OpenType (CFF)".to_string()),
+        (None, Some("TrueType")) => Some(true_type_outline_format(type_detail).to_string()),
+        (None, Some(format)) => Some(format.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn format_from_type_detail(type_detail: Option<&'static str>) -> &'static str {
+    match type_detail {
+        Some("TrueType font") => "TrueType",
+        Some("OpenType font") => "OpenType",
+        Some("WOFF font") => "WOFF",
+        Some("WOFF2 font") => "WOFF2",
+        _ => "Font",
+    }
+}
+
+fn true_type_outline_format(type_detail: Option<&'static str>) -> &'static str {
+    match type_detail {
+        Some("OpenType font") => "OpenType (TrueType)",
+        _ => "TrueType",
+    }
+}
+
+fn is_true_type_flavor(value: &[u8]) -> bool {
+    value == TRUE_TYPE_MAGIC || value == APPLE_TRUE_TYPE_MAGIC || value == TYPE_1_MAGIC
+}
+
+fn render_font_preview(detail: &str, metadata: FontMetadata) -> PreviewContent {
+    let palette = theme::palette();
+    let mut fields = Vec::new();
+    if let Some(family) = metadata.family {
+        fields.push(("Family", family));
+    }
+    if let Some(style) = metadata.style {
+        fields.push(("Style", style));
+    }
+    if let Some(postscript) = metadata.postscript {
+        fields.push(("PostScript", postscript));
+    }
+    fields.push(("Format", metadata.format));
+    if metadata.monospace {
+        fields.push(("Monospace", "Yes".to_string()));
+    }
+    if metadata.variable {
+        fields.push(("Variable", "Yes".to_string()));
+    }
+    fields.push(("File Size", metadata.file_size));
+
+    let label_width = fields
+        .iter()
+        .map(|(label, _)| label.len())
+        .max()
+        .unwrap_or(8);
+    let mut lines = vec![preview_section_line("Details", palette)];
+    for (label, value) in fields {
+        lines.push(preview_field_line(label, &value, label_width, palette));
+    }
+
+    PreviewContent::new(PreviewKind::Font, lines).with_detail(detail)
+}
+
+fn preview_section_line(title: &str, palette: theme::Palette) -> Line<'static> {
+    Line::from(Span::styled(
+        title.to_string(),
+        Style::default().fg(palette.accent),
+    ))
+}
+
+fn preview_field_line(
+    label: &str,
+    value: &str,
+    label_width: usize,
+    palette: theme::Palette,
+) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<width$} ", width = label_width + 1),
+            Style::default().fg(palette.muted),
+        ),
+        Span::styled(value.to_string(), Style::default().fg(palette.text)),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_fc_scan_output_extracts_clean_metadata() {
+        let output = "\
+JetBrainsMono Nerd Font,JetBrainsMono NF
+Regular
+JetBrainsMonoNF-Regular
+TrueType
+SFNT
+100
+True
+";
+
+        let metadata = parse_fc_scan_output(output).expect("expected parsed fc-scan metadata");
+
+        assert_eq!(metadata.family.as_deref(), Some("JetBrainsMono Nerd Font"));
+        assert_eq!(metadata.style.as_deref(), Some("Regular"));
+        assert_eq!(
+            metadata.postscript.as_deref(),
+            Some("JetBrainsMonoNF-Regular")
+        );
+        assert_eq!(metadata.font_format.as_deref(), Some("TrueType"));
+        assert_eq!(metadata.wrapper.as_deref(), Some("SFNT"));
+        assert!(metadata.monospace);
+        assert!(metadata.variable);
+    }
+
+    #[test]
+    fn normalize_format_prefers_wrapper_specific_labels() {
+        assert_eq!(
+            normalize_format(Some("WOFF2"), Some("TrueType"), Some("WOFF2 font")),
+            Some("WOFF2 (TrueType)".to_string())
+        );
+        assert_eq!(
+            normalize_format(Some("SFNT"), Some("CFF"), Some("OpenType font")),
+            Some("OpenType (CFF)".to_string())
+        );
+        assert_eq!(
+            normalize_format(Some("SFNT"), Some("TrueType"), Some("OpenType font")),
+            Some("OpenType (TrueType)".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_fc_scan_output_keeps_only_primary_style_name() {
+        let output = "\
+TypoGraphica
+Regular ,Normal, obyéejné, Standard, Kavov ika, Normaali
+TypoGraphica
+TrueType
+SFNT
+
+False
+";
+
+        let metadata = parse_fc_scan_output(output).expect("expected parsed fc-scan metadata");
+
+        assert_eq!(metadata.style.as_deref(), Some("Regular"));
+    }
+
+    #[test]
+    fn detect_font_format_from_header_uses_magic_wrappers() {
+        assert_eq!(
+            detect_font_format_from_header(b"wOFF\x00\x01\x00\x00", Some("WOFF font")),
+            "WOFF (TrueType)"
+        );
+        assert_eq!(
+            detect_font_format_from_header(b"wOF2OTTO", Some("WOFF2 font")),
+            "WOFF2 (CFF)"
+        );
+        assert_eq!(
+            detect_font_format_from_header(b"OTTOrest", Some("OpenType font")),
+            "OpenType (CFF)"
+        );
+        assert_eq!(
+            detect_font_format_from_header(b"\x00\x01\x00\x00rest", Some("TrueType font")),
+            "TrueType"
+        );
+    }
+}

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -7,6 +7,7 @@ mod data;
 mod directory;
 mod dispatch;
 mod document;
+mod font;
 mod layout;
 mod markdown;
 pub(crate) mod process;

--- a/src/preview/tests/fonts.rs
+++ b/src/preview/tests/fonts.rs
@@ -1,0 +1,116 @@
+use super::*;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn font_preview_uses_metadata_details_instead_of_binary_placeholder() {
+    let root = temp_path("font-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    for (file_name, detail, expected_format, bytes) in [
+        (
+            "demo.ttf",
+            "TrueType font",
+            "TrueType",
+            &b"\x00\x01\x00\x00rest"[..],
+        ),
+        (
+            "demo.otf",
+            "OpenType font",
+            "OpenType (CFF)",
+            &b"OTTOrest"[..],
+        ),
+        (
+            "demo.woff",
+            "WOFF font",
+            "WOFF (TrueType)",
+            &b"wOFF\x00\x01\x00\x00"[..],
+        ),
+        (
+            "demo.woff2",
+            "WOFF2 font",
+            "WOFF2 (TrueType)",
+            &b"wOF2\x00\x01\x00\x00"[..],
+        ),
+    ] {
+        let path = root.join(file_name);
+        fs::write(&path, bytes).expect("failed to write font fixture");
+
+        let preview = build_preview(&file_entry(path));
+        let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+        assert_eq!(preview.kind, PreviewKind::Font);
+        assert_eq!(preview.section_label(), "Font");
+        assert_eq!(preview.detail.as_deref(), Some(detail));
+        assert_eq!(line_texts.first().map(String::as_str), Some("Details"));
+        assert!(
+            line_texts
+                .iter()
+                .any(|line| line.contains("Format") && line.contains(expected_format))
+        );
+        assert!(line_texts.iter().any(|line| line.contains("File Size")));
+        assert!(
+            line_texts
+                .iter()
+                .all(|line| !line.contains("Binary or unsupported file"))
+        );
+        assert!(
+            line_texts
+                .iter()
+                .all(|line| !line.contains("No text preview available"))
+        );
+        assert!(
+            line_texts
+                .iter()
+                .all(|line| !line.contains("Loading preview"))
+        );
+    }
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn font_loading_preview_stays_silent() {
+    let root = temp_path("font-loading");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("demo.ttf");
+    fs::write(&path, b"\x00\x01\x00\x00rest").expect("failed to write font fixture");
+
+    let preview = loading_preview_for(&file_entry(path), &PreviewRequestOptions::Default);
+
+    assert_eq!(preview.kind, PreviewKind::Font);
+    assert_eq!(preview.section_label(), "Font");
+    assert_eq!(preview.detail.as_deref(), Some("TrueType font"));
+    assert!(preview.lines.is_empty());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+#[cfg(unix)]
+fn protected_font_preview_reports_permission_denied() {
+    // Skip when running as root (e.g. FreeBSD CI) — root bypasses chmod 000.
+    if unsafe { libc::getuid() } == 0 {
+        return;
+    }
+
+    let root = temp_path("protected-font-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("secret.ttf");
+    fs::write(&path, b"\x00\x01\x00\x00rest").expect("failed to write font fixture");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).expect("failed to lock file");
+
+    let preview = build_preview(&file_entry(path.clone()));
+
+    assert_eq!(preview.kind, PreviewKind::Unavailable);
+    assert_eq!(preview.detail.as_deref(), Some("Permission denied"));
+    assert!(
+        preview
+            .lines
+            .iter()
+            .any(|line| line_text(line).contains("permission"))
+    );
+
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("failed to unlock file");
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}

--- a/src/preview/tests/fonts.rs
+++ b/src/preview/tests/fonts.rs
@@ -54,6 +54,7 @@ fn font_preview_uses_metadata_details_instead_of_binary_placeholder() {
                 .iter()
                 .all(|line| !line.contains("Binary or unsupported file"))
         );
+        assert!(line_texts.iter().all(|line| !line.contains("PostScript")));
         assert!(
             line_texts
                 .iter()

--- a/src/preview/tests/mod.rs
+++ b/src/preview/tests/mod.rs
@@ -19,6 +19,7 @@ mod binaries;
 mod code;
 mod data;
 mod documents;
+mod fonts;
 mod helpers;
 mod images;
 mod markdown;

--- a/src/preview/types.rs
+++ b/src/preview/types.rs
@@ -56,6 +56,7 @@ pub(crate) enum PreviewKind {
     Data,
     Directory,
     Document,
+    Font,
     Image,
     Video,
     Markdown,
@@ -74,6 +75,7 @@ impl PreviewKind {
             Self::Data => "Data",
             Self::Directory => "Contents",
             Self::Document => "Document",
+            Self::Font => "Font",
             Self::Image => "Image",
             Self::Video => "Video",
             Self::Markdown => "Markdown",
@@ -89,6 +91,7 @@ impl PreviewKind {
             Self::Audio
                 | Self::Comic
                 | Self::Document
+                | Self::Font
                 | Self::Image
                 | Self::Video
                 | Self::Text

--- a/src/ui/theme/appearance/tests/classification.rs
+++ b/src/ui/theme/appearance/tests/classification.rs
@@ -218,6 +218,22 @@ fn type_labels_cover_supported_special_files() {
         specific_type_label(Path::new("app.jar"), EntryKind::File),
         Some("Java archive")
     );
+    assert_eq!(
+        specific_type_label(Path::new("JetBrainsMono.ttf"), EntryKind::File),
+        Some("TrueType font")
+    );
+    assert_eq!(
+        specific_type_label(Path::new("RedHatText.otf"), EntryKind::File),
+        Some("OpenType font")
+    );
+    assert_eq!(
+        specific_type_label(Path::new("KaTeX_Main.woff"), EntryKind::File),
+        Some("WOFF font")
+    );
+    assert_eq!(
+        specific_type_label(Path::new("FiraSans.woff2"), EntryKind::File),
+        Some("WOFF2 font")
+    );
 }
 
 #[test]
@@ -341,5 +357,21 @@ fn builtin_classification_covers_new_special_file_types() {
     assert_eq!(
         builtin_classify_path(Path::new("setup.exe"), EntryKind::File),
         FileClass::File
+    );
+    assert_eq!(
+        builtin_classify_path(Path::new("JetBrainsMono.ttf"), EntryKind::File),
+        FileClass::Font
+    );
+    assert_eq!(
+        builtin_classify_path(Path::new("RedHatText.otf"), EntryKind::File),
+        FileClass::Font
+    );
+    assert_eq!(
+        builtin_classify_path(Path::new("KaTeX_Main.woff"), EntryKind::File),
+        FileClass::Font
+    );
+    assert_eq!(
+        builtin_classify_path(Path::new("FiraSans.woff2"), EntryKind::File),
+        FileClass::Font
     );
 }


### PR DESCRIPTION
## Summary

Add dedicated metadata previews for common font formats so Elio shows useful font details instead of the generic binary fallback.

## What Changed

- Added a dedicated font preview path for `.ttf`, `.otf`, `.woff`, and `.woff2` files, including a `Font` preview kind and silent loading state.
- Added format-specific font type labels and a compact `Details` section with normalized metadata such as Family, Style, Format, optional Monospace/Variable flags, and File Size.
- Used `fc-scan` opportunistically for richer metadata when available while keeping a safe header-based fallback and preserving normal read-error handling.
- Added regression coverage for font classification, metadata rendering, silent loading behavior, and permission-denied previews.

## User Impact

Selecting supported font files now shows a fast, simple font metadata preview instead of `No text preview available` / `Binary or unsupported file`.

## Notes

This keeps the dependency footprint unchanged. Font previews still work without `fc-scan`, but show richer metadata when it is available.

Style values are normalized to the primary name so localized alias lists do not overwhelm the preview.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified locally on Linux with a variety of real `.ttf`, `.otf`, `.woff`, and `.woff2` files.
- Expanded manual coverage with additional downloaded font files to exercise more naming and metadata variants.
- Confirmed previews render quickly and the displayed metadata values looked correct across the tested files.

Result:

- All automated checks passed locally.
- Manual verification confirmed the new font previews are fast, useful, and visually clean.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
