### PR TITLE
fix(open): use desktop default apps on Linux/BSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Linux/BSD default-app dispatch and Open With MIME detection to prefer GLib's MIME resolution before falling back to `xdg-open` or `xdg-mime`, keeping system default launches aligned with desktop MIME associations.
 - Fixed Warp inline image and PDF previews by using Kitty direct placement instead of Kitty Unicode placeholders. (#75)
 - Fixed tmux relaying of Kitty Graphics preview sequences so inline image and PDF previews can render inside tmux when `KittyGraphics` is selected and `allow-passthrough` is enabled. Some tmux setups may still require preserved terminal markers or `ELIO_IMAGE_PREVIEWS=1`. (#74, #70)
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ See [Image Previews](#image-previews) and [Optional Preview Tools](#optional-pre
 
 ### Opening Files
 
-`Enter` enters folders and opens files with the system default application. `o` always opens the selected file or folder externally using the system launcher: `open` on macOS, `cmd /c start` on Windows, and `xdg-open` or `gio` on Linux and BSD desktop sessions.
+`Enter` enters folders and opens files with the system default application. `o` always opens the selected file or folder externally using the system launcher: `open` on macOS, `cmd /c start` on Windows, and `gio` (with `xdg-open` as fallback) on Linux and BSD desktop sessions.
 
 `O` is for files. On macOS and Linux/BSD desktop sessions, elio discovers matching applications, opens the file directly when there is one match, and shows the Open With chooser when there are multiple. Terminal apps such as `nvim` are supported too. When no match is found, or on platforms without app discovery, elio falls back to the default opener.
 

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -637,6 +637,8 @@ fn rebound_quit_key_sets_should_quit() {
 fn capital_o_opens_open_with_overlay_for_selected_file() {
     let root = temp_path("open-with-overlay-file");
     fs::write(root.join("document.txt"), "hello").expect("failed to write temp file");
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let _capture_guard = OpenInSystemCaptureGuard::install(root.join("open-capture.txt"));
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     wait_for_directory_load(&mut app);

--- a/src/app/open_with/discovery/mime.rs
+++ b/src/app/open_with/discovery/mime.rs
@@ -22,8 +22,23 @@ pub(super) fn detect_mime_type_with_name(
         return None;
     }
 
-    // Slow path: invoke xdg-mime for extensionless or ambiguous files that
-    // need content-based (magic-byte) detection.
+    // Slow path: gio info uses GLib's MIME detection, which agrees with gio open
+    // and handles extensionless or ambiguous files more consistently than
+    // xdg-mime's generic text fallback.
+    let mut cmd = Command::new("gio");
+    cmd.args(["info", "-a", "standard::content-type"]).arg(path);
+    if let Some(out) = run_command_capture_stdout_cancellable(cmd, "open-with-mime-gio", canceled) {
+        let text = String::from_utf8_lossy(&out);
+        if let Some(mime) = parse_gio_content_type(&text) {
+            return Some(mime);
+        }
+    }
+
+    if canceled() {
+        return None;
+    }
+
+    // Fallback: xdg-mime for systems without gio.
     let mut cmd = Command::new("xdg-mime");
     cmd.args(["query", "filetype"]).arg(path);
     if let Some(out) = run_command_capture_stdout_cancellable(cmd, "open-with-mime", canceled) {
@@ -130,6 +145,18 @@ pub(super) fn mime_from_data_dirs(path: &Path, data_dirs: &[PathBuf]) -> Option<
         }
     }
 
+    None
+}
+
+fn parse_gio_content_type(output: &str) -> Option<String> {
+    for line in output.lines() {
+        if let Some(rest) = line.trim().strip_prefix("standard::content-type:") {
+            let mime = rest.trim().to_string();
+            if !mime.is_empty() {
+                return Some(mime);
+            }
+        }
+    }
     None
 }
 
@@ -314,5 +341,30 @@ mod tests {
             Some("image/png"),
             "expected image/png for .png extension"
         );
+    }
+
+    // ── parse_gio_content_type ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_gio_content_type_extracts_mime_from_gio_info_output() {
+        let output = "uri: file:///home/user/Makefile\n\
+                      local path: /home/user/Makefile\n\
+                      attributes:\n\
+                        standard::content-type: text/x-makefile\n";
+        assert_eq!(
+            super::parse_gio_content_type(output).as_deref(),
+            Some("text/x-makefile")
+        );
+    }
+
+    #[test]
+    fn parse_gio_content_type_returns_none_for_missing_attribute() {
+        let output = "uri: file:///home/user/unknown\nattributes:\n";
+        assert!(super::parse_gio_content_type(output).is_none());
+    }
+
+    #[test]
+    fn parse_gio_content_type_handles_empty_output() {
+        assert!(super::parse_gio_content_type("").is_none());
     }
 }

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -341,7 +341,7 @@ pub(crate) fn open_in_system(target: &Path) -> Result<(), String> {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        open_with_unix_backends(target, &[("xdg-open", &[][..]), ("gio", &["open"][..])])
+        open_unix_preferring_gio(target)
     }
 }
 
