### PR TITLE
feat(open): open selected items in bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bulk opening for selected items: `Enter` and `o` now open the current selection instead of only the focused row. ([#111])
 - Added symlink-aware rendering in the file browser, directory previews, and Places, with inline `-> target` details, dedicated icons for symlinked folders and broken links, and a broken-link preview. Symlinked files keep their normal file-type appearance.
 - Added themable `symlink_directory` and `broken_symlink` classes, whose default colors track the `directory` class color and `preview.code.invalid` unless explicitly overridden.
 
@@ -162,3 +163,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#67]: https://github.com/elio-fm/elio/issues/67
 [#66]: https://github.com/elio-fm/elio/pull/66
 [#103]: https://github.com/elio-fm/elio/issues/103
+[#109]: https://github.com/elio-fm/elio/issues/109
+[#111]: https://github.com/elio-fm/elio/issues/111

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ See [Image Previews](#image-previews) and [Optional Preview Tools](#optional-pre
 
 ### Opening Files
 
-`Enter` enters folders and opens files with the system default application. `o` always opens the selected file or folder externally using the system launcher: `open` on macOS, `cmd /c start` on Windows, and `gio` (with `xdg-open` as fallback) on Linux and BSD desktop sessions.
+`Enter` enters folders and opens files with the system default application; when items are selected, it opens the selected items instead. `o` always opens the focused item or selected items externally using the system launcher: `open` on macOS, `cmd /c start` on Windows, and `gio` (with `xdg-open` as fallback) on Linux and BSD desktop sessions.
 
 `O` is for files. On macOS and Linux/BSD desktop sessions, elio discovers matching applications, opens the file directly when there is one match, and shows the Open With chooser when there are multiple. Terminal apps such as `nvim` are supported too. When no match is found, or on platforms without app discovery, elio falls back to the default opener.
 
@@ -328,7 +328,8 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 |---|---|
 | `↑` / `↓` · `j` / `k` | Move selection |
 | `←` · `h` · `Backspace` | Go to parent directory |
-| `→` · `l` · `Enter` | Enter folder / open file |
+| `→` · `l` | Enter folder |
+| `Enter` | Enter folder / open file or selection |
 | `g` | Go-to menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash) |
 | `G` | Jump to last item |
 | `PageUp` / `PageDown` | Page up / down |
@@ -347,7 +348,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 
 | Key | Action |
 |---|---|
-| `o` `*` | Open with the system default application |
+| `o` `*` | Open focused item or selection with the system default application |
 | `O` `*` | Open With chooser |
 | `a` `*` | Create file or folder |
 | `d` `*` | Trash; permanently delete if already in trash |

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -390,15 +390,46 @@ impl App {
     }
 
     pub(in crate::app) fn open_in_system(&mut self) -> Result<()> {
-        let Some(entry) = self.selected_entry() else {
+        let targets = self.open_in_system_targets();
+        if targets.is_empty() {
             return Ok(());
-        };
-
-        let target = entry.path.clone();
-        match crate::fs::open_in_system(&target) {
-            Ok(()) => self.status = format!("Opened {}", target.display()),
-            Err(e) => self.status = e,
         }
+
+        let total = targets.len();
+        let mut opened = 0;
+        let mut last_error = None;
+        for target in &targets {
+            match crate::fs::open_in_system(target) {
+                Ok(()) => opened += 1,
+                Err(error) => last_error = Some(error),
+            }
+        }
+
+        self.status = match (total, opened, last_error) {
+            (1, 1, _) => format!("Opened {}", targets[0].display()),
+            (_, opened, None) => format!("Opened {opened} items"),
+            (1, 0, Some(error)) => error,
+            (_, 0, Some(error)) => format!("Failed to open {total} items: {error}"),
+            (_, opened, Some(error)) => {
+                format!("Opened {opened}/{total} items; last error: {error}")
+            }
+        };
         Ok(())
+    }
+
+    fn open_in_system_targets(&self) -> Vec<PathBuf> {
+        if !self.navigation.selected_paths.is_empty() {
+            return self
+                .navigation
+                .entries
+                .iter()
+                .filter(|entry| self.navigation.selected_paths.contains(&entry.path))
+                .map(|entry| entry.path.clone())
+                .collect();
+        }
+
+        self.selected_entry()
+            .map(|entry| vec![entry.path.clone()])
+            .unwrap_or_default()
     }
 }

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -214,8 +214,8 @@ impl App {
             KeyCode::Right | KeyCode::Char('l') => {
                 if self.navigation.view_mode == ViewMode::Grid {
                     self.move_by_keyboard(1);
-                } else if self.selected_entry().is_some_and(Entry::is_dir) {
-                    self.open_selected()?;
+                } else if let Some(entry) = self.selected_entry().filter(|entry| entry.is_dir()) {
+                    self.set_dir(entry.path.clone())?;
                 } else {
                     self.status = "Press Enter to open files".to_string();
                 }
@@ -358,6 +358,10 @@ impl App {
     }
 
     pub(in crate::app) fn open_selected(&mut self) -> Result<()> {
+        if !self.navigation.selected_paths.is_empty() {
+            return self.dispatch_action(crate::config::Action::Open);
+        }
+
         let Some(entry) = self.selected_entry() else {
             return Ok(());
         };

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -14,6 +14,7 @@ struct OpenInSystemCaptureGuard;
 #[cfg(all(unix, not(target_os = "macos")))]
 impl OpenInSystemCaptureGuard {
     fn install(path: std::path::PathBuf) -> Self {
+        let _ = fs::remove_file(&path);
         crate::fs::set_open_in_system_capture_for_test(Some(path));
         Self
     }
@@ -24,6 +25,16 @@ impl Drop for OpenInSystemCaptureGuard {
     fn drop(&mut self) {
         crate::fs::set_open_in_system_capture_for_test(None);
     }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn read_open_capture(capture: &std::path::Path) -> String {
+    let deadline = Instant::now() + Duration::from_millis(1000);
+    while !capture.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    fs::read_to_string(capture).expect("capture should exist")
 }
 
 #[test]
@@ -85,12 +96,7 @@ fn enter_opens_selected_file_with_system_opener() {
     )))
     .expect("enter should open selected file");
 
-    let deadline = Instant::now() + Duration::from_millis(1000);
-    while !capture.exists() && Instant::now() < deadline {
-        thread::sleep(Duration::from_millis(10));
-    }
-
-    let opened = fs::read_to_string(&capture).expect("capture should exist");
+    let opened = read_open_capture(&capture);
     assert_eq!(opened, file_path.display().to_string());
 
     fs::remove_dir_all(root).ok();
@@ -115,13 +121,82 @@ fn newline_key_event_also_opens_selected_file() {
     )))
     .expect("newline key event should open selected file");
 
-    let deadline = Instant::now() + Duration::from_millis(1000);
-    while !capture.exists() && Instant::now() < deadline {
-        thread::sleep(Duration::from_millis(10));
-    }
-
-    let opened = fs::read_to_string(&capture).expect("capture should exist");
+    let opened = read_open_capture(&capture);
     assert_eq!(opened, file_path.display().to_string());
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn enter_opens_selected_entries_with_system_opener() {
+    let root = temp_path("enter-opens-selection");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    let gamma = root.join("gamma.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    fs::write(&gamma, "gamma").expect("failed to write gamma");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(gamma.clone());
+    app.navigation.selected_paths.insert(alpha.clone());
+    let beta_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == beta)
+        .expect("beta should be visible");
+    app.select_index(beta_index);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should open selected entries");
+
+    let opened = read_open_capture(&capture);
+    let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
+    assert_eq!(
+        opened,
+        vec![alpha.display().to_string(), gamma.display().to_string()]
+    );
+    assert_eq!(app.status, "Opened 2 items");
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn open_action_opens_selected_entries_with_system_opener() {
+    let root = temp_path("open-action-opens-selection");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('o'))))
+        .expect("o should open selected entries");
+
+    let opened = read_open_capture(&capture);
+    let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
+    assert_eq!(
+        opened,
+        vec![alpha.display().to_string(), beta.display().to_string()]
+    );
+    assert_eq!(app.status, "Opened 2 items");
 
     fs::remove_dir_all(root).ok();
 }

--- a/src/app/input/tests/navigation.rs
+++ b/src/app/input/tests/navigation.rs
@@ -52,6 +52,31 @@ fn right_arrow_enters_selected_directory_in_list_view() {
 }
 
 #[test]
+fn right_arrow_enters_focused_directory_even_when_selection_exists() {
+    let root = temp_path("right-dir-with-selection");
+    let child = root.join("child");
+    let file = root.join("selected.txt");
+    fs::create_dir_all(&child).expect("failed to create temp dirs");
+    fs::write(&file, "hello").expect("failed to write selected file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    app.navigation.selected_paths.insert(file);
+    app.select_index(0);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Right,
+        KeyModifiers::NONE,
+    )))
+    .expect("right arrow should be handled");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, child);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn left_arrow_in_list_view_reselects_previous_directory_in_parent() {
     let root = temp_path("left-parent-selection");
     let alpha = root.join("alpha");

--- a/src/fs/opener.rs
+++ b/src/fs/opener.rs
@@ -16,7 +16,18 @@ thread_local! {
 pub(crate) fn open_in_system(target: &Path) -> Result<(), String> {
     #[cfg(test)]
     if let Some(capture) = TEST_OPEN_IN_SYSTEM_CAPTURE.with(|slot| slot.borrow().clone()) {
-        return std::fs::write(&capture, target.display().to_string()).map_err(|e| e.to_string());
+        use std::{fs::OpenOptions, io::Write};
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&capture)
+            .map_err(|e| e.to_string())?;
+        if file.metadata().map_err(|e| e.to_string())?.len() > 0 {
+            writeln!(file).map_err(|e| e.to_string())?;
+        }
+        write!(file, "{}", target.display()).map_err(|e| e.to_string())?;
+        return Ok(());
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

Closes #111.

This PR makes the default open action selection-aware. When items are selected, `Enter` and `o` now open the selected items instead of only opening the focused row.

## What Changed

- Open selected items through the system opener when a selection exists.
- Preserve existing no-selection behavior: `Enter` still enters folders or opens the focused file.
- Keep `→` / `l` focused on directory navigation, even when a selection exists.
- Open selected items in visible browser order for deterministic behavior.
- Document the updated `Enter` / `o` behavior in the README.
- Add a changelog entry for the user-visible behavior change.

## Notes

`Open With` is unchanged. This PR only changes the default system opener path.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks on Linux:

- [x] Opened selected files with `Enter`
- [x] Opened selected folders with `Enter`
- [x] Opened mixed file/folder selections with `Enter`
- [x] Opened selected files and folders with `o`
- [x] Verified `→` / `l` still enter only the focused folder

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
