### PR TITLE
fix(search): include symlink entries in fuzzy search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed fuzzy search so symlinked folders, symlinked files, and broken symlinks appear as searchable entries. Linked directories are listed but not descended into.
 - Fixed `Tab` / `Shift+Tab` cycling and the active highlight for symlinked Places entries, which previously reset to Home after opening the symlink target. ([#109])
 
 ## [1.5.1] - 2026-05-15

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 
 ### Fuzzy Search
 
-`f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, skips symlinks, prunes common generated folders such as `.git`, `node_modules`, and `target`, and refreshes when the directory changes. Very large trees are capped so search stays responsive.
+`f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, includes symlinks as leaf entries (linked directories appear in folder search, linked files and broken symlinks in file search) but does not descend into linked directories, prunes common generated folders such as `.git`, `node_modules`, and `target`, and refreshes when the directory changes. Very large trees are capped so search stays responsive.
 
 ### Zoxide
 

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -72,6 +72,7 @@ impl App {
                     name: candidate.name.clone(),
                     relative: candidate.relative.clone(),
                     is_dir: candidate.is_dir,
+                    symlink: candidate.symlink.clone(),
                     selected: visible_index == search.selected,
                 })
             })

--- a/src/app/search/tests.rs
+++ b/src/app/search/tests.rs
@@ -78,6 +78,7 @@ fn opening_search_ignores_hidden_cache_when_browser_hides_dotfiles() {
             relative: ".hidden-root/needle".to_string(),
             relative_key: ".hidden-root/needle".to_string(),
             is_dir: true,
+            symlink: None,
         }]),
     });
 
@@ -146,6 +147,7 @@ fn refining_query_rechecks_full_candidate_set() {
             relative: name.clone(),
             relative_key: name,
             is_dir: true,
+            symlink: None,
         });
     }
     candidates.push(crate::fs::search::SearchCandidate {
@@ -155,6 +157,7 @@ fn refining_query_rechecks_full_candidate_set() {
         relative: "fastfetch".to_string(),
         relative_key: "fastfetch".to_string(),
         is_dir: true,
+        symlink: None,
     });
 
     app.overlays.search = Some(SearchOverlay {
@@ -419,6 +422,7 @@ fn confirm_search_selection_selects_file_already_in_current_directory() {
             relative: "beta.txt".to_string(),
             relative_key: "beta.txt".to_string(),
             is_dir: false,
+            symlink: None,
         }]),
         matches: vec![0],
         cached_matches: HashMap::from([(String::new(), base_cache_entry(vec![0]))]),
@@ -460,6 +464,7 @@ fn confirm_search_selection_keeps_overlay_open_when_reveal_fails() {
             relative: "missing/file.txt".to_string(),
             relative_key: "missing/file.txt".to_string(),
             is_dir: false,
+            symlink: None,
         }]),
         matches: vec![0],
         cached_matches: HashMap::from([(String::new(), base_cache_entry(vec![0]))]),

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -157,5 +157,6 @@ pub struct SearchRow {
     pub name: String,
     pub relative: String,
     pub is_dir: bool,
+    pub symlink: Option<crate::core::SymlinkInfo>,
     pub selected: bool,
 }

--- a/src/fs/search.rs
+++ b/src/fs/search.rs
@@ -1,3 +1,4 @@
+use crate::core::{EntryKind, SymlinkInfo};
 use anyhow::{Context, Result};
 use std::{
     collections::VecDeque,
@@ -15,6 +16,7 @@ pub(crate) struct SearchCandidate {
     pub relative: String,
     pub relative_key: String,
     pub is_dir: bool,
+    pub symlink: Option<SymlinkInfo>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -38,6 +40,7 @@ struct PendingSearchNode {
     relative: Option<String>,
     relative_key: Option<String>,
     is_dir: bool,
+    symlink: Option<SymlinkInfo>,
     enqueue_children: bool,
 }
 
@@ -52,6 +55,7 @@ impl PendingSearchNode {
             relative,
             relative_key,
             is_dir: self.is_dir,
+            symlink: self.symlink,
         })
     }
 }