@@ -360,6 +360,76 @@ fn open_with_unix_backends(target: &Path, backends: &[(&str, &[&str])]) -> Resul
         }
     }
     Err(String::from("No desktop opener available in this session"))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn open_unix_preferring_gio(target: &Path) -> Result<(), String> {
+    open_unix_preferring_gio_impl(target, "gio", "xdg-open")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn open_unix_preferring_gio_impl(target: &Path, gio: &str, xdg_open: &str) -> Result<(), String> {
+    // gio uses GLib MIME detection, which is more consistent with desktop
+    // defaults for extension- and name-based MIME matches than the xdg-open path
+    // in some sessions. Use a 250ms bounded wait so gio's synchronous failures
+    // can fall back. Longer-running portal startup is detached to keep opening
+    // responsive; late failures after that point cannot fall back.
+    match gio_open(gio, target) {
+        Ok(()) => return Ok(()),
+        Err(e)
+            if matches!(
+                e.kind(),
+                io::ErrorKind::NotFound
+                    | io::ErrorKind::Other
+                    | io::ErrorKind::PermissionDenied
+                    | io::ErrorKind::Interrupted
+            ) => {}
+        Err(e) => return Err(format!("{gio}: {e}")),
+    }
+    open_with_unix_backends(target, &[(xdg_open, &[][..])])
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn gio_open(program: &str, target: &Path) -> io::Result<()> {
+    use std::time::Duration;
+    const DEADLINE: Duration = Duration::from_millis(250);
+    const POLL: Duration = Duration::from_millis(10);
+
+    gio_open_with_deadline(program, target, DEADLINE, POLL)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn gio_open_with_deadline(
+    program: &str,
+    target: &Path,
+    deadline_duration: std::time::Duration,
+    poll: std::time::Duration,
+) -> io::Result<()> {
+    use std::time::Instant;
+
+    let mut child = Command::new(program)
+        .arg("open")
+        .arg(target)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()?;
+
+    let deadline = Instant::now() + deadline_duration;
+    while Instant::now() < deadline {
+        match child.try_wait()? {
+            Some(s) if s.success() => return Ok(()),
+            Some(s) => return Err(io::Error::other(format!("process exited with {s}"))),
+            None => std::thread::sleep(poll),
+        }
+    }
+    // Still running past the deadline: detach it to keep opening responsive.
+    // Reap the child in the background to avoid a zombie.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
 }
 
 #[cfg(any(test, target_os = "macos", all(unix, not(target_os = "macos"))))]
@@ -1003,6 +1073,204 @@ mod tests {
             !err.contains("should-not-run"),
             "second backend should not appear in error, got: {err}"
         );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn open_unix_preferring_gio_uses_gio_when_available() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_path("open-gio-preferred");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+
+        let capture = root.join("capture.txt");
+        let capture_str = capture.to_str().unwrap();
+
+        // fake-gio is invoked as: fake-gio open <target>; we only assert which binary ran.
+        let fake_gio = root.join("fake-gio");
+        let cmd = format!("printf 'gio' > {}", shell_quote(capture_str));
+        fs::write(&fake_gio, format!("#!/bin/sh\n{}\n", cmd)).expect("failed to write fake-gio");
+        let mut perms = fs::metadata(&fake_gio).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_gio, perms).unwrap();
+
+        let fake_xdg = root.join("fake-xdg-open");
+        let xdg_cmd = format!("printf 'xdg-open' > {}", shell_quote(capture_str));
+        fs::write(&fake_xdg, format!("#!/bin/sh\n{}\n", xdg_cmd))
+            .expect("failed to write fake-xdg-open");
+        let mut perms = fs::metadata(&fake_xdg).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_xdg, perms).unwrap();
+
+        let result = open_unix_preferring_gio_impl(
+            &capture,
+            fake_gio.to_str().unwrap(),
+            fake_xdg.to_str().unwrap(),
+        );
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+        // gio exited within the bounded-wait window, so capture is already written.
+        let recorded = fs::read_to_string(&capture).unwrap_or_default();
+        assert_eq!(
+            recorded.trim(),
+            "gio",
+            "gio should have been used, not xdg-open"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn open_unix_preferring_gio_falls_back_when_gio_missing() {
+        let root = temp_path("open-gio-missing-fallback");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+
+        let capture = root.join("capture.txt");
+        let capture_str = capture.to_str().unwrap();
+
+        let fake_xdg = root.join("fake-xdg-open");
+        let cmd = format!("printf 'xdg-open' > {}", shell_quote(capture_str));
+        fs::write(&fake_xdg, format!("#!/bin/sh\n{}\n", cmd))
+            .expect("failed to write fake-xdg-open");
+        let mut perms = fs::metadata(&fake_xdg).unwrap().permissions();
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_xdg, perms).unwrap();
+
+        let result = open_unix_preferring_gio_impl(
+            &capture,
+            "this-program-does-not-exist-elio-gio",
+            fake_xdg.to_str().unwrap(),
+        );
+
+        assert!(result.is_ok(), "expected Ok after fallback, got {result:?}");
+
+        // xdg-open is detached (spawned), so poll for the write.
+        let mut recorded = String::new();
+        for _ in 0..300 {
+            match fs::read_to_string(&capture) {
+                Ok(s) if !s.is_empty() => {
+                    recorded = s;
+                    break;
+                }
+                _ => {}
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        assert_eq!(recorded.trim(), "xdg-open");
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn open_unix_preferring_gio_falls_back_when_gio_exits_nonzero() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_path("open-gio-nonzero-fallback");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+
+        let capture = root.join("capture.txt");
+        let capture_str = capture.to_str().unwrap();
+
+        // gio exits 1 (no handler found)
+        let fake_gio = root.join("fake-gio-fail");
+        fs::write(&fake_gio, "#!/bin/sh\nexit 1\n").expect("failed to write fake-gio");
+        let mut perms = fs::metadata(&fake_gio).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_gio, perms).unwrap();
+
+        let fake_xdg = root.join("fake-xdg-open");
+        let cmd = format!("printf 'xdg-open' > {}", shell_quote(capture_str));
+        fs::write(&fake_xdg, format!("#!/bin/sh\n{}\n", cmd))
+            .expect("failed to write fake-xdg-open");
+        let mut perms = fs::metadata(&fake_xdg).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_xdg, perms).unwrap();
+
+        let result = open_unix_preferring_gio_impl(
+            &capture,
+            fake_gio.to_str().unwrap(),
+            fake_xdg.to_str().unwrap(),
+        );
+
+        assert!(result.is_ok(), "expected Ok after fallback, got {result:?}");
+
+        let mut recorded = String::new();
+        for _ in 0..300 {
+            match fs::read_to_string(&capture) {
+                Ok(s) if !s.is_empty() => {
+                    recorded = s;
+                    break;
+                }
+                _ => {}
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        assert_eq!(recorded.trim(), "xdg-open");
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn gio_open_detaches_when_deadline_expires() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_path("open-gio-timeout-detach");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+
+        let capture = root.join("capture.txt");
+        let capture_str = capture.to_str().unwrap();
+
+        // fake-gio sleeps past the injected deadline before writing. Use whole
+        // seconds because fractional sleep is not portable across all Unix shells.
+        let fake_gio = root.join("fake-gio-slow");
+        let cmd = format!("sleep 1; printf 'gio' > {}", shell_quote(capture_str));
+        fs::write(&fake_gio, format!("#!/bin/sh\n{}\n", cmd))
+            .expect("failed to write fake-gio-slow");
+        let mut perms = fs::metadata(&fake_gio).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_gio, perms).unwrap();
+
+        let started = std::time::Instant::now();
+        let result = gio_open_with_deadline(
+            fake_gio.to_str().unwrap(),
+            &capture,
+            std::time::Duration::from_millis(50),
+            std::time::Duration::from_millis(5),
+        );
+        let elapsed = started.elapsed();
+
+        assert!(
+            result.is_ok(),
+            "expected Ok via detach path, got {result:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "should return before fake-gio finishes its 1s sleep, took {elapsed:?}"
+        );
+
+        // Reaper thread is still waiting on fake-gio; poll for the eventual write
+        // to confirm the child was detached (not killed) and ran to completion.
+        let mut recorded = String::new();
+        for _ in 0..300 {
+            match fs::read_to_string(&capture) {
+                Ok(s) if !s.is_empty() => {
+                    recorded = s;
+                    break;
+                }
+                _ => {}
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert_eq!(recorded.trim(), "gio");
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }


### PR DESCRIPTION
## Summary

Fixes Linux/BSD default opening so `Enter` and `o` use MIME resolution that matches desktop defaults more reliably. This keeps direct launches aligned with the Open With chooser instead of letting `xdg-open` misclassify files through a generic MIME fallback.

## What Changed

- Prefer `gio open` before `xdg-open` for Linux/BSD default launches.
- Add a bounded wait around `gio open` so fast failures can fall back while slow portal startup does not block the UI.
- Detach long-running `gio` launches and reap them in the background.
- Consult `gio info` before `xdg-mime` during Open With MIME fallback detection.
- Add tests for `gio` preference, fallback behavior, detach behavior, and `gio info` parsing.

## User Impact

Default file launches on Linux/BSD now match desktop MIME associations more consistently, especially in non-GNOME or mixed desktop sessions. macOS and Windows behavior is unchanged.

## Notes

`gio open` is allowed 250ms to fail synchronously before Elio falls back to `xdg-open`. If it is still running after that deadline, Elio detaches it to keep the UI responsive; late failures after detaching cannot fall back. Extracting the opener code from `directory.rs` is intentionally left for a follow-up refactor PR.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested on CachyOS Linux under Hyprland and GNOME.
- Verified both default open and Open With behavior for code files, text files, images, PDFs, comics, audio, video, fonts, Makefiles, office documents, archives, ISO images, and XCF files.

Result:

All automated checks passed locally, and manual default-opening checks matched expected desktop MIME associations.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
