### PR TITLE
fix(tmux): enable passthrough automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Auto-enable tmux `allow-passthrough` for image previews in supported terminals, so users no longer need to configure it manually.
 - Fixed Kitty direct-placement preview transport and placement inside tmux for Konsole and Warp. ([#70])
 
 ## [1.4.0] - 2026-05-03

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -131,6 +131,12 @@ impl App {
         ));
         self.preview.terminal_images.identity = identity;
         self.preview.terminal_images.protocol = protocol;
+        if matches!(
+            protocol,
+            ImageProtocol::KittyGraphics | ImageProtocol::KittyDirectGraphics
+        ) {
+            tmux::enable_allow_passthrough();
+        }
         self.preview.pdf.pdf_tools_available = pdf_preview_tools_available();
         self.refresh_terminal_image_window_size();
         preview_log(format_args!(

--- a/src/app/overlays/inline_image/tmux.rs
+++ b/src/app/overlays/inline_image/tmux.rs
@@ -1,7 +1,7 @@
 //! tmux DCS-passthrough helpers for terminal image escape sequences.
 
 use ratatui::layout::Rect;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct TmuxPaneOrigin {
@@ -20,6 +20,37 @@ impl TmuxPaneOrigin {
 
 pub(super) fn inside_tmux() -> bool {
     std::env::var_os("TMUX").is_some()
+}
+
+pub(super) fn enable_allow_passthrough() {
+    if !inside_tmux() {
+        return;
+    }
+
+    let mut command = Command::new("tmux");
+    command.args(allow_passthrough_args(
+        std::env::var_os("TMUX_PANE").as_deref(),
+    ));
+    let _ = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn allow_passthrough_args(target_pane: Option<&std::ffi::OsStr>) -> Vec<std::ffi::OsString> {
+    let mut args = ["set-option", "-p", "-q"]
+        .into_iter()
+        .map(std::ffi::OsString::from)
+        .collect::<Vec<_>>();
+    if let Some(pane) = target_pane
+        && !pane.is_empty()
+    {
+        args.push("-t".into());
+        args.push(pane.into());
+    }
+    args.extend(["allow-passthrough", "on"].into_iter().map(Into::into));
+    args
 }
 
 pub(super) fn query_pane_origin() -> Option<TmuxPaneOrigin> {
@@ -134,6 +165,30 @@ mod tests {
         assert_eq!(parse_pane_origin("12\n"), None);
         assert_eq!(parse_pane_origin("top,4\n"), None);
         assert_eq!(parse_pane_origin("4,left\n"), None);
+    }
+
+    #[test]
+    fn allow_passthrough_args_target_current_pane_when_available() {
+        assert_eq!(
+            allow_passthrough_args(Some(std::ffi::OsStr::new("%7"))),
+            vec![
+                "set-option",
+                "-p",
+                "-q",
+                "-t",
+                "%7",
+                "allow-passthrough",
+                "on"
+            ]
+        );
+    }
+
+    #[test]
+    fn allow_passthrough_args_fall_back_to_implicit_target() {
+        assert_eq!(
+            allow_passthrough_args(None),
+            vec!["set-option", "-p", "-q", "allow-passthrough", "on"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Auto-enable tmux `allow-passthrough` for terminal image previews in supported terminals.

## What Changed

- Enables `allow-passthrough` on the current tmux pane during terminal image preview setup.
- Applies to the tmux passthrough preview paths used by Kitty, Ghostty, Warp, and Konsole.
- Silences tmux command output and treats failures as non-fatal.

## User Impact

Preview images inside tmux work without requiring users to configure `allow-passthrough` manually.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

Verified preview images inside tmux across Kitty, Ghostty, Warp, and Konsole.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