@@ -97,15 +101,14 @@ fn collect_candidates_with_limits(
             let Ok(file_type) = entry.file_type() else {
                 continue;
             };
-            if file_type.is_symlink() {
-                continue;
-            }
 
-            let is_dir = file_type.is_dir();
-            let is_file = file_type.is_file();
-            if !is_dir && !is_file {
+            let path = entry.path();
+            let classified = classify_entry(&path, &file_type);
+            let Some(classified) = classified else {
                 continue;
-            }
+            };
+            let is_dir = classified.is_dir;
+            let is_symlink_entry = classified.symlink.is_some();
 
             visited_nodes += 1;
 
@@ -116,12 +119,11 @@ fn collect_candidates_with_limits(
 
             let name = file_name.to_string_lossy().to_string();
             let name_key = name.to_lowercase();
-            let enqueue_children = is_dir && !should_prune_dir(&name_key);
+            let enqueue_children = is_dir && !is_symlink_entry && !should_prune_dir(&name_key);
             if !include_candidate && !enqueue_children {
                 continue;
             }
 
-            let path = entry.path();
             let (relative, relative_key) = if include_candidate {
                 let Ok(relative_path) = path.strip_prefix(cwd) else {
                     continue;
@@ -140,6 +142,7 @@ fn collect_candidates_with_limits(
                 relative,
                 relative_key,
                 is_dir,
+                symlink: classified.symlink,
                 enqueue_children,
             });
         }
@@ -227,6 +230,44 @@ where
 pub(crate) struct SearchFilterResult {
     pub(crate) pool: Vec<usize>,
     pub(crate) matches: Vec<usize>,
+}
+
+struct ClassifiedSearchEntry {
+    is_dir: bool,
+    symlink: Option<SymlinkInfo>,
+}
+
+fn classify_entry(path: &Path, file_type: &fs::FileType) -> Option<ClassifiedSearchEntry> {
+    if file_type.is_symlink() {
+        let target = fs::read_link(path).ok();
+        let target_kind = fs::metadata(path).ok().map(|metadata| {
+            if metadata.is_dir() {
+                EntryKind::Directory
+            } else {
+                EntryKind::File
+            }
+        });
+        let is_dir = matches!(target_kind, Some(EntryKind::Directory));
+        Some(ClassifiedSearchEntry {
+            is_dir,
+            symlink: Some(SymlinkInfo {
+                target,
+                target_kind,
+            }),
+        })
+    } else if file_type.is_dir() {
+        Some(ClassifiedSearchEntry {
+            is_dir: true,
+            symlink: None,
+        })
+    } else if file_type.is_file() {
+        Some(ClassifiedSearchEntry {
+            is_dir: false,
+            symlink: None,
+        })
+    } else {
+        None
+    }
 }
 
 fn should_include_candidate(is_dir: bool, scope: SearchCandidateScope) -> bool {
@@ -339,6 +380,7 @@ mod tests {
                 relative: "src/main.rs".to_string(),
                 relative_key: "src/main.rs".to_string(),
                 is_dir: false,
+                symlink: None,
             },
             SearchCandidate {
                 path: PathBuf::from("/tmp/docs/readme.md"),
@@ -347,6 +389,7 @@ mod tests {
                 relative: "docs/readme.md".to_string(),
                 relative_key: "docs/readme.md".to_string(),
                 is_dir: false,
+                symlink: None,
             },
         ];
 
@@ -457,6 +500,176 @@ mod tests {
         assert!(names.contains(&"top.txt"));
         assert!(names.contains(&"alpha/needle.txt"));
         assert!(!names.contains(&"alpha"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_candidates_includes_linked_directory_in_folder_search() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("symlink-dir-folder");
+        fs::create_dir_all(root.join("real-dir/inner")).expect("failed to create real dir");
+        symlink(root.join("real-dir"), root.join("linked-dir"))
+            .expect("failed to create dir symlink");
+
+        let candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
+                .expect("failed to collect folder candidates");
+        let linked = candidates
+            .iter()
+            .find(|candidate| candidate.relative == "linked-dir")
+            .expect("linked-dir should appear in folder search");
+        assert!(linked.is_dir, "linked dir should be classified as dir");
+        assert_eq!(
+            linked
+                .symlink
+                .as_ref()
+                .and_then(|symlink| symlink.target_kind),
+            Some(EntryKind::Directory)
+        );
+
+        let relatives = candidates
+            .iter()
+            .map(|candidate| candidate.relative.as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            !relatives.contains(&"linked-dir/inner"),
+            "symlinked dir should not be descended into"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_candidates_includes_linked_file_in_file_search() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("symlink-file");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("real.txt"), "data").expect("failed to write real file");
+        symlink(root.join("real.txt"), root.join("linked.txt"))
+            .expect("failed to create file symlink");
+
+        let candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
+                .expect("failed to collect file candidates");
+        let linked = candidates
+            .iter()
+            .find(|candidate| candidate.relative == "linked.txt")
+            .expect("linked.txt should appear in file search");
+        assert!(!linked.is_dir);
+        assert_eq!(
+            linked
+                .symlink
+                .as_ref()
+                .and_then(|symlink| symlink.target_kind),
+            Some(EntryKind::File)
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_candidates_includes_broken_symlink_in_file_search() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("symlink-broken");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        symlink(root.join("missing-target"), root.join("dangling"))
+            .expect("failed to create broken symlink");
+
+        let candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
+                .expect("failed to collect file candidates");
+        let broken = candidates
+            .iter()
+            .find(|candidate| candidate.relative == "dangling")
+            .expect("broken symlink should appear in file search");
+        assert!(!broken.is_dir);
+        let symlink_info = broken
+            .symlink
+            .as_ref()
+            .expect("broken candidate carries symlink info");
+        assert!(symlink_info.is_broken());
+
+        let folder_candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
+                .expect("failed to collect folder candidates");
+        assert!(
+            !folder_candidates
+                .iter()
+                .any(|candidate| candidate.relative == "dangling"),
+            "broken symlink should not appear in folder search"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_candidates_handles_symlink_cycle() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("symlink-cycle");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        // A self-referential symlink: even with the read_link follow this should
+        // be reported as a broken symlink (metadata resolution fails on cycles)
+        // and must never be descended into.
+        symlink(root.join("loop"), root.join("loop"))
+            .expect("failed to create self-referential symlink");
+
+        let candidates =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
+                .expect("failed to collect candidates");
+        let loop_entry = candidates
+            .iter()
+            .find(|candidate| candidate.relative == "loop")
+            .expect("cycle symlink should appear in file search");
+        assert!(!loop_entry.is_dir);
+        let symlink_info = loop_entry
+            .symlink
+            .as_ref()
+            .expect("cycle symlink should carry symlink info");
+        assert!(symlink_info.is_broken());
+        // The important invariant is that we returned at all (no infinite loop).
+        assert!(candidates.len() < 50);
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_candidates_hides_dot_prefixed_symlink_when_hidden_off() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("symlink-hidden");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("visible.txt"), "data").expect("failed to write visible");
+        symlink(root.join("visible.txt"), root.join(".hidden-link"))
+            .expect("failed to create hidden symlink");
+
+        let visible =
+            collect_candidates_with_limits(&root, false, SearchCandidateScope::Files, 100, 1_000)
+                .expect("failed to collect non-hidden candidates");
+        assert!(
+            !visible
+                .iter()
+                .any(|candidate| candidate.relative == ".hidden-link"),
+            "dot-prefixed symlink must respect hidden toggle"
+        );
+
+        let all =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
+                .expect("failed to collect hidden candidates");
+        assert!(
+            all.iter()
+                .any(|candidate| candidate.relative == ".hidden-link"),
+            "dot-prefixed symlink must appear when hidden toggle is on"
+        );
 
         fs::remove_dir_all(root).expect("failed to remove temp tree");
     }

--- a/src/ui/overlay_manager/search.rs
+++ b/src/ui/overlay_manager/search.rs
@@ -180,9 +180,10 @@ pub(super) fn render_search_overlay(
                 );
             }
 
-            let icon = theme::path_symbol(std::path::Path::new(&row.relative), row.is_dir);
+            let row_path = std::path::Path::new(&row.relative);
+            let icon = theme::path_symbol_with_symlink(row_path, row.is_dir, row.symlink.as_ref());
             let icon_color =
-                theme::path_color(std::path::Path::new(&row.relative), row.is_dir, palette);
+                theme::path_color_with_symlink(row_path, row.is_dir, row.symlink.as_ref(), palette);
             let name_width = rect.width.saturating_sub(6) as usize;
             let path_width = rect.width.saturating_sub(4) as usize;
             frame.render_widget(

--- a/src/ui/theme/appearance/mod.rs
+++ b/src/ui/theme/appearance/mod.rs
@@ -47,6 +47,14 @@ pub(crate) fn resolve_path(path: &Path, kind: EntryKind) -> ResolvedAppearance<'
     active_theme().resolve(path, kind)
 }
 
+pub(crate) fn resolve_path_with_class(
+    path: &Path,
+    kind: EntryKind,
+    class: FileClass,
+) -> ResolvedAppearance<'static> {
+    active_theme().resolve_with_builtin_class(path, kind, class)
+}
+
 pub(crate) fn resolve_entry(entry: &Entry) -> ResolvedAppearance<'static> {
     let builtin_class = resolve::symlink_entry_class(entry)
         .unwrap_or_else(|| crate::file_info::inspect_entry_cached(entry).builtin_class);

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -1,13 +1,13 @@
 mod appearance;
 mod builtin_themes;
 
-use crate::core::{Entry, EntryKind};
+use crate::core::{Entry, EntryKind, FileClass, SymlinkInfo};
 use ratatui::style::Color;
 use std::path::Path;
 
 pub(crate) use self::appearance::{
     Palette, code_preview_palette, initialize, palette, resolve_browser_entry, resolve_entry,
-    resolve_path,
+    resolve_path, resolve_path_with_class,
 };
 
 pub(super) fn mix_color(base: Color, tint: Color, tint_weight: u8) -> Color {
@@ -51,4 +51,47 @@ pub(super) fn path_symbol(path: &Path, is_dir: bool) -> &'static str {
         EntryKind::File
     };
     resolve_path(path, kind).icon
+}
+
+pub(super) fn path_symbol_with_symlink(
+    path: &Path,
+    is_dir: bool,
+    symlink: Option<&SymlinkInfo>,
+) -> &'static str {
+    let kind = if is_dir {
+        EntryKind::Directory
+    } else {
+        EntryKind::File
+    };
+    match symlink_file_class(symlink) {
+        Some(class) => resolve_path_with_class(path, kind, class).icon,
+        None => resolve_path(path, kind).icon,
+    }
+}
+
+pub(super) fn path_color_with_symlink(
+    path: &Path,
+    is_dir: bool,
+    symlink: Option<&SymlinkInfo>,
+    palette: Palette,
+) -> Color {
+    let _ = palette;
+    let kind = if is_dir {
+        EntryKind::Directory
+    } else {
+        EntryKind::File
+    };
+    match symlink_file_class(symlink) {
+        Some(class) => resolve_path_with_class(path, kind, class).color,
+        None => resolve_path(path, kind).color,
+    }
+}
+
+fn symlink_file_class(symlink: Option<&SymlinkInfo>) -> Option<FileClass> {
+    let symlink = symlink?;
+    match symlink.target_kind {
+        Some(EntryKind::Directory) => Some(FileClass::SymlinkDirectory),
+        None => Some(FileClass::BrokenSymlink),
+        Some(EntryKind::File) => None,
+    }
 }


### PR DESCRIPTION
## Summary

Includes symlinked folders, symlinked files, and broken symlinks in fuzzy search results while keeping symlinked directories as leaf entries so search does not recurse through links.

## What Changed

- Classifies symlinks during search candidate collection instead of skipping them.
- Shows symlinked directories in folder search.
- Shows symlinked files and broken symlinks in file search.
- Carries symlink state through search rows so linked-folder and broken-link icons/colors match the browser.
- Updates README and CHANGELOG for the new search behavior.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Focused coverage includes symlinked folders, symlinked files, broken symlinks, cyclic symlinks, hidden symlinks, and the no-recursion behavior for linked directories.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed