### PR TITLE
fix(preview): use Kitty direct placement for Warp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Warp inline image and PDF previews by using Kitty direct placement instead of Kitty Unicode placeholders. (#75)
 - Fixed tmux relaying of Kitty Graphics preview sequences so inline image and PDF previews can render inside tmux when `KittyGraphics` is selected and `allow-passthrough` is enabled. Some tmux setups may still require preserved terminal markers or `ELIO_IMAGE_PREVIEWS=1`. (#74, #70)
 
 ## [1.3.0] - 2026-04-28

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ Inline visual previews, including images, covers, thumbnails, and rendered pages
 |---|---|---|
 | [Kitty](https://sw.kovidgoyal.net/kitty/) | Kitty Graphics Protocol | ✓ Auto-detected |
 | [Ghostty](https://ghostty.org/) | Kitty Graphics Protocol | ✓ Auto-detected |
-| [Warp](https://www.warp.dev/) | Kitty Graphics Protocol | ✓ Auto-detected |
+| [Warp](https://www.warp.dev/) | Kitty direct-placement protocol | ✓ Auto-detected |
 | [WezTerm](https://wezfurlong.org/wezterm/) | iTerm2 Inline Protocol | ✓ Auto-detected |
 | [iTerm2](https://iterm2.com/) | iTerm2 Inline Protocol | ✓ Auto-detected |
-| [Konsole](https://konsole.kde.org/) | Kitty-based image protocol | ✓ Auto-detected |
+| [Konsole](https://konsole.kde.org/) | Kitty direct-placement protocol | ✓ Auto-detected |
 | [foot](https://codeberg.org/dnkl/foot) | Sixel | ✓ Auto-detected |
 | [Windows Terminal](https://github.com/microsoft/terminal) | Sixel | ✓ Auto-detected |
 | Alacritty | — | Not supported |

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -245,7 +245,7 @@ mod tests {
     fn konsole_png_overlay_uses_source_path_for_direct_display() {
         let (mut app, root, image_path) =
             build_selected_static_image_app("konsole-direct-source", "demo.png");
-        app.preview.terminal_images.protocol = ImageProtocol::KonsoleGraphics;
+        app.preview.terminal_images.protocol = ImageProtocol::KittyDirectGraphics;
         let request = ready_static_image_overlay(&mut app);
         let key = StaticImageKey::from_request(&request);
 
@@ -670,7 +670,7 @@ mod tests {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("konsole-resize-no-clear", "demo.png");
         let request = ready_static_image_overlay(&mut app);
-        app.preview.terminal_images.protocol = ImageProtocol::KonsoleGraphics;
+        app.preview.terminal_images.protocol = ImageProtocol::KittyDirectGraphics;
         app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
             &request,
             request.area,
@@ -811,13 +811,18 @@ mod tests {
     fn open_with_overlay_clears_konsole_image_and_closing_it_redraws_it() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("konsole-open-with-clear", "demo.png");
-        app.preview.terminal_images.protocol = ImageProtocol::KonsoleGraphics;
+        app.preview.terminal_images.protocol = ImageProtocol::KittyDirectGraphics;
         app.preview.image.selection_activation_delay = Duration::ZERO;
         app.sync_image_preview_selection_activation();
 
         let mut initial = Vec::new();
-        app.present_static_image_overlay(ImageProtocol::KonsoleGraphics, &[], false, &mut initial)
-            .expect("initial Konsole image presentation should succeed");
+        app.present_static_image_overlay(
+            ImageProtocol::KittyDirectGraphics,
+            &[],
+            false,
+            &mut initial,
+        )
+        .expect("initial Konsole image presentation should succeed");
         assert!(app.static_image_overlay_displayed());
 
         app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);

--- a/src/app/overlays/images/state.rs
+++ b/src/app/overlays/images/state.rs
@@ -140,7 +140,7 @@ impl App {
     ) -> bool {
         matches!(
             self.preview.terminal_images.protocol,
-            ImageProtocol::KittyGraphics | ImageProtocol::KonsoleGraphics
+            ImageProtocol::KittyGraphics | ImageProtocol::KittyDirectGraphics
         ) && !request.force_render_to_cache
             && static_image_format_for_overlay_request(request) == Some(StaticImageFormat::Png)
     }
@@ -150,7 +150,7 @@ impl App {
         request: &StaticImageOverlayRequest,
     ) -> bool {
         match self.preview.terminal_images.protocol {
-            ImageProtocol::KittyGraphics | ImageProtocol::KonsoleGraphics => {
+            ImageProtocol::KittyGraphics | ImageProtocol::KittyDirectGraphics => {
                 self.static_image_can_display_directly_now(request)
             }
             ImageProtocol::ItermInline => static_image_supports_iterm_source_passthrough(request),

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -72,13 +72,14 @@ pub(in crate::app) enum TerminalIdentity {
 /// the same protocol without coupling detection logic to rendering logic.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(in crate::app) enum ImageProtocol {
-    /// Kitty Graphics Protocol (APC `\x1b_G…\x1b\\`). Supported natively by
-    /// Kitty, Ghostty, and Warp.
+    /// Kitty Graphics Protocol (APC `\x1b_G…\x1b\\`) using the Unicode
+    /// placeholder extension. Used by Kitty and Ghostty.
     KittyGraphics,
-    /// Konsole's kitty-based image placement protocol. Unlike
-    /// `KittyGraphics`, this uses direct placements instead of Unicode
-    /// placeholders and therefore needs explicit delete commands.
-    KonsoleGraphics,
+    /// Direct-placement variant of the Kitty Graphics Protocol: same APC wire
+    /// format, but without the Unicode placeholder extension. Images are
+    /// positioned with an explicit CSI cursor move and need explicit delete
+    /// commands. Used by Konsole and Warp.
+    KittyDirectGraphics,
     /// iTerm2 inline image protocol (OSC 1337). Used by WezTerm and iTerm2.
     ItermInline,
     /// Sixel graphics protocol (DCS). Used by Windows Terminal (≥ 1.22).
@@ -291,7 +292,7 @@ impl App {
         }
 
         let popup_open = self.any_modal_overlay_open();
-        if protocol == ImageProtocol::KonsoleGraphics && popup_open {
+        if protocol == ImageProtocol::KittyDirectGraphics && popup_open {
             if self.static_image_overlay_displayed() || self.pdf_overlay_displayed() {
                 return self.clear_preview_overlay();
             }
@@ -496,7 +497,7 @@ pub(in crate::app) fn place_terminal_image(
         ImageProtocol::KittyGraphics => {
             kitty::place_terminal_image_with_kitty_protocol(path, area, excluded)
         }
-        ImageProtocol::KonsoleGraphics => {
+        ImageProtocol::KittyDirectGraphics => {
             konsole::place_terminal_image_with_konsole_protocol(path, area)
         }
         ImageProtocol::ItermInline => {
@@ -515,7 +516,9 @@ pub(in crate::app) fn place_terminal_image(
 pub(in crate::app) fn clear_terminal_images(protocol: ImageProtocol) -> Result<Vec<u8>> {
     match protocol {
         ImageProtocol::KittyGraphics => kitty::clear_terminal_images_with_kitty_protocol(),
-        ImageProtocol::KonsoleGraphics => konsole::clear_terminal_images_with_konsole_protocol(),
+        ImageProtocol::KittyDirectGraphics => {
+            konsole::clear_terminal_images_with_konsole_protocol()
+        }
         // iTerm2 has no clear primitive — the overlay is erased by the next
         // ratatui draw call overwriting the cell region.
         ImageProtocol::ItermInline | ImageProtocol::None => Ok(Vec::new()),

--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -53,8 +53,12 @@ pub(in crate::app) fn select_image_protocol(
     match identity {
         TerminalIdentity::Kitty => ImageProtocol::KittyGraphics,
         TerminalIdentity::Ghostty => ImageProtocol::KittyGraphics,
-        TerminalIdentity::Warp => ImageProtocol::KittyGraphics,
-        TerminalIdentity::Konsole => ImageProtocol::KonsoleGraphics,
+        // Warp implements the basic Kitty Graphics transmit-and-place protocol
+        // but not the Unicode placeholder extension that the `KittyGraphics`
+        // path emits (`U=1`). Route Warp through `KittyDirectGraphics`, which uses
+        // direct CSI cursor placement and matches what Warp actually renders.
+        TerminalIdentity::Warp => ImageProtocol::KittyDirectGraphics,
+        TerminalIdentity::Konsole => ImageProtocol::KittyDirectGraphics,
         TerminalIdentity::WezTerm | TerminalIdentity::ITerm2 => ImageProtocol::ItermInline,
         // Foot and Windows Terminal ≥ 1.22 both support Sixel graphics.
         TerminalIdentity::Foot | TerminalIdentity::WindowsTerminal => ImageProtocol::Sixel,
@@ -267,11 +271,11 @@ mod tests {
     fn select_image_protocol_konsole_always_enabled() {
         assert_eq!(
             select_image_protocol(TerminalIdentity::Konsole, false),
-            ImageProtocol::KonsoleGraphics
+            ImageProtocol::KittyDirectGraphics
         );
         assert_eq!(
             select_image_protocol(TerminalIdentity::Konsole, true),
-            ImageProtocol::KonsoleGraphics
+            ImageProtocol::KittyDirectGraphics
         );
     }
 
@@ -292,11 +296,11 @@ mod tests {
     fn select_image_protocol_warp_always_enabled() {
         assert_eq!(
             select_image_protocol(TerminalIdentity::Warp, false),
-            ImageProtocol::KittyGraphics
+            ImageProtocol::KittyDirectGraphics
         );
         assert_eq!(
             select_image_protocol(TerminalIdentity::Warp, true),
-            ImageProtocol::KittyGraphics
+            ImageProtocol::KittyDirectGraphics
         );
     }
 

--- a/src/app/overlays/pdf/tests/protocols.rs
+++ b/src/app/overlays/pdf/tests/protocols.rs
@@ -79,7 +79,7 @@ fn konsole_protocol_uses_kitty_graphics_sequence_for_pngs() {
 
     let output = String::from_utf8(
         crate::app::overlays::inline_image::place_terminal_image(
-            crate::app::overlays::inline_image::ImageProtocol::KonsoleGraphics,
+            crate::app::overlays::inline_image::ImageProtocol::KittyDirectGraphics,
             &path,
             Rect {
                 x: 2,


### PR DESCRIPTION
## Summary

- Routes Warp through the direct-placement variant of the Kitty
  Graphics protocol instead of the Unicode-placeholder variant, fixing
  empty inline image and PDF previews in Warp.
- Renames `ImageProtocol::KonsoleGraphics` to `KittyDirectGraphics`
  to better reflect that the variant is shared between Konsole and
  Warp.
- Updates the README terminal-support table and the CHANGELOG.

Verified locally by @MiguelRegueiro on Warp — image and PDF previews
now render with the same popup/resize behavior as the existing
direct-placement path used for Konsole.

Tmux passthrough for the direct-placement APC is intentionally left
as a follow-up, as discussed in #75.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (908 pass; one pre-existing flake in
      `doc_preview_shows_legacy_document_metadata` unrelated to this
      change)
- [x] `cargo doc --no-deps`
- [x] Manual verification on Warp (Miguel confirmed in #75)

Fixes #75