### PR TITLE
feat(navigation): add zoxide directory jumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: cargo fmt --check
         run: cargo fmt --check
@@ -95,6 +97,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: cargo build --locked
         run: cargo build --locked
@@ -115,6 +119,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: cargo build --locked
         run: cargo build --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a configurable `z` shortcut for jumping to directories with `zoxide query -i`, excluding the current directory from the picker and reporting missing zoxide, empty history, or history containing only the current directory clearly. ([#103])
 - Added `"none"` (alias: `"transparent"`) as accepted color values in `theme.toml`, resetting foreground or background colors to the terminal default. For background fields, this lets transparent terminals show through. See `examples/themes/transparent/theme.toml`. ([#86])
 - Added a `chip_text` palette field that controls the foreground of toolbar status chips (yank, cut, selected, trash, restore). Defaults to `#0c0c0c` on all themes; previously this color was reused from `chrome`. ([#86])
 
@@ -137,3 +138,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#74]: https://github.com/elio-fm/elio/pull/74
 [#70]: https://github.com/elio-fm/elio/issues/70
 [#66]: https://github.com/elio-fm/elio/pull/66
+[#103]: https://github.com/elio-fm/elio/issues/103

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Snappy, batteries-included terminal file manager with rich previews, inline imag
 - **Keyboard and mouse navigation** — browse comfortably either way
 - **Grid and list views** — switch with `v`, zoom the grid with `+` / `-`
 - **Fuzzy search** — find folders and files quickly
+- **Zoxide jumps** — jump to frequent directories from your zoxide history
 - **Theming** — full palette and file-class control via `theme.toml`
 
 ---
@@ -115,6 +116,7 @@ Useful environment variables:
 | Variable | Effect |
 |---|---|
 | `ELIO_IMAGE_PREVIEWS=1` | Force-enable on unrecognized terminals that support the Kitty Graphics Protocol |
+| `ELIO_ZOXIDE_OPTS` | Extra options appended to the zoxide interactive picker options |
 | `ELIO_DEBUG_PREVIEW` | Log image preview activity to `elio-preview.log` in the system temp directory |
 | `ELIO_LOG_MOUSE` | Log raw mouse events to `elio-mouse.log` in the system temp directory |
 
@@ -210,6 +212,10 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 ### Fuzzy Search
 
 `f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, skips symlinks, prunes common generated folders such as `.git`, `node_modules`, and `target`, and refreshes when the directory changes. Very large trees are capped so search stays responsive.
+
+### Zoxide
+
+`z` opens `zoxide query -i` for jumping to directories from your zoxide history. It requires `zoxide` to be installed and available in `PATH`, and it shows results only after zoxide has recorded directory history. The current directory is excluded from the picker. Extra picker options can be appended with `ELIO_ZOXIDE_OPTS`.
 
 ---
 
@@ -320,6 +326,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 |---|---|
 | `f` `*` | Fuzzy-find folders in the current tree |
 | `Ctrl+F` | Fuzzy-find files in the current tree |
+| `z` `*` | Jump with zoxide directory history |
 
 ### File Actions
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -71,6 +71,7 @@ show_top_bar = false
 # rename               = "r"
 # copy_path            = "c"
 # search_folders       = "f"
+# zoxide               = "z"
 # open                 = "o"
 # open_with            = "O"
 # sort                 = "s"

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -30,6 +30,21 @@ impl App {
         }
     }
 
+    pub(crate) fn open_zoxide_selection(&mut self, path: PathBuf) {
+        let target = if path.is_absolute() {
+            path
+        } else {
+            self.navigation.cwd.join(path)
+        };
+        if let Err(error) = self.set_dir(target) {
+            self.status = error.to_string();
+        }
+    }
+
+    pub(crate) fn set_status_message(&mut self, status: impl Into<String>) {
+        self.status = status.into();
+    }
+
     pub(in crate::app) fn toggle_view_mode(&mut self) {
         self.clear_wheel_scroll();
         self.navigation.view_mode = self.navigation.view_mode.toggle();

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -282,6 +282,10 @@ impl App {
             }
             Action::CopyPath => self.open_copy_overlay(),
             Action::SearchFolders => self.open_search_with_status(SearchScope::Folders),
+            Action::Zoxide => {
+                self.pending_terminal_task = Some(PendingTerminalTask::Zoxide);
+                self.status.clear();
+            }
             Action::Open => self.open_in_system()?,
             Action::OpenWith => self.open_open_with_overlay(),
             Action::Sort => self.cycle_sort_mode()?,

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -636,6 +636,49 @@ fn rebound_quit_key_sets_should_quit() {
 }
 
 #[test]
+fn zoxide_action_queues_pending_terminal_task() {
+    let root = temp_path("zoxide-action");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+    app.dispatch_action(Action::Zoxide)
+        .expect("dispatch should succeed");
+
+    assert_eq!(app.pending_terminal_task, Some(PendingTerminalTask::Zoxide));
+    assert!(app.status.is_empty());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn zoxide_selection_opens_directory() {
+    let root = temp_path("zoxide-selection");
+    let target = root.join("target");
+    fs::create_dir_all(&target).expect("failed to create target");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+    app.open_zoxide_selection(target.clone());
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, target);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn missing_zoxide_selection_reports_error() {
+    let root = temp_path("zoxide-missing-selection");
+    let missing = root.join("missing");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+    app.open_zoxide_selection(missing);
+
+    assert!(app.status_message().starts_with("Cannot open "));
+    assert_eq!(app.navigation.cwd, root);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn capital_o_opens_open_with_overlay_for_selected_file() {
     let root = temp_path("open-with-overlay-file");
     fs::write(root.join("document.txt"), "hello").expect("failed to write temp file");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 pub use self::state::App;
+pub(crate) use self::state::PendingTerminalTask;
 #[cfg(test)]
 pub use self::state::PreviewMetricsSnapshot;
 pub(crate) use crate::core::FileClass;

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use super::super::{
     App,
-    state::{OpenWithApp, OpenWithOverlay, OpenWithRow},
+    state::{OpenWithApp, OpenWithOverlay, OpenWithRow, PendingTerminalTask},
 };
 use crate::fs::{detached_open_command, open_in_system};
 use anyhow::Result;
@@ -93,7 +93,7 @@ impl App {
         self.overlays.open_with = None;
 
         if requires_terminal {
-            self.pending_terminal_command = Some((program, args));
+            self.pending_terminal_task = Some(PendingTerminalTask::Command { program, args });
             self.status.clear();
         } else {
             match detached_open_command(&program, &args) {
@@ -110,7 +110,7 @@ impl App {
     /// more.
     ///
     /// `launch_app` is called only for GUI apps (`requires_terminal == false`).
-    /// Terminal apps set `pending_terminal_command` on `self` directly so that
+    /// Terminal apps set `pending_terminal_task` on `self` directly so that
     /// the caller in `lib.rs` can suspend the TUI before running them.
     pub(in crate::app) fn handle_discovered_open_with_apps<F, G>(
         &mut self,
@@ -136,7 +136,10 @@ impl App {
             1 => {
                 let app = apps.remove(0);
                 if app.requires_terminal {
-                    self.pending_terminal_command = Some((app.program.clone(), app.args.clone()));
+                    self.pending_terminal_task = Some(PendingTerminalTask::Command {
+                        program: app.program.clone(),
+                        args: app.args.clone(),
+                    });
                     self.status.clear();
                 } else {
                     match launch_app(&app) {

--- a/src/app/open_with/tests.rs
+++ b/src/app/open_with/tests.rs
@@ -1,5 +1,8 @@
 use super::{
-    super::{App, state::OpenWithApp},
+    super::{
+        App,
+        state::{OpenWithApp, PendingTerminalTask},
+    },
     overlay::FallbackOpenOutcome,
     path_is_text_like,
 };
@@ -144,8 +147,11 @@ fn single_terminal_app_queues_pending_command_without_overlay() {
         "overlay must remain closed for direct terminal launch"
     );
     assert_eq!(
-        app.pending_terminal_command,
-        Some(("nvim".to_string(), vec!["/tmp/file.txt".to_string()]))
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Command {
+            program: "nvim".to_string(),
+            args: vec!["/tmp/file.txt".to_string()],
+        })
     );
     assert!(app.status.is_empty());
 
@@ -174,8 +180,11 @@ fn confirm_terminal_app_from_overlay_queues_pending_command() {
 
     assert!(app.overlays.open_with.is_none(), "overlay must close");
     assert_eq!(
-        app.pending_terminal_command,
-        Some(("nvim".to_string(), vec!["/tmp/file.txt".to_string()]))
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Command {
+            program: "nvim".to_string(),
+            args: vec!["/tmp/file.txt".to_string()],
+        })
     );
     assert!(app.status.is_empty());
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -583,6 +583,12 @@ pub(in crate::app) struct InputRuntime {
     pub(in crate::app) last_key_nav_at: Instant,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PendingTerminalTask {
+    Command { program: String, args: Vec<String> },
+    Zoxide,
+}
+
 pub struct App {
     pub(crate) navigation: NavigationState,
     pub(in crate::app) preview: PreviewRuntime,
@@ -591,10 +597,9 @@ pub struct App {
     pub(in crate::app) input: InputRuntime,
     pub(in crate::app) status: String,
     pub(crate) should_quit: bool,
-    /// Set by open-with when the chosen app has `Terminal=true`.  The event
-    /// loop in `lib.rs` drains this, suspends the TUI, runs the command
-    /// blocking in the current terminal, then restores the TUI.
-    pub(crate) pending_terminal_command: Option<(String, Vec<String>)>,
+    /// Set by features that need direct terminal control.  The event loop in
+    /// `lib.rs` drains this, suspends the TUI, runs the task, then restores the TUI.
+    pub(crate) pending_terminal_task: Option<PendingTerminalTask>,
 }
 
 impl App {
@@ -706,7 +711,7 @@ impl App {
             },
             status: String::new(),
             should_quit: false,
-            pending_terminal_command: None,
+            pending_terminal_task: None,
         };
         app.navigation.in_trash = App::path_is_trash(&app.navigation.cwd);
         let snapshot = crate::fs::load_directory_snapshot(

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -12,6 +12,7 @@ pub(crate) enum Action {
     Rename,
     CopyPath,
     SearchFolders,
+    Zoxide,
     Open,
     OpenWith,
     Sort,
@@ -37,6 +38,7 @@ pub(crate) struct KeyBindings {
     pub rename: char,
     pub copy_path: char,
     pub search_folders: char,
+    pub zoxide: char,
     pub open: char,
     pub open_with: char,
     pub sort: char,
@@ -71,6 +73,7 @@ impl Default for KeyBindings {
             rename: 'r',
             copy_path: 'c',
             search_folders: 'f',
+            zoxide: 'z',
             open: 'o',
             open_with: 'O',
             sort: 's',
@@ -95,6 +98,7 @@ pub(super) struct KeysConfigOverride {
     rename: Option<String>,
     copy_path: Option<String>,
     search_folders: Option<String>,
+    zoxide: Option<String>,
     open: Option<String>,
     open_with: Option<String>,
     sort: Option<String>,
@@ -119,6 +123,7 @@ impl KeyBindings {
             _ if c == self.rename => Some(Action::Rename),
             _ if c == self.copy_path => Some(Action::CopyPath),
             _ if c == self.search_folders => Some(Action::SearchFolders),
+            _ if c == self.zoxide => Some(Action::Zoxide),
             _ if c == self.open => Some(Action::Open),
             _ if c == self.open_with => Some(Action::OpenWith),
             _ if c == self.sort => Some(Action::Sort),
@@ -145,7 +150,7 @@ impl KeyBindings {
 
     pub(super) fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
         // Each entry: (field_name, user_override_string, default_char)
-        let raw: [(&str, Option<String>, char); 18] = [
+        let raw: [(&str, Option<String>, char); 19] = [
             ("quit", overrides.quit, defaults.quit),
             ("yank", overrides.yank, defaults.yank),
             ("cut", overrides.cut, defaults.cut),
@@ -159,6 +164,7 @@ impl KeyBindings {
                 overrides.search_folders,
                 defaults.search_folders,
             ),
+            ("zoxide", overrides.zoxide, defaults.zoxide),
             ("open", overrides.open, defaults.open),
             ("open_with", overrides.open_with, defaults.open_with),
             ("sort", overrides.sort, defaults.sort),
@@ -193,7 +199,7 @@ impl KeyBindings {
         // Step 1: parse each override string independently, falling back to
         // default on any format or reserved-char error.
         // (resolved_char, is_user_set)
-        let mut candidates: [(char, bool); 18] = [(' ', false); 18];
+        let mut candidates: [(char, bool); 19] = [(' ', false); 19];
         for (index, (name, override_str, default)) in raw.iter().enumerate() {
             candidates[index] = match override_str {
                 None => (*default, false),
@@ -232,12 +238,12 @@ impl KeyBindings {
         // binding does not silently leave a conflict with another.
         loop {
             let mut changed = false;
-            for index in 0..18 {
+            for index in 0..19 {
                 if !candidates[index].1 {
                     continue;
                 }
                 let candidate = candidates[index].0;
-                let collision = (0..18)
+                let collision = (0..19)
                     .filter(|&other_index| other_index != index)
                     .any(|other_index| candidates[other_index].0 == candidate);
                 if collision {
@@ -276,15 +282,16 @@ impl KeyBindings {
             rename: resolved(6),
             copy_path: resolved(7),
             search_folders: resolved(8),
-            open: resolved(9),
-            open_with: resolved(10),
-            sort: resolved(11),
-            toggle_view: resolved(12),
-            toggle_hidden: resolved(13),
-            scroll_preview_left: resolved(14),
-            scroll_preview_right: resolved(15),
-            scroll_preview_up: resolved(16),
-            scroll_preview_down: resolved(17),
+            zoxide: resolved(9),
+            open: resolved(10),
+            open_with: resolved(11),
+            sort: resolved(12),
+            toggle_view: resolved(13),
+            toggle_hidden: resolved(14),
+            scroll_preview_left: resolved(15),
+            scroll_preview_right: resolved(16),
+            scroll_preview_up: resolved(17),
+            scroll_preview_down: resolved(18),
         }
     }
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -7,6 +7,7 @@ fn keys_default_bindings_are_sane() {
     assert_eq!(config.keys.cut, 'x');
     assert_eq!(config.keys.paste, 'p');
     assert_eq!(config.keys.quit, 'q');
+    assert_eq!(config.keys.zoxide, 'z');
 }
 
 #[test]
@@ -119,8 +120,8 @@ fn action_for_returns_correct_action_for_default_bindings() {
     assert_eq!(key_bindings.action_for('q'), Some(Action::Quit));
     assert_eq!(key_bindings.action_for('o'), Some(Action::Open));
     assert_eq!(key_bindings.action_for('O'), Some(Action::OpenWith));
+    assert_eq!(key_bindings.action_for('z'), Some(Action::Zoxide));
     assert_eq!(key_bindings.action_for('j'), None);
-    assert_eq!(key_bindings.action_for('z'), None);
 }
 
 #[test]
@@ -154,6 +155,19 @@ open_with = "w"
     .expect("config should parse");
     assert_eq!(config.keys.action_for('w'), Some(Action::OpenWith));
     assert_eq!(config.keys.action_for('O'), None);
+}
+
+#[test]
+fn zoxide_can_be_overridden() {
+    let config = Config::from_str(
+        r#"
+[keys]
+zoxide = "Z"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('Z'), Some(Action::Zoxide));
+    assert_eq!(config.keys.action_for('z'), None);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@ mod file_info;
 mod fs;
 mod preview;
 mod ui;
+mod zoxide;
 
-use crate::app::App;
+use crate::app::{App, PendingTerminalTask};
 use anyhow::Result;
 use crossterm::{
     cursor::SetCursorStyle,
@@ -96,7 +97,10 @@ fn try_init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
 
 /// Temporarily tears down the TUI so a blocking terminal app can use stdout.
 /// Call [`resume_terminal`] afterwards to restore the TUI.
-fn suspend_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+fn suspend_terminal(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    leave_alternate: bool,
+) -> Result<()> {
     let backend = terminal.backend_mut();
     write!(backend, "\x1b[>4;0m")?;
     write!(backend, "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l")?;
@@ -106,9 +110,13 @@ fn suspend_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Re
         terminal.backend_mut(),
         event::DisableMouseCapture,
         DisableFocusChange,
-        SetCursorStyle::DefaultUserShape,
-        LeaveAlternateScreen
+        SetCursorStyle::DefaultUserShape
     )?;
+    if leave_alternate {
+        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    } else {
+        terminal.clear()?;
+    }
     disable_raw_mode()?;
     terminal.show_cursor()?;
     Ok(())
@@ -139,6 +147,20 @@ fn resume_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Res
 /// unable to open a file) should not crash the file manager.
 fn run_blocking_in_terminal(program: &str, args: &[String]) {
     let _ = Command::new(program).args(args).status();
+}
+
+fn apply_zoxide_query_result(app: &mut App, result: zoxide::QueryResult) {
+    match result {
+        zoxide::QueryResult::Selected(path) => app.open_zoxide_selection(path),
+        zoxide::QueryResult::Cancelled => {}
+        zoxide::QueryResult::NotFound => app.set_status_message("zoxide not found"),
+        zoxide::QueryResult::PickerNotFound => app.set_status_message("fzf not found"),
+        zoxide::QueryResult::Empty => app.set_status_message("No zoxide directory history found"),
+        zoxide::QueryResult::OnlyCurrentDirectory => {
+            app.set_status_message("Zoxide history only contains the current directory")
+        }
+        zoxide::QueryResult::LaunchFailed => app.set_status_message("Could not run zoxide"),
+    }
 }
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
@@ -404,12 +426,31 @@ fn run_app(
                 break;
             }
 
-            // A terminal app (e.g. nvim) was chosen from Open With.
-            // Suspend the TUI, run the command blocking, then restore.
-            if let Some((program, args)) = app.pending_terminal_command.take() {
-                suspend_terminal(terminal)?;
-                run_blocking_in_terminal(&program, &args);
-                resume_terminal(terminal)?;
+            // A terminal task (e.g. nvim from Open With, or zoxide) needs the real terminal.
+            // Suspend the TUI, run the task blocking, then restore.
+            if let Some(task) = app.pending_terminal_task.take() {
+                let zoxide_result = match task {
+                    PendingTerminalTask::Command { program, args } => {
+                        suspend_terminal(terminal, true)?;
+                        run_blocking_in_terminal(&program, &args);
+                        resume_terminal(terminal)?;
+                        None
+                    }
+                    PendingTerminalTask::Zoxide => {
+                        let cwd = app.navigation.cwd.clone();
+                        if let Some(result) = zoxide::preflight(&cwd) {
+                            Some(result)
+                        } else {
+                            suspend_terminal(terminal, false)?;
+                            let result = zoxide::run_query_in_terminal(&cwd);
+                            resume_terminal(terminal)?;
+                            Some(result)
+                        }
+                    }
+                };
+                if let Some(result) = zoxide_result {
+                    apply_zoxide_query_result(&mut app, result);
+                }
                 dirty = true;
             }
         }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1193,6 +1193,10 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
         "expected help overlay to keep the file search shortcut visible, got: {rendered:?}"
     );
     assert!(
+        rendered.contains("zoxide history"),
+        "expected help overlay to list the zoxide shortcut, got: {rendered:?}"
+    );
+    assert!(
         rendered.contains("Alt/Shift+Enter"),
         "expected help overlay to show the current create prompt newline hint, got: {rendered:?}"
     );

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -28,6 +28,7 @@ pub(super) fn render_help(
         e("Alt+← / Alt+→", "back / forward"),
     ];
     let search_entries = vec![
+        e(&kb.zoxide.to_string(), "zoxide history"),
         e(&kb.search_folders.to_string(), "search folders"),
         e("Ctrl+F", "search files"),
         e("Ctrl+←→", "move by word"),
@@ -109,7 +110,7 @@ pub(super) fn render_help(
         },
     ];
 
-    let popup = helpers::centered_rect(area, 90, 30);
+    let popup = helpers::centered_rect(area, 90, 31);
     state.help_panel = Some(popup);
     frame.render_widget(Clear, popup);
     frame.render_widget(

--- a/src/zoxide.rs
+++ b/src/zoxide.rs
@@ -1,0 +1,142 @@
+use std::{
+    env, io,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+
+pub(crate) enum QueryResult {
+    Selected(PathBuf),
+    Cancelled,
+    NotFound,
+    PickerNotFound,
+    Empty,
+    OnlyCurrentDirectory,
+    LaunchFailed,
+}
+
+pub(crate) fn preflight(cwd: &Path) -> Option<QueryResult> {
+    match has_match_excluding(cwd) {
+        Ok(true) => None,
+        Ok(false) => match has_any_match() {
+            Ok(true) => Some(QueryResult::OnlyCurrentDirectory),
+            Ok(false) => Some(QueryResult::Empty),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Some(QueryResult::NotFound),
+            Err(_) => None,
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Some(QueryResult::NotFound),
+        Err(_) => None,
+    }
+}
+
+pub(crate) fn run_query_in_terminal(cwd: &Path) -> QueryResult {
+    let output = match Command::new("zoxide")
+        .args(["query", "-i", "--exclude"])
+        .arg(cwd)
+        .env("SHELL", "sh")
+        .env("CLICOLOR", "1")
+        .env("CLICOLOR_FORCE", "1")
+        .env("_ZO_FZF_OPTS", fzf_options())
+        .stdin(Stdio::inherit())
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return QueryResult::NotFound,
+        Err(_) => return QueryResult::LaunchFailed,
+    };
+
+    if !output.status.success() {
+        if stderr_mentions_missing_fzf(&output.stderr) {
+            return QueryResult::PickerNotFound;
+        }
+        return QueryResult::Cancelled;
+    }
+
+    match path_from_command_stdout(output.stdout) {
+        Some(path) => QueryResult::Selected(path),
+        None => QueryResult::Cancelled,
+    }
+}
+
+fn has_match_excluding(cwd: &Path) -> io::Result<bool> {
+    let output = Command::new("zoxide")
+        .args(["query", "-l", "--exclude"])
+        .arg(cwd)
+        .output()?;
+    Ok(!output.stdout.is_empty())
+}
+
+fn has_any_match() -> io::Result<bool> {
+    let output = Command::new("zoxide").args(["query", "-l"]).output()?;
+    Ok(!output.stdout.is_empty())
+}
+
+fn stderr_mentions_missing_fzf(stderr: &[u8]) -> bool {
+    // zoxide reports a missing interactive picker through stderr; keep this
+    // narrow so ordinary cancellations remain silent.
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    stderr.contains("fzf")
+        && (stderr.contains("not found")
+            || stderr.contains("not installed")
+            || stderr.contains("no such file")
+            || stderr.contains("could not find"))
+}
+
+fn fzf_options() -> String {
+    let mut defaults = vec![
+        "--exact",
+        "--no-sort",
+        "--bind=ctrl-z:ignore,btab:up,tab:down",
+        "--cycle",
+        "--keep-right",
+        "--layout=reverse",
+        "--height=100%",
+        "--border",
+        "--info=inline",
+        "--tabstop=1",
+        "--exit-0",
+    ];
+
+    #[cfg(target_os = "linux")]
+    {
+        defaults.push("--preview-window=down,30%,sharp");
+        defaults
+            .push("--preview='\\command -p ls -Cp --color=always --group-directories-first {2..}'");
+    }
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        defaults.push("--preview-window=down,30%,sharp");
+        defaults.push("--preview='\\command -p ls -Cp {2..}'");
+    }
+
+    let defaults = defaults.join(" ");
+
+    match (env::var("FZF_DEFAULT_OPTS"), env::var("ELIO_ZOXIDE_OPTS")) {
+        (Ok(base), Ok(extra)) => format!("{base} {defaults} {extra}"),
+        (Ok(base), Err(_)) => format!("{base} {defaults}"),
+        (Err(_), Ok(extra)) => format!("{defaults} {extra}"),
+        (Err(_), Err(_)) => defaults,
+    }
+}
+
+fn path_from_command_stdout(mut stdout: Vec<u8>) -> Option<PathBuf> {
+    while matches!(stdout.last(), Some(b'\n' | b'\r')) {
+        stdout.pop();
+    }
+    if stdout.is_empty() {
+        return None;
+    }
+
+    #[cfg(unix)]
+    {
+        Some(PathBuf::from(OsString::from_vec(stdout)))
+    }
+    #[cfg(not(unix))]
+    {
+        String::from_utf8(stdout).ok().map(PathBuf::from)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a configurable zoxide jump action for navigating to directories from zoxide history. Pressing `z` opens `zoxide query -i`, excludes the current directory from the picker, and restores elio cleanly after the picker exits.

Fixes #103.

## What Changed

- Added a new configurable `zoxide` key binding, defaulting to `z`.
- Added a zoxide terminal task that runs `zoxide query -i --exclude <cwd>` from inside elio.
- Reused the terminal suspend/resume path used by terminal Open With apps, while keeping the zoxide picker visually integrated in the alternate screen.
- Added preflight handling for missing zoxide, empty history, and history containing only the current directory.
- Configured the picker with full-height layout and a Unix directory-content preview pane (`ls -Cp` of the highlighted candidate).
- Added `ELIO_ZOXIDE_OPTS` for appending extra picker options.
- Updated README controls/config docs, example config, help overlay, tests, and changelog.

## User Impact

Users with zoxide installed can press `z` to jump directly to directories from their zoxide history. The binding can be remapped in `[keys]` with `zoxide = "..."`.

elio now reports clear status messages when zoxide is missing, when zoxide has no history, or when the only known history entry is the current directory.

## Notes

The current directory is intentionally excluded from the picker, matching the expected jump-to-something-else workflow.

The integration relies on `zoxide query -i`; elio does not document `fzf` as a hard dependency, but it reports `fzf not found` if zoxide itself fails that way at runtime.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Linux:
  - zoxide picker opens and navigates correctly
  - remapped zoxide key works
  - missing zoxide status appears when expected
  - empty zoxide history status appears when expected
  - terminal state is restored after selection and cancel
- WSL:
  - missing zoxide status before installing zoxide
  - empty history status with no zoxide entries
  - "current directory only" status when history only contains the current directory
  - picker opens with one non-current entry
  - picker opens with multiple entries, including and excluding the current directory
- Regression check:
  - terminal Open With apps such as Neovim still run correctly after the pending terminal task refactor

Result:

All automated checks passed locally. Manual zoxide behavior passed across the tested Linux and WSL environments.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
