### PR TITLE
fix(preview): support iTerm inline previews in tmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Auto-enable tmux `allow-passthrough` for image previews in supported terminals, so users no longer need to configure it manually.
+- Fixed iTerm inline preview transport and placement inside tmux, including correct pane-relative positioning and compact cached payloads for large JPEG/GIF previews that could otherwise lag or disappear. ([#70])
 - Fixed Kitty direct-placement preview transport and placement inside tmux for Konsole and Warp. ([#70])
 
 ## [1.4.0] - 2026-05-03

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -25,9 +25,11 @@ const STATIC_IMAGE_INLINE_PAYLOAD_CACHE_LIMIT: usize = 16;
 const SIXEL_DCS_CACHE_LIMIT: usize = 128;
 const STATIC_IMAGE_PRELOAD_LIMIT: usize = 12;
 const STATIC_IMAGE_PRELOAD_LIMIT_SLOW_SIXEL: usize = 2;
+// Keep base64 + OSC overhead below the 1 MiB iTerm/tmux single-sequence limit.
+const STATIC_IMAGE_ITERM_SOURCE_PASSTHROUGH_MAX_BYTES: u64 = 700 * 1024;
 const STATIC_IMAGE_INLINE_FALLBACK_PREPARE_MAX_BYTES: u64 = 512 * 1024;
 const STATIC_IMAGE_INLINE_EXTERNAL_PREPARE_MAX_BYTES: u64 = 16 * 1024 * 1024;
-const STATIC_IMAGE_RENDER_CACHE_VERSION: usize = 3;
+const STATIC_IMAGE_RENDER_CACHE_VERSION: usize = 5;
 const FAST_FORCE_RENDER_FFMPEG_RASTER_ARGS: [&str; 4] =
     ["-compression_level", "1", "-sws_flags", "fast_bilinear"];
 const DEFAULT_FFMPEG_RASTER_ARGS: [&str; 0] = [];

--- a/src/app/overlays/images/prepare.rs
+++ b/src/app/overlays/images/prepare.rs
@@ -3,13 +3,15 @@ use super::format::{
     static_image_format_for_overlay_request, static_image_format_for_prepare_request,
 };
 use super::render::{
-    apply_raster_orientation, render_raster_to_png_with_ffmpeg, render_svg_to_png_with_magick,
-    render_svg_to_png_with_resvg, should_render_raster_with_ffmpeg, shrink_image_to_fit,
+    apply_raster_orientation, render_raster_to_jpeg_with_ffmpeg, render_raster_to_png_with_ffmpeg,
+    render_svg_to_png_with_magick, render_svg_to_png_with_resvg, should_render_raster_with_ffmpeg,
+    shrink_image_to_fit,
 };
 use super::{
     PreparedStaticImageAsset, STATIC_IMAGE_INLINE_EXTERNAL_PREPARE_MAX_BYTES,
-    STATIC_IMAGE_INLINE_FALLBACK_PREPARE_MAX_BYTES, STATIC_IMAGE_RENDER_CACHE_VERSION, SixelDcsKey,
-    StaticImageKey, StaticImageOverlayRequest,
+    STATIC_IMAGE_INLINE_FALLBACK_PREPARE_MAX_BYTES,
+    STATIC_IMAGE_ITERM_SOURCE_PASSTHROUGH_MAX_BYTES, STATIC_IMAGE_RENDER_CACHE_VERSION,
+    SixelDcsKey, StaticImageKey, StaticImageOverlayRequest,
 };
 use crate::app::jobs;
 use crate::app::overlays::inline_image::{
@@ -98,7 +100,7 @@ where
     }
 
     if format == StaticImageFormat::Svg {
-        let cache_path = static_image_render_cache_path(&key)?;
+        let cache_path = static_image_render_cache_path(&key, StaticImageRenderCacheFormat::Png)?;
         if cache_path.exists() {
             let payload = inline_payload(&cache_path)?;
             let (sixel_dcs, sixel_dcs_key) = prepare_sixel_dcs(&cache_path);
@@ -144,7 +146,8 @@ where
         return None;
     }
 
-    let cache_path = static_image_render_cache_path(&key)?;
+    let render_format = static_image_render_cache_format(request, format);
+    let cache_path = static_image_render_cache_path(&key, render_format)?;
     if cache_path.exists() {
         let payload = inline_payload(&cache_path)?;
         let (sixel_dcs, sixel_dcs_key) = prepare_sixel_dcs(&cache_path);
@@ -161,17 +164,26 @@ where
     }
     let temp_path = static_image_render_temp_path(&cache_path)?;
 
-    if request.ffmpeg_available
+    let rendered_with_ffmpeg = request.ffmpeg_available
         && should_render_raster_with_ffmpeg(format)
-        && render_raster_to_png_with_ffmpeg(
-            &request.path,
-            &temp_path,
-            target_width_px,
-            target_height_px,
-            request.force_render_to_cache,
-            &canceled,
-        )
-    {
+        && match render_format {
+            StaticImageRenderCacheFormat::Jpeg => render_raster_to_jpeg_with_ffmpeg(
+                &request.path,
+                &temp_path,
+                target_width_px,
+                target_height_px,
+                &canceled,
+            ),
+            StaticImageRenderCacheFormat::Png => render_raster_to_png_with_ffmpeg(
+                &request.path,
+                &temp_path,
+                target_width_px,
+                target_height_px,
+                static_image_use_fast_png_render(request),
+                &canceled,
+            ),
+        };
+    if rendered_with_ffmpeg {
         finalize_static_image_render(&temp_path, &cache_path)?;
         let payload = inline_payload(&cache_path)?;
         let (sixel_dcs, sixel_dcs_key) = prepare_sixel_dcs(&cache_path);
@@ -201,7 +213,7 @@ where
     if canceled() {
         return None;
     }
-    image.save_with_format(&temp_path, ImageFormat::Png).ok()?;
+    save_dynamic_image(&image, &temp_path, render_format)?;
     finalize_static_image_render(&temp_path, &cache_path)?;
     let payload = inline_payload(&cache_path)?;
     let (sixel_dcs, sixel_dcs_key) = prepare_sixel_dcs(&cache_path);
@@ -215,20 +227,74 @@ where
     })
 }
 
-fn static_image_render_cache_path(key: &StaticImageKey) -> Option<PathBuf> {
+#[derive(Clone, Copy, Hash)]
+enum StaticImageRenderCacheFormat {
+    Png,
+    Jpeg,
+}
+
+impl StaticImageRenderCacheFormat {
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Jpeg => "jpg",
+        }
+    }
+}
+
+fn static_image_render_cache_format(
+    request: &jobs::ImagePrepareRequest,
+    format: StaticImageFormat,
+) -> StaticImageRenderCacheFormat {
+    if request.prepare_inline_payload && format == StaticImageFormat::Jpeg {
+        StaticImageRenderCacheFormat::Jpeg
+    } else {
+        StaticImageRenderCacheFormat::Png
+    }
+}
+
+fn static_image_use_fast_png_render(request: &jobs::ImagePrepareRequest) -> bool {
+    request.force_render_to_cache && !request.prepare_inline_payload
+}
+
+fn save_dynamic_image(
+    image: &image::DynamicImage,
+    path: &Path,
+    format: StaticImageRenderCacheFormat,
+) -> Option<()> {
+    match format {
+        StaticImageRenderCacheFormat::Png => image.save_with_format(path, ImageFormat::Png).ok()?,
+        StaticImageRenderCacheFormat::Jpeg => image
+            .to_rgb8()
+            .save_with_format(path, ImageFormat::Jpeg)
+            .ok()?,
+    }
+    Some(())
+}
+
+fn static_image_render_cache_path(
+    key: &StaticImageKey,
+    format: StaticImageRenderCacheFormat,
+) -> Option<PathBuf> {
     let mut hasher = DefaultHasher::new();
     STATIC_IMAGE_RENDER_CACHE_VERSION.hash(&mut hasher);
+    format.hash(&mut hasher);
     key.path.hash(&mut hasher);
     key.size.hash(&mut hasher);
     key.modified.hash(&mut hasher);
     key.target_width_px.hash(&mut hasher);
     key.target_height_px.hash(&mut hasher);
     key.force_render_to_cache.hash(&mut hasher);
+    key.prepare_inline_payload.hash(&mut hasher);
     let cache_dir = env::temp_dir().join(format!(
         "elio-image-preview-v{STATIC_IMAGE_RENDER_CACHE_VERSION}"
     ));
     fs::create_dir_all(&cache_dir).ok()?;
-    Some(cache_dir.join(format!("image-{:016x}.png", hasher.finish())))
+    Some(cache_dir.join(format!(
+        "image-{:016x}.{}",
+        hasher.finish(),
+        format.extension()
+    )))
 }
 
 fn static_image_render_temp_path(path: &Path) -> Option<PathBuf> {
@@ -286,9 +352,13 @@ pub(super) fn static_image_can_prepare_inline(
 pub(super) fn static_image_supports_iterm_source_passthrough(
     request: &StaticImageOverlayRequest,
 ) -> bool {
+    if request.force_render_to_cache
+        || request.size > STATIC_IMAGE_ITERM_SOURCE_PASSTHROUGH_MAX_BYTES
+    {
+        return false;
+    }
     static_image_format_for_overlay_request(request)
         .is_some_and(|format| static_image_supports_iterm_source_format(&request.path, format))
-        && !request.force_render_to_cache
 }
 
 fn static_image_supports_iterm_source_passthrough_for_prepare(
@@ -297,6 +367,7 @@ fn static_image_supports_iterm_source_passthrough_for_prepare(
 ) -> bool {
     request.prepare_inline_payload
         && !request.force_render_to_cache
+        && request.size <= STATIC_IMAGE_ITERM_SOURCE_PASSTHROUGH_MAX_BYTES
         && static_image_supports_iterm_source_format(&request.path, format)
 }
 
@@ -306,5 +377,42 @@ fn static_image_supports_iterm_source_format(path: &Path, format: StaticImageFor
         StaticImageFormat::Ico => false,
         StaticImageFormat::Jpeg => read_exif_orientation(path).unwrap_or(1) == 1,
         StaticImageFormat::Gif | StaticImageFormat::Webp | StaticImageFormat::Svg => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image_prepare_request(
+        force_render_to_cache: bool,
+        prepare_inline_payload: bool,
+    ) -> jobs::ImagePrepareRequest {
+        jobs::ImagePrepareRequest {
+            path: PathBuf::from("demo.gif"),
+            size: 1024,
+            modified: None,
+            target_width_px: 320,
+            target_height_px: 180,
+            ffmpeg_available: true,
+            resvg_available: false,
+            magick_available: false,
+            force_render_to_cache,
+            prepare_inline_payload,
+            sixel_prepare: None,
+        }
+    }
+
+    #[test]
+    fn iterm_inline_forced_cache_does_not_use_fast_png_rendering() {
+        assert!(!static_image_use_fast_png_render(&image_prepare_request(
+            true, true,
+        )));
+        assert!(static_image_use_fast_png_render(&image_prepare_request(
+            true, false,
+        )));
+        assert!(!static_image_use_fast_png_render(&image_prepare_request(
+            false, true,
+        )));
     }
 }

--- a/src/app/overlays/images/render.rs
+++ b/src/app/overlays/images/render.rs
@@ -135,6 +135,45 @@ pub(super) fn render_raster_to_png_with_ffmpeg(
         .is_some_and(|status| status.success() && output_path.exists())
 }
 
+pub(super) fn render_raster_to_jpeg_with_ffmpeg(
+    input_path: &Path,
+    output_path: &Path,
+    target_width_px: u32,
+    target_height_px: u32,
+    canceled: &impl Fn() -> bool,
+) -> bool {
+    if let Some(parent) = output_path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        return false;
+    }
+
+    let mut command = Command::new("ffmpeg");
+    command
+        .arg("-v")
+        .arg("error")
+        .arg("-y")
+        .arg("-i")
+        .arg(input_path)
+        .arg("-frames:v")
+        .arg("1")
+        .arg("-vf")
+        .arg(format!(
+            "scale=w={}:h={}:force_original_aspect_ratio=decrease",
+            target_width_px.max(1),
+            target_height_px.max(1)
+        ))
+        .arg("-q:v")
+        // Good preview-pane quality while keeping iTerm inline payloads small.
+        .arg("3")
+        .arg(output_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    run_cancelable_command(&mut command, canceled)
+        .is_some_and(|status| status.success() && output_path.exists())
+}
+
 pub(super) fn apply_raster_orientation(image: DynamicImage, orientation: u16) -> DynamicImage {
     match orientation {
         2 => image.fliph(),

--- a/src/app/overlays/images/state.rs
+++ b/src/app/overlays/images/state.rs
@@ -234,6 +234,7 @@ impl App {
             .ffmpeg_available
             .unwrap_or_else(|| command_exists("ffmpeg"));
         !static_image_can_prepare_inline(visual.size, format, ffmpeg_available)
+            || self.uses_iterm_inline_protocol_inside_tmux()
     }
 
     pub(in crate::app) fn displayed_static_image_matches_active(&self) -> bool {
@@ -312,7 +313,7 @@ impl App {
             target_width_px: image_target_width_px(area, self.cached_terminal_window()),
             target_height_px: image_target_height_px(area, self.cached_terminal_window()),
             mode: StaticImageOverlayMode::FullPane,
-            force_render_to_cache: false,
+            force_render_to_cache: self.uses_iterm_inline_protocol_inside_tmux(),
             prepare_inline_payload: self.preview.terminal_images.protocol
                 == ImageProtocol::ItermInline,
         })

--- a/src/app/overlays/inline_image/iterm.rs
+++ b/src/app/overlays/inline_image/iterm.rs
@@ -5,7 +5,10 @@ use std::{fs, io::Write as _, path::Path, sync::Arc};
 
 use crate::app::FrameState;
 
-use super::geometry::intersect_rect;
+use super::{
+    geometry::intersect_rect,
+    tmux::{self, TmuxPaneOrigin},
+};
 
 pub(in crate::app) fn encode_iterm_inline_payload(path: &Path) -> Option<Arc<str>> {
     let data = fs::read(path).ok()?;
@@ -25,17 +28,44 @@ pub(super) fn place_terminal_image_with_iterm_protocol(
             .map(|payload| payload.to_string())
             .context("failed to encode iTerm inline image payload")?,
     };
+    if tmux::inside_tmux() {
+        let origin = tmux::query_pane_origin()
+            .ok_or_else(|| anyhow::anyhow!("tmux pane origin unavailable"))?;
+        return Ok(build_iterm_tmux_placement_sequence(&encoded, area, origin));
+    }
+    Ok(build_iterm_placement_sequence(&encoded, area))
+}
+
+fn build_iterm_placement_sequence(encoded: &str, area: Rect) -> Vec<u8> {
+    build_iterm_placement_sequence_at(
+        encoded,
+        area.y.saturating_add(1).into(),
+        area.x.saturating_add(1).into(),
+        area,
+    )
+}
+
+fn build_iterm_tmux_placement_sequence(
+    encoded: &str,
+    area: Rect,
+    origin: TmuxPaneOrigin,
+) -> Vec<u8> {
+    let (row, col) = origin.absolute_cursor_for(area);
+    tmux::wrap_sequence_for_tmux(&build_iterm_placement_sequence_at(encoded, row, col, area))
+}
+
+fn build_iterm_placement_sequence_at(encoded: &str, row: u32, col: u32, area: Rect) -> Vec<u8> {
     // Move cursor to the top-left cell of the placement area, then emit the
     // OSC 1337 sequence. `width` and `height` are in terminal cells.
-    let seq = format!(
+    format!(
         "\x1b[{};{}H\x1b]1337;File=inline=1;width={};height={};preserveAspectRatio=1:{}\x07",
-        area.y.saturating_add(1),
-        area.x.saturating_add(1),
+        row,
+        col,
         area.width.max(1),
         area.height.max(1),
         encoded
-    );
-    Ok(seq.into_bytes())
+    )
+    .into_bytes()
 }
 
 /// Overwrite every cell in `area` with a space colored with the panel background
@@ -100,6 +130,28 @@ pub(super) fn expand_raster_erase_area(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_iterm_tmux_placement_wraps_absolute_cursor_and_inline_payload() {
+        let output = String::from_utf8(build_iterm_tmux_placement_sequence(
+            "YWJj",
+            Rect {
+                x: 10,
+                y: 4,
+                width: 8,
+                height: 6,
+            },
+            TmuxPaneOrigin { top: 2, left: 3 },
+        ))
+        .expect("tmux iTerm placement should be utf8");
+
+        assert!(output.starts_with("\x1bPtmux;\x1b\x1b[7;14H\x1b\x1b]1337;File=inline=1;"));
+        assert!(output.contains("width=8"));
+        assert!(output.contains("height=6"));
+        assert!(output.contains("preserveAspectRatio=1:YWJj\x07"));
+        assert!(output.ends_with("\x1b\\"));
+        assert!(!output.contains("\x1b[5;11H"));
+    }
 
     #[test]
     fn expand_raster_erase_area_can_grow_right_and_bottom_within_preview_bounds() {

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -133,7 +133,9 @@ impl App {
         self.preview.terminal_images.protocol = protocol;
         if matches!(
             protocol,
-            ImageProtocol::KittyGraphics | ImageProtocol::KittyDirectGraphics
+            ImageProtocol::KittyGraphics
+                | ImageProtocol::KittyDirectGraphics
+                | ImageProtocol::ItermInline
         ) {
             tmux::enable_allow_passthrough();
         }
@@ -179,6 +181,10 @@ impl App {
 
     pub(in crate::app) fn uses_sixel_image_protocol(&self) -> bool {
         self.preview.terminal_images.protocol == ImageProtocol::Sixel
+    }
+
+    pub(in crate::app) fn uses_iterm_inline_protocol_inside_tmux(&self) -> bool {
+        self.preview.terminal_images.protocol == ImageProtocol::ItermInline && tmux::inside_tmux()
     }
 
     pub(crate) fn is_windows_terminal(&self) -> bool {

--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -137,8 +137,12 @@ fn classify_tmux_recovered_identity(
         Some(TerminalIdentity::Kitty)
     } else if term.contains("ghostty") || term_program == "ghostty" {
         Some(TerminalIdentity::Ghostty)
+    } else if term.contains("wezterm") || term_program == "wezterm" {
+        Some(TerminalIdentity::WezTerm)
     } else if term_program.contains("warp") || warp_session_id_set {
         Some(TerminalIdentity::Warp)
+    } else if term_program == "iterm.app" {
+        Some(TerminalIdentity::ITerm2)
     } else if konsole_dbus_set {
         Some(TerminalIdentity::Konsole)
     } else if kitty_window_id_set {
@@ -787,6 +791,40 @@ mod tests {
             },
         );
         assert_eq!(id, TerminalIdentity::Ghostty);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_term_program_wezterm() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            no_tmux_env_lookup,
+            |name| {
+                if name == "TERM_PROGRAM" {
+                    Some("WezTerm".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::WezTerm);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_term_program_iterm2() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            no_tmux_env_lookup,
+            |name| {
+                if name == "TERM_PROGRAM" {
+                    Some("iTerm.app".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::ITerm2);
     }
 
     #[test]

--- a/src/app/overlays/pdf/tests/protocols.rs
+++ b/src/app/overlays/pdf/tests/protocols.rs
@@ -1,6 +1,22 @@
 use super::helpers::*;
+use image::{DynamicImage, Rgb, RgbImage};
 use ratatui::layout::Rect;
 use std::fs;
+
+fn write_large_test_jpeg(path: &std::path::Path) {
+    let mut image = RgbImage::new(1800, 1200);
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+        *pixel = Rgb([
+            ((x * 31 + y * 17) & 0xff) as u8,
+            ((x * 13 + y * 47) & 0xff) as u8,
+            ((x * 71 + y * 5) & 0xff) as u8,
+        ]);
+    }
+
+    DynamicImage::ImageRgb8(image)
+        .save_with_format(path, ImageFormat::Jpeg)
+        .expect("failed to write large jpeg");
+}
 
 #[test]
 fn iterm_png_and_jpeg_static_images_use_direct_source_payloads() {
@@ -44,6 +60,67 @@ fn iterm_png_and_jpeg_static_images_use_direct_source_payloads() {
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }
+}
+
+#[test]
+fn iterm_large_jpeg_static_image_uses_compact_cached_payload() {
+    let root = temp_root("iterm-compact-static-image");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("large.jpg");
+    write_large_test_jpeg(&path);
+    let metadata = fs::metadata(&path).expect("image metadata should exist");
+    assert!(
+        metadata.len() > 800 * 1024,
+        "test jpeg should be large enough to skip source passthrough"
+    );
+
+    let prepared = crate::app::overlays::images::prepare_static_image_asset(
+        &crate::app::jobs::ImagePrepareRequest {
+            path: path.clone(),
+            size: metadata.len(),
+            modified: None,
+            target_width_px: 360,
+            target_height_px: 240,
+            ffmpeg_available: false,
+            resvg_available: false,
+            magick_available: false,
+            force_render_to_cache: false,
+            prepare_inline_payload: true,
+            sixel_prepare: None,
+        },
+        || false,
+    )
+    .expect("large iterm jpeg should prepare successfully");
+
+    assert_ne!(prepared.display_path, path);
+    assert_eq!(
+        prepared
+            .display_path
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("jpg")
+    );
+    assert!(
+        prepared
+            .inline_payload
+            .as_ref()
+            .is_some_and(|payload| payload.len() < metadata.len() as usize)
+    );
+
+    let rendered = image::ImageReader::open(&prepared.display_path)
+        .expect("compact jpeg should exist")
+        .decode()
+        .expect("compact jpeg should decode");
+    assert!(rendered.width() <= 360);
+    assert!(rendered.height() <= 240);
+    assert!(
+        fs::metadata(&prepared.display_path)
+            .expect("compact jpeg metadata should exist")
+            .len()
+            < metadata.len()
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
 #[test]

--- a/src/app/overlays/preview_visual/tests/cache.rs
+++ b/src/app/overlays/preview_visual/tests/cache.rs
@@ -129,7 +129,7 @@ fn concurrent_inline_raster_prepares_keep_shared_render_cache_readable() {
                     prepared
                         .display_path
                         .parent()
-                        .is_some_and(|parent| parent.ends_with("elio-image-preview-v3"))
+                        .is_some_and(|parent| parent.ends_with("elio-image-preview-v5"))
                 );
             }
         }));


### PR DESCRIPTION
## Summary

Adds iTerm inline image preview support inside tmux, fixing image previews for iTerm-compatible terminals in tmux. Ref #70.

## What Changed

- Detect iTerm2 and WezTerm identities from tmux client/session environment.
- Wrap iTerm inline image sequences for tmux passthrough and place them using absolute pane coordinates.
- Force cached iTerm payloads inside tmux so originals are not sent directly through tmux.
- Compact large iTerm JPEG previews to preview-sized cached JPEGs.
- Use normal PNG compression for iTerm inline cached PNG/GIF frames to avoid oversized tmux payloads.
- Added regression coverage for tmux/iTerm placement, identity recovery, and large iTerm JPEG payload prep.

## User Impact

Image previews now render in iTerm-compatible terminals inside tmux. Large JPEGs and GIF-derived preview frames should render faster and avoid disappearing due to tmux/iTerm sequence-size limits.

## Notes

Multipart iTerm transport is still a possible future hardening step, but this keeps payloads small enough for the tested static image, GIF, EPUB, comic, PDF, video thumbnail, and audio artwork preview paths.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Linux: WezTerm outside tmux and inside tmux
- Linux: Kitty and Konsole smoke checks
- macOS VM: iTerm2 outside tmux and inside tmux
- Previewed static images: PNG, GIF, large JPEGs, and other common raster images
- Previewed document-backed image surfaces: EPUB, comics, and PDF pages
- Previewed media-backed image surfaces: video thumbnails and audio artwork
- Verified tmux rendering, non-tmux rendering, placement, and switching between preview types

Result:

All checks passed locally. Manual preview smoke checks passed across terminals, tmux modes, and preview formats.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
