### PR TITLE
fix(ui): align compact browser metadata columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a dedicated QML file icon in the built-in browser theme.
 - Added metadata previews for TrueType, OpenType, WOFF, and WOFF2 font files, replacing the generic binary fallback.
 
+### Fixed
+
+- Fixed compact file browser rows so folder item counts and file sizes stay visually aligned across singular/plural counts and differing size units.
+
 ## [1.1.0] - 2026-04-18
 
 ### Added

--- a/src/app/directory_counts.rs
+++ b/src/app/directory_counts.rs
@@ -3,7 +3,12 @@ use std::path::Path;
 
 impl App {
     pub(crate) fn directory_item_count_label(&self, entry: &Entry) -> Option<String> {
-        self.directory_item_count(entry).map(format_item_count)
+        self.directory_item_count_value(entry)
+            .map(format_item_count)
+    }
+
+    pub(crate) fn directory_item_count_value(&self, entry: &Entry) -> Option<usize> {
+        self.directory_item_count(entry)
     }
 
     pub(super) fn cache_directory_item_count(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -32,7 +32,8 @@ pub use self::state::App;
 pub use self::state::PreviewMetricsSnapshot;
 pub(crate) use crate::core::FileClass;
 pub(crate) use crate::fs::{
-    format_item_count, format_size, format_time_ago, rect_contains, sanitize_terminal_text,
+    format_item_count, format_size, format_size_parts, format_time_ago, rect_contains,
+    sanitize_terminal_text,
 };
 
 pub(crate) use self::types::ClipOp;

--- a/src/fs/format.rs
+++ b/src/fs/format.rs
@@ -1,6 +1,8 @@
 use ratatui::layout::Rect;
 use std::{io, time::SystemTime};
 
+const SIZE_UNITS: [&str; 7] = ["B", "kB", "MB", "GB", "TB", "PB", "EB"];
+
 pub(crate) fn rect_contains(rect: Rect, x: u16, y: u16) -> bool {
     x >= rect.x
         && x < rect.x.saturating_add(rect.width)
@@ -9,14 +11,18 @@ pub(crate) fn rect_contains(rect: Rect, x: u16, y: u16) -> bool {
 }
 
 pub(crate) fn format_size(size: u64) -> String {
-    const UNITS: [&str; 5] = ["B", "kB", "MB", "GB", "TB"];
+    let (quantity, unit) = format_size_parts(size);
+    format!("{quantity} {unit}")
+}
+
+pub(crate) fn format_size_parts(size: u64) -> (String, &'static str) {
     if size < 1000 {
-        return format!("{} B", format_with_grouping(size));
+        return (format_with_grouping(size), SIZE_UNITS[0]);
     }
 
     let mut value = size as f64;
     let mut unit = 0usize;
-    while value >= 1000.0 && unit < UNITS.len() - 1 {
+    while value >= 1000.0 && unit < SIZE_UNITS.len() - 1 {
         value /= 1000.0;
         unit += 1;
     }
@@ -28,7 +34,7 @@ pub(crate) fn format_size(size: u64) -> String {
     } else {
         0
     };
-    format!("{} {}", format_decimal(value, precision), UNITS[unit])
+    (format_decimal(value, precision), SIZE_UNITS[unit])
 }
 
 pub(crate) fn format_item_count(count: usize) -> String {
@@ -115,6 +121,8 @@ mod tests {
         assert_eq!(format_size(2_048), "2.05 kB");
         assert_eq!(format_size(5_488), "5.49 kB");
         assert_eq!(format_size(12_345_678), "12.3 MB");
+        assert_eq!(format_size(1_000_000_000_000_000), "1 PB");
+        assert_eq!(format_size(u64::MAX), "18.4 EB");
     }
 
     #[test]

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -41,8 +41,8 @@ pub(crate) use directory::{
 };
 pub(crate) use directory_stats::{DirectoryStats, DirectoryStatsScanResult, scan_directory_stats};
 pub(crate) use format::{
-    describe_io_error, format_item_count, format_size, format_time_ago, rect_contains,
-    sanitize_terminal_text,
+    describe_io_error, format_item_count, format_size, format_size_parts, format_time_ago,
+    rect_contains, sanitize_terminal_text,
 };
 pub(crate) use item_count::count_directory_items;
 pub(crate) use places::{build_sidebar_rows, home_dir, trash_dir};

--- a/src/ui/browser/entries.rs
+++ b/src/ui/browser/entries.rs
@@ -1,7 +1,7 @@
 use super::super::theme::Palette;
 use super::super::{helpers, theme};
 use super::{grid::render_grid, list::render_list};
-use crate::app::{App, ClipOp, Entry, FrameState, format_size, format_time_ago};
+use crate::app::{App, ClipOp, Entry, FrameState, format_size, format_size_parts, format_time_ago};
 use ratatui::{
     Frame,
     layout::Rect,
@@ -87,7 +87,7 @@ pub(super) fn render_compact_list_row(
     const COMPACT_PREFIX_WIDTH: usize = 4;
     const COMPACT_NAME_MIN_WIDTH: usize = 18;
     const COMPACT_NAME_SOFT_MAX_WIDTH: usize = 56;
-    const COMPACT_DETAIL_SLOT_WIDTH: usize = 9;
+    const COMPACT_DETAIL_SLOT_WIDTH: usize = 10;
     const COMPACT_MODIFIED_SLOT_WIDTH: usize = 10;
     const COMPACT_METADATA_LEADING_GAP: usize = 2;
     const COMPACT_METADATA_COLUMN_GAP: usize = 1;
@@ -124,7 +124,8 @@ pub(super) fn render_compact_list_row(
     let muted_style = Style::default().fg(palette.muted);
     let available_width = row_width.saturating_sub(COMPACT_PREFIX_WIDTH as u16).max(1) as usize;
     let min_name_width = available_width.min(COMPACT_NAME_MIN_WIDTH);
-    let detail_text = browser_entry_detail(app, entry).unwrap_or_default();
+    let detail_text =
+        compact_browser_entry_detail(app, entry, COMPACT_DETAIL_SLOT_WIDTH).unwrap_or_default();
     let detail_slot_width = if detail_text.is_empty() {
         0
     } else {
@@ -193,10 +194,7 @@ pub(super) fn render_compact_list_row(
     ];
     if show_detail {
         spans.push(Span::raw(if show_modified { "   " } else { "  " }));
-        spans.push(Span::styled(
-            pad_left(detail_text, detail_slot_width),
-            muted_style,
-        ));
+        spans.push(Span::styled(detail_text, muted_style));
     }
     if show_modified {
         spans.push(Span::raw(if show_detail { " " } else { "  " }));
@@ -224,4 +222,84 @@ fn pad_right(text: String, width: usize) -> String {
         return helpers::clamp_label(&text, width);
     }
     format!("{text}{}", " ".repeat(width - visible))
+}
+
+fn compact_browser_entry_detail(app: &App, entry: &Entry, width: usize) -> Option<String> {
+    if entry.is_dir() {
+        app.directory_item_count_value(entry)
+            .map(|count| format_compact_directory_count(count, width))
+    } else {
+        Some(format_compact_file_size(entry.size, width))
+    }
+}
+
+fn format_compact_directory_count(count: usize, width: usize) -> String {
+    const NOUN_WIDTH: usize = 5;
+    let quantity_width = width.saturating_sub(NOUN_WIDTH + 1);
+    let quantity = format_compact_directory_quantity(count, quantity_width);
+    let noun = if count == 1 { "item" } else { "items" };
+    format_compact_measure(quantity, noun, width, NOUN_WIDTH)
+}
+
+fn format_compact_directory_quantity(count: usize, width: usize) -> String {
+    let exact = count.to_string();
+    if helpers::display_width(&exact) <= width {
+        return exact;
+    }
+
+    for (divisor, suffix) in [
+        (1_000_000_000_000usize, "T"),
+        (1_000_000_000usize, "B"),
+        (1_000_000usize, "M"),
+        (1_000usize, "K"),
+    ] {
+        if count < divisor {
+            continue;
+        }
+
+        let whole = count / divisor;
+        if whole < 10 && width >= 4 {
+            let tenth = (count % divisor) * 10 / divisor;
+            if tenth > 0 {
+                let decimal = format!("{whole}.{tenth}{suffix}");
+                if helpers::display_width(&decimal) <= width {
+                    return decimal;
+                }
+            }
+        }
+
+        let compact = format!("{whole}{suffix}");
+        if helpers::display_width(&compact) <= width {
+            return compact;
+        }
+    }
+
+    helpers::clamp_label(&exact, width)
+}
+
+fn format_compact_file_size(size: u64, width: usize) -> String {
+    const UNIT_WIDTH: usize = 2;
+
+    let (quantity, unit) = format_size_parts(size);
+    format_compact_measure(quantity, unit, width, UNIT_WIDTH)
+}
+
+fn format_compact_measure(
+    quantity: String,
+    suffix: &str,
+    width: usize,
+    suffix_width: usize,
+) -> String {
+    if width <= suffix_width + 1 {
+        return helpers::clamp_label(&format!("{quantity} {suffix}"), width);
+    }
+
+    let quantity_width = width - suffix_width - 1;
+    let quantity = if helpers::display_width(&quantity) > quantity_width {
+        helpers::clamp_label(&quantity, quantity_width)
+    } else {
+        pad_left(quantity, quantity_width)
+    };
+
+    format!("{quantity} {}", pad_right(suffix.to_string(), suffix_width))
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1613,3 +1613,128 @@ fn compact_list_rows_align_file_and_directory_metadata_columns() {
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
+
+#[test]
+fn compact_list_rows_align_directory_count_nouns_for_singular_and_plural() {
+    let root = temp_path("compact-list-directory-count-alignment");
+    let single = root.join("single");
+    let many = root.join("many");
+    fs::create_dir_all(&single).expect("failed to create single dir");
+    fs::create_dir_all(&many).expect("failed to create many dir");
+    fs::write(single.join("child-0.txt"), "x").expect("failed to write single child");
+    for index in 0..10 {
+        fs::write(many.join(format!("child-{index}.txt")), "x")
+            .expect("failed to write many child");
+    }
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    let mut terminal = Terminal::new(TestBackend::new(90, 24)).expect("terminal should init");
+    draw_ui(&mut terminal, &mut app);
+    wait_for_directory_counts(&mut app);
+
+    let single_entry = app
+        .navigation
+        .entries
+        .iter()
+        .find(|entry| entry.path == single)
+        .expect("single entry should be present");
+    let many_entry = app
+        .navigation
+        .entries
+        .iter()
+        .find(|entry| entry.path == many)
+        .expect("many entry should be present");
+
+    let single_row = line_text(&render_compact_list_row(
+        &app,
+        single_entry,
+        true,
+        90,
+        theme::palette(),
+    ));
+    let many_row = line_text(&render_compact_list_row(
+        &app,
+        many_entry,
+        true,
+        90,
+        theme::palette(),
+    ));
+
+    let single_item_index = single_row
+        .find("item")
+        .expect("single row should show singular item count");
+    let many_item_index = many_row
+        .find("items")
+        .expect("many row should show plural item count");
+    let single_item_column = helpers::display_width(&single_row[..single_item_index]);
+    let many_item_column = helpers::display_width(&many_row[..many_item_index]);
+
+    assert_eq!(
+        single_item_column, many_item_column,
+        "expected singular and plural directory counts to align, got single={single_row:?} many={many_row:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn compact_list_rows_align_file_size_units_for_small_and_large_sizes() {
+    let root = temp_path("compact-list-file-size-alignment");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let small_path = root.join("small.bin");
+    let large_path = root.join("large.bin");
+    let small_file = fs::File::create(&small_path).expect("failed to create small file");
+    small_file.set_len(68).expect("failed to size small file");
+    let large_file = fs::File::create(&large_path).expect("failed to create large file");
+    large_file
+        .set_len(3_720)
+        .expect("failed to size large file");
+
+    let app = App::new_at(root.clone()).expect("app should load temp directory");
+    let small_entry = app
+        .navigation
+        .entries
+        .iter()
+        .find(|entry| entry.path == small_path)
+        .expect("small entry should be present");
+    let large_entry = app
+        .navigation
+        .entries
+        .iter()
+        .find(|entry| entry.path == large_path)
+        .expect("large entry should be present");
+
+    let small_row = line_text(&render_compact_list_row(
+        &app,
+        small_entry,
+        true,
+        90,
+        theme::palette(),
+    ));
+    let large_row = line_text(&render_compact_list_row(
+        &app,
+        large_entry,
+        true,
+        90,
+        theme::palette(),
+    ));
+
+    let small_unit_index = small_row
+        .rfind(" B ")
+        .map(|index| index + 1)
+        .expect("small row should show byte unit");
+    let large_unit_index = large_row
+        .rfind(" kB")
+        .map(|index| index + 1)
+        .expect("large row should show kilobyte unit");
+    let small_unit_column = helpers::display_width(&small_row[..small_unit_index]);
+    let large_unit_column = helpers::display_width(&large_row[..large_unit_index]);
+
+    assert_eq!(
+        small_unit_column, large_unit_column,
+        "expected small and large file size units to align, got small={small_row:?} large={large_row:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}


### PR DESCRIPTION
## Summary

Align compact file browser metadata so directory counts and file sizes render as stable quantity-and-suffix columns instead of shifting when singular/plural text or size units change.

## What Changed

- Reworked compact browser metadata rendering to format directory counts and file sizes as structured quantity and suffix cells.
- Added compact formatting helpers for directory counts and file sizes, including large-value handling for counts and extended size units through `EB`.
- Added regression tests covering singular/plural count alignment, file-size unit alignment, and existing compact-row column behavior.
- Added a changelog entry for the user-visible browser alignment fix.

## User Impact

Compact browser rows keep folder counts and file sizes visually aligned across singular/plural counts, different size units, and varying terminal zoom/font settings.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified the compact browser metadata layout locally across different terminal zoom levels and font sizes.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed