### PR TITLE
feat(cli): accept startup directory argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional startup directory argument, so `elio <directory>` opens that directory and invalid or non-directory paths return a clear error.
+
 ## [1.3.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Install from crates.io:
 cargo install elio
 ```
 
-`elio` starts in your current working directory by default.
+`elio` starts in your current working directory by default. Pass a directory path to start there instead, for example `elio path/to/directory`.
 
 > [!TIP]
 > Recommended: use a Nerd Font in your terminal so icons display correctly.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Install from crates.io:
 cargo install elio
 ```
 
-`elio` starts in your current working directory.
+`elio` starts in your current working directory by default.
 
 > [!TIP]
 > Recommended: use a Nerd Font in your terminal so icons display correctly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use crossterm::{
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::{
     io::{self, ErrorKind, Write},
+    path::PathBuf,
     process::Command,
     time::{Duration, Instant},
 };
@@ -33,10 +34,18 @@ const WINDOWS_TERMINAL_ACTIVE_POLL_INTERVAL: Duration = Duration::from_millis(24
 const RELATIVE_TIME_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 pub fn run() -> Result<()> {
+    run_at_path(None)
+}
+
+pub fn run_at(cwd: PathBuf) -> Result<()> {
+    run_at_path(Some(cwd))
+}
+
+fn run_at_path(cwd: Option<PathBuf>) -> Result<()> {
     config::initialize();
     ui::theme::initialize();
     let mut terminal = init_terminal()?;
-    let result = run_app(&mut terminal);
+    let result = run_app(&mut terminal, cwd);
     restore_terminal(&mut terminal)?;
     result
 }
@@ -202,8 +211,14 @@ fn keyboard_enhancement_is_unsupported(error: &io::Error) -> bool {
             .contains("Keyboard progressive enhancement not implemented")
 }
 
-fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
-    let mut app = App::new()?;
+fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    cwd: Option<PathBuf>,
+) -> Result<()> {
+    let mut app = match cwd {
+        Some(cwd) => App::new_at(cwd)?,
+        None => App::new()?,
+    };
 
     // Enable terminal image previews. Detection handles the current policy:
     // Kitty, Ghostty, Warp, WezTerm, iTerm2, and Konsole auto-enable supported

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 use anyhow::Result;
-use std::{env, process::ExitCode};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
 
 fn main() -> ExitCode {
     match run() {
@@ -30,6 +34,8 @@ fn run() -> Result<()> {
         [arg, unexpected, ..] if arg == "--help" || arg == "-h" => {
             Err(anyhow::anyhow!(unknown_argument_message(unexpected)))
         }
+        [arg] if arg.starts_with('-') => Err(anyhow::anyhow!(unknown_argument_message(arg))),
+        [arg] => elio::run_at(resolve_startup_directory(arg)?),
         [arg, ..] => Err(anyhow::anyhow!(unknown_argument_message(arg))),
     }
 }
@@ -41,11 +47,35 @@ fn print_version() {
 fn print_help() {
     println!("elio {}", env!("CARGO_PKG_VERSION"));
     println!();
-    println!("Usage: elio [OPTIONS]");
+    println!("Usage: elio [OPTIONS] [DIRECTORY]");
+    println!();
+    println!("Arguments:");
+    println!("  [DIRECTORY]  Start elio in this directory");
     println!();
     println!("Options:");
     println!("  -h, --help     Print help");
     println!("  -V, --version  Print version");
+}
+
+fn resolve_startup_directory(arg: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(arg);
+    let metadata = fs::metadata(&path).map_err(|error| startup_path_error(&path, &error))?;
+    if !metadata.is_dir() {
+        return Err(anyhow::anyhow!(
+            "Cannot open \"{}\": not a directory",
+            path.display()
+        ));
+    }
+    Ok(path.canonicalize().unwrap_or(path))
+}
+
+fn startup_path_error(path: &Path, error: &io::Error) -> anyhow::Error {
+    let detail = match error.kind() {
+        io::ErrorKind::NotFound => "no such file or directory".to_string(),
+        io::ErrorKind::PermissionDenied => "permission denied".to_string(),
+        _ => error.to_string(),
+    };
+    anyhow::anyhow!("Cannot open \"{}\": {detail}", path.display())
 }
 
 fn unknown_argument_message(arg: &str) -> String {
@@ -59,7 +89,78 @@ fn unknown_argument_message(arg: &str) -> String {
         message.push_str("\n\n  tip: a similar argument exists: '--help'");
     }
 
-    message.push_str("\n\nUsage: elio [OPTIONS]");
+    message.push_str("\n\nUsage: elio [OPTIONS] [DIRECTORY]");
     message.push_str("\n\nFor more information, try '--help'.");
     message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_startup_directory;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-main-{label}-{unique}"))
+    }
+
+    #[test]
+    fn resolve_startup_directory_accepts_existing_directory() {
+        let root = temp_path("directory");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+
+        let resolved = resolve_startup_directory(root.to_str().expect("temp path should be utf-8"))
+            .expect("existing directory should resolve");
+
+        assert_eq!(
+            resolved,
+            root.canonicalize()
+                .expect("temp directory should canonicalize successfully")
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn resolve_startup_directory_rejects_missing_path() {
+        let missing = temp_path("missing");
+
+        let error =
+            resolve_startup_directory(missing.to_str().expect("temp path should be valid utf-8"))
+                .expect_err("missing path should return an error");
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Cannot open \"{}\": no such file or directory",
+                missing.display()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_startup_directory_rejects_files() {
+        let root = temp_path("file");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let file = root.join("notes.txt");
+        fs::write(&file, "hello").expect("temp file should be created");
+
+        let error =
+            resolve_startup_directory(file.to_str().expect("temp path should be valid utf-8"))
+                .expect_err("file path should return an error");
+
+        assert_eq!(
+            error.to_string(),
+            format!("Cannot open \"{}\": not a directory", file.display())
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,20 @@
 use std::process::Command;
+use std::{
+    fs,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 fn elio() -> Command {
     Command::new(env!("CARGO_BIN_EXE_elio"))
+}
+
+fn temp_path(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("elio-cli-{label}-{unique}"))
 }
 
 #[test]
@@ -28,7 +41,9 @@ fn help_prints_usage() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Usage: elio [OPTIONS]"));
+    assert!(stdout.contains("Usage: elio [OPTIONS] [DIRECTORY]"));
+    assert!(stdout.contains("Arguments:"));
+    assert!(stdout.contains("[DIRECTORY]  Start elio in this directory"));
     assert!(stdout.contains("-h, --help"));
     assert!(stdout.contains("-V, --version"));
     assert!(output.stderr.is_empty());
@@ -57,4 +72,46 @@ fn extra_argument_after_version_reports_the_extra_argument() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("error: unexpected argument 'extra' found"));
     assert!(!stderr.contains("tip: a similar argument exists"));
+}
+
+#[test]
+fn missing_directory_argument_exits_with_clear_error() {
+    let missing = temp_path("missing");
+
+    let output = elio()
+        .arg(missing.to_str().expect("temp path should be valid utf-8"))
+        .output()
+        .expect("failed to run elio with missing directory");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Cannot open \"{}\": no such file or directory\n",
+            missing.display()
+        )
+    );
+}
+
+#[test]
+fn file_argument_exits_with_not_a_directory_error() {
+    let root = temp_path("file");
+    fs::create_dir_all(&root).expect("temp directory should be created");
+    let file = root.join("notes.txt");
+    fs::write(&file, "hello").expect("temp file should be created");
+
+    let output = elio()
+        .arg(file.to_str().expect("temp path should be valid utf-8"))
+        .output()
+        .expect("failed to run elio with file path");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!("Cannot open \"{}\": not a directory\n", file.display())
+    );
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
 }


### PR DESCRIPTION
## Summary

Support starting `elio` from an optional directory argument.

Closes #71.

## What Changed

- Added an optional `[DIRECTORY]` CLI argument
- Start `elio` in the given directory when it exists
- Return clear errors for missing or non-directory paths
- Updated `--help` output to document the positional argument
- Added CLI tests for valid directories and error cases
- Updated the README and `CHANGELOG.md`

## User Impact

Users can now run `elio <directory>` to start directly in a chosen directory. Invalid or non-directory paths now fail with a clear error instead of being ignored.

## Notes

The behavior is intentionally narrow:

- `elio <directory>` opens that directory
- invalid or non-directory paths return a clear error
- elio does not silently fall back to the current directory when an explicit path was given

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified `cargo run -- --help`
- Verified valid relative and absolute directories, including `.`, `..`, `./src`, `src`, `../elio`, `/tmp`, `/`, and `~/Downloads`
- Verified missing paths return `Cannot open "...": no such file or directory`, including nonexistent relative and absolute paths
- Verified file paths return `Cannot open "...": not a directory`
- Verified directory symlinks open correctly and file symlinks are rejected
- Verified paths with spaces, trailing slashes, and normalized relative paths
- Verified invalid option-like input such as `--v` still reports a CLI error

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
