### PR TITLE
fix(preview): support Sixel previews in tmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Auto-enable tmux `allow-passthrough` for image previews in supported terminals, so users no longer need to configure it manually.
+- Fixed Sixel preview support inside tmux, including Foot and Windows Terminal detection from tmux client/session environment. Windows Terminal now uses tmux's native Sixel path to avoid corrupted alternate-screen rendering in WSL. ([#70])
+- Fixed undersized Windows Terminal Sixel previews on WSL outside tmux by querying the terminal cell pixel size before falling back to default cell dimensions.
 - Fixed iTerm inline preview transport and placement inside tmux, including correct pane-relative positioning and compact cached payloads for large JPEG/GIF previews that could otherwise lag or disappear. ([#70])
 - Fixed Kitty direct-placement preview transport and placement inside tmux for Konsole and Warp. ([#70])
 

--- a/src/app/overlays/images/present.rs
+++ b/src/app/overlays/images/present.rs
@@ -296,7 +296,7 @@ impl App {
                     dcs
                 }
             };
-            return Ok(place_sixel_from_dcs(&dcs, placement));
+            return place_sixel_from_dcs(&dcs, placement);
         }
         place_terminal_image(
             protocol,

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -136,6 +136,7 @@ impl App {
             ImageProtocol::KittyGraphics
                 | ImageProtocol::KittyDirectGraphics
                 | ImageProtocol::ItermInline
+                | ImageProtocol::Sixel
         ) {
             tmux::enable_allow_passthrough();
         }

--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -46,7 +46,7 @@ fn detect_terminal_identity_with(
     }
 
     if let Some(term) = tmux_client_term()
-        && let Some(id) = classify_kitty_or_ghostty(&term, "", false)
+        && let Some(id) = classify_tmux_client_termname(&term)
     {
         return id;
     }
@@ -105,20 +105,14 @@ fn classify_from_env(env_lookup: &impl Fn(&str) -> Option<String>) -> TerminalId
     }
 }
 
-/// Narrow Kitty/Ghostty match used by the tmux fallback. `kitty_window_id_set`
-/// is presence-only (empty values still count as Kitty), matching the
-/// `env::var_os(...).is_some()` semantics of the direct-env path.
-fn classify_kitty_or_ghostty(
-    term: &str,
-    term_program: &str,
-    kitty_window_id_set: bool,
-) -> Option<TerminalIdentity> {
+fn classify_tmux_client_termname(term: &str) -> Option<TerminalIdentity> {
     let term = term.to_ascii_lowercase();
-    let term_program = term_program.to_ascii_lowercase();
-    if kitty_window_id_set || term.contains("xterm-kitty") || term_program == "kitty" {
+    if term.contains("xterm-kitty") {
         Some(TerminalIdentity::Kitty)
-    } else if term.contains("ghostty") || term_program == "ghostty" {
+    } else if term.contains("ghostty") {
         Some(TerminalIdentity::Ghostty)
+    } else if term == "foot" || term == "foot-extra" {
+        Some(TerminalIdentity::Foot)
     } else {
         None
     }
@@ -130,6 +124,7 @@ fn classify_tmux_recovered_identity(
     kitty_window_id_set: bool,
     warp_session_id_set: bool,
     konsole_dbus_set: bool,
+    windows_terminal_session_set: bool,
 ) -> Option<TerminalIdentity> {
     let term = term.to_ascii_lowercase();
     let term_program = term_program.to_ascii_lowercase();
@@ -145,6 +140,10 @@ fn classify_tmux_recovered_identity(
         Some(TerminalIdentity::ITerm2)
     } else if konsole_dbus_set {
         Some(TerminalIdentity::Konsole)
+    } else if term == "foot" || term == "foot-extra" {
+        Some(TerminalIdentity::Foot)
+    } else if windows_terminal_session_set {
+        Some(TerminalIdentity::WindowsTerminal)
     } else if kitty_window_id_set {
         Some(TerminalIdentity::Kitty)
     } else {
@@ -163,6 +162,7 @@ fn classify_supported_tmux_env(
         env_lookup("KONSOLE_DBUS_SESSION").is_some()
             || env_lookup("KONSOLE_DBUS_SERVICE").is_some()
             || env_lookup("KONSOLE_DBUS_WINDOW").is_some(),
+        env_lookup("WT_SESSION").is_some(),
     )
 }
 
@@ -181,13 +181,17 @@ fn recover_direct_graphics_identity_from_tmux(
         return None;
     }
 
-    // If tmux can identify a Kitty/Ghostty client directly, preserve that
-    // identity. Direct-placement terminals such as Konsole and Warp typically
-    // report only generic xterm-compatible TERM names to tmux.
+    // If tmux can identify a client directly, use that to correct stale
+    // markers inherited by the tmux pane. Kitty returns None because the direct
+    // environment already selected the same identity.
     if let Some(client_term) = tmux_client_term()
-        && classify_kitty_or_ghostty(&client_term, "", false).is_some()
+        && let Some(client_identity) = classify_tmux_client_termname(&client_term)
     {
-        return None;
+        return if client_identity == TerminalIdentity::Kitty {
+            None
+        } else {
+            Some(client_identity)
+        };
     }
 
     if let Some(client_identity) = classify_supported_tmux_env(tmux_client_env_lookup) {
@@ -758,6 +762,28 @@ mod tests {
     }
 
     #[test]
+    fn detect_terminal_identity_inside_tmux_uses_client_termname_for_foot() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            || Some("foot".to_string()),
+            no_tmux_env_lookup,
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::Foot);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_uses_client_termname_for_foot_extra() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            || Some("foot-extra".to_string()),
+            no_tmux_env_lookup,
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::Foot);
+    }
+
+    #[test]
     fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_kitty_window_id_presence() {
         // Empty value still counts as Kitty: tmux records `KITTY_WINDOW_ID=` for
         // present-but-empty vars, which must mirror `env::var_os(...).is_some()`.
@@ -859,6 +885,57 @@ mod tests {
             },
         );
         assert_eq!(id, TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_foot_term() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            no_tmux_env_lookup,
+            |name| {
+                if name == "TERM" {
+                    Some("foot".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::Foot);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_live_client_wt_session() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            |name| {
+                if name == "WT_SESSION" {
+                    Some("live-wt".to_string())
+                } else {
+                    None
+                }
+            },
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::WindowsTerminal);
+    }
+
+    #[test]
+    fn detect_terminal_identity_inside_tmux_falls_back_to_session_env_wt_session() {
+        let id = detect_terminal_identity_with(
+            tmux_set_only("/tmp/tmux-1000/default,123,4"),
+            no_tmux_client_term,
+            no_tmux_env_lookup,
+            |name| {
+                if name == "WT_SESSION" {
+                    Some("session-wt".to_string())
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(id, TerminalIdentity::WindowsTerminal);
     }
 
     #[test]
@@ -1050,6 +1127,46 @@ mod tests {
             no_tmux_env_lookup,
         );
         assert_eq!(id, TerminalIdentity::Konsole);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recovers_foot_from_tmux_when_stale_kitty_marker_leaks() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("foot".to_string()),
+            no_tmux_env_lookup,
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::Foot);
+    }
+
+    #[test]
+    fn detect_terminal_identity_recovers_wt_from_live_client_env_when_stale_kitty_marker_leaks() {
+        let id = detect_terminal_identity_with(
+            |name| match name {
+                "TMUX" => Some("/tmp/tmux-1000/default,123,4".to_string()),
+                "TERM" => Some("tmux-256color".to_string()),
+                "TERM_PROGRAM" => Some("tmux".to_string()),
+                "KITTY_WINDOW_ID" => Some("1".to_string()),
+                _ => None,
+            },
+            || Some("xterm-256color".to_string()),
+            |name| {
+                if name == "WT_SESSION" {
+                    Some("live-wt".to_string())
+                } else {
+                    None
+                }
+            },
+            no_tmux_env_lookup,
+        );
+        assert_eq!(id, TerminalIdentity::WindowsTerminal);
     }
 
     #[test]

--- a/src/app/overlays/inline_image/sixel.rs
+++ b/src/app/overlays/inline_image/sixel.rs
@@ -55,6 +55,9 @@ pub(in crate::app) fn encode_sixel_dcs(
 /// re-running the expensive encode for re-renders of the same image.
 pub(in crate::app) fn place_sixel_from_dcs(dcs: &[u8], placement: Rect) -> Result<Vec<u8>> {
     if tmux::inside_tmux() {
+        if detect_terminal_identity() == TerminalIdentity::WindowsTerminal {
+            return Ok(build_sixel_tmux_native_placement_sequence(dcs, placement));
+        }
         let origin = tmux::query_pane_origin()
             .ok_or_else(|| anyhow::anyhow!("tmux pane origin unavailable"))?;
         return Ok(build_sixel_tmux_placement_sequence(dcs, placement, origin));
@@ -68,6 +71,13 @@ fn build_sixel_placement_sequence(dcs: &[u8], placement: Rect) -> Vec<u8> {
         placement.y.saturating_add(1).into(),
         placement.x.saturating_add(1).into(),
     )
+}
+
+// Windows Terminal via WSL+tmux renders tmux passthrough Sixel incorrectly in
+// the alternate screen. Let tmux consume the raw Sixel and render it through
+// its native Sixel path instead.
+fn build_sixel_tmux_native_placement_sequence(dcs: &[u8], placement: Rect) -> Vec<u8> {
+    build_sixel_placement_sequence(dcs, placement)
 }
 
 fn build_sixel_tmux_placement_sequence(
@@ -650,6 +660,21 @@ mod tests {
             s,
             "\x1bPtmux;\x1b\x1b[7;14H\x1b\x1bP0;1;0qABC\x1b\x1b\\\x1b\\"
         );
+    }
+
+    #[test]
+    fn build_sixel_tmux_native_placement_keeps_pane_local_cursor_and_raw_dcs() {
+        let dcs = b"\x1bP0;1;0qABC\x1b\\";
+        let placement = Rect {
+            x: 10,
+            y: 4,
+            width: 3,
+            height: 2,
+        };
+        let out = build_sixel_tmux_native_placement_sequence(dcs, placement);
+        let s = String::from_utf8(out).expect("output should be valid utf8");
+
+        assert_eq!(s, "\x1b[5;11H\x1bP0;1;0qABC\x1b\\");
     }
 
     #[test]

--- a/src/app/overlays/inline_image/sixel.rs
+++ b/src/app/overlays/inline_image/sixel.rs
@@ -13,6 +13,7 @@ use std::{
 use super::{
     TerminalIdentity, TerminalWindowSize, area_pixel_size, fit_image_area,
     protocol::{command_exists, detect_terminal_identity},
+    tmux::{self, TmuxPaneOrigin},
 };
 
 const SIXEL_COLOR_LIMIT_DEFAULT: usize = 256;
@@ -52,14 +53,35 @@ pub(in crate::app) fn encode_sixel_dcs(
 ///
 /// This is O(n) in the DCS buffer size due to the memory copy, but avoids
 /// re-running the expensive encode for re-renders of the same image.
-pub(in crate::app) fn place_sixel_from_dcs(dcs: &[u8], placement: Rect) -> Vec<u8> {
+pub(in crate::app) fn place_sixel_from_dcs(dcs: &[u8], placement: Rect) -> Result<Vec<u8>> {
+    if tmux::inside_tmux() {
+        let origin = tmux::query_pane_origin()
+            .ok_or_else(|| anyhow::anyhow!("tmux pane origin unavailable"))?;
+        return Ok(build_sixel_tmux_placement_sequence(dcs, placement, origin));
+    }
+    Ok(build_sixel_placement_sequence(dcs, placement))
+}
+
+fn build_sixel_placement_sequence(dcs: &[u8], placement: Rect) -> Vec<u8> {
+    build_sixel_placement_sequence_at(
+        dcs,
+        placement.y.saturating_add(1).into(),
+        placement.x.saturating_add(1).into(),
+    )
+}
+
+fn build_sixel_tmux_placement_sequence(
+    dcs: &[u8],
+    placement: Rect,
+    origin: TmuxPaneOrigin,
+) -> Vec<u8> {
+    let (row, col) = origin.absolute_cursor_for(placement);
+    tmux::wrap_sequence_for_tmux(&build_sixel_placement_sequence_at(dcs, row, col))
+}
+
+fn build_sixel_placement_sequence_at(dcs: &[u8], row: u32, col: u32) -> Vec<u8> {
     let mut out = Vec::with_capacity(dcs.len() + 16);
-    let _ = write!(
-        out,
-        "\x1b[{};{}H",
-        placement.y.saturating_add(1),
-        placement.x.saturating_add(1)
-    );
+    let _ = write!(out, "\x1b[{row};{col}H");
     out.extend_from_slice(dcs);
     out
 }
@@ -86,7 +108,7 @@ pub(super) fn place_terminal_image_with_sixel_protocol(
     let (target_w, target_h) = area_pixel_size(placement, window_size);
 
     let dcs = encode_sixel_dcs_from_image(img, target_w, target_h, sixel_encode_profile())?;
-    Ok(place_sixel_from_dcs(&dcs, placement))
+    place_sixel_from_dcs(&dcs, placement)
 }
 
 /// No explicit clear primitive exists for Sixel — the next ratatui draw
@@ -400,6 +422,8 @@ mod tests {
                 "KONSOLE_DBUS_SESSION",
                 "KONSOLE_DBUS_SERVICE",
                 "KONSOLE_DBUS_WINDOW",
+                "TMUX",
+                "TMUX_PANE",
             ];
 
             let saved = VARS
@@ -430,6 +454,8 @@ mod tests {
 
     #[test]
     fn sixel_sequence_has_dcs_preamble_and_terminator() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
         let root = temp_root("sixel-preamble");
         fs::create_dir_all(&root).expect("failed to create temp root");
         let path = root.join("demo.png");
@@ -456,6 +482,8 @@ mod tests {
 
     #[test]
     fn sixel_sequence_positions_cursor_at_area_top_left() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
         let root = temp_root("sixel-cursor");
         fs::create_dir_all(&root).expect("failed to create temp root");
         let path = root.join("demo.png");
@@ -487,6 +515,8 @@ mod tests {
 
     #[test]
     fn sixel_sequence_contains_raster_attributes_and_palette() {
+        let _lock = terminal_env_lock();
+        let _guard = TerminalEnvGuard::isolate();
         let root = temp_root("sixel-raster");
         fs::create_dir_all(&root).expect("failed to create temp root");
         let path = root.join("demo.png");
@@ -593,7 +623,7 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let out = place_sixel_from_dcs(dcs, placement);
+        let out = build_sixel_placement_sequence(dcs, placement);
         let s = String::from_utf8(out).expect("output should be valid utf8");
 
         assert!(
@@ -601,6 +631,25 @@ mod tests {
             "expected cursor move to row 3 col 5, got: {s}"
         );
         assert!(s.contains("\x1bP"), "DCS stream should follow cursor move");
+    }
+
+    #[test]
+    fn build_sixel_tmux_placement_wraps_absolute_cursor_and_dcs() {
+        let dcs = b"\x1bP0;1;0qABC\x1b\\";
+        let placement = Rect {
+            x: 10,
+            y: 4,
+            width: 3,
+            height: 2,
+        };
+        let origin = TmuxPaneOrigin { top: 2, left: 3 };
+        let out = build_sixel_tmux_placement_sequence(dcs, placement, origin);
+        let s = String::from_utf8(out).expect("output should be valid utf8");
+
+        assert_eq!(
+            s,
+            "\x1bPtmux;\x1b\x1b[7;14H\x1b\x1bP0;1;0qABC\x1b\x1b\\\x1b\\"
+        );
     }
 
     #[test]

--- a/src/app/overlays/inline_image/window.rs
+++ b/src/app/overlays/inline_image/window.rs
@@ -1,6 +1,6 @@
 use super::TerminalWindowSize;
 use crossterm::terminal;
-#[cfg(windows)]
+#[cfg(any(unix, windows))]
 use std::{env, sync::OnceLock};
 
 pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
@@ -9,15 +9,16 @@ pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
         .as_ref()
         .map(|size| (size.columns, size.rows))
         .or_else(|| terminal::size().ok())?;
-    let (pixels_width, pixels_height) = terminal_size
-        .as_ref()
-        .and_then(|size| {
-            let width = u32::from(size.width);
-            let height = u32::from(size.height);
-            (width > 0 && height > 0).then_some((width, height))
-        })
-        .or_else(|| query_windows_terminal_pixels_from_cell_size(cells_width, cells_height))
-        .unwrap_or_else(|| fallback_window_size_pixels(cells_width, cells_height));
+    let (pixels_width, pixels_height) =
+        query_windows_terminal_pixels_from_cell_size(cells_width, cells_height)
+            .or_else(|| {
+                terminal_size.as_ref().and_then(|size| {
+                    let width = u32::from(size.width);
+                    let height = u32::from(size.height);
+                    (width > 0 && height > 0).then_some((width, height))
+                })
+            })
+            .unwrap_or_else(|| fallback_window_size_pixels(cells_width, cells_height));
     Some(TerminalWindowSize {
         cells_width,
         cells_height,
@@ -26,14 +27,14 @@ pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
     })
 }
 
-#[cfg(windows)]
+#[cfg(any(unix, windows))]
 fn query_windows_terminal_pixels_from_cell_size(
     cells_width: u16,
     cells_height: u16,
 ) -> Option<(u32, u32)> {
     static CELL_PX: OnceLock<Option<(u32, u32)>> = OnceLock::new();
 
-    if env::var_os("WT_SESSION").is_none() {
+    if env::var_os("WT_SESSION").is_none() || env::var_os("TMUX").is_some() {
         return None;
     }
 
@@ -44,7 +45,7 @@ fn query_windows_terminal_pixels_from_cell_size(
     ))
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(unix, windows)))]
 fn query_windows_terminal_pixels_from_cell_size(
     _cells_width: u16,
     _cells_height: u16,
@@ -128,7 +129,58 @@ fn query_windows_terminal_cell_pixel_size() -> Option<(u32, u32)> {
     parse_cell_pixel_response(std::str::from_utf8(&buf[..filled]).ok()?)
 }
 
-#[cfg(any(test, windows))]
+#[cfg(unix)]
+fn query_windows_terminal_cell_pixel_size() -> Option<(u32, u32)> {
+    use std::io::Write;
+    use std::time::{Duration, Instant};
+
+    let mut stdout = std::io::stdout();
+    stdout.write_all(b"\x1b[16t").ok()?;
+    stdout.flush().ok()?;
+
+    let deadline = Instant::now() + Duration::from_millis(300);
+    let mut buf = [0u8; 64];
+    let mut filled = 0usize;
+
+    loop {
+        let remaining_ms = deadline
+            .saturating_duration_since(Instant::now())
+            .as_millis()
+            .min(300) as i32;
+        if remaining_ms <= 0 {
+            return None;
+        }
+
+        let mut poll_fd = libc::pollfd {
+            fd: libc::STDIN_FILENO,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let poll_result = unsafe { libc::poll(&mut poll_fd, 1, remaining_ms) };
+        if poll_result <= 0 || poll_fd.revents & libc::POLLIN == 0 {
+            return None;
+        }
+
+        let space = buf.len().saturating_sub(filled);
+        if space == 0 {
+            return None;
+        }
+        let bytes_read =
+            unsafe { libc::read(libc::STDIN_FILENO, buf[filled..].as_mut_ptr().cast(), space) };
+        if bytes_read <= 0 {
+            return None;
+        }
+        filled += bytes_read as usize;
+
+        if buf[..filled].contains(&b't') {
+            break;
+        }
+    }
+
+    parse_cell_pixel_response(std::str::from_utf8(&buf[..filled]).ok()?)
+}
+
+#[cfg(any(test, unix, windows))]
 fn parse_cell_pixel_response(s: &str) -> Option<(u32, u32)> {
     let start = s.find("\x1b[6;")?;
     let rest = &s[start + 4..];

--- a/src/app/overlays/inline_image/window.rs
+++ b/src/app/overlays/inline_image/window.rs
@@ -1,15 +1,7 @@
 use super::TerminalWindowSize;
 use crossterm::terminal;
-use std::env;
 #[cfg(windows)]
-use std::sync::OnceLock;
-
-// Reject TIOCGWINSZ pixels outside these per-cell bounds: tmux on WSL/ConPTY
-// leaks Windows Terminal's full-window pixel size as if it were the pane's.
-const MIN_PLAUSIBLE_CELL_PX_WIDTH: u32 = 4;
-const MAX_PLAUSIBLE_CELL_PX_WIDTH: u32 = 20;
-const MIN_PLAUSIBLE_CELL_PX_HEIGHT: u32 = 8;
-const MAX_PLAUSIBLE_CELL_PX_HEIGHT: u32 = 40;
+use std::{env, sync::OnceLock};
 
 pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
     let terminal_size = terminal::window_size().ok();
@@ -22,15 +14,7 @@ pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
         .and_then(|size| {
             let width = u32::from(size.width);
             let height = u32::from(size.height);
-            if width == 0 || height == 0 {
-                return None;
-            }
-            if env::var_os("TMUX").is_some()
-                && !is_plausible_cell_pixel_ratio(width, height, cells_width, cells_height)
-            {
-                return None;
-            }
-            Some((width, height))
+            (width > 0 && height > 0).then_some((width, height))
         })
         .or_else(|| query_windows_terminal_pixels_from_cell_size(cells_width, cells_height))
         .unwrap_or_else(|| fallback_window_size_pixels(cells_width, cells_height));
@@ -40,18 +24,6 @@ pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
         pixels_width,
         pixels_height,
     })
-}
-
-fn is_plausible_cell_pixel_ratio(
-    pixels_width: u32,
-    pixels_height: u32,
-    cells_width: u16,
-    cells_height: u16,
-) -> bool {
-    let cell_px_w = pixels_width / u32::from(cells_width.max(1));
-    let cell_px_h = pixels_height / u32::from(cells_height.max(1));
-    (MIN_PLAUSIBLE_CELL_PX_WIDTH..=MAX_PLAUSIBLE_CELL_PX_WIDTH).contains(&cell_px_w)
-        && (MIN_PLAUSIBLE_CELL_PX_HEIGHT..=MAX_PLAUSIBLE_CELL_PX_HEIGHT).contains(&cell_px_h)
 }
 
 #[cfg(windows)]
@@ -204,13 +176,5 @@ mod tests {
     fn fallback_window_size_pixels_uses_reasonable_cell_defaults() {
         assert_eq!(fallback_window_size_pixels(100, 40), (800, 640));
         assert_eq!(fallback_window_size_pixels(0, 0), (8, 16));
-    }
-
-    #[test]
-    fn plausible_cell_pixel_ratio_filters_leaked_window_pixels() {
-        assert!(is_plausible_cell_pixel_ratio(800, 480, 80, 24)); // 10×20
-        assert!(is_plausible_cell_pixel_ratio(1280, 768, 80, 24)); // 16×32
-        assert!(!is_plausible_cell_pixel_ratio(1920, 1080, 80, 24)); // 24×45
-        assert!(!is_plausible_cell_pixel_ratio(10, 10, 80, 24)); // 0×0
     }
 }

--- a/src/app/overlays/inline_image/window.rs
+++ b/src/app/overlays/inline_image/window.rs
@@ -1,7 +1,15 @@
 use super::TerminalWindowSize;
 use crossterm::terminal;
+use std::env;
 #[cfg(windows)]
-use std::{env, sync::OnceLock};
+use std::sync::OnceLock;
+
+// Reject TIOCGWINSZ pixels outside these per-cell bounds: tmux on WSL/ConPTY
+// leaks Windows Terminal's full-window pixel size as if it were the pane's.
+const MIN_PLAUSIBLE_CELL_PX_WIDTH: u32 = 4;
+const MAX_PLAUSIBLE_CELL_PX_WIDTH: u32 = 20;
+const MIN_PLAUSIBLE_CELL_PX_HEIGHT: u32 = 8;
+const MAX_PLAUSIBLE_CELL_PX_HEIGHT: u32 = 40;
 
 pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
     let terminal_size = terminal::window_size().ok();
@@ -14,7 +22,15 @@ pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
         .and_then(|size| {
             let width = u32::from(size.width);
             let height = u32::from(size.height);
-            (width > 0 && height > 0).then_some((width, height))
+            if width == 0 || height == 0 {
+                return None;
+            }
+            if env::var_os("TMUX").is_some()
+                && !is_plausible_cell_pixel_ratio(width, height, cells_width, cells_height)
+            {
+                return None;
+            }
+            Some((width, height))
         })
         .or_else(|| query_windows_terminal_pixels_from_cell_size(cells_width, cells_height))
         .unwrap_or_else(|| fallback_window_size_pixels(cells_width, cells_height));
@@ -24,6 +40,18 @@ pub(super) fn query_terminal_window_size() -> Option<TerminalWindowSize> {
         pixels_width,
         pixels_height,
     })
+}
+
+fn is_plausible_cell_pixel_ratio(
+    pixels_width: u32,
+    pixels_height: u32,
+    cells_width: u16,
+    cells_height: u16,
+) -> bool {
+    let cell_px_w = pixels_width / u32::from(cells_width.max(1));
+    let cell_px_h = pixels_height / u32::from(cells_height.max(1));
+    (MIN_PLAUSIBLE_CELL_PX_WIDTH..=MAX_PLAUSIBLE_CELL_PX_WIDTH).contains(&cell_px_w)
+        && (MIN_PLAUSIBLE_CELL_PX_HEIGHT..=MAX_PLAUSIBLE_CELL_PX_HEIGHT).contains(&cell_px_h)
 }
 
 #[cfg(windows)]
@@ -176,5 +204,13 @@ mod tests {
     fn fallback_window_size_pixels_uses_reasonable_cell_defaults() {
         assert_eq!(fallback_window_size_pixels(100, 40), (800, 640));
         assert_eq!(fallback_window_size_pixels(0, 0), (8, 16));
+    }
+
+    #[test]
+    fn plausible_cell_pixel_ratio_filters_leaked_window_pixels() {
+        assert!(is_plausible_cell_pixel_ratio(800, 480, 80, 24)); // 10×20
+        assert!(is_plausible_cell_pixel_ratio(1280, 768, 80, 24)); // 16×32
+        assert!(!is_plausible_cell_pixel_ratio(1920, 1080, 80, 24)); // 24×45
+        assert!(!is_plausible_cell_pixel_ratio(10, 10, 80, 24)); // 0×0
     }
 }

--- a/src/app/overlays/pdf/present.rs
+++ b/src/app/overlays/pdf/present.rs
@@ -71,7 +71,7 @@ impl App {
                     let _ = self.ensure_pdf_render(&render_key);
                     return Ok(OverlayPresentState::Waiting);
                 };
-                place_sixel_from_dcs(&dcs, placement.image_area)
+                place_sixel_from_dcs(&dcs, placement.image_area)?
             }
             _ => match place_terminal_image(
                 protocol,


### PR DESCRIPTION
## Summary

Fixes Sixel preview behavior across tmux and Windows Terminal/WSL. The branch adds tmux Sixel preview support for Foot and Windows Terminal, routes Windows Terminal in WSL+tmux through tmux's native Sixel path, and fixes undersized Windows Terminal previews on WSL outside tmux.

Fixes #70.

## What Changed

- Detect Foot and Windows Terminal from tmux client/session environment so Sixel previews can be selected correctly inside tmux.
- Enable tmux passthrough for Sixel-capable preview sessions.
- Place Sixel previews correctly inside tmux:
  - Foot and other passthrough-compatible terminals use tmux passthrough with pane-origin-adjusted cursor placement.
  - Windows Terminal inside tmux uses tmux's native Sixel path to avoid corrupted alternate-screen rendering under WSL.
- Query Windows Terminal cell pixel size on WSL outside tmux before falling back to default cell dimensions.
- Updated the changelog for the Sixel/tmux and WT/WSL preview fixes.

## User Impact

Sixel image/PDF previews now work in tmux for Foot and Windows Terminal. Windows Terminal users on WSL also get correctly sized Sixel previews outside tmux instead of half-size renders.

## Notes

Windows Terminal under WSL+tmux cannot reliably render tmux passthrough Sixel in the alternate screen, but native tmux Sixel works there. This PR keeps the existing passthrough path for terminals that handle it correctly and only special-cases Windows Terminal inside tmux.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Windows Terminal
- Windows Terminal on WSL
- Windows Terminal on WSL inside tmux
- Foot outside tmux
- Foot inside tmux
- WezTerm outside tmux
- WezTerm inside tmux
- Kitty outside tmux
- Kitty inside tmux
- Konsole outside tmux
- Konsole inside tmux

Checked image preview rendering and sizing across the affected terminal/tmux combinations.

Result:

All automated checks passed locally. Manual preview checks passed across the tested terminals.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
