### PR TITLE
bumping lofty dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Konsole inline image preview support with a dedicated backend and conservative popup clearing to avoid preview artifacts.
 
+### Fixed
+
+- Fixed `cargo install elio` from crates.io by upgrading `lofty` from the yanked `0.23` series to `0.24`. Thanks @jprobichaud for catching this in #66.
+
 ## [1.2.0] - 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0c107dba5af049cf1c36b646fc1ba0cd2705f40d766d2c4c64f1b797c5fbed"
+checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
 dependencies = [
  "byteorder",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elio"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.93"
 description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support."
@@ -22,7 +22,7 @@ flate2 = { version = "1.1", default-features = false, features = ["rust_backend"
 image = { version = "0.25", default-features = false, features = ["gif", "ico", "jpeg", "png", "webp"] }
 notify = "8.2"
 json5 = "0.4"
-lofty = "0.23"
+lofty = "0.24"
 pulldown-cmark = "0.13"
 quick-xml = "0.38"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "crossterm_0_29"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elio"
-version = "1.2.1"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support."


### PR DESCRIPTION
## Summary

The package in crates.io use a yanked dependency, bumping

## What Changed

lofty 0.23 -> 0.24