### PR TITLE
docs: document SSH usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ Most users do **not** need these, but they can help in edge cases:
 
 ---
 
+## Using elio over SSH
+
+`elio` works well over SSH for navigation, file operations, text and code previews, and terminal-based workflows. Rich visual previews and open actions depend on the local terminal and the remote host.
+
+- Text and code previews work well, including plain text, source code, Markdown, logs, JSON, YAML, TOML, and HTML previewed as source code.
+- Rich visual previews such as images, rendered PDF pages, video thumbnails, album art, SVG previews, and archive extras depend on terminal image protocol support and optional preview tools on the remote machine.
+- Terminal apps chosen through `Open With`, including default terminal app matches, run inside the current SSH session.
+- `Enter`, `o`, fallback system openers, and GUI-style `Open With` entries use the remote host's opener stack, so they may open there, fail, or do nothing useful from an SSH session.
+
+See [Image Previews](#image-previews) and [Optional Preview Tools](#optional-preview-tools).
+
+---
+
 ## Workflow
 
 ### Opening Files


### PR DESCRIPTION
  ## Summary

  Document how `elio` behaves over SSH, including preview limitations and remote opener behavior.

  ## What Changed

  - Added a README section for SSH usage.
  - Clarified that text/code previews and terminal-based workflows work well over SSH.
  - Documented that rich visual previews depend on the local terminal and helper tools on the remote host.
  - Clarified that `Enter`, `o`, fallback system openers, and GUI-style open actions use the remote host's opener stack.

  ## User Impact

  Users running `elio` over SSH have clearer expectations for previews, terminal apps, and external open actions.

  ## Testing

  Docs-only change. Verified README rendering locally.

  ## Documentation and Changelog

  - [x] Updated docs
  - [ ] Added a `CHANGELOG.md` entry for user-visible changes
  - [ ] Docs and changelog are not needed