### PR TITLE
fix(places): match symlinked entries by resolved path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Tab` / `Shift+Tab` cycling and the active highlight for symlinked Places entries, which previously reset to Home after opening the symlink target. ([#109])
+
 ## [1.5.1] - 2026-05-15
 
 ### Added

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -343,7 +343,7 @@ impl App {
 
         let current = places
             .iter()
-            .position(|item| item.path == self.navigation.cwd);
+            .position(|item| item.identity_path == self.navigation.cwd);
         let next = if delta >= 0 {
             current.map(|index| (index + 1) % places.len()).unwrap_or(0)
         } else {

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -201,11 +201,13 @@ fn tab_and_shift_tab_cycle_sidebar_locations_and_skip_section_rows() {
                 "Home",
                 "H",
                 root.clone(),
+                root.clone(),
             )),
             SidebarRow::Item(SidebarItem::new(
                 SidebarItemKind::Downloads,
                 "Downloads",
                 "D",
+                downloads.clone(),
                 downloads.clone(),
             )),
             SidebarRow::Section { title: "Devices" },
@@ -213,6 +215,7 @@ fn tab_and_shift_tab_cycle_sidebar_locations_and_skip_section_rows() {
                 SidebarItemKind::Device { removable: true },
                 "USB",
                 "U",
+                usb.clone(),
                 usb.clone(),
             )),
         ]
@@ -247,6 +250,80 @@ fn tab_and_shift_tab_cycle_sidebar_locations_and_skip_section_rows() {
         .expect("shift-tab should walk sidebar locations in reverse");
     wait_for_directory_load(&mut app);
     assert_eq!(app.navigation.cwd, downloads);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(unix)]
+#[test]
+fn tab_and_shift_tab_match_symlinked_sidebar_locations_by_identity() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_path("tab-cycles-symlinked-places");
+    let target = root.join("target");
+    let linked = root.join("linked");
+    let next = root.join("next");
+    fs::create_dir_all(&target).expect("failed to create target dir");
+    fs::create_dir_all(&next).expect("failed to create next dir");
+    symlink(&target, &linked).expect("failed to create sidebar symlink");
+
+    let root_identity = root.canonicalize().expect("root should canonicalize");
+    let target_identity = target.canonicalize().expect("target should canonicalize");
+    let next_identity = next.canonicalize().expect("next should canonicalize");
+    let sidebar_rows = || {
+        vec![
+            SidebarRow::Item(SidebarItem::new(
+                SidebarItemKind::Home,
+                "Home",
+                "H",
+                root.clone(),
+                root_identity.clone(),
+            )),
+            SidebarRow::Item(SidebarItem::new(
+                SidebarItemKind::Custom,
+                "Linked",
+                "L",
+                linked.clone(),
+                target_identity.clone(),
+            )),
+            SidebarRow::Item(SidebarItem::new(
+                SidebarItemKind::Downloads,
+                "Next",
+                "N",
+                next.clone(),
+                next_identity.clone(),
+            )),
+        ]
+    };
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.set_dir(linked.clone())
+        .expect("symlinked place should open");
+    wait_for_directory_load(&mut app);
+    assert_eq!(app.navigation.cwd, target_identity);
+
+    app.navigation.sidebar = sidebar_rows();
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Tab)))
+        .expect("tab should advance past the symlinked sidebar location");
+    wait_for_directory_load(&mut app);
+    assert_eq!(app.navigation.cwd, next_identity);
+
+    app.set_dir(linked.clone())
+        .expect("symlinked place should reopen");
+    wait_for_directory_load(&mut app);
+    app.navigation.sidebar = sidebar_rows();
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::BackTab)))
+        .expect("shift-tab should walk backward from the symlinked sidebar location");
+    wait_for_directory_load(&mut app);
+    assert_eq!(app.navigation.cwd, root_identity);
+
+    app.set_dir(next.clone()).expect("next place should open");
+    wait_for_directory_load(&mut app);
+    app.navigation.sidebar = sidebar_rows();
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::BackTab)))
+        .expect("shift-tab should open the symlinked sidebar location");
+    wait_for_directory_load(&mut app);
+    assert_eq!(app.navigation.cwd, target_identity);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -609,6 +609,7 @@ impl App {
     }
 
     pub fn new_at(cwd: PathBuf) -> Result<Self> {
+        let cwd = cwd.canonicalize().unwrap_or(cwd);
         let scheduler = JobScheduler::new();
         let (directory_watch_tx, directory_watch_rx) = std::sync::mpsc::channel();
         let mut app = Self {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -609,7 +609,6 @@ impl App {
     }
 
     pub fn new_at(cwd: PathBuf) -> Result<Self> {
-        let cwd = cwd.canonicalize().unwrap_or(cwd);
         let scheduler = JobScheduler::new();
         let (directory_watch_tx, directory_watch_rx) = std::sync::mpsc::channel();
         let mut app = Self {

--- a/src/core/sidebar.rs
+++ b/src/core/sidebar.rs
@@ -5,6 +5,8 @@ pub struct SidebarItem {
     pub kind: SidebarItemKind,
     pub title: String,
     pub icon: String,
+    /// Canonical comparison key for this path. `path` remains the path to open.
+    pub identity_path: PathBuf,
     pub path: PathBuf,
 }
 
@@ -14,11 +16,13 @@ impl SidebarItem {
         title: impl Into<String>,
         icon: impl Into<String>,
         path: PathBuf,
+        identity_path: PathBuf,
     ) -> Self {
         Self {
             kind,
             title: title.into(),
             icon: icon.into(),
+            identity_path,
             path,
         }
     }

--- a/src/fs/places/devices.rs
+++ b/src/fs/places/devices.rs
@@ -4,7 +4,7 @@
     target_os = "freebsd",
     target_os = "openbsd"
 ))]
-use super::resolution::path_identity_key;
+use super::resolution::{path_identity_key, sidebar_item};
 use crate::core::SidebarItem;
 #[cfg(any(
     target_os = "macos",
@@ -67,7 +67,7 @@ pub(super) fn mounted_device_items(
             continue;
         };
 
-        items.push(SidebarItem::new(
+        items.push(sidebar_item(
             SidebarItemKind::Device { removable: false },
             title,
             "󰋊",
@@ -95,7 +95,7 @@ pub(super) fn mounted_device_items(
     for letter in b'A'..=b'Z' {
         let path = PathBuf::from(format!("{}:\\", letter as char));
         if path.exists() && !pinned_paths.contains(&path_identity_key(&path)) {
-            items.push(SidebarItem::new(
+            items.push(sidebar_item(
                 SidebarItemKind::Device { removable: false },
                 format!("{}:", letter as char),
                 "󰋊",
@@ -155,7 +155,7 @@ pub(super) fn mounted_device_items(
             })
             .unwrap_or_else(|| path.display().to_string());
 
-        items.push(SidebarItem::new(
+        items.push(sidebar_item(
             SidebarItemKind::Device { removable: false },
             title,
             "󰋊",

--- a/src/fs/places/linux.rs
+++ b/src/fs/places/linux.rs
@@ -1,4 +1,4 @@
-use super::resolution::path_identity_key;
+use super::resolution::{path_identity_key, sidebar_item};
 use crate::core::{SidebarItem, SidebarItemKind};
 use std::{
     collections::{HashMap, HashSet},
@@ -69,7 +69,7 @@ fn linux_device_items_from_mounts(
             continue;
         }
 
-        items.push(SidebarItem::new(
+        items.push(sidebar_item(
             SidebarItemKind::Device { removable },
             linux_mount_title(mount, labels),
             if removable { "󰕓" } else { "󰋊" },

--- a/src/fs/places/resolution.rs
+++ b/src/fs/places/resolution.rs
@@ -50,7 +50,7 @@ pub(super) fn build_sidebar_rows_with_context(
     let pinned_items = build_pinned_sidebar_items(places, context);
     let pinned_paths = pinned_items
         .iter()
-        .map(|item| path_identity_key(&item.path))
+        .map(|item| item.identity_path.clone())
         .collect::<HashSet<_>>();
     let mut rows = pinned_items
         .into_iter()
@@ -97,7 +97,7 @@ fn build_pinned_sidebar_items(
         let Some(item) = resolve_place_entry(entry, context) else {
             continue;
         };
-        if seen_paths.insert(path_identity_key(&item.path)) {
+        if seen_paths.insert(item.identity_path.clone()) {
             items.push(item);
         }
     }
@@ -113,7 +113,7 @@ fn resolve_place_entry(
         PlaceEntrySpec::Builtin { place, icon } => {
             resolve_builtin_place(*place, icon.as_deref(), context)
         }
-        PlaceEntrySpec::Custom { title, path, icon } => Some(SidebarItem::new(
+        PlaceEntrySpec::Custom { title, path, icon } => Some(sidebar_item(
             SidebarItemKind::Custom,
             title.clone(),
             icon.as_deref().unwrap_or(CUSTOM_PLACE_ICON),
@@ -128,14 +128,14 @@ fn resolve_builtin_place(
     context: &PlaceResolutionContext,
 ) -> Option<SidebarItem> {
     match place {
-        BuiltinPlace::Home => Some(SidebarItem::new(
+        BuiltinPlace::Home => Some(sidebar_item(
             SidebarItemKind::Home,
             "Home",
             icon_override.unwrap_or("󰋜"),
             context.home.clone(),
         )),
         BuiltinPlace::Desktop => context.desktop.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Desktop,
                 localized_place_title(&path, "Desktop"),
                 icon_override.unwrap_or("󰍹"),
@@ -143,7 +143,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Documents => context.documents.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Documents,
                 localized_place_title(&path, "Documents"),
                 icon_override.unwrap_or("󰲃"),
@@ -151,7 +151,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Downloads => context.downloads.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Downloads,
                 localized_place_title(&path, "Downloads"),
                 icon_override.unwrap_or("󰉍"),
@@ -159,7 +159,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Pictures => context.pictures.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Pictures,
                 localized_place_title(&path, "Pictures"),
                 icon_override.unwrap_or("󰉏"),
@@ -167,7 +167,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Music => context.music.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Music,
                 localized_place_title(&path, "Music"),
                 icon_override.unwrap_or("󱍙"),
@@ -175,7 +175,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Videos => context.videos.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Videos,
                 localized_place_title(&path, videos_label()),
                 icon_override.unwrap_or("󰕧"),
@@ -183,7 +183,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Root => context.root.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Root,
                 "Root",
                 icon_override.unwrap_or("󰋊"),
@@ -191,7 +191,7 @@ fn resolve_builtin_place(
             )
         }),
         BuiltinPlace::Trash => context.trash.clone().map(|path| {
-            SidebarItem::new(
+            sidebar_item(
                 SidebarItemKind::Trash,
                 "Trash",
                 icon_override.unwrap_or("󰩺"),
@@ -199,6 +199,16 @@ fn resolve_builtin_place(
             )
         }),
     }
+}
+
+pub(super) fn sidebar_item(
+    kind: SidebarItemKind,
+    title: impl Into<String>,
+    icon: impl Into<String>,
+    path: PathBuf,
+) -> SidebarItem {
+    let identity_path = path_identity_key(&path);
+    SidebarItem::new(kind, title, icon, path, identity_path)
 }
 
 fn localized_place_title(path: &Path, fallback: &'static str) -> String {

--- a/src/fs/places/tests.rs
+++ b/src/fs/places/tests.rs
@@ -193,3 +193,36 @@ fn places_deduplicate_entries_by_resolved_path() {
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
+
+#[cfg(unix)]
+#[test]
+fn custom_symlinked_places_store_resolved_identity_path() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_path("symlink-identity-sidebar");
+    let context = context_for(&root);
+    let target = root.join("target");
+    let linked = root.join("linked");
+    fs::create_dir_all(&target).expect("failed to create target dir");
+    symlink(&target, &linked).expect("failed to create symlinked place");
+    let places = PlacesConfig {
+        show_devices: false,
+        entries: vec![PlaceEntrySpec::Custom {
+            title: "Linked".to_string(),
+            path: linked.clone(),
+            icon: None,
+        }],
+    };
+
+    let rows = build_sidebar_rows_with_context(&places, &context);
+    let items = rows.iter().filter_map(SidebarRow::item).collect::<Vec<_>>();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].path, linked);
+    assert_eq!(
+        items[0].identity_path,
+        target.canonicalize().expect("target should canonicalize")
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}

--- a/src/ui/browser/sidebar.rs
+++ b/src/ui/browser/sidebar.rs
@@ -50,7 +50,7 @@ pub(super) fn render_sidebar(
                 );
             }
             SidebarRow::Item(item) => {
-                let active = helpers::path_is_active(&app.navigation.cwd, &item.path);
+                let active = helpers::path_is_active(&app.navigation.cwd, &item.identity_path);
                 let bg = if active {
                     palette.sidebar_active
                 } else {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -527,6 +527,7 @@ fn sidebar_clamps_long_labels_when_width_is_tight() {
         "Downloads Directory",
         "D",
         root.clone(),
+        root.clone(),
     ))];
 
     let mut terminal = Terminal::new(TestBackend::new(14, 5)).expect("terminal should init");
@@ -566,6 +567,7 @@ fn sidebar_sections_render_without_creating_click_targets() {
             "Vacation",
             "U",
             drive.clone(),
+            drive.clone(),
         )),
     ];
 
@@ -591,6 +593,52 @@ fn sidebar_sections_render_without_creating_click_targets() {
     );
     assert_eq!(frame_state.sidebar_hits.len(), 1);
     assert_eq!(frame_state.sidebar_hits[0].path, drive);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(unix)]
+#[test]
+fn sidebar_marks_symlinked_place_active_by_identity_path() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_path("sidebar-symlink-active");
+    let target = root.join("target");
+    let linked = root.join("linked");
+    fs::create_dir_all(&target).expect("failed to create target dir");
+    symlink(&target, &linked).expect("failed to create sidebar symlink");
+
+    let target_identity = target.canonicalize().expect("target should canonicalize");
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    app.navigation.cwd = target_identity.clone();
+    app.navigation.sidebar = vec![SidebarRow::Item(SidebarItem::new(
+        SidebarItemKind::Custom,
+        "Linked",
+        "L",
+        linked.clone(),
+        target_identity,
+    ))];
+
+    let mut terminal = Terminal::new(TestBackend::new(18, 4)).expect("terminal should init");
+    let mut frame_state = FrameState::default();
+    terminal
+        .draw(|frame| {
+            render_sidebar(
+                frame,
+                frame.area(),
+                &app,
+                &mut frame_state,
+                theme::palette(),
+            );
+        })
+        .expect("sidebar should render");
+
+    assert!(
+        row_text(terminal.backend().buffer(), 1).contains("▌"),
+        "symlinked sidebar place should render as active"
+    );
+    assert_eq!(frame_state.sidebar_hits.len(), 1);
+    assert_eq!(frame_state.sidebar_hits[0].path, linked);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }


### PR DESCRIPTION
## Summary

Fixes #109. `Tab` / `Shift+Tab` cycling and the active Places highlight no longer break on symlinked Places entries. Entries are now matched by their resolved path identity while still being opened at the configured path.

## What Changed

- Added a cached resolved identity path to `SidebarItem`.
- Updated Places cycling to match entries by resolved identity instead of raw configured path.
- Updated the active Places highlight to use the same identity comparison.
- Reused the resolved identity during Places deduplication.
- Added regression coverage for symlinked Places entries.

## User Impact

Opening a symlinked Places entry no longer makes the next `Tab` / `Shift+Tab` cycle reset to Home, and the active Places highlight stays on the matching entry.

## Notes

The configured Places path is still preserved for opening entries. The resolved identity path is only used for comparison, so symlinked Places entries can match the canonical cwd without doing filesystem work while rendering.

Symlink-specific icons are not included in this PR.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks on Linux:

- Added symlinked and real-target Places entries for local config folders.
- Configured both the symlinked path and its canonical target as separate Places entries and verified only the first one is shown.
- Ran `cargo run -- ~/.config/fcitx5`.
- Confirmed the symlinked Places entry was highlighted.
- Confirmed `Tab` / `Shift+Tab` moved through Places entries instead of resetting to Home.
- Confirmed `Alt+Left` returned to the symlinked Places entry as expected.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
