### PR TITLE
feat(preview): add keyboard scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an optional startup directory argument, so `elio <directory>` opens that directory and invalid or non-directory paths return a clear error.
+- Added keyboard-driven preview scrolling that mirrors `[` / `]`: `Shift+K` / `Shift+J` (configurable) step pages on PDF, comic, and EPUB previews and otherwise scroll the preview up / down. `[` / `]` now also scrolls text/code/log previews while keeping its page-step behavior on paged previews. ([#79])
+- Added a dedicated Preview section to the help overlay (`?`) listing the new vertical scroll keys, `[` / `]` page-stepping, and the horizontal scroll keys, and rebalanced the overlay columns so both sides end at the same height.
+
+### Changed
+
+- Changed the default horizontal preview scroll bindings from `<` / `>` to `Shift+H` / `Shift+L` so all four preview scroll directions share a consistent vim-style modifier pattern. Existing `scroll_preview_left` / `scroll_preview_right` overrides in `config.toml` continue to work unchanged.
 
 ### Fixed
 
@@ -103,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#79]: https://github.com/elio-fm/elio/issues/79
 [#77]: https://github.com/elio-fm/elio/pull/77
 [#75]: https://github.com/elio-fm/elio/issues/75
 [#74]: https://github.com/elio-fm/elio/pull/74

--- a/README.md
+++ b/README.md
@@ -338,7 +338,14 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `+` / `-` | Grid zoom in / out |
 | `.` `*` | Show / hide dotfiles |
 | `s` `*` | Cycle sort (Name → Modified → Size) |
-| `<` / `>` `*` | Scroll preview left / right |
+
+### Preview
+
+| Key | Action |
+|---|---|
+| `Shift+K` / `Shift+J` `*` | Step page (PDF, comic, EPUB) or scroll preview up / down |
+| `Shift+H` / `Shift+L` `*` | Scroll preview left / right |
+| `[` / `]` | Step page (PDF, comic, EPUB) or scroll text/code |
 
 ### Selection and Clipboard
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -62,19 +62,21 @@ show_top_bar = false
 # Omit any key to keep the built-in default shown in the comment.
 #
 # [keys]
-# quit              = "q"
-# yank              = "y"
-# cut               = "x"
-# paste             = "p"
-# trash             = "d"
-# create            = "a"
-# rename            = "r"
-# copy_path         = "c"
-# search_folders    = "f"
-# open              = "o"
-# open_with         = "O"
-# sort              = "s"
-# toggle_view       = "v"
-# toggle_hidden     = "."
-# scroll_preview_left  = "<"
-# scroll_preview_right = ">"
+# quit                 = "q"
+# yank                 = "y"
+# cut                  = "x"
+# paste                = "p"
+# trash                = "d"
+# create               = "a"
+# rename               = "r"
+# copy_path            = "c"
+# search_folders       = "f"
+# open                 = "o"
+# open_with            = "O"
+# sort                 = "s"
+# toggle_view          = "v"
+# toggle_hidden        = "."
+# scroll_preview_up    = "K"   # Shift+K
+# scroll_preview_down  = "J"   # Shift+J
+# scroll_preview_left  = "H"   # Shift+H
+# scroll_preview_right = "L"   # Shift+L

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -162,12 +162,16 @@ impl App {
                     {
                         return Ok(());
                     }
+                    self.scroll_preview_lines(-1);
+                    return Ok(());
                 }
                 KeyCode::Char(']') => {
                     if self.step_epub_section(1) || self.step_comic_page(1) || self.step_pdf_page(1)
                     {
                         return Ok(());
                     }
+                    self.scroll_preview_lines(1);
+                    return Ok(());
                 }
                 _ => {}
             }
@@ -288,6 +292,20 @@ impl App {
             }
             Action::ScrollPreviewRight => {
                 let _ = self.scroll_preview_columns(1);
+            }
+            Action::ScrollPreviewUp => {
+                if !self.step_epub_section(-1)
+                    && !self.step_comic_page(-1)
+                    && !self.step_pdf_page(-1)
+                {
+                    let _ = self.scroll_preview_lines(-1);
+                }
+            }
+            Action::ScrollPreviewDown => {
+                if !self.step_epub_section(1) && !self.step_comic_page(1) && !self.step_pdf_page(1)
+                {
+                    let _ = self.scroll_preview_lines(1);
+                }
             }
         }
         Ok(())

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -1,5 +1,7 @@
 use super::super::*;
-use super::helpers::{temp_path, wait_for_background_preview, wait_for_directory_load};
+use super::helpers::{
+    temp_path, wait_for_background_preview, wait_for_directory_load, write_epub_fixture,
+};
 use crate::config::Action;
 use std::{
     fs, thread,
@@ -842,4 +844,189 @@ fn confirm_open_with_launch_failure_sets_status() {
     assert_eq!(app.status, "Failed to open with Ghost App");
 
     fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn bracket_keys_scroll_text_preview_vertically() {
+    let root = temp_path("bracket-scroll-text-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let long_file = root.join("long.txt");
+    let contents = (0..120)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&long_file, &contents).expect("failed to write long file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    let long_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|e| e.path == long_file)
+        .expect("long.txt should be in entries");
+    app.select_index(long_index);
+    app.set_frame_state(FrameState {
+        preview_panel: Some(Rect {
+            x: 21,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
+        preview_rows_visible: 16,
+        preview_cols_visible: 38,
+        ..FrameState::default()
+    });
+    wait_for_background_preview(&mut app);
+
+    assert_eq!(app.preview.state.scroll, 0, "preview should start at top");
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(']'))))
+        .expect("] should be handled");
+    let after_down = app.preview.state.scroll;
+    assert!(
+        after_down > 0,
+        "] should scroll the text preview down, got {after_down}"
+    );
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('['))))
+        .expect("[ should be handled");
+    assert!(
+        app.preview.state.scroll < after_down,
+        "[ should scroll the text preview back up, got {} (was {after_down})",
+        app.preview.state.scroll
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn shift_j_k_step_epub_sections_on_paged_preview() {
+    let root = temp_path("shift-jk-step-epub-sections");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let archive = root.join("story.epub");
+    write_epub_fixture(
+        &archive,
+        &[
+            ("Opening", "<p>Opening chapter text.</p>"),
+            ("Middle", "<p>Middle chapter text.</p>"),
+            ("Closing", "<p>Closing chapter text.</p>"),
+        ],
+    );
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    let archive_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|e| e.path == archive)
+        .expect("story.epub should be in entries");
+    app.select_index(archive_index);
+    wait_for_background_preview(&mut app);
+    app.set_frame_state(FrameState {
+        preview_panel: Some(Rect {
+            x: 21,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
+        preview_rows_visible: 16,
+        preview_cols_visible: 38,
+        ..FrameState::default()
+    });
+
+    assert_eq!(
+        app.preview.state.content.ebook_section_index,
+        Some(0),
+        "EPUB preview should open on the first section"
+    );
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('J'),
+        KeyModifiers::SHIFT,
+    )))
+    .expect("Shift+J should be handled");
+    assert_eq!(
+        app.preview.state.content.ebook_section_index,
+        Some(1),
+        "Shift+J should step EPUB to the next section"
+    );
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('K'),
+        KeyModifiers::SHIFT,
+    )))
+    .expect("Shift+K should be handled");
+    assert_eq!(
+        app.preview.state.content.ebook_section_index,
+        Some(0),
+        "Shift+K should step EPUB back to the previous section"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn shift_j_k_scroll_text_preview_vertically() {
+    let root = temp_path("shift-jk-scroll-text-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let long_file = root.join("long.txt");
+    let contents = (0..120)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&long_file, &contents).expect("failed to write long file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    let long_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|e| e.path == long_file)
+        .expect("long.txt should be in entries");
+    app.select_index(long_index);
+    app.set_frame_state(FrameState {
+        preview_panel: Some(Rect {
+            x: 21,
+            y: 0,
+            width: 40,
+            height: 20,
+        }),
+        preview_rows_visible: 16,
+        preview_cols_visible: 38,
+        ..FrameState::default()
+    });
+    wait_for_background_preview(&mut app);
+
+    let selected_before = app.navigation.selected;
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('J'),
+        KeyModifiers::SHIFT,
+    )))
+    .expect("Shift+J should be handled");
+    let after_down = app.preview.state.scroll;
+    assert!(
+        after_down > 0,
+        "Shift+J should scroll the text preview down, got {after_down}"
+    );
+    assert_eq!(
+        app.navigation.selected, selected_before,
+        "Shift+J must not move the file selection"
+    );
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('K'),
+        KeyModifiers::SHIFT,
+    )))
+    .expect("Shift+K should be handled");
+    assert!(
+        app.preview.state.scroll < after_down,
+        "Shift+K should scroll the text preview back up, got {} (was {after_down})",
+        app.preview.state.scroll
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/wheel.rs
+++ b/src/app/input/wheel.rs
@@ -651,7 +651,7 @@ impl App {
         preview_ready.then_some(WheelTarget::Preview)
     }
 
-    fn scroll_preview_lines(&mut self, delta: isize) -> bool {
+    pub(in crate::app) fn scroll_preview_lines(&mut self, delta: isize) -> bool {
         let previous = self.preview.state.scroll;
         let step = self.preview_scroll_step();
         if delta.is_negative() {

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -19,6 +19,8 @@ pub(crate) enum Action {
     ToggleHidden,
     ScrollPreviewLeft,
     ScrollPreviewRight,
+    ScrollPreviewUp,
+    ScrollPreviewDown,
 }
 
 /// Single-character key bindings for browser actions.
@@ -42,6 +44,8 @@ pub(crate) struct KeyBindings {
     pub toggle_hidden: char,
     pub scroll_preview_left: char,
     pub scroll_preview_right: char,
+    pub scroll_preview_up: char,
+    pub scroll_preview_down: char,
 }
 
 /// Characters that are hard-wired to non-configurable actions and may not be
@@ -72,8 +76,10 @@ impl Default for KeyBindings {
             sort: 's',
             toggle_view: 'v',
             toggle_hidden: '.',
-            scroll_preview_left: '<',
-            scroll_preview_right: '>',
+            scroll_preview_left: 'H',
+            scroll_preview_right: 'L',
+            scroll_preview_up: 'K',
+            scroll_preview_down: 'J',
         }
     }
 }
@@ -96,6 +102,8 @@ pub(super) struct KeysConfigOverride {
     toggle_hidden: Option<String>,
     scroll_preview_left: Option<String>,
     scroll_preview_right: Option<String>,
+    scroll_preview_up: Option<String>,
+    scroll_preview_down: Option<String>,
 }
 
 impl KeyBindings {
@@ -118,6 +126,8 @@ impl KeyBindings {
             _ if c == self.toggle_hidden => Some(Action::ToggleHidden),
             _ if c == self.scroll_preview_left => Some(Action::ScrollPreviewLeft),
             _ if c == self.scroll_preview_right => Some(Action::ScrollPreviewRight),
+            _ if c == self.scroll_preview_up => Some(Action::ScrollPreviewUp),
+            _ if c == self.scroll_preview_down => Some(Action::ScrollPreviewDown),
             _ => None,
         }
     }
@@ -135,7 +145,7 @@ impl KeyBindings {
 
     pub(super) fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
         // Each entry: (field_name, user_override_string, default_char)
-        let raw: [(&str, Option<String>, char); 16] = [
+        let raw: [(&str, Option<String>, char); 18] = [
             ("quit", overrides.quit, defaults.quit),
             ("yank", overrides.yank, defaults.yank),
             ("cut", overrides.cut, defaults.cut),
@@ -168,12 +178,22 @@ impl KeyBindings {
                 overrides.scroll_preview_right,
                 defaults.scroll_preview_right,
             ),
+            (
+                "scroll_preview_up",
+                overrides.scroll_preview_up,
+                defaults.scroll_preview_up,
+            ),
+            (
+                "scroll_preview_down",
+                overrides.scroll_preview_down,
+                defaults.scroll_preview_down,
+            ),
         ];
 
         // Step 1: parse each override string independently, falling back to
         // default on any format or reserved-char error.
         // (resolved_char, is_user_set)
-        let mut candidates: [(char, bool); 16] = [(' ', false); 16];
+        let mut candidates: [(char, bool); 18] = [(' ', false); 18];
         for (index, (name, override_str, default)) in raw.iter().enumerate() {
             candidates[index] = match override_str {
                 None => (*default, false),
@@ -212,12 +232,12 @@ impl KeyBindings {
         // binding does not silently leave a conflict with another.
         loop {
             let mut changed = false;
-            for index in 0..16 {
+            for index in 0..18 {
                 if !candidates[index].1 {
                     continue;
                 }
                 let candidate = candidates[index].0;
-                let collision = (0..16)
+                let collision = (0..18)
                     .filter(|&other_index| other_index != index)
                     .any(|other_index| candidates[other_index].0 == candidate);
                 if collision {
@@ -263,6 +283,8 @@ impl KeyBindings {
             toggle_hidden: resolved(13),
             scroll_preview_left: resolved(14),
             scroll_preview_right: resolved(15),
+            scroll_preview_up: resolved(16),
+            scroll_preview_down: resolved(17),
         }
     }
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -155,3 +155,91 @@ open_with = "w"
     assert_eq!(config.keys.action_for('w'), Some(Action::OpenWith));
     assert_eq!(config.keys.action_for('O'), None);
 }
+
+#[test]
+fn preview_scroll_defaults_map_to_shift_h_j_k_l() {
+    let key_bindings = KeyBindings::default();
+    assert_eq!(key_bindings.scroll_preview_up, 'K');
+    assert_eq!(key_bindings.scroll_preview_down, 'J');
+    assert_eq!(key_bindings.scroll_preview_left, 'H');
+    assert_eq!(key_bindings.scroll_preview_right, 'L');
+    assert_eq!(key_bindings.action_for('K'), Some(Action::ScrollPreviewUp));
+    assert_eq!(
+        key_bindings.action_for('J'),
+        Some(Action::ScrollPreviewDown)
+    );
+    assert_eq!(
+        key_bindings.action_for('H'),
+        Some(Action::ScrollPreviewLeft)
+    );
+    assert_eq!(
+        key_bindings.action_for('L'),
+        Some(Action::ScrollPreviewRight)
+    );
+}
+
+#[test]
+fn scroll_preview_up_can_be_overridden() {
+    let config = Config::from_str(
+        r#"
+[keys]
+scroll_preview_up = "U"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.scroll_preview_up, 'U');
+    assert_eq!(config.keys.action_for('U'), Some(Action::ScrollPreviewUp));
+    assert_eq!(config.keys.action_for('K'), None);
+    assert_eq!(
+        config.keys.action_for('J'),
+        Some(Action::ScrollPreviewDown),
+        "untouched bindings should keep their defaults"
+    );
+}
+
+#[test]
+fn scroll_preview_keys_reject_collision_with_other_default() {
+    let config = Config::from_str(
+        r#"
+[keys]
+scroll_preview_up = "y"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(
+        config.keys.scroll_preview_up, 'K',
+        "user override colliding with default 'y' (yank) must fall back to default 'K'"
+    );
+    assert_eq!(config.keys.yank, 'y');
+    assert_eq!(config.keys.action_for('y'), Some(Action::Yank));
+    assert_eq!(
+        config.keys.action_for('K'),
+        Some(Action::ScrollPreviewUp),
+        "default 'K' must remain bound to ScrollPreviewUp"
+    );
+}
+
+#[test]
+fn scroll_preview_keys_reject_user_user_duplicate() {
+    // When two user-set bindings collide, the first one in iteration order
+    // falls back to its default; the second keeps the user-set value (since
+    // the collision is gone after the first reset). This matches the
+    // existing yank/paste collision behavior.
+    let config = Config::from_str(
+        r#"
+[keys]
+scroll_preview_up   = "U"
+scroll_preview_down = "U"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.scroll_preview_up, 'K');
+    assert_eq!(config.keys.scroll_preview_down, 'U');
+    assert_eq!(config.keys.action_for('U'), Some(Action::ScrollPreviewDown));
+    assert_eq!(config.keys.action_for('K'), Some(Action::ScrollPreviewUp));
+    assert_eq!(
+        config.keys.action_for('J'),
+        None,
+        "default 'J' is no longer bound because scroll_preview_down was overridden to 'U'"
+    );
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1175,7 +1175,7 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
 
     let mut app = App::new_at(root.clone()).expect("app should load temp directory");
     app.overlays.help = true;
-    let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal should init");
+    let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal should init");
 
     draw_ui(&mut terminal, &mut app);
     let rendered = buffer_text(terminal.backend().buffer());
@@ -1199,6 +1199,22 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
     assert!(
         rendered.contains("Wheel              scroll"),
         "expected help overlay to describe wheel routing accurately, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Preview"),
+        "expected help overlay to include the Preview section header, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Shift+K / Shift+J"),
+        "expected help overlay to list the vertical preview scroll keys, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("View"),
+        "expected help overlay to include the View section header, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("toggle grid / list"),
+        "expected help overlay to keep View entries visible, got: {rendered:?}"
     );
     assert!(
         !rendered.contains("Double clickopen"),

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -55,13 +55,20 @@ pub(super) fn render_help(
         e(&kb.open.to_string(), "open with default app"),
         e(&kb.open_with.to_string(), "open with"),
     ];
-    let scroll_key = format!("{} / {}", kb.scroll_preview_left, kb.scroll_preview_right);
     let view_entries = vec![
         e(&kb.toggle_view.to_string(), "toggle grid / list"),
         e("+ / -", "grid zoom in / out"),
         e(&kb.toggle_hidden.to_string(), "toggle dotfiles"),
         e(&kb.sort.to_string(), "cycle sort"),
-        e(&scroll_key, "scroll preview left / right"),
+    ];
+    let preview_vertical_key =
+        format_preview_scroll_key(kb.scroll_preview_up, kb.scroll_preview_down);
+    let preview_horizontal_key =
+        format_preview_scroll_key(kb.scroll_preview_left, kb.scroll_preview_right);
+    let preview_entries = vec![
+        e(&preview_vertical_key, "step page or scroll"),
+        e("[ / ]", "step page or scroll"),
+        e(&preview_horizontal_key, "scroll left / right"),
     ];
     let mouse_entries = vec![
         e("Click", "select item"),
@@ -79,18 +86,22 @@ pub(super) fn render_help(
             entries: search_entries,
         },
         HelpSection {
-            title: "Mouse",
-            entries: mouse_entries,
+            title: "Selection & Clipboard",
+            entries: clipboard_entries,
         },
     ];
     let right_sections = vec![
+        HelpSection {
+            title: "Mouse",
+            entries: mouse_entries,
+        },
         HelpSection {
             title: "File Actions",
             entries: files_entries,
         },
         HelpSection {
-            title: "Selection & Clipboard",
-            entries: clipboard_entries,
+            title: "Preview",
+            entries: preview_entries,
         },
         HelpSection {
             title: "View",
@@ -98,7 +109,7 @@ pub(super) fn render_help(
         },
     ];
 
-    let popup = helpers::centered_rect(area, 88, 26);
+    let popup = helpers::centered_rect(area, 90, 30);
     state.help_panel = Some(popup);
     frame.render_widget(Clear, popup);
     frame.render_widget(
@@ -140,11 +151,13 @@ pub(super) fn render_help(
             Span::raw(" "),
             helpers::chip_span("search", palette.accent_soft, palette.accent_text, true),
             Span::raw(" "),
+            helpers::chip_span("selection", palette.accent_soft, palette.accent_text, true),
+            Span::raw(" "),
             helpers::chip_span("mouse", palette.accent_soft, palette.accent_text, true),
             Span::raw(" "),
             helpers::chip_span("actions", palette.accent_soft, palette.accent_text, true),
             Span::raw(" "),
-            helpers::chip_span("selection", palette.accent_soft, palette.accent_text, true),
+            helpers::chip_span("preview", palette.accent_soft, palette.accent_text, true),
             Span::raw(" "),
             helpers::chip_span("view", palette.accent_soft, palette.accent_text, true),
         ])])
@@ -157,7 +170,7 @@ pub(super) fn render_help(
         .constraints([
             Constraint::Length(39),
             Constraint::Length(3),
-            Constraint::Length(44),
+            Constraint::Length(46),
         ])
         .split(rows[1]);
 
@@ -200,6 +213,16 @@ pub(super) fn render_help(
         .style(Style::default().bg(palette.chrome_alt).fg(palette.muted)),
         rows[2],
     );
+}
+
+/// Render a preview-scroll key pair: defaults like 'H'/'L' show as "Shift+H / Shift+L";
+/// overrides such as '<'/'>' show as "< / >".
+fn format_preview_scroll_key(low: char, high: char) -> String {
+    if low.is_ascii_uppercase() && high.is_ascii_uppercase() {
+        format!("Shift+{low} / Shift+{high}")
+    } else {
+        format!("{low} / {high}")
+    }
 }
 
 struct HelpEntry {


### PR DESCRIPTION
## Summary

Adds first-class keyboard scrolling for the preview pane and documents the preview controls.

Closes #79.

## What Changed

- Added configurable vertical preview scroll actions with `Shift+K` / `Shift+J` defaults.
- Changed horizontal preview scroll defaults from `<` / `>` to `Shift+H` / `Shift+L`.
- Extended `[` / `]` so they still step PDF/comic/EPUB previews, and now scroll text/code/log previews when page stepping does not apply.
- Added a dedicated Preview section to the help overlay.
- Updated README, example config, changelog, and regression tests.

## User Impact

Users can now scroll text/code/log previews vertically from the keyboard. Preview scrolling also follows a consistent `Shift+H/J/K/L` pattern, while existing config overrides for horizontal preview scrolling continue to work.

## Notes

`[` / `]` keep their existing paged-preview behavior for PDF, comic, and EPUB previews. On non-paged previews they now scroll the preview instead of silently doing nothing.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified `[` / `]` and `Shift+K` / `Shift+J` scroll text previews up and down.
- Verified `Shift+H` / `Shift+L` scroll text previews left and right.
- Verified changing preview scroll bindings in `config.toml` works.
- Verified repeated page-step/scroll input at the end of a paged preview no-ops cleanly.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed