### PR TITLE
fix(preview): wrap Kitty Graphics APC in tmux DCS passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed inline image and PDF previews not rendering inside tmux when the host terminal uses the Kitty Graphics Protocol (Kitty, Ghostty, Warp), by wrapping the emitted APC sequences in tmux DCS passthrough so tmux relays them to the host terminal. Requires `allow-passthrough on` in tmux.
+- Fixed tmux relaying of Kitty Graphics preview sequences so inline image and PDF previews can render inside tmux when `KittyGraphics` is selected and `allow-passthrough` is enabled. Some tmux setups may still require preserved terminal markers or `ELIO_IMAGE_PREVIEWS=1`. (#74, #70)
 
 ## [1.3.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an optional startup directory argument, so `elio <directory>` opens that directory and invalid or non-directory paths return a clear error.
 
+### Fixed
+
+- Fixed inline image and PDF previews not rendering inside tmux when the host terminal uses the Kitty Graphics Protocol (Kitty, Ghostty, Warp), by wrapping the emitted APC sequences in tmux DCS passthrough so tmux relays them to the host terminal. Requires `allow-passthrough on` in tmux.
+
 ## [1.3.0] - 2026-04-28
 
 ### Added

--- a/src/app/overlays/inline_image/kitty.rs
+++ b/src/app/overlays/inline_image/kitty.rs
@@ -15,11 +15,52 @@ pub(super) fn place_terminal_image_with_kitty_protocol(
     let id = kitty_image_id();
     let mut out = build_kitty_upload_sequence(path, id, area)?;
     out.extend(build_kitty_placeholder_sequence(id, area, excluded));
-    Ok(out)
+    Ok(maybe_wrap_kitty_apcs_for_tmux(out))
 }
 
 pub(super) fn clear_terminal_images_with_kitty_protocol() -> Result<Vec<u8>> {
-    Ok(build_kitty_clear_sequence().as_bytes().to_vec())
+    Ok(maybe_wrap_kitty_apcs_for_tmux(
+        build_kitty_clear_sequence().as_bytes().to_vec(),
+    ))
+}
+
+/// Inside tmux, wrap each Kitty APC sequence in the tmux DCS passthrough
+/// envelope so tmux relays it to the host terminal. CSI sequences and the
+/// Unicode placeholder characters are emitted unchanged. Outside tmux the
+/// input is returned untouched.
+///
+/// Background: tmux's `allow-passthrough on` only forwards DCS sequences with
+/// the `\ePtmux;<seq>\e\\` envelope. Raw APC sequences (`\e_G…\e\\`, used by
+/// the Kitty Graphics Protocol) are swallowed by tmux and never reach the
+/// host terminal — so the host terminal never registers the image and the
+/// Unicode placeholders render as empty cells.
+fn maybe_wrap_kitty_apcs_for_tmux(buf: Vec<u8>) -> Vec<u8> {
+    if std::env::var_os("TMUX").is_none() {
+        return buf;
+    }
+    wrap_kitty_apcs_for_tmux(&buf)
+}
+
+fn wrap_kitty_apcs_for_tmux(buf: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(buf.len() + buf.len() / 4);
+    let mut i = 0;
+    while i < buf.len() {
+        if buf.len() - i >= 3
+            && &buf[i..i + 3] == b"\x1b_G"
+            && let Some(rel) = buf[i + 3..].iter().position(|&b| b == 0x1b)
+            && buf.get(i + 3 + rel + 1) == Some(&b'\\')
+        {
+            let body_end = i + 3 + rel;
+            out.extend_from_slice(b"\x1bPtmux;\x1b\x1b_G");
+            out.extend_from_slice(&buf[i + 3..body_end]);
+            out.extend_from_slice(b"\x1b\x1b\\\x1b\\");
+            i = body_end + 2;
+            continue;
+        }
+        out.push(buf[i]);
+        i += 1;
+    }
+    out
 }
 
 fn build_kitty_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec<u8>> {
@@ -265,5 +306,21 @@ mod tests {
     #[test]
     fn build_kitty_clear_sequence_deletes_visible_images() {
         assert_eq!(build_kitty_clear_sequence(), "\u{1b}_Ga=d,d=A,q=2\u{1b}\\");
+    }
+
+    #[test]
+    fn wrap_kitty_apcs_for_tmux_envelopes_each_apc_and_leaves_csi_alone() {
+        let input =
+            b"\x1b_Ga=T,i=1,c=2,r=2;AAAA\x1b\\\x1b[5;10H\xf4\x8e\xbb\xae\x1b_Gm=0;BBBB\x1b\\";
+        let out = wrap_kitty_apcs_for_tmux(input);
+        let expected: &[u8] = b"\x1bPtmux;\x1b\x1b_Ga=T,i=1,c=2,r=2;AAAA\x1b\x1b\\\x1b\\\x1b[5;10H\xf4\x8e\xbb\xae\x1bPtmux;\x1b\x1b_Gm=0;BBBB\x1b\x1b\\\x1b\\";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn wrap_kitty_apcs_for_tmux_is_noop_without_apcs() {
+        let input = b"\x1b[5;10Hhello\x1b[0m";
+        let out = wrap_kitty_apcs_for_tmux(input);
+        assert_eq!(out, input);
     }
 }


### PR DESCRIPTION
## Summary

Refs #70. Fixes tmux relaying of Kitty Graphics preview sequences so inline image and PDF previews can render inside tmux when `KittyGraphics` is selected and `allow-passthrough` is enabled. Some tmux setups may still require preserved terminal markers or `ELIO_IMAGE_PREVIEWS=1`.

## What Changed

- `src/app/overlays/inline_image/kitty.rs`: wrap each emitted Kitty Graphics APC sequence (`\e_G…\e\\`) in tmux's DCS passthrough envelope (`\ePtmux;\e\e_G…\e\e\\\e\\`) when `$TMUX` is set. Applied to both upload chunks and the clear sequence. CSI cursor positioning and the Unicode placeholder characters are emitted unchanged.
- Two unit tests covering the wrapper: APC-wrapping with mixed CSI in the buffer, and no-op behavior when there are no APCs.

## User Impact

Before this change, running elio inside tmux on a host terminal that supports Kitty Graphics produced empty preview panes (metadata only) for images and PDFs, because tmux silently dropped the raw APC sequences and the host terminal never registered the image referenced by the Unicode placeholders.

After this change, those previews render through tmux as they do outside it. No behavior change outside tmux.

## Notes

- Why DCS, not raw APC: tmux's `allow-passthrough on` only forwards sequences wrapped in the `\ePtmux;<seq>\e\\` DCS envelope; raw APC is not in scope.
- `src/app/overlays/inline_image/konsole.rs` emits the same Kitty-style APC and likely has the same blocker under tmux. I scoped this PR to the path the issue reports (Kitty Graphics on Ghostty); happy to extend it to Konsole in the same PR or a follow-up if you prefer.
- Detection is `std::env::var_os("TMUX").is_some()` evaluated on each emit. Cheap, and stays correct if tmux state changes mid-session.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- OS: Arch Linux (Omarchy)
- Terminal: Ghostty 1.3.1 hosting tmux 3.6a with `allow-passthrough on`
- Verified inline JPG/PNG previews and PDF page previews render under tmux.
- Verified the unmodified non-tmux path (running elio directly in Ghostty) still renders previews.
- Navigated between image, PDF, and non-preview entries to confirm clear/redraw behavior is unaffected.

Note: one pre-existing test in `preview::tests::documents::office::doc_preview_shows_legacy_document_metadata` fails locally regardless of this branch (it asserts a year in a formatted timestamp that crosses a day boundary in non-UTC zones — also fails on a clean checkout of `main` in TZ=America/Mexico_City). Unrelated to this change; CI runs in UTC and passes.

Result: All other checks passed locally.

## Documentation and Changelog

- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Docs and changelog are not needed (only changelog needed; no doc surface affected)
