### PR TITLE
feat(preview): add isolated Konsole image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Konsole inline image preview support with a dedicated backend and conservative popup clearing to avoid preview artifacts.
+
 ## [1.2.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ Inline visual previews, including images, covers, thumbnails, and rendered pages
 | [Warp](https://www.warp.dev/) | Kitty Graphics Protocol | ✓ Auto-detected |
 | [WezTerm](https://wezfurlong.org/wezterm/) | iTerm2 Inline Protocol | ✓ Auto-detected |
 | [iTerm2](https://iterm2.com/) | iTerm2 Inline Protocol | ✓ Auto-detected |
+| [Konsole](https://konsole.kde.org/) | Kitty-based image protocol | ✓ Auto-detected |
 | [foot](https://codeberg.org/dnkl/foot) | Sixel | ✓ Auto-detected |
 | [Windows Terminal](https://github.com/microsoft/terminal) | Sixel | ✓ Auto-detected |
 | Alacritty | — | Not supported |
 | Other | Kitty Graphics Protocol | Set `ELIO_IMAGE_PREVIEWS=1` to enable |
 
 > Sixel terminals can render large or first-time previews more slowly than Kitty Graphics or iTerm2 Inline backends.
+>
+> In Konsole, inline previews are temporarily cleared while modal popups are open to avoid rendering artifacts.
 
 Useful environment variables:
 

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -243,6 +243,40 @@ mod tests {
     }
 
     #[test]
+    fn konsole_png_overlay_uses_source_path_for_direct_display() {
+        let (mut app, root, image_path) =
+            build_selected_static_image_app("konsole-direct-source", "demo.png");
+        app.preview.terminal_images.protocol = ImageProtocol::KonsoleGraphics;
+        let request = ready_static_image_overlay(&mut app);
+        let key = StaticImageKey::from_request(&request);
+
+        match app.prepared_static_image_for_overlay(&request) {
+            StaticImageOverlayPreparation::Ready(prepared) => {
+                assert_eq!(prepared.display_path, image_path);
+                assert_eq!(
+                    prepared.dimensions,
+                    RenderedImageDimensions {
+                        width_px: 600,
+                        height_px: 300,
+                    }
+                );
+                assert!(prepared.inline_payload.is_none());
+            }
+            StaticImageOverlayPreparation::Pending => {
+                panic!("png source path should display directly in Konsole")
+            }
+            StaticImageOverlayPreparation::Failed => {
+                panic!("png source path should not fail direct Konsole display")
+            }
+        }
+
+        assert!(app.preview.image.dimensions.contains_key(&key));
+        assert!(!app.preview.image.pending_prepares.contains(&key));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
     fn cached_rendered_overlay_reuses_cached_path_and_inline_payload() {
         let (mut app, root, image_path) =
             build_selected_static_image_app("cache-reuse", "demo.png");
@@ -633,6 +667,26 @@ mod tests {
     }
 
     #[test]
+    fn konsole_resize_does_not_request_full_screen_clear() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("konsole-resize-no-clear", "demo.png");
+        let request = ready_static_image_overlay(&mut app);
+        app.preview.terminal_images.protocol = ImageProtocol::KonsoleGraphics;
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+            &request,
+            request.area,
+            request.area,
+        ));
+
+        app.handle_terminal_image_resize();
+
+        assert!(!app.take_pending_resize_clear());
+        assert!(app.static_image_overlay_displayed());
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
     fn sixel_resize_requests_full_screen_clear_for_displayed_overlay() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("sixel-resize-clear", "demo.png");
@@ -750,6 +804,62 @@ mod tests {
         assert!(
             app.preview.image.displayed_excluded.is_empty(),
             "closing the popup should remove kitty exclusions"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn open_with_overlay_clears_konsole_image_and_closing_it_redraws_it() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("konsole-open-with-clear", "demo.png");
+        app.preview.terminal_images.protocol = ImageProtocol::KonsoleGraphics;
+        app.preview.image.selection_activation_delay = Duration::ZERO;
+        app.sync_image_preview_selection_activation();
+
+        let mut initial = Vec::new();
+        app.present_static_image_overlay(ImageProtocol::KonsoleGraphics, &[], false, &mut initial)
+            .expect("initial Konsole image presentation should succeed");
+        assert!(app.static_image_overlay_displayed());
+
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('O'))))
+            .expect("O should open the open-with overlay");
+        app.input.frame_state.open_with_panel = Some(Rect {
+            x: 4,
+            y: 5,
+            width: 12,
+            height: 4,
+        });
+
+        let cleared = String::from_utf8(
+            app.present_preview_overlay()
+                .expect("opening the open-with overlay should clear the Konsole image"),
+        )
+        .expect("Konsole clear output should be valid utf8");
+        assert!(
+            cleared.contains("\u{1b}_Ga=d,d=I,"),
+            "opening the popup should send a Konsole delete command"
+        );
+        assert!(
+            !app.static_image_overlay_displayed(),
+            "opening the popup should clear the tracked Konsole image"
+        );
+
+        app.overlays.open_with = None;
+        app.input.frame_state.open_with_panel = None;
+
+        let restored = String::from_utf8(
+            app.present_preview_overlay()
+                .expect("closing the open-with overlay should redraw the Konsole image"),
+        )
+        .expect("Konsole redraw output should be valid utf8");
+        assert!(
+            restored.contains("\u{1b}_Ga=T,"),
+            "closing the popup should redraw the Konsole image"
+        );
+        assert!(
+            app.static_image_overlay_displayed(),
+            "closing the popup should restore the tracked Konsole image"
         );
 
         fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -121,7 +121,6 @@ mod tests {
     use crate::app::overlays::inline_image::{
         ImageProtocol, OverlayPresentState, RenderedImageDimensions, TerminalWindowSize,
     };
-    use crossterm::event::{Event, KeyCode, KeyEvent};
     use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
     use ratatui::layout::Rect;
     use std::{
@@ -768,8 +767,7 @@ mod tests {
             .expect("initial static image presentation should succeed");
         assert!(app.preview.image.displayed_excluded.is_empty());
 
-        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('O'))))
-            .expect("O should open the open-with overlay");
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
         let popup = Rect {
             x: 4,
             y: 5,
@@ -822,8 +820,7 @@ mod tests {
             .expect("initial Konsole image presentation should succeed");
         assert!(app.static_image_overlay_displayed());
 
-        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('O'))))
-            .expect("O should open the open-with overlay");
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
         app.input.frame_state.open_with_panel = Some(Rect {
             x: 4,
             y: 5,

--- a/src/app/overlays/images/present.rs
+++ b/src/app/overlays/images/present.rs
@@ -256,10 +256,10 @@ impl App {
         dimensions: RenderedImageDimensions,
         window_size: TerminalWindowSize,
     ) -> Rect {
-        // Kitty fills the entire cell area and lets the terminal handle scaling
-        // via unicode placeholders, so no fitting is needed.  iTerm2 and Sixel
-        // both paint pixel buffers and need a cell area that matches the image's
-        // aspect ratio so the encoder can produce the correct pixel dimensions.
+        // Kitty unicode placeholders fill the entire cell area and let the
+        // terminal handle scaling, so no fitting is needed. Konsole direct
+        // placements, iTerm2, and Sixel all need a cell area that already
+        // matches the image's aspect ratio.
         if self.preview.terminal_images.protocol == ImageProtocol::KittyGraphics {
             request.area
         } else {

--- a/src/app/overlays/images/state.rs
+++ b/src/app/overlays/images/state.rs
@@ -138,8 +138,10 @@ impl App {
         &self,
         request: &StaticImageOverlayRequest,
     ) -> bool {
-        self.preview.terminal_images.protocol == ImageProtocol::KittyGraphics
-            && !request.force_render_to_cache
+        matches!(
+            self.preview.terminal_images.protocol,
+            ImageProtocol::KittyGraphics | ImageProtocol::KonsoleGraphics
+        ) && !request.force_render_to_cache
             && static_image_format_for_overlay_request(request) == Some(StaticImageFormat::Png)
     }
 
@@ -148,7 +150,9 @@ impl App {
         request: &StaticImageOverlayRequest,
     ) -> bool {
         match self.preview.terminal_images.protocol {
-            ImageProtocol::KittyGraphics => self.static_image_can_display_directly_now(request),
+            ImageProtocol::KittyGraphics | ImageProtocol::KonsoleGraphics => {
+                self.static_image_can_display_directly_now(request)
+            }
             ImageProtocol::ItermInline => static_image_supports_iterm_source_passthrough(request),
             // Sixel requires decoding and re-encoding the image, so the source path
             // can never be used directly — always go through the prepare pipeline.

--- a/src/app/overlays/inline_image/konsole.rs
+++ b/src/app/overlays/inline_image/konsole.rs
@@ -1,0 +1,189 @@
+use anyhow::{Context, Result};
+use base64::Engine as _;
+use ratatui::layout::Rect;
+use std::{
+    fs::File,
+    io::{Read, Write as _},
+    path::Path,
+};
+
+pub(super) fn place_terminal_image_with_konsole_protocol(
+    path: &Path,
+    area: Rect,
+) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    let _ = write!(
+        out,
+        "\x1b[{};{}H",
+        area.y.saturating_add(1),
+        area.x.saturating_add(1)
+    );
+    out.extend(build_konsole_upload_sequence(
+        path,
+        konsole_image_id(),
+        area,
+    )?);
+    Ok(out)
+}
+
+pub(super) fn clear_terminal_images_with_konsole_protocol() -> Result<Vec<u8>> {
+    Ok(build_konsole_clear_sequence(konsole_image_id())
+        .as_bytes()
+        .to_vec())
+}
+
+fn build_konsole_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec<u8>> {
+    let mut file = File::open(path)
+        .with_context(|| format!("failed to open Konsole preview image {}", path.display()))?;
+    let total = file
+        .metadata()
+        .with_context(|| format!("failed to stat Konsole preview image {}", path.display()))?
+        .len() as usize;
+    if total == 0 {
+        anyhow::bail!("Konsole preview image {} is empty", path.display());
+    }
+
+    let mut sent = 0usize;
+    let mut chunk = vec![0u8; 3 * 4096 / 4];
+    let mut out = Vec::new();
+    while sent < total {
+        let remaining = total.saturating_sub(sent);
+        let chunk_len = remaining.min(chunk.len());
+        file.read_exact(&mut chunk[..chunk_len])
+            .with_context(|| format!("failed to read Konsole preview image {}", path.display()))?;
+        sent += chunk_len;
+        let more = sent < total;
+        let payload = base64::engine::general_purpose::STANDARD.encode(&chunk[..chunk_len]);
+        if sent == chunk_len {
+            write!(
+                out,
+                "\u{1b}_Ga=T,q=2,f=100,i={id},p=1,c={},r={},C=1,m={};{payload}\u{1b}\\",
+                area.width.max(1),
+                area.height.max(1),
+                if more { 1 } else { 0 },
+            )?;
+        } else {
+            write!(
+                out,
+                "\u{1b}_Gm={};{payload}\u{1b}\\",
+                if more { 1 } else { 0 },
+            )?;
+        }
+    }
+    Ok(out)
+}
+
+fn build_konsole_clear_sequence(id: u32) -> String {
+    format!("\u{1b}_Ga=d,d=I,i={id},p=1,q=2\u{1b}\\")
+}
+
+fn konsole_image_id() -> u32 {
+    std::process::id() % (0xff_ffff + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+    use image::ImageFormat;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_root(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-konsole-inline-image-{label}-{unique}"))
+    }
+
+    fn write_test_raster_image(path: &Path, format: ImageFormat, width: u32, height: u32) {
+        let image =
+            image::DynamicImage::ImageRgba8(image::RgbaImage::from_fn(width, height, |x, y| {
+                image::Rgba([(x % 255) as u8, (y % 255) as u8, 0x80, 0xff])
+            }));
+        image
+            .save_with_format(path, format)
+            .expect("test raster image should save");
+    }
+
+    #[test]
+    fn build_konsole_upload_sequence_uses_direct_placement_mode() {
+        let root = temp_root("konsole-upload-sequence");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("demo.png");
+        write_test_raster_image(&path, ImageFormat::Png, 24, 16);
+        let payload = fs::read(&path).expect("png payload should exist");
+        let id = 42_u32;
+        let area = Rect {
+            x: 10,
+            y: 4,
+            width: 30,
+            height: 20,
+        };
+
+        let sequence = String::from_utf8(
+            build_konsole_upload_sequence(&path, id, area)
+                .expect("Konsole upload sequence should build"),
+        )
+        .expect("Konsole upload sequence should be utf8");
+
+        assert!(sequence.starts_with("\u{1b}_G"));
+        assert!(sequence.contains("a=T"));
+        assert!(sequence.contains("q=2"));
+        assert!(sequence.contains("f=100"));
+        assert!(sequence.contains(&format!("i={id}")));
+        assert!(sequence.contains("p=1"));
+        assert!(sequence.contains("c=30"));
+        assert!(sequence.contains("r=20"));
+        assert!(sequence.contains("C=1"));
+        assert!(sequence.contains("m=0"));
+        assert!(!sequence.contains("U=1"));
+        assert!(sequence.contains(&BASE64_STANDARD.encode(payload)));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn place_konsole_terminal_image_prefixes_cursor_move() {
+        let root = temp_root("konsole-cursor-prefix");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("demo.png");
+        write_test_raster_image(&path, ImageFormat::Png, 16, 16);
+
+        let output = String::from_utf8(
+            place_terminal_image_with_konsole_protocol(
+                &path,
+                Rect {
+                    x: 10,
+                    y: 4,
+                    width: 8,
+                    height: 6,
+                },
+            )
+            .expect("Konsole placement should build"),
+        )
+        .expect("Konsole placement should be utf8");
+
+        assert!(output.starts_with("\x1b[5;11H\x1b_G"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn clear_konsole_uses_targeted_delete_sequence() {
+        let sequence = String::from_utf8(
+            clear_terminal_images_with_konsole_protocol()
+                .expect("Konsole clear sequence should build"),
+        )
+        .expect("Konsole clear sequence should be utf8");
+
+        assert_eq!(
+            sequence,
+            format!("\u{1b}_Ga=d,d=I,i={},p=1,q=2\u{1b}\\", konsole_image_id())
+        );
+    }
+}

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -1,6 +1,7 @@
 mod geometry;
 mod iterm;
 mod kitty;
+mod konsole;
 mod protocol;
 mod sixel;
 mod window;
@@ -58,6 +59,7 @@ pub(in crate::app) enum TerminalIdentity {
     Warp,
     WezTerm,
     ITerm2,
+    Konsole,
     Alacritty,
     Foot,
     WindowsTerminal,
@@ -73,6 +75,10 @@ pub(in crate::app) enum ImageProtocol {
     /// Kitty Graphics Protocol (APC `\x1b_G…\x1b\\`). Supported natively by
     /// Kitty, Ghostty, and Warp.
     KittyGraphics,
+    /// Konsole's kitty-based image placement protocol. Unlike
+    /// `KittyGraphics`, this uses direct placements instead of Unicode
+    /// placeholders and therefore needs explicit delete commands.
+    KonsoleGraphics,
     /// iTerm2 inline image protocol (OSC 1337). Used by WezTerm and iTerm2.
     ItermInline,
     /// Sixel graphics protocol (DCS). Used by Windows Terminal (≥ 1.22).
@@ -111,12 +117,15 @@ impl App {
         let image_previews_override = env::var_os("ELIO_IMAGE_PREVIEWS").is_some();
         let protocol = select_image_protocol(identity, image_previews_override);
         preview_log(format_args!(
-            "enable_terminal_image_previews:\n  TERM={}\n  TERM_PROGRAM={}\n  KITTY_WINDOW_ID={}\n  WARP_SESSION_ID={}\n  WT_SESSION={}\n  identity={identity:?}\n  override={image_previews_override}\n  protocol={protocol:?}",
+            "enable_terminal_image_previews:\n  TERM={}\n  TERM_PROGRAM={}\n  KITTY_WINDOW_ID={}\n  WARP_SESSION_ID={}\n  WT_SESSION={}\n  KONSOLE_DBUS_SESSION={}\n  KONSOLE_DBUS_SERVICE={}\n  KONSOLE_DBUS_WINDOW={}\n  identity={identity:?}\n  override={image_previews_override}\n  protocol={protocol:?}",
             env::var("TERM").unwrap_or_default(),
             env::var("TERM_PROGRAM").unwrap_or_default(),
             env::var_os("KITTY_WINDOW_ID").is_some(),
             env::var_os("WARP_SESSION_ID").is_some(),
             env::var_os("WT_SESSION").is_some(),
+            env::var_os("KONSOLE_DBUS_SESSION").is_some(),
+            env::var_os("KONSOLE_DBUS_SERVICE").is_some(),
+            env::var_os("KONSOLE_DBUS_WINDOW").is_some(),
         ));
         self.preview.terminal_images.identity = identity;
         self.preview.terminal_images.protocol = protocol;
@@ -282,6 +291,13 @@ impl App {
         }
 
         let popup_open = self.any_modal_overlay_open();
+        if protocol == ImageProtocol::KonsoleGraphics && popup_open {
+            if self.static_image_overlay_displayed() || self.pdf_overlay_displayed() {
+                return self.clear_preview_overlay();
+            }
+            return Ok(Vec::new());
+        }
+
         if protocol.is_raster()
             && popup_open
             && (self.static_image_overlay_displayed() || self.pdf_overlay_displayed())
@@ -480,6 +496,9 @@ pub(in crate::app) fn place_terminal_image(
         ImageProtocol::KittyGraphics => {
             kitty::place_terminal_image_with_kitty_protocol(path, area, excluded)
         }
+        ImageProtocol::KonsoleGraphics => {
+            konsole::place_terminal_image_with_konsole_protocol(path, area)
+        }
         ImageProtocol::ItermInline => {
             iterm::place_terminal_image_with_iterm_protocol(path, area, inline_payload)
         }
@@ -496,6 +515,7 @@ pub(in crate::app) fn place_terminal_image(
 pub(in crate::app) fn clear_terminal_images(protocol: ImageProtocol) -> Result<Vec<u8>> {
     match protocol {
         ImageProtocol::KittyGraphics => kitty::clear_terminal_images_with_kitty_protocol(),
+        ImageProtocol::KonsoleGraphics => konsole::clear_terminal_images_with_konsole_protocol(),
         // iTerm2 has no clear primitive — the overlay is erased by the next
         // ratatui draw call overwriting the cell region.
         ImageProtocol::ItermInline | ImageProtocol::None => Ok(Vec::new()),

--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -11,6 +11,9 @@ pub(in crate::app) fn detect_terminal_identity() -> TerminalIdentity {
         .unwrap_or_default()
         .to_ascii_lowercase();
     let kitty_window_id = env::var_os("KITTY_WINDOW_ID").is_some();
+    let konsole_dbus = env::var_os("KONSOLE_DBUS_SESSION").is_some()
+        || env::var_os("KONSOLE_DBUS_SERVICE").is_some()
+        || env::var_os("KONSOLE_DBUS_WINDOW").is_some();
 
     if kitty_window_id || term.contains("xterm-kitty") || term_program == "kitty" {
         TerminalIdentity::Kitty
@@ -27,6 +30,10 @@ pub(in crate::app) fn detect_terminal_identity() -> TerminalIdentity {
         || env::var_os("ALACRITTY_SOCKET").is_some()
     {
         TerminalIdentity::Alacritty
+    } else if konsole_dbus {
+        // Konsole exports D-Bus identifiers into child shells so scripts can
+        // address the current window/session.
+        TerminalIdentity::Konsole
     } else if term == "foot" || term == "foot-extra" {
         // Foot sets TERM=foot or TERM=foot-extra and supports Sixel natively.
         TerminalIdentity::Foot
@@ -47,6 +54,7 @@ pub(in crate::app) fn select_image_protocol(
         TerminalIdentity::Kitty => ImageProtocol::KittyGraphics,
         TerminalIdentity::Ghostty => ImageProtocol::KittyGraphics,
         TerminalIdentity::Warp => ImageProtocol::KittyGraphics,
+        TerminalIdentity::Konsole => ImageProtocol::KonsoleGraphics,
         TerminalIdentity::WezTerm | TerminalIdentity::ITerm2 => ImageProtocol::ItermInline,
         // Foot and Windows Terminal ≥ 1.22 both support Sixel graphics.
         TerminalIdentity::Foot | TerminalIdentity::WindowsTerminal => ImageProtocol::Sixel,
@@ -136,6 +144,9 @@ mod tests {
                 "WARP_SESSION_ID",
                 "ALACRITTY_SOCKET",
                 "WT_SESSION",
+                "KONSOLE_DBUS_SESSION",
+                "KONSOLE_DBUS_SERVICE",
+                "KONSOLE_DBUS_WINDOW",
             ];
 
             let saved = VARS
@@ -226,6 +237,55 @@ mod tests {
             select_image_protocol(TerminalIdentity::ITerm2, true),
             ImageProtocol::ItermInline
         );
+    }
+
+    #[test]
+    fn detect_terminal_identity_recognizes_konsole_dbus_session() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
+
+        unsafe {
+            env::set_var("KONSOLE_DBUS_SESSION", "/Sessions/7");
+        }
+
+        assert_eq!(detect_terminal_identity(), TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recognizes_konsole_dbus_service() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
+
+        unsafe {
+            env::set_var("KONSOLE_DBUS_SERVICE", "org.kde.konsole-12345");
+        }
+
+        assert_eq!(detect_terminal_identity(), TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn select_image_protocol_konsole_always_enabled() {
+        assert_eq!(
+            select_image_protocol(TerminalIdentity::Konsole, false),
+            ImageProtocol::KonsoleGraphics
+        );
+        assert_eq!(
+            select_image_protocol(TerminalIdentity::Konsole, true),
+            ImageProtocol::KonsoleGraphics
+        );
+    }
+
+    #[test]
+    fn wezterm_takes_precedence_over_inherited_konsole_markers() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
+
+        unsafe {
+            env::set_var("TERM_PROGRAM", "WezTerm");
+            env::set_var("KONSOLE_DBUS_SESSION", "/Sessions/9");
+        }
+
+        assert_eq!(detect_terminal_identity(), TerminalIdentity::WezTerm);
     }
 
     #[test]

--- a/src/app/overlays/inline_image/sixel.rs
+++ b/src/app/overlays/inline_image/sixel.rs
@@ -397,6 +397,9 @@ mod tests {
                 "WARP_SESSION_ID",
                 "ALACRITTY_SOCKET",
                 "WT_SESSION",
+                "KONSOLE_DBUS_SESSION",
+                "KONSOLE_DBUS_SERVICE",
+                "KONSOLE_DBUS_WINDOW",
             ];
 
             let saved = VARS

--- a/src/app/overlays/pdf/tests/protocols.rs
+++ b/src/app/overlays/pdf/tests/protocols.rs
@@ -71,6 +71,42 @@ fn iterm_inline_protocol_uses_preencoded_payload_without_reading_source() {
 }
 
 #[test]
+fn konsole_protocol_uses_kitty_graphics_sequence_for_pngs() {
+    let root = temp_root("konsole-direct-placement");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("demo.png");
+    write_test_raster_image(&path, ImageFormat::Png, 600, 300);
+
+    let output = String::from_utf8(
+        crate::app::overlays::inline_image::place_terminal_image(
+            crate::app::overlays::inline_image::ImageProtocol::KonsoleGraphics,
+            &path,
+            Rect {
+                x: 2,
+                y: 3,
+                width: 10,
+                height: 4,
+            },
+            &[],
+            None,
+            None,
+        )
+        .expect("Konsole direct placement should build"),
+    )
+    .expect("Konsole placement should be utf8");
+
+    assert!(output.starts_with("\x1b[4;3H\x1b_G"));
+    assert!(output.contains("a=T"));
+    assert!(output.contains("q=2"));
+    assert!(output.contains("c=10"));
+    assert!(output.contains("r=4"));
+    assert!(output.contains("C=1"));
+    assert!(!output.contains("]1337;File=inline=1;"));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn iterm_static_image_requests_prepare_inline_payloads() {
     let (mut app, root) = build_selected_static_image_app("iterm-request", "demo.png");
     configure_iterm_image_support(&mut app);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> 
     let mut app = App::new()?;
 
     // Enable terminal image previews. Detection handles the current policy:
-    // Kitty, Ghostty, Warp, WezTerm, and iTerm2 auto-enable supported image protocols;
+    // Kitty, Ghostty, Warp, WezTerm, iTerm2, and Konsole auto-enable supported
+    // image protocols;
     // ELIO_IMAGE_PREVIEWS=1 force-enables Kitty graphics on otherwise unrecognized terminals.
     // All image bytes are routed through terminal.backend_mut() so they never bypass
     // crossterm and cannot corrupt mouse reporting.


### PR DESCRIPTION
## Summary

Add Konsole inline image preview support through an isolated backend instead of reusing the iTerm2 path.

## What Changed

- Added Konsole terminal detection and a dedicated inline-image backend.
- Implemented Konsole inline previews with explicit clear/redraw handling.
- Clear Konsole previews while modal popups are open to avoid rendering artifacts.
- Added tests for Konsole protocol selection, popup behavior, resize behavior, PDF/image previews, and Konsole-sensitive Sixel test isolation.
- Updated the README and `CHANGELOG.md`.

## User Impact

Konsole users now get inline image previews for supported content, including images, covers, thumbnails, comics, EPUB page images, and rendered PDF pages.

In Konsole, inline previews are temporarily cleared while modal popups are open to avoid rendering artifacts. Existing behavior for Kitty, Ghostty, Warp, WezTerm, iTerm2, foot, and Windows Terminal is unchanged.

## Notes

- Konsole support uses a separate backend instead of the iTerm2 inline path because the shared iTerm2 approach produced Konsole-specific rendering artifacts; isolating it reduces regression risk for existing terminals.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Linux + Konsole
- Tested transparent PNG, PNG, JPEG, WebP, GIF, SVG, PDF, EPUB, CBZ, CBR, MP4, and WEBM previews across multiple files
- Repeated popup open/close over previews
- Resized the terminal while previews were visible
- Compared fast navigation behavior against `v1.2.0` on the same machine
- Verified quitting while a preview was visible

Result:

- All checks passed locally.
- Manual Konsole testing showed correct rendering, no gray-edge/background issue, and no observed regressions in existing preview behavior.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
