### PR TITLE
feat(packaging): add Debian release package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
   build-linux:
     name: Build release artifact (Linux)
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -155,8 +155,21 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Install Debian packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y desktop-file-utils dpkg-dev liblzma-dev pkg-config
+          cargo install --locked cargo-deb --version 3.7.0
+
       - name: Build release binary
         run: cargo build --locked --release
+
+      - name: Build Debian package
+        run: |
+          desktop-file-validate packaging/linux/elio.desktop
+          cargo deb --no-build
+          mkdir -p dist
+          cp target/debian/*.deb dist/elio_amd64.deb
 
       - name: Package Linux artifact
         shell: bash
@@ -177,7 +190,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: release-asset-linux
-          path: dist/*.tar.gz
+          path: |
+            dist/*.tar.gz
+            dist/*.deb
 
   build-macos:
     name: Build release artifact (macOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Linux desktop entry metadata and hicolor application icons for packaged installs, allowing desktop launchers to discover elio as a terminal file manager. ([#67])
+- Added `amd64` Debian package assets to GitHub releases, including the Linux desktop entry and hicolor application icons for launcher integration.
 
 ## [1.5.0] - 2026-05-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,27 @@ strip = true
 lto = "thin"
 codegen-units = 1
 
+[package.metadata.deb]
+maintainer = "Miguel Regueiro <67692547+MiguelRegueiro@users.noreply.github.com>"
+license-file = ["LICENSE-MIT", "0"]
+section = "utils"
+priority = "optional"
+depends = "$auto, hicolor-icon-theme, desktop-file-utils"
+extended-description = """\
+elio is a snappy, batteries-included terminal file manager with rich previews, \
+inline images, bulk actions, and trash support.
+"""
+assets = [
+    ["target/release/elio", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/elio/README.md", "644"],
+    ["CHANGELOG.md", "usr/share/doc/elio/CHANGELOG.md", "644"],
+    ["packaging/linux/elio.desktop", "usr/share/applications/elio.desktop", "644"],
+    ["packaging/linux/icons/hicolor/48x48/apps/elio.png", "usr/share/icons/hicolor/48x48/apps/elio.png", "644"],
+    ["packaging/linux/icons/hicolor/128x128/apps/elio.png", "usr/share/icons/hicolor/128x128/apps/elio.png", "644"],
+    ["packaging/linux/icons/hicolor/256x256/apps/elio.png", "usr/share/icons/hicolor/256x256/apps/elio.png", "644"],
+    ["packaging/linux/icons/hicolor/512x512/apps/elio.png", "usr/share/icons/hicolor/512x512/apps/elio.png", "644"],
+]
+
 [target.'cfg(target_os = "macos")'.dependencies]
 # Foundation types for path/string handling, display names, and bundle IDs.
 # CoreServices (linked inline in macos.rs) provides the Launch Services C API

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ sudo dnf copr enable miguelregueiro/elio
 sudo dnf install elio
 ```
 
+### Debian / Ubuntu
+
+Download the `amd64` `.deb` package from the [latest release](https://github.com/elio-fm/elio/releases/latest) and install it with `apt`:
+
+```bash
+curl -LO https://github.com/elio-fm/elio/releases/latest/download/elio_amd64.deb
+sudo apt install ./elio_amd64.deb
+```
+
+This does not configure an apt repository. To update elio, re-run the two commands above — they always fetch the latest release.
+
 ### Homebrew
 
 Install from the Homebrew tap:

--- a/packaging/fedora/elio.spec
+++ b/packaging/fedora/elio.spec
@@ -22,8 +22,8 @@ BuildRequires:  desktop-file-utils
 Requires:       hicolor-icon-theme
 
 %description
-elio is a terminal-native file manager with a three-pane layout, rich previews,
-inline images, customizable Places, trash support, and quick actions.
+elio is a snappy, batteries-included terminal file manager with rich previews,
+inline images, bulk actions, and trash support.
 
 %prep
 %autosetup -a 1


### PR DESCRIPTION
## Summary

Adds `amd64` Debian package generation for GitHub releases so Debian/Ubuntu users can install elio with `apt install ./elio_amd64.deb`.

## What Changed

- Added `cargo-deb` metadata with Debian package dependencies, license metadata, docs, desktop entry, and hicolor icon assets.
- Updated the Linux release job to build on `ubuntu-22.04`, generate a `.deb`, and upload both versioned and stable `elio_amd64.deb` release assets.
- Added Debian / Ubuntu install instructions using the stable latest-release `.deb` URL.
- Aligned the Fedora package description with the current project description.

## User Impact

Debian, Ubuntu, Mint, Pop, and related `apt`-based users can download the GitHub release `.deb` and install elio with `apt`. The package includes the Linux desktop entry and application icons, matching the Fedora/AUR desktop integration path.

## Notes

This also addresses Debian/Ubuntu install requests from user feedback.

This intentionally does not add an apt repository. The stable `elio_amd64.deb` filename provides a copy-paste install/update flow without adding GPG key management, repository metadata signing, or repo hosting. A native apt repository can be added later as a focused follow-up if user demand justifies the extra security and maintenance surface.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Built the release binary with `cargo build --locked --release`.
- Built the Debian package locally with `cargo deb --no-build`.
- Inspected package metadata with `dpkg-deb -I target/debian/*.deb`.
- Inspected package contents with `dpkg-deb -c target/debian/*.deb`, confirming `/usr/bin/elio`, `/usr/share/applications/elio.desktop`, and all hicolor icon sizes are included.
- Validated `packaging/linux/elio.desktop` with `desktop-file-validate`.

Result:

All automated checks passed locally. Local Debian package structure checks passed. On Arch, `dpkg-shlibdeps` cannot resolve Debian `$auto` library dependencies, so dependency generation is expected to be validated by the `ubuntu-22.04` release workflow environment.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed