### PR TITLE
fix(preview): support Kitty direct graphics in tmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved Kitty and Ghostty image preview auto-detection inside tmux when tmux hides the usual terminal environment markers. ([#70])
 
+### Fixed
+
+- Fixed Kitty direct-placement preview transport and placement inside tmux for Konsole and Warp. ([#70])
+
 ## [1.4.0] - 2026-05-03
 
 ### Added

--- a/src/app/overlays/inline_image/kitty.rs
+++ b/src/app/overlays/inline_image/kitty.rs
@@ -7,6 +7,8 @@ use std::{
     path::Path,
 };
 
+use super::tmux::maybe_wrap_kitty_apcs_for_tmux;
+
 pub(super) fn place_terminal_image_with_kitty_protocol(
     path: &Path,
     area: Rect,
@@ -22,45 +24,6 @@ pub(super) fn clear_terminal_images_with_kitty_protocol() -> Result<Vec<u8>> {
     Ok(maybe_wrap_kitty_apcs_for_tmux(
         build_kitty_clear_sequence().as_bytes().to_vec(),
     ))
-}
-
-/// Inside tmux, wrap each Kitty APC sequence in the tmux DCS passthrough
-/// envelope so tmux relays it to the host terminal. CSI sequences and the
-/// Unicode placeholder characters are emitted unchanged. Outside tmux the
-/// input is returned untouched.
-///
-/// Background: tmux's `allow-passthrough on` only forwards DCS sequences with
-/// the `\ePtmux;<seq>\e\\` envelope. Raw APC sequences (`\e_G…\e\\`, used by
-/// the Kitty Graphics Protocol) are swallowed by tmux and never reach the
-/// host terminal — so the host terminal never registers the image and the
-/// Unicode placeholders render as empty cells.
-fn maybe_wrap_kitty_apcs_for_tmux(buf: Vec<u8>) -> Vec<u8> {
-    if std::env::var_os("TMUX").is_none() {
-        return buf;
-    }
-    wrap_kitty_apcs_for_tmux(&buf)
-}
-
-fn wrap_kitty_apcs_for_tmux(buf: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(buf.len() + buf.len() / 4);
-    let mut i = 0;
-    while i < buf.len() {
-        if buf.len() - i >= 3
-            && &buf[i..i + 3] == b"\x1b_G"
-            && let Some(rel) = buf[i + 3..].iter().position(|&b| b == 0x1b)
-            && buf.get(i + 3 + rel + 1) == Some(&b'\\')
-        {
-            let body_end = i + 3 + rel;
-            out.extend_from_slice(b"\x1bPtmux;\x1b\x1b_G");
-            out.extend_from_slice(&buf[i + 3..body_end]);
-            out.extend_from_slice(b"\x1b\x1b\\\x1b\\");
-            i = body_end + 2;
-            continue;
-        }
-        out.push(buf[i]);
-        i += 1;
-    }
-    out
 }
 
 fn build_kitty_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec<u8>> {
@@ -306,21 +269,5 @@ mod tests {
     #[test]
     fn build_kitty_clear_sequence_deletes_visible_images() {
         assert_eq!(build_kitty_clear_sequence(), "\u{1b}_Ga=d,d=A,q=2\u{1b}\\");
-    }
-
-    #[test]
-    fn wrap_kitty_apcs_for_tmux_envelopes_each_apc_and_leaves_csi_alone() {
-        let input =
-            b"\x1b_Ga=T,i=1,c=2,r=2;AAAA\x1b\\\x1b[5;10H\xf4\x8e\xbb\xae\x1b_Gm=0;BBBB\x1b\\";
-        let out = wrap_kitty_apcs_for_tmux(input);
-        let expected: &[u8] = b"\x1bPtmux;\x1b\x1b_Ga=T,i=1,c=2,r=2;AAAA\x1b\x1b\\\x1b\\\x1b[5;10H\xf4\x8e\xbb\xae\x1bPtmux;\x1b\x1b_Gm=0;BBBB\x1b\x1b\\\x1b\\";
-        assert_eq!(out, expected);
-    }
-
-    #[test]
-    fn wrap_kitty_apcs_for_tmux_is_noop_without_apcs() {
-        let input = b"\x1b[5;10Hhello\x1b[0m";
-        let out = wrap_kitty_apcs_for_tmux(input);
-        assert_eq!(out, input);
     }
 }

--- a/src/app/overlays/inline_image/konsole.rs
+++ b/src/app/overlays/inline_image/konsole.rs
@@ -7,10 +7,33 @@ use std::{
     path::Path,
 };
 
+use super::tmux::{self, TmuxPaneOrigin};
+
 pub(super) fn place_terminal_image_with_konsole_protocol(
     path: &Path,
     area: Rect,
 ) -> Result<Vec<u8>> {
+    let id = konsole_image_id();
+    if tmux::inside_tmux() {
+        let origin = tmux::query_pane_origin()
+            .ok_or_else(|| anyhow::anyhow!("tmux pane origin unavailable"))?;
+        return build_konsole_tmux_placement_sequence(path, id, area, origin);
+    }
+    build_konsole_placement_sequence(path, id, area)
+}
+
+pub(super) fn clear_terminal_images_with_konsole_protocol() -> Result<Vec<u8>> {
+    let raw = build_konsole_clear_sequence(konsole_image_id())
+        .as_bytes()
+        .to_vec();
+    if tmux::inside_tmux() {
+        Ok(tmux::wrap_sequence_for_tmux(&raw))
+    } else {
+        Ok(raw)
+    }
+}
+
+fn build_konsole_placement_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     let _ = write!(
         out,
@@ -18,21 +41,49 @@ pub(super) fn place_terminal_image_with_konsole_protocol(
         area.y.saturating_add(1),
         area.x.saturating_add(1)
     );
-    out.extend(build_konsole_upload_sequence(
-        path,
-        konsole_image_id(),
-        area,
-    )?);
+    for chunk in build_konsole_upload_chunks(path, id, area)? {
+        out.extend(chunk);
+    }
     Ok(out)
 }
 
-pub(super) fn clear_terminal_images_with_konsole_protocol() -> Result<Vec<u8>> {
-    Ok(build_konsole_clear_sequence(konsole_image_id())
-        .as_bytes()
-        .to_vec())
+fn build_konsole_tmux_placement_sequence(
+    path: &Path,
+    id: u32,
+    area: Rect,
+    origin: TmuxPaneOrigin,
+) -> Result<Vec<u8>> {
+    let (row, col) = origin.absolute_cursor_for(area);
+    let mut chunks = build_konsole_upload_chunks(path, id, area)?
+        .into_iter()
+        .peekable();
+    let mut out = Vec::new();
+    while let Some(chunk) = chunks.next() {
+        if chunks.peek().is_some() {
+            out.extend(tmux::wrap_sequence_for_tmux(&chunk));
+        } else {
+            // Direct placement uses the cursor position when the final m=0
+            // chunk arrives, so move the outer terminal cursor in the same
+            // passthrough envelope as that final chunk.
+            let mut final_chunk = Vec::new();
+            let _ = write!(final_chunk, "\x1b[{row};{col}H");
+            final_chunk.extend(chunk);
+            out.extend(tmux::wrap_sequence_for_tmux(&final_chunk));
+        }
+    }
+    Ok(out)
 }
 
+#[cfg(test)]
 fn build_konsole_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    for chunk in build_konsole_upload_chunks(path, id, area)? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+fn build_konsole_upload_chunks(path: &Path, id: u32, area: Rect) -> Result<Vec<Vec<u8>>> {
     let mut file = File::open(path)
         .with_context(|| format!("failed to open Konsole preview image {}", path.display()))?;
     let total = file
@@ -45,7 +96,7 @@ fn build_konsole_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec
 
     let mut sent = 0usize;
     let mut chunk = vec![0u8; 3 * 4096 / 4];
-    let mut out = Vec::new();
+    let mut chunks = Vec::new();
     while sent < total {
         let remaining = total.saturating_sub(sent);
         let chunk_len = remaining.min(chunk.len());
@@ -54,6 +105,7 @@ fn build_konsole_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec
         sent += chunk_len;
         let more = sent < total;
         let payload = base64::engine::general_purpose::STANDARD.encode(&chunk[..chunk_len]);
+        let mut out = Vec::new();
         if sent == chunk_len {
             write!(
                 out,
@@ -69,8 +121,9 @@ fn build_konsole_upload_sequence(path: &Path, id: u32, area: Rect) -> Result<Vec
                 if more { 1 } else { 0 },
             )?;
         }
+        chunks.push(out);
     }
-    Ok(out)
+    Ok(chunks)
 }
 
 fn build_konsole_clear_sequence(id: u32) -> String {
@@ -155,8 +208,9 @@ mod tests {
         write_test_raster_image(&path, ImageFormat::Png, 16, 16);
 
         let output = String::from_utf8(
-            place_terminal_image_with_konsole_protocol(
+            build_konsole_placement_sequence(
                 &path,
+                42,
                 Rect {
                     x: 10,
                     y: 4,
@@ -174,16 +228,97 @@ mod tests {
     }
 
     #[test]
+    fn tmux_konsole_placement_wraps_absolute_cursor_and_upload_together() {
+        let root = temp_root("konsole-tmux-placement");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("demo.png");
+        write_test_raster_image(&path, ImageFormat::Png, 16, 16);
+
+        let output = String::from_utf8(
+            build_konsole_tmux_placement_sequence(
+                &path,
+                42,
+                Rect {
+                    x: 10,
+                    y: 4,
+                    width: 8,
+                    height: 6,
+                },
+                TmuxPaneOrigin { top: 2, left: 3 },
+            )
+            .expect("Konsole tmux placement should build"),
+        )
+        .expect("Konsole tmux placement should be utf8");
+
+        assert!(output.starts_with("\x1bPtmux;\x1b\x1b[7;14H\x1b\x1b_G"));
+        assert!(output.ends_with("\x1b\x1b\\\x1b\\"));
+        assert_eq!(output.matches("\x1bPtmux;").count(), 1);
+        assert!(output.contains("a=T"));
+        assert!(output.contains("c=8"));
+        assert!(output.contains("r=6"));
+        assert!(output.contains("C=1"));
+        assert!(!output.contains("\x1b[5;11H"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn tmux_konsole_placement_wraps_each_chunk_and_positions_final_chunk() {
+        let root = temp_root("konsole-tmux-chunked-placement");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("demo.png");
+        let payload = (0..5000).map(|i| (i % 251) as u8).collect::<Vec<_>>();
+        fs::write(&path, payload).expect("failed to write chunked payload");
+
+        let output = String::from_utf8(
+            build_konsole_tmux_placement_sequence(
+                &path,
+                42,
+                Rect {
+                    x: 10,
+                    y: 4,
+                    width: 8,
+                    height: 6,
+                },
+                TmuxPaneOrigin { top: 2, left: 3 },
+            )
+            .expect("Konsole tmux placement should build"),
+        )
+        .expect("Konsole tmux placement should be utf8");
+
+        assert_eq!(output.matches("\x1bPtmux;").count(), 2);
+        assert!(output.starts_with("\x1bPtmux;\x1b\x1b_Ga=T"));
+        assert!(output.contains("m=1;"));
+        assert!(output.contains("\x1b\x1b\\\x1b\\\x1bPtmux;\x1b\x1b[7;14H\x1b\x1b_Gm=0;"));
+        assert!(!output.starts_with("\x1bPtmux;\x1b\x1b[7;14H\x1b\x1b_Ga=T"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
     fn clear_konsole_uses_targeted_delete_sequence() {
         let sequence = String::from_utf8(
-            clear_terminal_images_with_konsole_protocol()
-                .expect("Konsole clear sequence should build"),
+            build_konsole_clear_sequence(konsole_image_id())
+                .as_bytes()
+                .to_vec(),
         )
         .expect("Konsole clear sequence should be utf8");
 
         assert_eq!(
             sequence,
             format!("\u{1b}_Ga=d,d=I,i={},p=1,q=2\u{1b}\\", konsole_image_id())
+        );
+    }
+
+    #[test]
+    fn tmux_konsole_clear_wraps_delete_sequence() {
+        let raw = build_konsole_clear_sequence(42);
+        let wrapped = String::from_utf8(tmux::wrap_sequence_for_tmux(raw.as_bytes()))
+            .expect("wrapped clear should be utf8");
+
+        assert_eq!(
+            wrapped,
+            "\x1bPtmux;\x1b\x1b_Ga=d,d=I,i=42,p=1,q=2\x1b\x1b\\\x1b\\"
         );
     }
 }

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -4,6 +4,7 @@ mod kitty;
 mod konsole;
 mod protocol;
 mod sixel;
+mod tmux;
 mod window;
 
 use anyhow::{Context, Result};

--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -6,22 +6,39 @@ pub(super) fn pdf_preview_tools_available() -> bool {
 }
 
 pub(in crate::app) fn detect_terminal_identity() -> TerminalIdentity {
-    detect_terminal_identity_with(real_env_lookup, query_tmux_client_termname, query_tmux_env)
+    detect_terminal_identity_with(
+        real_env_lookup,
+        query_tmux_client_termname,
+        query_tmux_client_env,
+        query_tmux_env,
+    )
 }
 
 /// Inner detection logic with injectable lookups so tests can drive the tmux
-/// fallback without spawning tmux. Direct process env wins; if it returns
-/// `Other` and `$TMUX` is set, recover Kitty/Ghostty by consulting (in order)
-/// the live tmux client `TERM`, the tmux session env, and the tmux server
-/// global env. Other identities are intentionally not recovered via tmux —
-/// adding them needs per-protocol passthrough verification.
+/// fallback without spawning tmux. Direct process env usually wins; the one
+/// exception is a Kitty identity inside tmux, where a stale `KITTY_WINDOW_ID`
+/// can leak from another attached terminal. In tmux, recover supported
+/// identities by consulting (in order) the live tmux client `TERM`, the live
+/// tmux client environment, the tmux session env, and the tmux server global
+/// env.
 fn detect_terminal_identity_with(
     env_lookup: impl Fn(&str) -> Option<String>,
     tmux_client_term: impl Fn() -> Option<String>,
+    tmux_client_env_lookup: impl Fn(&str) -> Option<String>,
     tmux_env_lookup: impl Fn(&str) -> Option<String>,
 ) -> TerminalIdentity {
     let identity = classify_from_env(&env_lookup);
     if identity != TerminalIdentity::Other {
+        if identity == TerminalIdentity::Kitty
+            && let Some(tmux_identity) = recover_direct_graphics_identity_from_tmux(
+                &env_lookup,
+                &tmux_client_term,
+                &tmux_client_env_lookup,
+                &tmux_env_lookup,
+            )
+        {
+            return tmux_identity;
+        }
         return identity;
     }
     if env_lookup("TMUX").is_none() {
@@ -34,10 +51,11 @@ fn detect_terminal_identity_with(
         return id;
     }
 
-    let kitty_window_id_set = tmux_env_lookup("KITTY_WINDOW_ID").is_some();
-    let term_program = tmux_env_lookup("TERM_PROGRAM").unwrap_or_default();
-    let term = tmux_env_lookup("TERM").unwrap_or_default();
-    if let Some(id) = classify_kitty_or_ghostty(&term, &term_program, kitty_window_id_set) {
+    if let Some(id) = classify_supported_tmux_env(&tmux_client_env_lookup) {
+        return id;
+    }
+
+    if let Some(id) = classify_supported_tmux_env(&tmux_env_lookup) {
         return id;
     }
 
@@ -54,7 +72,7 @@ fn classify_from_env(env_lookup: &impl Fn(&str) -> Option<String>) -> TerminalId
         || env_lookup("KONSOLE_DBUS_SERVICE").is_some()
         || env_lookup("KONSOLE_DBUS_WINDOW").is_some();
 
-    if kitty_window_id || term.contains("xterm-kitty") || term_program == "kitty" {
+    if term.contains("xterm-kitty") || term_program == "kitty" {
         TerminalIdentity::Kitty
     } else if term.contains("ghostty") || term_program == "ghostty" {
         TerminalIdentity::Ghostty
@@ -73,6 +91,8 @@ fn classify_from_env(env_lookup: &impl Fn(&str) -> Option<String>) -> TerminalId
         // Konsole exports D-Bus identifiers into child shells so scripts can
         // address the current window/session.
         TerminalIdentity::Konsole
+    } else if kitty_window_id {
+        TerminalIdentity::Kitty
     } else if term == "foot" || term == "foot-extra" {
         // Foot sets TERM=foot or TERM=foot-extra and supports Sixel natively.
         TerminalIdentity::Foot
@@ -104,6 +124,85 @@ fn classify_kitty_or_ghostty(
     }
 }
 
+fn classify_tmux_recovered_identity(
+    term: &str,
+    term_program: &str,
+    kitty_window_id_set: bool,
+    warp_session_id_set: bool,
+    konsole_dbus_set: bool,
+) -> Option<TerminalIdentity> {
+    let term = term.to_ascii_lowercase();
+    let term_program = term_program.to_ascii_lowercase();
+    if term.contains("xterm-kitty") || term_program == "kitty" {
+        Some(TerminalIdentity::Kitty)
+    } else if term.contains("ghostty") || term_program == "ghostty" {
+        Some(TerminalIdentity::Ghostty)
+    } else if term_program.contains("warp") || warp_session_id_set {
+        Some(TerminalIdentity::Warp)
+    } else if konsole_dbus_set {
+        Some(TerminalIdentity::Konsole)
+    } else if kitty_window_id_set {
+        Some(TerminalIdentity::Kitty)
+    } else {
+        None
+    }
+}
+
+fn classify_supported_tmux_env(
+    env_lookup: &impl Fn(&str) -> Option<String>,
+) -> Option<TerminalIdentity> {
+    classify_tmux_recovered_identity(
+        &env_lookup("TERM").unwrap_or_default(),
+        &env_lookup("TERM_PROGRAM").unwrap_or_default(),
+        env_lookup("KITTY_WINDOW_ID").is_some(),
+        env_lookup("WARP_SESSION_ID").is_some(),
+        env_lookup("KONSOLE_DBUS_SESSION").is_some()
+            || env_lookup("KONSOLE_DBUS_SERVICE").is_some()
+            || env_lookup("KONSOLE_DBUS_WINDOW").is_some(),
+    )
+}
+
+fn recover_direct_graphics_identity_from_tmux(
+    env_lookup: &impl Fn(&str) -> Option<String>,
+    tmux_client_term: &impl Fn() -> Option<String>,
+    tmux_client_env_lookup: &impl Fn(&str) -> Option<String>,
+    tmux_env_lookup: &impl Fn(&str) -> Option<String>,
+) -> Option<TerminalIdentity> {
+    env_lookup("TMUX")?;
+    let term = env_lookup("TERM").unwrap_or_default().to_ascii_lowercase();
+    let term_program = env_lookup("TERM_PROGRAM")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if !term.contains("tmux") && term_program != "tmux" {
+        return None;
+    }
+
+    // If tmux can identify a Kitty/Ghostty client directly, preserve that
+    // identity. Direct-placement terminals such as Konsole and Warp typically
+    // report only generic xterm-compatible TERM names to tmux.
+    if let Some(client_term) = tmux_client_term()
+        && classify_kitty_or_ghostty(&client_term, "", false).is_some()
+    {
+        return None;
+    }
+
+    if let Some(client_identity) = classify_supported_tmux_env(tmux_client_env_lookup) {
+        return if client_identity == TerminalIdentity::Kitty {
+            None
+        } else {
+            Some(client_identity)
+        };
+    }
+
+    if let Some(session_identity) = classify_supported_tmux_env(tmux_env_lookup)
+        && session_identity != TerminalIdentity::Kitty
+    {
+        return Some(session_identity);
+    }
+
+    None
+}
+
 fn real_env_lookup(name: &str) -> Option<String> {
     // `to_string_lossy` keeps presence-only semantics for non-UTF-8 values:
     // they still produce `Some(_)` rather than collapsing to `None` like
@@ -129,6 +228,44 @@ fn query_tmux_client_termname() -> Option<String> {
     } else {
         Some(trimmed.to_string())
     }
+}
+
+fn query_tmux_client_env(name: &str) -> Option<String> {
+    let pid = query_tmux_client_pid()?;
+    read_process_env(pid, name)
+}
+
+fn query_tmux_client_pid() -> Option<u32> {
+    let output = Command::new("tmux")
+        .args(["display-message", "-p", "#{client_pid}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    stdout.trim().parse().ok()
+}
+
+#[cfg(target_os = "linux")]
+fn read_process_env(pid: u32, name: &str) -> Option<String> {
+    let environ = fs::read(format!("/proc/{pid}/environ")).ok()?;
+    parse_proc_environ(&environ, name)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_process_env(_: u32, _: &str) -> Option<String> {
+    None
+}
+
+fn parse_proc_environ(environ: &[u8], name: &str) -> Option<String> {
+    let mut prefix = name.as_bytes().to_vec();
+    prefix.push(b'=');
+    environ.split(|&byte| byte == 0).find_map(|entry| {
+        entry
+            .strip_prefix(prefix.as_slice())
+            .map(|value| String::from_utf8_lossy(value).into_owned())
+    })
 }
 
 /// Look up `name` in the tmux session environment, then in the server-global
@@ -391,6 +528,19 @@ mod tests {
     }
 
     #[test]
+    fn konsole_dbus_takes_precedence_over_inherited_kitty_window_id() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
+
+        unsafe {
+            env::set_var("KITTY_WINDOW_ID", "1");
+            env::set_var("KONSOLE_DBUS_SESSION", "/Sessions/9");
+        }
+
+        assert_eq!(detect_terminal_identity(), TerminalIdentity::Konsole);
+    }
+
+    #[test]
     fn select_image_protocol_konsole_always_enabled() {
         assert_eq!(
             select_image_protocol(TerminalIdentity::Konsole, false),
@@ -425,6 +575,19 @@ mod tests {
             select_image_protocol(TerminalIdentity::Warp, true),
             ImageProtocol::KittyDirectGraphics
         );
+    }
+
+    #[test]
+    fn warp_markers_take_precedence_over_inherited_kitty_window_id() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
+
+        unsafe {
+            env::set_var("KITTY_WINDOW_ID", "1");
+            env::set_var("WARP_SESSION_ID", "123");
+        }
+
+        assert_eq!(detect_terminal_identity(), TerminalIdentity::Warp);
     }
 
     #[test]
@@ -574,6 +737,7 @@ mod tests {
             tmux_set_only("/tmp/tmux-1000/default,123,4"),
             || Some("xterm-kitty".to_string()),
             no_tmux_env_lookup,
+            no_tmux_env_lookup,
         );
         assert_eq!(id, TerminalIdentity::Kitty);
     }
@@ -583,6 +747,7 @@ mod tests {
         let id = detect_terminal_identity_with(
             tmux_set_only("/tmp/tmux-1000/default,123,4"),
             || Some("xterm-ghostty".to_string()),
+            no_tmux_env_lookup,
             no_tmux_env_lookup,
         );
         assert_eq!(id, TerminalIdentity::Ghostty);
@@ -595,6 +760,7 @@ mod tests {
         let id = detect_terminal_identity_with(
             tmux_set_only("/tmp/tmux-1000/default,123,4"),
             no_tmux_client_term,
+            no_tmux_env_lookup,
             |name| {
                 if name == "KITTY_WINDOW_ID" {
                     Some(String::new())
@@ -611,6 +777,7 @@ mod tests {
         let id = detect_terminal_identity_with(
             tmux_set_only("/tmp/tmux-1000/default,123,4"),
             no_tmux_client_term,
+            no_tmux_env_lookup,
             |name| {
                 if name == "TERM_PROGRAM" {
                     Some("ghostty".to_string())
@@ -623,10 +790,68 @@ mod tests {
     }
 
     #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_warp() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            no_tmux_env_lookup,
+            |name| {
+                if name == "WARP_SESSION_ID" {
+                    Some("123".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Warp);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_konsole() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            no_tmux_env_lookup,
+            |name| {
+                if name == "KONSOLE_DBUS_SESSION" {
+                    Some("/Sessions/3".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_uses_live_client_env_before_session_env() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            |name| {
+                if name == "WARP_SESSION_ID" {
+                    Some("live-client".to_string())
+                } else {
+                    None
+                }
+            },
+            |name| {
+                if name == "KITTY_WINDOW_ID" {
+                    Some("stale-session".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Warp);
+    }
+
+    #[test]
     fn detect_terminal_identity_inside_tmux_returns_other_for_generic_client_termname() {
         let id = detect_terminal_identity_with(
             tmux_set_only("/tmp/tmux-1000/default,123,4"),
             || Some("xterm-256color".to_string()),
+            no_tmux_env_lookup,
             no_tmux_env_lookup,
         );
         assert_eq!(id, TerminalIdentity::Other);
@@ -637,6 +862,7 @@ mod tests {
         use std::cell::Cell;
 
         let client_calls = Cell::new(0u32);
+        let client_env_calls = Cell::new(0u32);
         let env_calls = Cell::new(0u32);
         let id = detect_terminal_identity_with(
             |_| None,
@@ -645,43 +871,199 @@ mod tests {
                 Some("xterm-kitty".to_string())
             },
             |_| {
+                client_env_calls.set(client_env_calls.get() + 1);
+                Some(String::new())
+            },
+            |_| {
                 env_calls.set(env_calls.get() + 1);
                 Some(String::new())
             },
         );
         assert_eq!(id, TerminalIdentity::Other);
         assert_eq!(client_calls.get(), 0);
+        assert_eq!(client_env_calls.get(), 0);
         assert_eq!(env_calls.get(), 0);
     }
 
     #[test]
-    fn detect_terminal_identity_direct_env_takes_precedence_over_tmux_lookups() {
+    fn detect_terminal_identity_non_kitty_direct_env_takes_precedence_over_tmux_lookups() {
         use std::cell::Cell;
 
         let client_calls = Cell::new(0u32);
+        let client_env_calls = Cell::new(0u32);
         let env_calls = Cell::new(0u32);
         let id = detect_terminal_identity_with(
             |name| match name {
                 "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
-                "KITTY_WINDOW_ID" => Some(String::new()),
+                "TERM_PROGRAM" => Some("ghostty".to_string()),
                 _ => None,
             },
             || {
                 client_calls.set(client_calls.get() + 1);
-                Some("xterm-ghostty".to_string())
+                Some("xterm-kitty".to_string())
+            },
+            |_| {
+                client_env_calls.set(client_env_calls.get() + 1);
+                None
             },
             |_| {
                 env_calls.set(env_calls.get() + 1);
                 None
             },
         );
-        assert_eq!(id, TerminalIdentity::Kitty);
+        assert_eq!(id, TerminalIdentity::Ghostty);
         assert_eq!(
             client_calls.get(),
             0,
-            "tmux helpers should not run when direct env detection succeeds"
+            "tmux helpers should not run when non-Kitty direct env detection succeeds"
         );
+        assert_eq!(client_env_calls.get(), 0);
         assert_eq!(env_calls.get(), 0);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recovers_warp_from_tmux_when_stale_kitty_marker_leaks() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-256color".to_string()),
+            no_tmux_env_lookup,
+            |name| {
+                if name == "WARP_SESSION_ID" {
+                    Some("123".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Warp);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recovers_warp_from_live_client_env_when_stale_kitty_marker_leaks() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-256color".to_string()),
+            |name| {
+                if name == "WARP_SESSION_ID" {
+                    Some("live-client".to_string())
+                } else {
+                    None
+                }
+            },
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::Warp);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recovers_konsole_from_tmux_when_stale_kitty_marker_leaks() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-256color".to_string()),
+            no_tmux_env_lookup,
+            |name| {
+                if name == "KONSOLE_DBUS_SESSION" {
+                    Some("/Sessions/3".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recovers_konsole_from_live_client_env_when_stale_kitty_marker_leaks()
+     {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-256color".to_string()),
+            |name| {
+                if name == "KONSOLE_DBUS_SESSION" {
+                    Some("/Sessions/live".to_string())
+                } else {
+                    None
+                }
+            },
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn detect_terminal_identity_keeps_kitty_when_tmux_client_reports_kitty() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-kitty".to_string()),
+            no_tmux_env_lookup,
+            |name| {
+                if name == "WARP_SESSION_ID" {
+                    Some("stale".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Kitty);
+    }
+
+    #[test]
+    fn detect_terminal_identity_keeps_live_client_kitty_over_stale_session_warp() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-256color".to_string()),
+            |name| {
+                if name == "KITTY_WINDOW_ID" {
+                    Some("live-client".to_string())
+                } else {
+                    None
+                }
+            },
+            |name| {
+                if name == "WARP_SESSION_ID" {
+                    Some("stale-session".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Kitty);
     }
 
     #[test]
@@ -703,5 +1085,19 @@ mod tests {
             parse_show_environment_line("OTHER=value\nKITTY_WINDOW_ID=7\n", "KITTY_WINDOW_ID"),
             Some("7".to_string())
         );
+    }
+
+    #[test]
+    fn parse_proc_environ_handles_present_empty_and_missing_values() {
+        let environ = b"TERM=xterm-256color\0WARP_SESSION_ID=123\0KITTY_WINDOW_ID=\0";
+        assert_eq!(
+            parse_proc_environ(environ, "WARP_SESSION_ID"),
+            Some("123".to_string())
+        );
+        assert_eq!(
+            parse_proc_environ(environ, "KITTY_WINDOW_ID"),
+            Some(String::new())
+        );
+        assert_eq!(parse_proc_environ(environ, "KONSOLE_DBUS_SESSION"), None);
     }
 }

--- a/src/app/overlays/inline_image/tmux.rs
+++ b/src/app/overlays/inline_image/tmux.rs
@@ -1,0 +1,150 @@
+//! tmux DCS-passthrough helpers for terminal image escape sequences.
+
+use ratatui::layout::Rect;
+use std::process::Command;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct TmuxPaneOrigin {
+    pub(super) top: u16,
+    pub(super) left: u16,
+}
+
+impl TmuxPaneOrigin {
+    pub(super) fn absolute_cursor_for(self, area: Rect) -> (u32, u32) {
+        (
+            u32::from(self.top) + u32::from(area.y) + 1,
+            u32::from(self.left) + u32::from(area.x) + 1,
+        )
+    }
+}
+
+pub(super) fn inside_tmux() -> bool {
+    std::env::var_os("TMUX").is_some()
+}
+
+pub(super) fn query_pane_origin() -> Option<TmuxPaneOrigin> {
+    if !inside_tmux() {
+        return None;
+    }
+    let output = Command::new("tmux")
+        .args(["display-message", "-p", "#{pane_top},#{pane_left}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    parse_pane_origin(&stdout)
+}
+
+pub(super) fn parse_pane_origin(raw: &str) -> Option<TmuxPaneOrigin> {
+    let trimmed = raw.trim();
+    let (top, left) = trimmed.split_once(',')?;
+    Some(TmuxPaneOrigin {
+        top: top.parse().ok()?,
+        left: left.parse().ok()?,
+    })
+}
+
+/// Wrap a complete escape sequence for tmux passthrough. Every ESC byte inside
+/// the payload must be doubled so tmux does not treat it as the outer DCS
+/// terminator.
+pub(super) fn wrap_sequence_for_tmux(seq: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(seq.len() + seq.len() / 8 + 16);
+    out.extend_from_slice(b"\x1bPtmux;");
+    for &byte in seq {
+        if byte == 0x1b {
+            out.extend_from_slice(b"\x1b\x1b");
+        } else {
+            out.push(byte);
+        }
+    }
+    out.extend_from_slice(b"\x1b\\");
+    out
+}
+
+/// Wrap each Kitty APC sequence in the tmux DCS passthrough envelope when the
+/// current process is running inside tmux. Non-APC bytes remain outside the
+/// passthrough wrapper so the Kitty placeholder path still lets tmux lay out
+/// its text placeholders normally.
+pub(super) fn maybe_wrap_kitty_apcs_for_tmux(buf: Vec<u8>) -> Vec<u8> {
+    if !inside_tmux() {
+        return buf;
+    }
+    wrap_kitty_apcs_for_tmux(&buf)
+}
+
+fn wrap_kitty_apcs_for_tmux(buf: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(buf.len() + buf.len() / 4);
+    let mut i = 0;
+    while i < buf.len() {
+        if buf.len() - i >= 3
+            && &buf[i..i + 3] == b"\x1b_G"
+            && let Some(rel) = buf[i + 3..].iter().position(|&b| b == 0x1b)
+            && buf.get(i + 3 + rel + 1) == Some(&b'\\')
+        {
+            let body_end = i + 3 + rel;
+            out.extend(wrap_sequence_for_tmux(&buf[i..body_end + 2]));
+            i = body_end + 2;
+            continue;
+        }
+        out.push(buf[i]);
+        i += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_sequence_for_tmux_doubles_inner_escape_bytes() {
+        let input = b"\x1b[7;14H\x1b_Ga=T;AAAA\x1b\\";
+        let expected: &[u8] = b"\x1bPtmux;\x1b\x1b[7;14H\x1b\x1b_Ga=T;AAAA\x1b\x1b\\\x1b\\";
+        assert_eq!(wrap_sequence_for_tmux(input), expected);
+    }
+
+    #[test]
+    fn wrap_kitty_apcs_for_tmux_envelopes_each_apc_and_leaves_csi_alone() {
+        let input =
+            b"\x1b_Ga=T,i=1,c=2,r=2;AAAA\x1b\\\x1b[5;10H\xf4\x8e\xbb\xae\x1b_Gm=0;BBBB\x1b\\";
+        let out = wrap_kitty_apcs_for_tmux(input);
+        let expected: &[u8] = b"\x1bPtmux;\x1b\x1b_Ga=T,i=1,c=2,r=2;AAAA\x1b\x1b\\\x1b\\\x1b[5;10H\xf4\x8e\xbb\xae\x1bPtmux;\x1b\x1b_Gm=0;BBBB\x1b\x1b\\\x1b\\";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn wrap_kitty_apcs_for_tmux_is_noop_without_apcs() {
+        let input = b"\x1b[5;10Hhello\x1b[0m";
+        let out = wrap_kitty_apcs_for_tmux(input);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn parse_pane_origin_reads_top_and_left() {
+        assert_eq!(
+            parse_pane_origin("12,34\n"),
+            Some(TmuxPaneOrigin { top: 12, left: 34 })
+        );
+    }
+
+    #[test]
+    fn parse_pane_origin_rejects_bad_values() {
+        assert_eq!(parse_pane_origin("12\n"), None);
+        assert_eq!(parse_pane_origin("top,4\n"), None);
+        assert_eq!(parse_pane_origin("4,left\n"), None);
+    }
+
+    #[test]
+    fn pane_origin_calculates_one_based_absolute_cursor() {
+        let origin = TmuxPaneOrigin { top: 2, left: 3 };
+        let area = Rect {
+            x: 10,
+            y: 4,
+            width: 8,
+            height: 6,
+        };
+        assert_eq!(origin.absolute_cursor_for(area), (7, 14));
+    }
+}


### PR DESCRIPTION
## Summary

Fix tmux preview support for Kitty direct-placement graphics in Konsole and Warp.

Refs #70

## What Changed

- Detect Warp and Konsole correctly inside tmux, including stale Kitty env marker cases.
- Add shared tmux DCS passthrough helpers for Kitty graphics sequences.
- Wrap Kitty direct-placement graphics through tmux passthrough.
- Position direct-placement previews using tmux pane offsets, so images render in the preview pane.

## User Impact

Terminal image previews now render correctly for Konsole and Warp inside tmux when `allow-passthrough` is enabled. This covers every preview path that uses elio’s terminal image renderer, including images, PDFs, comics, audio covers, and video thumbnails.

Kitty and Ghostty tmux preview behavior is preserved.

## Notes

`allow-passthrough on` is still required in tmux. This PR covers Konsole and Warp direct-placement graphics; Kitty and Ghostty continue using the existing KittyGraphics placeholder path.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested inside tmux in Konsole, Warp, Ghostty, and Kitty with:
  - `tmux set -g allow-passthrough on`
  - `cargo run`
- Repeated inside tmux in all four terminals with debug logging:
  - `rm -f /tmp/elio-preview.log`
  - `ELIO_DEBUG_PREVIEW=1 cargo run`
  - `tail -n 80 /tmp/elio-preview.log`
- Tested outside tmux with `cargo run` in all four terminals.
- Tested sanitized tmux-like env with the branch binary in all four terminals:
  - `env -u ELIO_IMAGE_PREVIEWS -u KITTY_WINDOW_ID TERM=tmux-256color TERM_PROGRAM=tmux cargo run`

Result:

All automated checks passed locally. Manual preview checks passed for terminal image previews in Konsole, Warp, Ghostty, and Kitty, both inside and outside tmux.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed