### PR TITLE
perf(search): stream fuzzy search results while scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved fuzzy search for large directory trees: matches now appear while scanning continues, stale scans are canceled automatically, the scan cap is much higher, and the overlay reports `scan limit reached` when the cap is hit.
 - Fixed fuzzy search so symlinked folders, symlinked files, and broken symlinks appear as searchable entries. Linked directories are listed but not descended into.
 - Fixed `Tab` / `Shift+Tab` cycling and the active highlight for symlinked Places entries, which previously reset to Home after opening the symlink target. ([#109])
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 
 ### Fuzzy Search
 
-`f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, includes symlinks as leaf entries (linked directories appear in folder search, linked files and broken symlinks in file search) but does not descend into linked directories, prunes common generated folders such as `.git`, `node_modules`, and `target`, and refreshes when the directory changes. Very large trees are capped so search stays responsive.
+`f` searches folders and `Ctrl+F` searches files in the current directory tree. Search follows the hidden-file setting, includes symlinks as leaf entries (linked directories appear in folder search, linked files and broken symlinks in file search) but does not descend into linked directories, prunes common generated folders such as `.git`, `node_modules`, and `target`, streams results while scanning, and refreshes when the directory changes. Very large trees are capped so search stays responsive; when the cap is reached, the overlay shows `scan limit reached`.
 
 ### Zoxide
 

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -225,6 +225,7 @@ impl App {
 
         self.jobs.search_loading = false;
         self.jobs.search_token = self.jobs.search_token.wrapping_add(1);
+        self.jobs.scheduler.cancel_search();
     }
 
     fn remembered_view_for(&self, cwd: &Path) -> Option<DirectoryViewMemory> {
@@ -441,6 +442,7 @@ impl App {
             search.scroll = 0;
             search.loading = true;
             search.error = None;
+            search.stats = crate::fs::search::SearchIndexStats::default();
         }
         self.prewarm_search_index(scope);
     }

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -17,8 +17,8 @@ pub(super) use self::types::{
     DirectoryStatsRequest, ImageJobPriority, ImagePrepareBuild, ImagePrepareRequest, JobResult,
     PasteBuild, PasteRequest, PdfJobPriority, PdfProbeBuild, PdfProbeRequest, PdfRenderBuild,
     PdfRenderRequest, PreviewBuild, PreviewLineCountBuild, PreviewLineCountRequest,
-    PreviewPriority, PreviewRequest, RestoreBuild, RestoreRequest, SearchBuild, SearchRequest,
-    SixelPrepareConfig, TrashBuild, TrashRequest,
+    PreviewPriority, PreviewRequest, RestoreBuild, RestoreRequest, SearchBatchBuild, SearchBuild,
+    SearchRequest, SixelPrepareConfig, TrashBuild, TrashRequest,
 };
 use self::{config::SchedulerConfig, metrics::SchedulerMetrics};
 #[cfg(test)]

--- a/src/app/jobs/pool/search.rs
+++ b/src/app/jobs/pool/search.rs
@@ -1,7 +1,11 @@
 use super::*;
 use std::{
     path::PathBuf,
-    sync::{Arc, Condvar, Mutex, mpsc},
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     thread,
     time::Instant,
 };
@@ -20,8 +24,14 @@ struct SearchShared {
 struct SearchState {
     pending: Option<SearchRequest>,
     pending_key: Option<SearchJobKey>,
-    active_key: Option<SearchJobKey>,
+    active: Option<ActiveSearchJob>,
     closed: bool,
+}
+
+#[derive(Clone, Debug)]
+struct ActiveSearchJob {
+    key: SearchJobKey,
+    canceled: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -42,7 +52,7 @@ impl SearchPool {
             state: Mutex::new(SearchState {
                 pending: None,
                 pending_key: None,
-                active_key: None,
+                active: None,
                 closed: false,
             }),
             available: Condvar::new(),
@@ -53,18 +63,48 @@ impl SearchPool {
             let result_tx = result_tx.clone();
             let metrics = Arc::clone(&metrics);
             workers.push(thread::spawn(move || {
-                while let Some(request) = SearchShared::pop(&shared) {
+                while let Some((request, canceled)) = SearchShared::pop(&shared) {
                     let key = SearchJobKey::from_request(&request);
                     let started_at = Instant::now();
-                    let result = crate::fs::search::collect_candidates(
+                    let progress_cwd = request.cwd.clone();
+                    let progress_scope = request.scope;
+                    let progress_show_hidden = request.show_hidden;
+                    let progress_fingerprint = request.fingerprint;
+                    let progress_token = request.token;
+                    let mut progress_send_failed = false;
+                    let result = crate::fs::search::collect_candidates_streaming(
                         &request.cwd,
                         request.show_hidden,
                         request.scope.candidate_scope(),
+                        || canceled.load(Ordering::Relaxed),
+                        |batch| {
+                            if result_tx
+                                .send(JobResult::SearchBatch(SearchBatchBuild {
+                                    token: progress_token,
+                                    cwd: progress_cwd.clone(),
+                                    scope: progress_scope,
+                                    show_hidden: progress_show_hidden,
+                                    fingerprint: progress_fingerprint,
+                                    batch,
+                                }))
+                                .is_err()
+                            {
+                                progress_send_failed = true;
+                                return false;
+                            }
+                            true
+                        },
                     )
-                    .map(Arc::new)
                     .map_err(|error| error.to_string());
+                    if progress_send_failed {
+                        SearchShared::finish(&shared, &key);
+                        break;
+                    }
                     SearchShared::finish(&shared, &key);
                     lock_unpoison(&metrics).record_search_completed(started_at.elapsed());
+                    if canceled.load(Ordering::Relaxed) {
+                        continue;
+                    }
                     if result_tx
                         .send(JobResult::Search(SearchBuild {
                             token: request.token,
@@ -96,19 +136,34 @@ impl SearchPool {
         }
         if state.pending_key.as_ref() == Some(&key) {
             state.pending = Some(request);
+            if let Some(active) = &state.active {
+                active.canceled.store(true, Ordering::Relaxed);
+            }
             self.shared.available.notify_one();
             return true;
         }
         state.pending = Some(request);
         state.pending_key = Some(key);
+        if let Some(active) = &state.active {
+            active.canceled.store(true, Ordering::Relaxed);
+        }
         lock_unpoison(&self.metrics).search_jobs_submitted += 1;
         self.shared.available.notify_one();
         true
     }
 
+    pub(in crate::app::jobs) fn cancel_all(&self) {
+        let mut state = lock_unpoison(&self.shared.state);
+        state.pending = None;
+        state.pending_key = None;
+        if let Some(active) = &state.active {
+            active.canceled.store(true, Ordering::Relaxed);
+        }
+    }
+
     pub(in crate::app::jobs) fn has_pending_work(&self) -> bool {
         let state = lock_unpoison(&self.shared.state);
-        state.pending.is_some() || state.active_key.is_some()
+        state.pending.is_some() || state.active.is_some()
     }
 
     #[cfg(test)]
@@ -118,7 +173,10 @@ impl SearchPool {
 
     #[cfg(test)]
     pub(in crate::app::jobs) fn active_key(&self) -> Option<SearchJobKey> {
-        lock_unpoison(&self.shared.state).active_key.clone()
+        lock_unpoison(&self.shared.state)
+            .active
+            .as_ref()
+            .map(|active| active.key.clone())
     }
 }
 
@@ -129,6 +187,9 @@ impl Drop for SearchPool {
             state.closed = true;
             state.pending = None;
             state.pending_key = None;
+            if let Some(active) = &state.active {
+                active.canceled.store(true, Ordering::Relaxed);
+            }
         }
         self.shared.available.notify_all();
         for worker in self.workers.drain(..) {
@@ -138,15 +199,25 @@ impl Drop for SearchPool {
 }
 
 impl SearchShared {
-    fn pop(shared: &Arc<Self>) -> Option<SearchRequest> {
+    fn pop(shared: &Arc<Self>) -> Option<(SearchRequest, Arc<AtomicBool>)> {
         let mut state = lock_unpoison(&shared.state);
         loop {
             if state.closed {
                 return None;
             }
-            if let Some(request) = state.pending.take() {
-                state.active_key = state.pending_key.take();
-                return Some(request);
+            if state.active.is_none()
+                && let Some(request) = state.pending.take()
+            {
+                let key = state
+                    .pending_key
+                    .take()
+                    .expect("pending key should exist for search job");
+                let canceled = Arc::new(AtomicBool::new(false));
+                state.active = Some(ActiveSearchJob {
+                    key,
+                    canceled: Arc::clone(&canceled),
+                });
+                return Some((request, canceled));
             }
             state = wait_unpoison(&shared.available, state);
         }
@@ -154,8 +225,13 @@ impl SearchShared {
 
     fn finish(shared: &Arc<Self>, key: &SearchJobKey) {
         let mut state = lock_unpoison(&shared.state);
-        if state.active_key.as_ref() == Some(key) {
-            state.active_key = None;
+        if state
+            .active
+            .as_ref()
+            .is_some_and(|active| &active.key == key)
+        {
+            state.active = None;
+            shared.available.notify_one();
         }
     }
 }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -147,10 +147,36 @@ impl App {
                 JobResult::ImagePrepare(build) => {
                     dirty |= self.apply_image_prepare_build(build);
                 }
+                JobResult::SearchBatch(build) => {
+                    if build.token != self.jobs.search_token
+                        || build.cwd != self.navigation.cwd
+                        || build.show_hidden != self.effective_show_hidden()
+                        || build.fingerprint != self.navigation.directory_runtime.fingerprint
+                    {
+                        continue;
+                    }
+
+                    let mut sync_search_scroll = false;
+                    if let Some(search) = &mut self.overlays.search
+                        && search.scope == build.scope
+                    {
+                        search.loading = true;
+                        search.error = None;
+                        search.stats = build.batch.stats;
+                        if !build.batch.candidates.is_empty() {
+                            append_streamed_search_candidates(search, build.batch.candidates);
+                            sync_search_scroll = true;
+                        }
+                        dirty = true;
+                    }
+                    if sync_search_scroll {
+                        self.sync_search_scroll();
+                    }
+                }
                 JobResult::Search(build) => {
                     if build.token != self.jobs.search_token
                         || build.cwd != self.navigation.cwd
-                        || build.show_hidden != self.navigation.show_hidden
+                        || build.show_hidden != self.effective_show_hidden()
                         || build.fingerprint != self.navigation.directory_runtime.fingerprint
                     {
                         continue;
@@ -160,13 +186,16 @@ impl App {
                     dirty = true;
 
                     match build.result {
-                        Ok(candidates) => {
+                        Ok(index) => {
+                            let stats = index.stats;
+                            let candidates = Arc::new(index.candidates);
                             self.jobs.search_cache = Some(SearchCache {
                                 cwd: build.cwd,
                                 scope: build.scope,
                                 show_hidden: build.show_hidden,
                                 fingerprint: build.fingerprint,
                                 candidates: candidates.clone(),
+                                stats,
                             });
                             if let Some(search) = &mut self.overlays.search
                                 && search.scope == build.scope
@@ -180,6 +209,7 @@ impl App {
                                 )]);
                                 search.loading = false;
                                 search.error = None;
+                                search.stats = stats;
                             }
                             self.refresh_search_matches("");
                         }
@@ -198,6 +228,7 @@ impl App {
                                 search.scroll = 0;
                                 search.loading = false;
                                 search.error = Some(error);
+                                search.stats = crate::fs::search::SearchIndexStats::default();
                             }
                         }
                     }
@@ -486,6 +517,106 @@ impl App {
 
         dirty
     }
+}
+
+fn append_streamed_search_candidates(
+    search: &mut SearchOverlay,
+    candidates: Vec<crate::fs::search::SearchCandidate>,
+) {
+    let start = search.candidates.len();
+    let end = start + candidates.len();
+    Arc::make_mut(&mut search.candidates).extend(candidates);
+
+    append_empty_query_search_cache(search, start, end);
+
+    let query = search.query.clone();
+    let query_key = crate::app::search::search_cache_key(&query);
+    search
+        .cached_matches
+        .retain(|cached_query, _| cached_query.is_empty() || cached_query == &query_key);
+
+    if query_key.is_empty() {
+        if let Some(entry) = search.cached_matches.get("") {
+            search.matches = entry.matches.clone();
+        }
+    } else {
+        update_streamed_query_search_cache(search, &query, &query_key, start, end);
+    }
+
+    clamp_search_selection(search);
+}
+
+fn append_empty_query_search_cache(search: &mut SearchOverlay, start: usize, end: usize) {
+    let base = search
+        .cached_matches
+        .entry(String::new())
+        .or_insert_with(|| crate::app::search::build_base_search_cache_entry((0..start).collect()));
+    for index in start..end {
+        base.pool.push(index);
+        if base.matches.len() < SEARCH_MATCH_LIMIT {
+            base.matches.push(index);
+        }
+    }
+}
+
+fn update_streamed_query_search_cache(
+    search: &mut SearchOverlay,
+    query: &str,
+    query_key: &str,
+    start: usize,
+    end: usize,
+) {
+    let Some(existing) = search.cached_matches.remove(query_key) else {
+        let result = crate::fs::search::filter_candidates_in(
+            &search.candidates,
+            0..end,
+            query,
+            SEARCH_MATCH_LIMIT,
+        );
+        search.matches = result.matches.clone();
+        search.cached_matches.insert(
+            query_key.to_string(),
+            crate::app::search::build_search_cache_entry(result.pool, result.matches),
+        );
+        return;
+    };
+
+    let new_result = crate::fs::search::filter_candidates_in(
+        &search.candidates,
+        start..end,
+        query,
+        SEARCH_MATCH_LIMIT,
+    );
+    let mut pool = existing.pool;
+    pool.extend(new_result.pool.iter().copied());
+
+    let rerank_pool = existing
+        .matches
+        .iter()
+        .copied()
+        .chain(new_result.pool.iter().copied());
+    let matches = crate::fs::search::filter_candidates_in(
+        &search.candidates,
+        rerank_pool,
+        query,
+        SEARCH_MATCH_LIMIT,
+    )
+    .matches;
+
+    search.matches = matches.clone();
+    search.cached_matches.insert(
+        query_key.to_string(),
+        crate::app::search::build_search_cache_entry(pool, matches),
+    );
+}
+
+fn clamp_search_selection(search: &mut SearchOverlay) {
+    if search.matches.is_empty() {
+        search.selected = 0;
+        search.scroll = 0;
+        return;
+    }
+    search.selected = search.selected.min(search.matches.len().saturating_sub(1));
 }
 
 #[cfg(test)]

--- a/src/app/jobs/scheduler.rs
+++ b/src/app/jobs/scheduler.rs
@@ -233,6 +233,10 @@ impl JobScheduler {
         self.search.submit(request)
     }
 
+    pub(in crate::app) fn cancel_search(&self) {
+        self.search.cancel_all();
+    }
+
     pub(in crate::app) fn submit_preview(&self, request: PreviewRequest) -> bool {
         self.preview.submit(request)
     }

--- a/src/app/jobs/tests.rs
+++ b/src/app/jobs/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::preview::{PreviewRequestOptions, PreviewWorkClass, default_code_preview_line_limit};
-use std::sync::Arc;
 
 fn image_prepare_request(name: &str) -> ImagePrepareRequest {
     ImagePrepareRequest {
@@ -395,6 +394,23 @@ fn scheduler_reports_pending_work_when_jobs_are_queued() {
 }
 
 #[test]
+fn scheduler_can_cancel_pending_search_work() {
+    let scheduler = JobScheduler::new_for_tests(0, 0, 2);
+    assert!(scheduler.submit_search(SearchRequest {
+        token: 1,
+        cwd: PathBuf::from("/tmp/a"),
+        scope: SearchScope::Files,
+        show_hidden: false,
+        fingerprint: crate::fs::DirectoryFingerprint::default(),
+    }));
+
+    scheduler.cancel_search();
+
+    assert!(!scheduler.has_pending_work());
+    assert!(scheduler.snapshot().search_pending.is_none());
+}
+
+#[test]
 fn scheduler_reports_pending_work_for_buffered_results() {
     let scheduler = JobScheduler::new_for_tests(0, 0, 2);
     scheduler.defer_result(JobResult::Search(SearchBuild {
@@ -403,7 +419,10 @@ fn scheduler_reports_pending_work_for_buffered_results() {
         scope: SearchScope::Files,
         show_hidden: false,
         fingerprint: crate::fs::DirectoryFingerprint::default(),
-        result: Ok(Arc::new(Vec::new())),
+        result: Ok(crate::fs::search::SearchIndex {
+            candidates: Vec::new(),
+            stats: crate::fs::search::SearchIndexStats::default(),
+        }),
     }));
 
     assert!(scheduler.has_pending_work());

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -3,7 +3,7 @@ use crate::app::overlays::inline_image::TerminalWindowSize;
 use crate::app::overlays::pdf::PdfProbeResult;
 use crate::app::{ClipOp, SearchScope};
 use crate::core::{Entry, SortMode};
-use crate::fs::search::SearchCandidate;
+use crate::fs::search::{SearchIndex, SearchIndexBatch};
 use crate::{preview, preview::PreviewWorkClass};
 use std::{path::PathBuf, sync::Arc, time::SystemTime};
 
@@ -47,7 +47,17 @@ pub(in crate::app) struct SearchBuild {
     pub(in crate::app) scope: SearchScope,
     pub(in crate::app) show_hidden: bool,
     pub(in crate::app) fingerprint: crate::fs::DirectoryFingerprint,
-    pub(in crate::app) result: Result<Arc<Vec<SearchCandidate>>, String>,
+    pub(in crate::app) result: Result<SearchIndex, String>,
+}
+
+#[derive(Debug)]
+pub(in crate::app) struct SearchBatchBuild {
+    pub(in crate::app) token: u64,
+    pub(in crate::app) cwd: PathBuf,
+    pub(in crate::app) scope: SearchScope,
+    pub(in crate::app) show_hidden: bool,
+    pub(in crate::app) fingerprint: crate::fs::DirectoryFingerprint,
+    pub(in crate::app) batch: SearchIndexBatch,
 }
 
 #[derive(Clone, Debug)]
@@ -292,6 +302,7 @@ pub(in crate::app) enum JobResult {
     ImagePrepare(ImagePrepareBuild),
     PdfProbe(PdfProbeBuild),
     PdfRender(PdfRenderBuild),
+    SearchBatch(SearchBatchBuild),
     Search(SearchBuild),
     Preview(Box<PreviewBuild>),
     Paste(PasteBuild),

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -39,6 +39,22 @@ impl App {
             .unwrap_or(0)
     }
 
+    pub fn search_scanned_count(&self) -> usize {
+        let candidate_count = self.search_candidate_count();
+        self.overlays
+            .search
+            .as_ref()
+            .map(|search| search.stats.visited_nodes.max(candidate_count))
+            .unwrap_or(0)
+    }
+
+    pub fn search_index_is_limited(&self) -> bool {
+        self.overlays
+            .search
+            .as_ref()
+            .is_some_and(|search| search.stats.is_limited())
+    }
+
     pub fn search_scope(&self) -> Option<SearchScope> {
         self.overlays.search.as_ref().map(|search| search.scope)
     }
@@ -82,6 +98,7 @@ impl App {
     pub(in crate::app) fn open_fuzzy_finder(&mut self, scope: SearchScope) -> Result<()> {
         self.clear_wheel_scroll();
         self.overlays.help = false;
+        let show_hidden = self.effective_show_hidden();
         let cached = self
             .jobs
             .search_cache
@@ -89,11 +106,16 @@ impl App {
             .filter(|cache| {
                 cache.cwd == self.navigation.cwd
                     && cache.scope == scope
-                    && cache.show_hidden == self.navigation.show_hidden
+                    && cache.show_hidden == show_hidden
                     && cache.fingerprint == self.navigation.directory_runtime.fingerprint
             })
-            .map(|cache| cache.candidates.clone());
-        let candidates = cached.clone().unwrap_or_else(|| Arc::new(Vec::new()));
+            .map(|cache| (cache.candidates.clone(), cache.stats));
+        let (candidates, stats) = cached.clone().unwrap_or_else(|| {
+            (
+                Arc::new(Vec::new()),
+                crate::fs::search::SearchIndexStats::default(),
+            )
+        });
         let base_matches = (0..candidates.len()).collect::<Vec<_>>();
         let matches = base_matches
             .iter()
@@ -118,23 +140,30 @@ impl App {
             scroll: 0,
             loading,
             error: None,
+            stats,
         });
         self.status.clear();
         Ok(())
     }
 
+    fn close_search_overlay(&mut self) {
+        self.overlays.search = None;
+        self.jobs.search_loading = false;
+        self.jobs.search_token = self.jobs.search_token.wrapping_add(1);
+        self.jobs.scheduler.cancel_search();
+        self.clear_wheel_scroll();
+    }
+
     pub(in crate::app) fn handle_search_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.overlays.search = None;
-            self.clear_wheel_scroll();
+            self.close_search_overlay();
             self.status.clear();
             return Ok(());
         }
 
         match key.code {
             KeyCode::Esc => {
-                self.overlays.search = None;
-                self.clear_wheel_scroll();
+                self.close_search_overlay();
                 self.status.clear();
             }
             KeyCode::Enter => self.confirm_search_selection()?,
@@ -240,8 +269,7 @@ impl App {
                     .search_panel
                     .is_none_or(|rect| !rect_contains(rect, mouse.column, mouse.row))
                 {
-                    self.overlays.search = None;
-                    self.clear_wheel_scroll();
+                    self.close_search_overlay();
                     self.status.clear();
                 }
             }
@@ -342,7 +370,7 @@ impl App {
         };
 
         self.reveal_path(path)?;
-        self.overlays.search = None;
+        self.close_search_overlay();
         Ok(())
     }
 

--- a/src/app/search/tests.rs
+++ b/src/app/search/tests.rs
@@ -22,6 +22,18 @@ fn base_cache_entry(pool: Vec<usize>) -> SearchMatchCacheEntry {
     super::build_base_search_cache_entry(pool)
 }
 
+fn folder_candidate(root: &std::path::Path, name: &str) -> crate::fs::search::SearchCandidate {
+    crate::fs::search::SearchCandidate {
+        path: root.join(name),
+        name: name.to_string(),
+        name_key: name.to_lowercase(),
+        relative: name.to_string(),
+        relative_key: name.to_lowercase(),
+        is_dir: true,
+        symlink: None,
+    }
+}
+
 fn wait_for_search_candidates(app: &mut App, expected: usize) {
     for _ in 0..300 {
         let _ = app.process_background_jobs();
@@ -80,6 +92,7 @@ fn opening_search_ignores_hidden_cache_when_browser_hides_dotfiles() {
             is_dir: true,
             symlink: None,
         }]),
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     app.open_fuzzy_finder(SearchScope::Folders)
@@ -87,6 +100,251 @@ fn opening_search_ignores_hidden_cache_when_browser_hides_dotfiles() {
 
     assert_eq!(app.search_candidate_count(), 0);
     assert!(app.search_is_loading());
+
+    fs::remove_dir_all(root).expect("failed to remove temp tree");
+}
+
+#[test]
+fn opening_search_preserves_cached_limit_status() {
+    let root = temp_path("cached-limit-status");
+    fs::create_dir_all(root.join("needle")).expect("failed to create temp tree");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    let stats = crate::fs::search::SearchIndexStats {
+        visited_nodes: 5_000_000,
+        node_limit_reached: true,
+        candidate_limit_reached: false,
+    };
+    app.jobs.search_cache = Some(SearchCache {
+        cwd: root.clone(),
+        scope: SearchScope::Folders,
+        show_hidden: app.navigation.show_hidden,
+        fingerprint: app.navigation.directory_runtime.fingerprint,
+        candidates: Arc::new(vec![crate::fs::search::SearchCandidate {
+            path: root.join("needle"),
+            name: "needle".to_string(),
+            name_key: "needle".to_string(),
+            relative: "needle".to_string(),
+            relative_key: "needle".to_string(),
+            is_dir: true,
+            symlink: None,
+        }]),
+        stats,
+    });
+
+    app.open_fuzzy_finder(SearchScope::Folders)
+        .expect("failed to open search");
+
+    assert!(!app.search_is_loading());
+    assert!(app.search_index_is_limited());
+    assert_eq!(app.search_candidate_count(), 1);
+
+    fs::remove_dir_all(root).expect("failed to remove temp tree");
+}
+
+#[test]
+fn search_progress_batch_updates_open_overlay_while_loading() {
+    let root = temp_path("progress-batch");
+    fs::create_dir_all(&root).expect("failed to create temp tree");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.jobs.search_token = 42;
+    app.jobs.search_loading = true;
+    app.overlays.search = Some(SearchOverlay {
+        scope: SearchScope::Folders,
+        query: "link".to_string(),
+        query_cursor: 4,
+        candidates: Arc::new(Vec::new()),
+        matches: Vec::new(),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(Vec::new()))]),
+        selected: 0,
+        scroll: 0,
+        loading: true,
+        error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
+    });
+
+    app.jobs
+        .scheduler
+        .defer_result(crate::app::jobs::JobResult::SearchBatch(
+            crate::app::jobs::SearchBatchBuild {
+                token: 42,
+                cwd: root.clone(),
+                scope: SearchScope::Folders,
+                show_hidden: app.navigation.show_hidden,
+                fingerprint: app.navigation.directory_runtime.fingerprint,
+                batch: crate::fs::search::SearchIndexBatch {
+                    candidates: vec![crate::fs::search::SearchCandidate {
+                        path: root.join("linked-folder"),
+                        name: "linked-folder".to_string(),
+                        name_key: "linked-folder".to_string(),
+                        relative: "linked-folder".to_string(),
+                        relative_key: "linked-folder".to_string(),
+                        is_dir: true,
+                        symlink: None,
+                    }],
+                    stats: crate::fs::search::SearchIndexStats {
+                        visited_nodes: 9,
+                        node_limit_reached: false,
+                        candidate_limit_reached: false,
+                    },
+                },
+            },
+        ));
+
+    assert!(app.process_background_jobs());
+
+    assert!(app.search_is_loading());
+    assert_eq!(app.search_candidate_count(), 1);
+    assert_eq!(app.search_match_count(), 1);
+    assert_eq!(app.search_scanned_count(), 9);
+    assert_eq!(app.search_rows(10)[0].relative, "linked-folder");
+
+    fs::remove_dir_all(root).expect("failed to remove temp tree");
+}
+
+#[test]
+fn search_progress_batches_update_current_query_incrementally() {
+    let root = temp_path("progress-batch-query-cache");
+    fs::create_dir_all(&root).expect("failed to create temp tree");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.jobs.search_token = 42;
+    app.jobs.search_loading = true;
+    app.overlays.search = Some(SearchOverlay {
+        scope: SearchScope::Folders,
+        query: "fast".to_string(),
+        query_cursor: 4,
+        candidates: Arc::new(Vec::new()),
+        matches: Vec::new(),
+        cached_matches: HashMap::from([
+            (String::new(), base_cache_entry(Vec::new())),
+            (
+                "fast".to_string(),
+                super::build_search_cache_entry(Vec::new(), Vec::new()),
+            ),
+        ]),
+        selected: 0,
+        scroll: 0,
+        loading: true,
+        error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
+    });
+
+    for (visited_nodes, candidates) in [
+        (
+            2,
+            vec![
+                folder_candidate(&root, "alpha"),
+                folder_candidate(&root, "fastfetch"),
+            ],
+        ),
+        (3, vec![folder_candidate(&root, "fastlane")]),
+    ] {
+        app.jobs
+            .scheduler
+            .defer_result(crate::app::jobs::JobResult::SearchBatch(
+                crate::app::jobs::SearchBatchBuild {
+                    token: 42,
+                    cwd: root.clone(),
+                    scope: SearchScope::Folders,
+                    show_hidden: app.navigation.show_hidden,
+                    fingerprint: app.navigation.directory_runtime.fingerprint,
+                    batch: crate::fs::search::SearchIndexBatch {
+                        candidates,
+                        stats: crate::fs::search::SearchIndexStats {
+                            visited_nodes,
+                            node_limit_reached: false,
+                            candidate_limit_reached: false,
+                        },
+                    },
+                },
+            ));
+        assert!(app.process_background_jobs());
+    }
+
+    let search = app.overlays.search.as_ref().expect("search should be open");
+    assert_eq!(search.candidates.len(), 3);
+    assert_eq!(app.search_match_count(), 2);
+    let rows = app.search_rows(10);
+    let relatives = rows
+        .iter()
+        .map(|row| row.relative.as_str())
+        .collect::<Vec<_>>();
+    assert!(relatives.contains(&"fastfetch"));
+    assert!(relatives.contains(&"fastlane"));
+    assert_eq!(
+        search
+            .cached_matches
+            .get("")
+            .expect("base cache should exist")
+            .pool,
+        vec![0, 1, 2]
+    );
+    assert_eq!(
+        search
+            .cached_matches
+            .get("fast")
+            .expect("query cache should stay warm")
+            .pool
+            .len(),
+        2
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp tree");
+}
+
+#[test]
+fn closing_search_cancels_inflight_index_token() {
+    let root = temp_path("close-cancels-search");
+    fs::create_dir_all(&root).expect("failed to create temp tree");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.jobs.search_token = 42;
+    app.jobs.search_loading = true;
+    app.overlays.search = Some(SearchOverlay {
+        scope: SearchScope::Folders,
+        query: String::new(),
+        query_cursor: 0,
+        candidates: Arc::new(Vec::new()),
+        matches: Vec::new(),
+        cached_matches: HashMap::from([(String::new(), base_cache_entry(Vec::new()))]),
+        selected: 0,
+        scroll: 0,
+        loading: true,
+        error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
+    });
+
+    app.handle_search_key(KeyEvent::from(KeyCode::Esc))
+        .expect("closing search should work");
+
+    assert!(!app.search_is_open());
+    assert!(!app.jobs.search_loading);
+    assert_eq!(app.jobs.search_token, 43);
+
+    app.jobs
+        .scheduler
+        .defer_result(crate::app::jobs::JobResult::SearchBatch(
+            crate::app::jobs::SearchBatchBuild {
+                token: 42,
+                cwd: root.clone(),
+                scope: SearchScope::Folders,
+                show_hidden: app.navigation.show_hidden,
+                fingerprint: app.navigation.directory_runtime.fingerprint,
+                batch: crate::fs::search::SearchIndexBatch {
+                    candidates: vec![folder_candidate(&root, "stale")],
+                    stats: crate::fs::search::SearchIndexStats {
+                        visited_nodes: 1,
+                        node_limit_reached: false,
+                        candidate_limit_reached: false,
+                    },
+                },
+            },
+        ));
+
+    assert!(!app.process_background_jobs());
+    assert!(!app.search_is_open());
 
     fs::remove_dir_all(root).expect("failed to remove temp tree");
 }
@@ -171,6 +429,7 @@ fn refining_query_rechecks_full_candidate_set() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
     app.refresh_search_matches("");
     let fastfetch_index = app
@@ -221,6 +480,7 @@ fn search_query_cursor_inserts_and_deletes_in_place() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     app.handle_search_key(KeyEvent::from(KeyCode::Char('s')))
@@ -255,6 +515,7 @@ fn search_query_ctrl_arrows_move_across_word_boundaries() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     app.handle_search_key(KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL))
@@ -301,6 +562,7 @@ fn search_query_ctrl_backspace_and_delete_remove_word_units() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     app.handle_search_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::CONTROL))
@@ -338,6 +600,7 @@ fn search_query_terminal_fallback_word_delete_bindings_work() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     app.handle_search_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL))
@@ -390,6 +653,7 @@ fn search_rows_ignore_stale_match_indexes() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     assert!(app.search_rows(10).is_empty());
@@ -430,6 +694,7 @@ fn confirm_search_selection_selects_file_already_in_current_directory() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     app.confirm_search_selection()
@@ -472,6 +737,7 @@ fn confirm_search_selection_keeps_overlay_open_when_reveal_fails() {
         scroll: 0,
         loading: false,
         error: None,
+        stats: crate::fs::search::SearchIndexStats::default(),
     });
 
     assert!(app.confirm_search_selection().is_err());

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -14,7 +14,7 @@ use super::{
     types::*,
 };
 use crate::core::{Entry, SidebarRow, SortMode};
-use crate::fs::search::SearchCandidate;
+use crate::fs::search::{SearchCandidate, SearchIndexStats};
 use crate::preview;
 
 #[derive(Clone, Debug)]
@@ -194,6 +194,7 @@ pub(super) struct SearchOverlay {
     pub(super) scroll: usize,
     pub(super) loading: bool,
     pub(super) error: Option<String>,
+    pub(super) stats: SearchIndexStats,
 }
 
 #[derive(Clone, Debug)]
@@ -270,6 +271,7 @@ pub(super) struct SearchCache {
     pub(super) show_hidden: bool,
     pub(super) fingerprint: crate::fs::DirectoryFingerprint,
     pub(super) candidates: Arc<Vec<SearchCandidate>>,
+    pub(super) stats: SearchIndexStats,
 }
 
 #[derive(Clone, Debug)]

--- a/src/fs/search.rs
+++ b/src/fs/search.rs
@@ -6,7 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const SEARCH_NODE_VISIT_LIMIT: usize = 250_000;
+const SEARCH_NODE_VISIT_LIMIT: usize = 5_000_000;
+const SEARCH_CANDIDATE_BATCH_SIZE: usize = 512;
+const SEARCH_PROGRESS_NODE_INTERVAL: usize = 2_048;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SearchCandidate {
@@ -19,18 +21,56 @@ pub(crate) struct SearchCandidate {
     pub symlink: Option<SymlinkInfo>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct SearchIndexStats {
+    pub(crate) visited_nodes: usize,
+    pub(crate) node_limit_reached: bool,
+    pub(crate) candidate_limit_reached: bool,
+}
+
+impl SearchIndexStats {
+    pub(crate) fn is_limited(self) -> bool {
+        self.node_limit_reached || self.candidate_limit_reached
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SearchIndex {
+    pub(crate) candidates: Vec<SearchCandidate>,
+    pub(crate) stats: SearchIndexStats,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SearchIndexBatch {
+    pub(crate) candidates: Vec<SearchCandidate>,
+    pub(crate) stats: SearchIndexStats,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SearchCandidateScope {
     Files,
     Folders,
 }
 
-pub(crate) fn collect_candidates(
+pub(crate) fn collect_candidates_streaming(
     cwd: &Path,
     show_hidden: bool,
     scope: SearchCandidateScope,
-) -> Result<Vec<SearchCandidate>> {
-    collect_candidates_with_limits(cwd, show_hidden, scope, usize::MAX, SEARCH_NODE_VISIT_LIMIT)
+    is_canceled: impl Fn() -> bool,
+    emit_batch: impl FnMut(SearchIndexBatch) -> bool,
+) -> Result<SearchIndex> {
+    collect_candidates_with_limits_and_emitter(
+        cwd,
+        show_hidden,
+        scope,
+        SearchCollectionLimits {
+            candidate_limit: usize::MAX,
+            node_visit_limit: SEARCH_NODE_VISIT_LIMIT,
+            batch_size: SEARCH_CANDIDATE_BATCH_SIZE,
+        },
+        is_canceled,
+        emit_batch,
+    )
 }
 
 struct PendingSearchNode {
@@ -42,6 +82,13 @@ struct PendingSearchNode {
     is_dir: bool,
     symlink: Option<SymlinkInfo>,
     enqueue_children: bool,
+}
+
+#[derive(Clone, Copy)]
+struct SearchCollectionLimits {
+    candidate_limit: usize,
+    node_visit_limit: usize,
+    batch_size: usize,
 }
 
 impl PendingSearchNode {
@@ -60,19 +107,55 @@ impl PendingSearchNode {
     }
 }
 
+#[cfg(test)]
 fn collect_candidates_with_limits(
     cwd: &Path,
     show_hidden: bool,
     scope: SearchCandidateScope,
     candidate_limit: usize,
     node_visit_limit: usize,
-) -> Result<Vec<SearchCandidate>> {
+) -> Result<SearchIndex> {
+    collect_candidates_with_limits_and_emitter(
+        cwd,
+        show_hidden,
+        scope,
+        SearchCollectionLimits {
+            candidate_limit,
+            node_visit_limit,
+            batch_size: 0,
+        },
+        || false,
+        |_| true,
+    )
+}
+
+fn collect_candidates_with_limits_and_emitter(
+    cwd: &Path,
+    show_hidden: bool,
+    scope: SearchCandidateScope,
+    limits: SearchCollectionLimits,
+    is_canceled: impl Fn() -> bool,
+    mut emit_batch: impl FnMut(SearchIndexBatch) -> bool,
+) -> Result<SearchIndex> {
     let mut queue = VecDeque::from([cwd.to_path_buf()]);
     let mut visited_nodes = 0usize;
+    let mut node_limit_reached = false;
     let mut candidates = Vec::new();
+    let emit_batches = limits.batch_size > 0;
+    let mut pending_candidates = Vec::with_capacity(limits.batch_size);
+    let mut next_progress_at = SEARCH_PROGRESS_NODE_INTERVAL;
 
     while let Some(dir) = queue.pop_front() {
-        if visited_nodes >= node_visit_limit {
+        if is_canceled() {
+            return Ok(build_search_index(
+                candidates,
+                visited_nodes,
+                node_limit_reached,
+                limits.candidate_limit,
+            ));
+        }
+        if search_scan_limit_reached(visited_nodes, limits.node_visit_limit) {
+            node_limit_reached = true;
             break;
         }
 
@@ -86,7 +169,16 @@ fn collect_candidates_with_limits(
 
         let mut nodes = Vec::new();
         for entry in read_dir {
-            if visited_nodes >= node_visit_limit {
+            if is_canceled() {
+                return Ok(build_search_index(
+                    candidates,
+                    visited_nodes,
+                    node_limit_reached,
+                    limits.candidate_limit,
+                ));
+            }
+            if search_scan_limit_reached(visited_nodes, limits.node_visit_limit) {
+                node_limit_reached = true;
                 break;
             }
 
@@ -111,6 +203,32 @@ fn collect_candidates_with_limits(
             let is_symlink_entry = classified.symlink.is_some();
 
             visited_nodes += 1;
+            if emit_batches && visited_nodes >= next_progress_at {
+                let stats = SearchIndexStats {
+                    visited_nodes,
+                    node_limit_reached: false,
+                    candidate_limit_reached: false,
+                };
+                if !emit_search_batch(
+                    &mut pending_candidates,
+                    limits.batch_size,
+                    stats,
+                    true,
+                    &mut emit_batch,
+                ) {
+                    return Ok(SearchIndex { candidates, stats });
+                }
+                next_progress_at = visited_nodes.saturating_add(SEARCH_PROGRESS_NODE_INTERVAL);
+            }
+
+            if is_canceled() {
+                return Ok(build_search_index(
+                    candidates,
+                    visited_nodes,
+                    node_limit_reached,
+                    limits.candidate_limit,
+                ));
+            }
 
             let include_candidate = should_include_candidate(is_dir, scope);
             if !is_dir && !include_candidate {
@@ -155,19 +273,101 @@ fn collect_candidates_with_limits(
         });
 
         for node in nodes {
+            if is_canceled() {
+                return Ok(build_search_index(
+                    candidates,
+                    visited_nodes,
+                    node_limit_reached,
+                    limits.candidate_limit,
+                ));
+            }
             if node.enqueue_children {
                 queue.push_back(node.path.clone());
             }
             if let Some(candidate) = node.into_candidate() {
                 candidates.push(candidate);
+                if emit_batches {
+                    pending_candidates.push(
+                        candidates
+                            .last()
+                            .expect("candidate was just pushed")
+                            .clone(),
+                    );
+                    if pending_candidates.len() >= limits.batch_size {
+                        let stats = SearchIndexStats {
+                            visited_nodes,
+                            node_limit_reached,
+                            candidate_limit_reached: false,
+                        };
+                        if !emit_search_batch(
+                            &mut pending_candidates,
+                            limits.batch_size,
+                            stats,
+                            false,
+                            &mut emit_batch,
+                        ) {
+                            return Ok(SearchIndex { candidates, stats });
+                        }
+                    }
+                }
             }
         }
     }
 
-    if candidates.len() > candidate_limit {
+    let index = build_search_index(
+        candidates,
+        visited_nodes,
+        node_limit_reached,
+        limits.candidate_limit,
+    );
+    if emit_batches {
+        let _ = emit_search_batch(
+            &mut pending_candidates,
+            limits.batch_size,
+            index.stats,
+            false,
+            &mut emit_batch,
+        );
+    }
+    Ok(index)
+}
+
+fn build_search_index(
+    mut candidates: Vec<SearchCandidate>,
+    visited_nodes: usize,
+    node_limit_reached: bool,
+    candidate_limit: usize,
+) -> SearchIndex {
+    let candidate_limit_reached = candidates.len() > candidate_limit;
+    if candidate_limit_reached {
         candidates.truncate(candidate_limit);
     }
-    Ok(candidates)
+    SearchIndex {
+        candidates,
+        stats: SearchIndexStats {
+            visited_nodes,
+            node_limit_reached,
+            candidate_limit_reached,
+        },
+    }
+}
+
+fn emit_search_batch(
+    pending_candidates: &mut Vec<SearchCandidate>,
+    batch_size: usize,
+    stats: SearchIndexStats,
+    force_progress: bool,
+    emit_batch: &mut impl FnMut(SearchIndexBatch) -> bool,
+) -> bool {
+    if pending_candidates.is_empty() && !force_progress {
+        return true;
+    }
+    let candidates = std::mem::replace(pending_candidates, Vec::with_capacity(batch_size));
+    emit_batch(SearchIndexBatch { candidates, stats })
+}
+
+fn search_scan_limit_reached(visited_nodes: usize, node_visit_limit: usize) -> bool {
+    visited_nodes >= node_visit_limit
 }
 
 pub(crate) fn filter_candidates_in<I>(
@@ -405,7 +605,8 @@ mod tests {
 
         let hidden_off =
             collect_candidates_with_limits(&root, false, SearchCandidateScope::Folders, 100, 1_000)
-                .expect("failed to collect visible candidates");
+                .expect("failed to collect visible candidates")
+                .candidates;
         assert!(
             hidden_off
                 .iter()
@@ -424,7 +625,8 @@ mod tests {
 
         let hidden_on =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
-                .expect("failed to collect hidden candidates");
+                .expect("failed to collect hidden candidates")
+                .candidates;
         assert!(
             hidden_on
                 .iter()
@@ -444,7 +646,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 6, 1_000)
-                .expect("failed to collect candidates");
+                .expect("failed to collect candidates")
+                .candidates;
 
         assert_eq!(candidates[0].relative, ".hidden-root");
         assert_eq!(candidates[1].relative, "alpha");
@@ -468,7 +671,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
-                .expect("failed to collect candidates");
+                .expect("failed to collect candidates")
+                .candidates;
         let names = candidates
             .iter()
             .map(|candidate| candidate.relative.as_str())
@@ -491,7 +695,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
-                .expect("failed to collect file candidates");
+                .expect("failed to collect file candidates")
+                .candidates;
         let names = candidates
             .iter()
             .map(|candidate| candidate.relative.as_str())
@@ -500,6 +705,125 @@ mod tests {
         assert!(names.contains(&"top.txt"));
         assert!(names.contains(&"alpha/needle.txt"));
         assert!(!names.contains(&"alpha"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[test]
+    fn collect_candidates_reports_node_limit_truncation() {
+        let root = temp_path("node-limit");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("alpha.txt"), "alpha").expect("failed to write alpha");
+        fs::write(root.join("beta.txt"), "beta").expect("failed to write beta");
+        fs::write(root.join("gamma.txt"), "gamma").expect("failed to write gamma");
+
+        let index =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 2)
+                .expect("failed to collect candidates");
+
+        assert_eq!(index.stats.visited_nodes, 2);
+        assert!(index.stats.node_limit_reached);
+        assert!(!index.stats.candidate_limit_reached);
+        assert!(index.stats.is_limited());
+        assert_eq!(index.candidates.len(), 2);
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[test]
+    fn collect_candidates_reports_candidate_limit_truncation() {
+        let root = temp_path("candidate-limit");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("alpha.txt"), "alpha").expect("failed to write alpha");
+        fs::write(root.join("beta.txt"), "beta").expect("failed to write beta");
+        fs::write(root.join("gamma.txt"), "gamma").expect("failed to write gamma");
+
+        let index =
+            collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 2, 100)
+                .expect("failed to collect candidates");
+
+        assert_eq!(index.stats.visited_nodes, 3);
+        assert!(!index.stats.node_limit_reached);
+        assert!(index.stats.candidate_limit_reached);
+        assert!(index.stats.is_limited());
+        assert_eq!(index.candidates.len(), 2);
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[test]
+    fn collect_candidates_streaming_emits_batches_before_final_index() {
+        let root = temp_path("streaming-batches");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        for index in 0..(SEARCH_CANDIDATE_BATCH_SIZE + 1) {
+            fs::write(root.join(format!("file-{index:04}.txt")), "data")
+                .expect("failed to write file");
+        }
+
+        let mut batches = Vec::new();
+        let index = collect_candidates_streaming(
+            &root,
+            true,
+            SearchCandidateScope::Files,
+            || false,
+            |batch| {
+                batches.push((batch.candidates.len(), batch.stats.visited_nodes));
+                true
+            },
+        )
+        .expect("failed to collect streaming candidates");
+
+        assert_eq!(index.candidates.len(), SEARCH_CANDIDATE_BATCH_SIZE + 1);
+        assert!(
+            batches
+                .iter()
+                .any(|(candidate_count, _)| *candidate_count == SEARCH_CANDIDATE_BATCH_SIZE),
+            "expected at least one full candidate batch, got {batches:?}"
+        );
+        assert!(
+            batches
+                .iter()
+                .any(|(candidate_count, _)| *candidate_count == 1),
+            "expected the trailing candidate to be flushed, got {batches:?}"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp tree");
+    }
+
+    #[test]
+    fn collect_candidates_streaming_stops_after_cancellation() {
+        use std::cell::Cell;
+
+        let root = temp_path("streaming-cancel");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        for index in 0..10 {
+            fs::write(root.join(format!("file-{index:04}.txt")), "data")
+                .expect("failed to write file");
+        }
+
+        let canceled = Cell::new(false);
+        let mut batches = 0usize;
+        let index = collect_candidates_with_limits_and_emitter(
+            &root,
+            true,
+            SearchCandidateScope::Files,
+            SearchCollectionLimits {
+                candidate_limit: usize::MAX,
+                node_visit_limit: 100,
+                batch_size: 1,
+            },
+            || canceled.get(),
+            |batch| {
+                batches += 1;
+                assert_eq!(batch.candidates.len(), 1);
+                canceled.set(true);
+                true
+            },
+        )
+        .expect("failed to collect streaming candidates");
+
+        assert_eq!(batches, 1);
+        assert_eq!(index.candidates.len(), 1);
 
         fs::remove_dir_all(root).expect("failed to remove temp tree");
     }
@@ -516,7 +840,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
-                .expect("failed to collect folder candidates");
+                .expect("failed to collect folder candidates")
+                .candidates;
         let linked = candidates
             .iter()
             .find(|candidate| candidate.relative == "linked-dir")
@@ -555,7 +880,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
-                .expect("failed to collect file candidates");
+                .expect("failed to collect file candidates")
+                .candidates;
         let linked = candidates
             .iter()
             .find(|candidate| candidate.relative == "linked.txt")
@@ -584,7 +910,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
-                .expect("failed to collect file candidates");
+                .expect("failed to collect file candidates")
+                .candidates;
         let broken = candidates
             .iter()
             .find(|candidate| candidate.relative == "dangling")
@@ -598,7 +925,8 @@ mod tests {
 
         let folder_candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Folders, 100, 1_000)
-                .expect("failed to collect folder candidates");
+                .expect("failed to collect folder candidates")
+                .candidates;
         assert!(
             !folder_candidates
                 .iter()
@@ -624,7 +952,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
-                .expect("failed to collect candidates");
+                .expect("failed to collect candidates")
+                .candidates;
         let loop_entry = candidates
             .iter()
             .find(|candidate| candidate.relative == "loop")
@@ -654,7 +983,8 @@ mod tests {
 
         let visible =
             collect_candidates_with_limits(&root, false, SearchCandidateScope::Files, 100, 1_000)
-                .expect("failed to collect non-hidden candidates");
+                .expect("failed to collect non-hidden candidates")
+                .candidates;
         assert!(
             !visible
                 .iter()
@@ -664,7 +994,8 @@ mod tests {
 
         let all =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 100, 1_000)
-                .expect("failed to collect hidden candidates");
+                .expect("failed to collect hidden candidates")
+                .candidates;
         assert!(
             all.iter()
                 .any(|candidate| candidate.relative == ".hidden-link"),
@@ -684,7 +1015,8 @@ mod tests {
 
         let candidates =
             collect_candidates_with_limits(&root, true, SearchCandidateScope::Files, 10, 1_000)
-                .expect("failed to collect candidates");
+                .expect("failed to collect candidates")
+                .candidates;
         let names = candidates
             .iter()
             .map(|candidate| candidate.name.as_str())

--- a/src/ui/overlay_manager/search.rs
+++ b/src/ui/overlay_manager/search.rs
@@ -10,6 +10,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Clear, Paragraph},
 };
+use unicode_width::UnicodeWidthStr;
 
 pub(super) fn render_search_overlay(
     frame: &mut Frame<'_>,
@@ -44,15 +45,17 @@ pub(super) fn render_search_overlay(
         .search_scope()
         .map(|scope| scope.label())
         .unwrap_or("Search");
-    let summary = if app.search_is_loading() {
-        "indexing…".to_string()
-    } else {
-        format!(
-            "{} results  •  {} indexed",
-            app.search_match_count(),
-            app.search_candidate_count()
-        )
-    };
+    let summary_prefix = format!("{scope_label}  ");
+    let summary_width = usize::from(rows[0].width)
+        .saturating_sub(UnicodeWidthStr::width(summary_prefix.as_str()))
+        .saturating_sub(2);
+    let summary = build_search_summary(
+        app.search_is_loading(),
+        app.search_index_is_limited(),
+        app.search_match_count(),
+        app.search_scanned_count(),
+        summary_width,
+    );
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled(
@@ -61,7 +64,6 @@ pub(super) fn render_search_overlay(
                     .fg(palette.accent)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled("  current folder tree", Style::default().fg(palette.muted)),
             Span::raw("  "),
             helpers::chip_span(&summary, palette.accent_soft, palette.accent_text, true),
         ]))
@@ -123,11 +125,11 @@ pub(super) fn render_search_overlay(
     state.search_rows_visible = visible_rows;
 
     let rows_data = app.search_rows(visible_rows);
-    if app.search_is_loading() {
+    if app.search_is_loading() && rows_data.is_empty() {
         helpers::render_empty_state_with_bg(
             frame,
             results_area,
-            "Indexing current folder tree…",
+            "Scanning current tree…",
             palette,
             palette.chrome_alt,
         );
@@ -283,4 +285,80 @@ fn render_query_line(
         .saturating_add(visible_cursor as u16)
         .min(origin_x.saturating_add(width.saturating_sub(1)));
     (Line::from(spans), cursor_x)
+}
+
+fn format_search_count(count: usize) -> String {
+    let digits = count.to_string();
+    let mut grouped = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            grouped.push(',');
+        }
+        grouped.push(ch);
+    }
+    grouped
+}
+
+fn build_search_summary(
+    loading: bool,
+    limited: bool,
+    result_count: usize,
+    scanned_count: usize,
+    max_width: usize,
+) -> String {
+    let results = format_search_count(result_count);
+    let scanned = format_search_count(scanned_count);
+    let variants = if loading && scanned_count == 0 {
+        vec!["scanning…".to_string()]
+    } else if loading {
+        vec![
+            format!("{results} results  •  {scanned} scanned  •  scanning…"),
+            format!("scanning…  •  {scanned} scanned"),
+            "scanning…".to_string(),
+        ]
+    } else if limited {
+        vec![
+            format!("scan limit reached  •  {scanned} scanned  •  {results} results"),
+            format!("scan limit reached  •  {scanned} scanned"),
+            "scan limit reached".to_string(),
+            "limit reached".to_string(),
+        ]
+    } else {
+        vec![
+            format!("{results} results  •  {scanned} scanned"),
+            format!("{scanned} scanned"),
+        ]
+    };
+
+    variants
+        .iter()
+        .find(|variant| UnicodeWidthStr::width(variant.as_str()) <= max_width)
+        .cloned()
+        .unwrap_or_else(|| variants.last().cloned().unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn limited_search_summary_keeps_limit_status_when_width_is_tight() {
+        let summary = build_search_summary(false, true, 127_053, 5_000_000, 45);
+
+        assert_eq!(summary, "scan limit reached  •  5,000,000 scanned");
+    }
+
+    #[test]
+    fn loading_search_summary_prioritizes_scanning_status_when_width_is_tight() {
+        let summary = build_search_summary(true, false, 127_053, 1_000_000, 40);
+
+        assert_eq!(summary, "scanning…  •  1,000,000 scanned");
+    }
+
+    #[test]
+    fn loading_search_summary_keeps_count_order_when_width_allows() {
+        let summary = build_search_summary(true, false, 86_472, 518_144, 60);
+
+        assert_eq!(summary, "86,472 results  •  518,144 scanned  •  scanning…");
+    }
 }


### PR DESCRIPTION
## Summary

Improves fuzzy search behavior on large directory trees by showing matches while scanning continues instead of waiting for the full scan to finish. The PR also cancels stale scans, raises the hard scan cap, and makes scan progress/limit state visible in the overlay.

## What Changed

- Reworked fuzzy search collection to stream candidate batches while building the final search index.
- Added search batch job results so the open overlay can update incrementally.
- Canceled stale active/pending scans when search is closed, replaced, or invalidated by directory changes.
- Removed the adaptive 10s scan cutoff and raised the hard visited-entry cap to `5_000_000`.
- Updated the overlay summary to show result count, scanned count, `scanning...`, and `scan limit reached`.
- Updated search cache/stat handling so streamed results and cached limited indexes stay consistent.

## User Impact

Large fuzzy searches now become usable much sooner: matches appear while the filesystem scan continues, instead of the overlay waiting for the whole scan to complete.

This is especially noticeable on large home directories and external mounted drives. Searches can also reach many more entries before hitting the scan cap, and capped scans are shown explicitly with `scan limit reached`.

## Notes

Search scope semantics are unchanged.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested folder and file fuzzy search in `$HOME`.
- Tested hidden-file search in `$HOME`, including large scans over 1M scanned entries.
- Tested file fuzzy search on an external mounted drive, where results appeared while scanning continued.
- Verified the overlay summary for `results`, `scanned`, `scanning...`, and `scan limit reached`.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
