### PR TITLE
feat(shell): open shell in current folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `!` to open the user's shell in the current folder and return to elio when the shell exits. ([#112])
 - Added bulk opening for selected items: `Enter` and `o` now open the current selection instead of only the focused row. ([#111])
 - Added symlink-aware rendering in the file browser, directory previews, and Places, with inline `-> target` details, dedicated icons for symlinked folders and broken links, and a broken-link preview. Symlinked files keep their normal file-type appearance.
 - Added themable `symlink_directory` and `broken_symlink` classes, whose default colors track the `directory` class color and `preview.code.invalid` unless explicitly overridden.
@@ -165,3 +166,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#103]: https://github.com/elio-fm/elio/issues/103
 [#109]: https://github.com/elio-fm/elio/issues/109
 [#111]: https://github.com/elio-fm/elio/issues/111
+[#112]: https://github.com/elio-fm/elio/issues/112

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 
 `z` opens `zoxide query -i` for jumping to directories from your zoxide history. It requires `zoxide` to be installed and available in `PATH`, and it shows results only after zoxide has recorded directory history. The current directory is excluded from the picker. Extra picker options can be appended with `ELIO_ZOXIDE_OPTS`.
 
+### Shell
+
+`!` opens your shell in the current folder. elio temporarily leaves its TUI, shows a short return hint, then resumes and refreshes the folder after the shell exits. Use `exit` to return to elio; Unix-style shells usually also support `Ctrl-D` on an empty prompt.
+
+On Unix, macOS, and WSL, elio uses `$SHELL` with `/bin/sh` as a fallback. On Windows, it uses `COMSPEC` with PowerShell and `cmd` fallbacks. The child shell receives `ELIO_SHELL=1` and an `ELIO_LEVEL` nesting counter for custom prompts and shell startup files.
+
 ---
 
 ## Preview Coverage
@@ -350,6 +356,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 |---|---|
 | `o` `*` | Open focused item or selection with the system default application |
 | `O` `*` | Open With chooser |
+| `!` `*` | Open shell in current folder |
 | `a` `*` | Create file or folder |
 | `d` `*` | Trash; permanently delete if already in trash |
 | `r` `*` | Rename / bulk rename / restore from trash |

--- a/README.md
+++ b/README.md
@@ -232,9 +232,11 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 
 ### Shell
 
-`!` opens your shell in the current folder. elio temporarily leaves its TUI, shows a short return hint, then resumes and refreshes the folder after the shell exits. Use `exit` to return to elio; Unix-style shells usually also support `Ctrl-D` on an empty prompt.
+`!` opens your shell in the current folder. elio temporarily leaves its TUI, shows a short return hint, then resumes and refreshes the folder after the shell exits. Use `exit` to return to elio; Linux, macOS, BSD, and WSL shells usually also support `Ctrl-D` on an empty prompt.
 
-On Unix, macOS, and WSL, elio uses `$SHELL` with `/bin/sh` as a fallback. On Windows, it uses `COMSPEC` with PowerShell and `cmd` fallbacks. The child shell receives `ELIO_SHELL=1` and an `ELIO_LEVEL` nesting counter for custom prompts and shell startup files.
+Changing directories inside that shell only affects the shell session; when it exits, elio returns to the folder where you opened it.
+
+On Linux, macOS, BSD, and WSL, elio uses `$SHELL` with `/bin/sh` as a fallback. On Windows, it uses `COMSPEC` with PowerShell and `cmd` fallbacks. The child shell receives `ELIO_SHELL=1` and an `ELIO_LEVEL` nesting counter for custom prompts and shell startup files.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ On Freedesktop Trash systems, the stored filename may be changed to avoid collis
 
 ### Shell
 
-`!` opens your shell in the current folder. elio temporarily leaves its TUI, shows a short return hint, then resumes and refreshes the folder after the shell exits. Use `exit` to return to elio; Linux, macOS, BSD, and WSL shells usually also support `Ctrl-D` on an empty prompt.
+`!` opens your shell in the current folder. elio temporarily leaves its TUI, shows a short return hint, then resumes and refreshes the folder after the shell exits. Use `exit` to return to elio; Linux, macOS, BSD, and WSL shells usually also support `Ctrl+D` on an empty prompt.
 
 Changing directories inside that shell only affects the shell session; when it exits, elio returns to the folder where you opened it.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -72,6 +72,7 @@ show_top_bar = false
 # copy_path            = "c"
 # search_folders       = "f"
 # zoxide               = "z"
+# shell                = "!"
 # open                 = "o"
 # open_with            = "O"
 # sort                 = "s"

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -261,12 +261,15 @@ impl App {
         let metadata = std::fs::metadata(&path).map_err(|error| {
             anyhow!(
                 "Cannot open {}: {}",
-                path.display(),
+                crate::path_display::user_facing(&path),
                 crate::fs::describe_io_error(&error)
             )
         })?;
         if !metadata.is_dir() {
-            bail!("{} is not a directory", path.display());
+            bail!(
+                "{} is not a directory",
+                crate::path_display::user_facing(&path)
+            );
         }
         let normalized = path.canonicalize().unwrap_or(path);
         if normalized == self.navigation.cwd
@@ -278,7 +281,10 @@ impl App {
                 self.apply_directory_completion(completion);
                 return Ok(());
             }
-            self.status = format!("Already in {}", self.navigation.cwd.display());
+            self.status = format!(
+                "Already in {}",
+                crate::path_display::user_facing(&self.navigation.cwd)
+            );
             return Ok(());
         }
         if self
@@ -294,7 +300,10 @@ impl App {
                 }
                 load.completion = completion;
             }
-            self.status = format!("Already opening {}", normalized.display());
+            self.status = format!(
+                "Already opening {}",
+                crate::path_display::user_facing(&normalized)
+            );
             return Ok(());
         }
 
@@ -302,7 +311,7 @@ impl App {
             self.remembered_view_for(&normalized)
                 .and_then(|view| view.selected_path)
         });
-        self.status = format!("Opening {}", normalized.display());
+        self.status = format!("Opening {}", crate::path_display::user_facing(&normalized));
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
             target_cwd: normalized,

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -16,7 +16,10 @@ impl App {
                     suffix,
                 )
             }
-            None => format!("0/0  {}", self.navigation.cwd.display()),
+            None => format!(
+                "0/0  {}",
+                crate::path_display::user_facing(&self.navigation.cwd)
+            ),
         }
     }
 

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -286,6 +286,12 @@ impl App {
                 self.pending_terminal_task = Some(PendingTerminalTask::Zoxide);
                 self.status.clear();
             }
+            Action::Shell => {
+                self.pending_terminal_task = Some(PendingTerminalTask::Shell {
+                    cwd: self.navigation.cwd.clone(),
+                });
+                self.status.clear();
+            }
             Action::Open => self.open_in_system()?,
             Action::OpenWith => self.open_open_with_overlay(),
             Action::Sort => self.cycle_sort_mode()?,

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -802,6 +802,47 @@ fn zoxide_action_queues_pending_terminal_task() {
 }
 
 #[test]
+fn shell_action_queues_shell_in_current_directory() {
+    let root = temp_path("shell-action");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+    app.dispatch_action(Action::Shell)
+        .expect("dispatch should succeed");
+
+    assert_eq!(
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Shell { cwd: root.clone() })
+    );
+    assert!(app.status.is_empty());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn rebound_shell_key_queues_shell_action() {
+    use crate::config::KeyBindings;
+
+    let kb = KeyBindings::from_toml_str("[keys]\nshell = \"S\"");
+    assert_eq!(kb.action_for('S'), Some(Action::Shell));
+    assert_eq!(kb.action_for('!'), None);
+
+    let root = temp_path("rebind-shell-e2e");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+    app.dispatch_action(kb.action_for('S').unwrap())
+        .expect("dispatch should succeed");
+
+    assert_eq!(
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Shell { cwd: root.clone() })
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn zoxide_selection_opens_directory() {
     let root = temp_path("zoxide-selection");
     let target = root.join("target");

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -588,6 +588,7 @@ pub(in crate::app) struct InputRuntime {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PendingTerminalTask {
     Command { program: String, args: Vec<String> },
+    Shell { cwd: PathBuf },
     Zoxide,
 }
 

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -13,6 +13,7 @@ pub(crate) enum Action {
     CopyPath,
     SearchFolders,
     Zoxide,
+    Shell,
     Open,
     OpenWith,
     Sort,
@@ -39,6 +40,7 @@ pub(crate) struct KeyBindings {
     pub copy_path: char,
     pub search_folders: char,
     pub zoxide: char,
+    pub shell: char,
     pub open: char,
     pub open_with: char,
     pub sort: char,
@@ -74,6 +76,7 @@ impl Default for KeyBindings {
             copy_path: 'c',
             search_folders: 'f',
             zoxide: 'z',
+            shell: '!',
             open: 'o',
             open_with: 'O',
             sort: 's',
@@ -99,6 +102,7 @@ pub(super) struct KeysConfigOverride {
     copy_path: Option<String>,
     search_folders: Option<String>,
     zoxide: Option<String>,
+    shell: Option<String>,
     open: Option<String>,
     open_with: Option<String>,
     sort: Option<String>,
@@ -124,6 +128,7 @@ impl KeyBindings {
             _ if c == self.copy_path => Some(Action::CopyPath),
             _ if c == self.search_folders => Some(Action::SearchFolders),
             _ if c == self.zoxide => Some(Action::Zoxide),
+            _ if c == self.shell => Some(Action::Shell),
             _ if c == self.open => Some(Action::Open),
             _ if c == self.open_with => Some(Action::OpenWith),
             _ if c == self.sort => Some(Action::Sort),
@@ -150,7 +155,7 @@ impl KeyBindings {
 
     pub(super) fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
         // Each entry: (field_name, user_override_string, default_char)
-        let raw: [(&str, Option<String>, char); 19] = [
+        let raw: [(&str, Option<String>, char); 20] = [
             ("quit", overrides.quit, defaults.quit),
             ("yank", overrides.yank, defaults.yank),
             ("cut", overrides.cut, defaults.cut),
@@ -165,6 +170,7 @@ impl KeyBindings {
                 defaults.search_folders,
             ),
             ("zoxide", overrides.zoxide, defaults.zoxide),
+            ("shell", overrides.shell, defaults.shell),
             ("open", overrides.open, defaults.open),
             ("open_with", overrides.open_with, defaults.open_with),
             ("sort", overrides.sort, defaults.sort),
@@ -199,7 +205,7 @@ impl KeyBindings {
         // Step 1: parse each override string independently, falling back to
         // default on any format or reserved-char error.
         // (resolved_char, is_user_set)
-        let mut candidates: [(char, bool); 19] = [(' ', false); 19];
+        let mut candidates: [(char, bool); 20] = [(' ', false); 20];
         for (index, (name, override_str, default)) in raw.iter().enumerate() {
             candidates[index] = match override_str {
                 None => (*default, false),
@@ -238,12 +244,12 @@ impl KeyBindings {
         // binding does not silently leave a conflict with another.
         loop {
             let mut changed = false;
-            for index in 0..19 {
+            for index in 0..20 {
                 if !candidates[index].1 {
                     continue;
                 }
                 let candidate = candidates[index].0;
-                let collision = (0..19)
+                let collision = (0..20)
                     .filter(|&other_index| other_index != index)
                     .any(|other_index| candidates[other_index].0 == candidate);
                 if collision {
@@ -283,15 +289,16 @@ impl KeyBindings {
             copy_path: resolved(7),
             search_folders: resolved(8),
             zoxide: resolved(9),
-            open: resolved(10),
-            open_with: resolved(11),
-            sort: resolved(12),
-            toggle_view: resolved(13),
-            toggle_hidden: resolved(14),
-            scroll_preview_left: resolved(15),
-            scroll_preview_right: resolved(16),
-            scroll_preview_up: resolved(17),
-            scroll_preview_down: resolved(18),
+            shell: resolved(10),
+            open: resolved(11),
+            open_with: resolved(12),
+            sort: resolved(13),
+            toggle_view: resolved(14),
+            toggle_hidden: resolved(15),
+            scroll_preview_left: resolved(16),
+            scroll_preview_right: resolved(17),
+            scroll_preview_up: resolved(18),
+            scroll_preview_down: resolved(19),
         }
     }
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -8,6 +8,7 @@ fn keys_default_bindings_are_sane() {
     assert_eq!(config.keys.paste, 'p');
     assert_eq!(config.keys.quit, 'q');
     assert_eq!(config.keys.zoxide, 'z');
+    assert_eq!(config.keys.shell, '!');
 }
 
 #[test]
@@ -121,6 +122,7 @@ fn action_for_returns_correct_action_for_default_bindings() {
     assert_eq!(key_bindings.action_for('o'), Some(Action::Open));
     assert_eq!(key_bindings.action_for('O'), Some(Action::OpenWith));
     assert_eq!(key_bindings.action_for('z'), Some(Action::Zoxide));
+    assert_eq!(key_bindings.action_for('!'), Some(Action::Shell));
     assert_eq!(key_bindings.action_for('j'), None);
 }
 
@@ -168,6 +170,26 @@ zoxide = "Z"
     .expect("config should parse");
     assert_eq!(config.keys.action_for('Z'), Some(Action::Zoxide));
     assert_eq!(config.keys.action_for('z'), None);
+}
+
+#[test]
+fn shell_defaults_to_bang() {
+    let key_bindings = KeyBindings::default();
+    assert_eq!(key_bindings.shell, '!');
+    assert_eq!(key_bindings.action_for('!'), Some(Action::Shell));
+}
+
+#[test]
+fn shell_can_be_overridden() {
+    let config = Config::from_str(
+        r#"
+[keys]
+shell = "S"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('S'), Some(Action::Shell));
+    assert_eq!(config.keys.action_for('!'), None);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod core;
 mod file_info;
 mod fs;
+mod path_display;
 mod preview;
 mod shell;
 mod ui;
@@ -151,6 +152,7 @@ fn run_blocking_in_terminal(program: &str, args: &[String]) {
 }
 
 fn refresh_after_shell(app: &mut App, cwd: &Path) {
+    let cwd_label = path_display::user_facing(cwd);
     match cwd.try_exists() {
         Ok(true) => {
             if let Err(error) = app.reload() {
@@ -159,11 +161,10 @@ fn refresh_after_shell(app: &mut App, cwd: &Path) {
         }
         Ok(false) => app.set_status_message(format!(
             "Current folder was removed while shell was open: {}",
-            cwd.display()
+            cwd_label
         )),
         Err(error) => app.set_status_message(format!(
-            "Could not refresh {} after shell: {error}",
-            cwd.display()
+            "Could not refresh {cwd_label} after shell: {error}"
         )),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod core;
 mod file_info;
 mod fs;
 mod preview;
+mod shell;
 mod ui;
 mod zoxide;
 
@@ -24,7 +25,7 @@ use crossterm::{
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::{
     io::{self, ErrorKind, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
     time::{Duration, Instant},
 };
@@ -147,6 +148,24 @@ fn resume_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Res
 /// unable to open a file) should not crash the file manager.
 fn run_blocking_in_terminal(program: &str, args: &[String]) {
     let _ = Command::new(program).args(args).status();
+}
+
+fn refresh_after_shell(app: &mut App, cwd: &Path) {
+    match cwd.try_exists() {
+        Ok(true) => {
+            if let Err(error) = app.reload() {
+                app.report_runtime_error("Shell refresh failed", &error);
+            }
+        }
+        Ok(false) => app.set_status_message(format!(
+            "Current folder was removed while shell was open: {}",
+            cwd.display()
+        )),
+        Err(error) => app.set_status_message(format!(
+            "Could not refresh {} after shell: {error}",
+            cwd.display()
+        )),
+    }
 }
 
 fn apply_zoxide_query_result(app: &mut App, result: zoxide::QueryResult) {
@@ -434,6 +453,16 @@ fn run_app(
                         suspend_terminal(terminal, true)?;
                         run_blocking_in_terminal(&program, &args);
                         resume_terminal(terminal)?;
+                        None
+                    }
+                    PendingTerminalTask::Shell { cwd } => {
+                        suspend_terminal(terminal, true)?;
+                        let shell_result = shell::run_in_current_terminal(&cwd);
+                        resume_terminal(terminal)?;
+                        match shell_result {
+                            Ok(()) => refresh_after_shell(&mut app, &cwd),
+                            Err(error) => app.set_status_message(error),
+                        }
                         None
                     }
                     PendingTerminalTask::Zoxide => {

--- a/src/path_display.rs
+++ b/src/path_display.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+pub(crate) fn user_facing(path: &Path) -> String {
+    strip_windows_verbatim_prefix(&path.display().to_string())
+}
+
+fn strip_windows_verbatim_prefix(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_windows_verbatim_prefix;
+
+    #[test]
+    fn removes_windows_drive_verbatim_prefix() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\C:\Users\migue\AppData\Roaming"),
+            r"C:\Users\migue\AppData\Roaming"
+        );
+    }
+
+    #[test]
+    fn removes_windows_unc_verbatim_prefix() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\UNC\server\share\folder"),
+            r"\\server\share\folder"
+        );
+    }
+
+    #[test]
+    fn leaves_regular_paths_unchanged() {
+        assert_eq!(
+            strip_windows_verbatim_prefix("/home/user/project"),
+            "/home/user/project"
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"C:\Users\migue"),
+            r"C:\Users\migue"
+        );
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -29,11 +29,12 @@ impl ShellInvocation {
 
 pub(crate) fn run_in_current_terminal(cwd: &Path) -> Result<(), String> {
     ensure_cwd_exists(cwd)?;
+    let cwd_label = crate::path_display::user_facing(cwd);
 
     let invocations = shell_invocations();
     let tried: Vec<String> = invocations.iter().map(ShellInvocation::label).collect();
 
-    print_shell_banner(cwd)?;
+    print_shell_banner(&cwd_label)?;
     for invocation in invocations {
         match Command::new(&invocation.program)
             .args(&invocation.args)
@@ -50,22 +51,18 @@ pub(crate) fn run_in_current_terminal(cwd: &Path) -> Result<(), String> {
                 ensure_cwd_exists(cwd)?;
             }
             Err(error) => {
-                return Err(format!(
-                    "Could not open shell in {}: {error}",
-                    cwd.display()
-                ));
+                return Err(format!("Could not open shell in {cwd_label}: {error}"));
             }
         }
     }
 
     Err(format!(
-        "Could not find a shell to open in {} (tried {})",
-        cwd.display(),
+        "Could not find a shell to open in {cwd_label} (tried {})",
         tried.join(", ")
     ))
 }
 
-fn print_shell_banner(cwd: &Path) -> Result<(), String> {
+fn print_shell_banner(cwd_label: &str) -> Result<(), String> {
     let mut stdout = io::stdout();
     let (label_style, value_style, dim_style, reset_style) = if shell_banner_color_enabled() {
         ("\x1b[1;36m", "\x1b[1m", "\x1b[2m", "\x1b[0m")
@@ -76,7 +73,7 @@ fn print_shell_banner(cwd: &Path) -> Result<(), String> {
     writeln!(
         stdout,
         "{label_style}elio:{reset_style} opened shell in {value_style}{}{reset_style}",
-        cwd.display()
+        cwd_label
     )
     .and_then(|()| {
         writeln!(
@@ -87,7 +84,7 @@ fn print_shell_banner(cwd: &Path) -> Result<(), String> {
     })
     .and_then(|()| writeln!(stdout))
     .and_then(|()| stdout.flush())
-    .map_err(|error| format!("Could not prepare shell in {}: {error}", cwd.display()))
+    .map_err(|error| format!("Could not prepare shell in {cwd_label}: {error}"))
 }
 
 fn shell_banner_color_enabled() -> bool {
@@ -103,7 +100,7 @@ fn shell_return_hint() -> &'static str {
 
     #[cfg(not(windows))]
     {
-        "exit or Ctrl-D"
+        "exit or Ctrl+D"
     }
 }
 
@@ -184,13 +181,14 @@ fn next_shell_level(current: Option<OsString>) -> OsString {
 }
 
 fn ensure_cwd_exists(cwd: &Path) -> Result<(), String> {
+    let cwd_label = crate::path_display::user_facing(cwd);
     match cwd.try_exists() {
         Ok(true) => Ok(()),
         Ok(false) => Err(format!(
             "Cannot open shell in {}: folder no longer exists",
-            cwd.display()
+            cwd_label
         )),
-        Err(error) => Err(format!("Cannot open shell in {}: {error}", cwd.display())),
+        Err(error) => Err(format!("Cannot open shell in {cwd_label}: {error}")),
     }
 }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,329 @@
+use std::{
+    ffi::OsString,
+    io::{self, ErrorKind, Write},
+    path::Path,
+    process::Command,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ShellInvocation {
+    pub(crate) program: OsString,
+    pub(crate) args: Vec<OsString>,
+}
+
+impl ShellInvocation {
+    fn label(&self) -> String {
+        if self.args.is_empty() {
+            self.program.to_string_lossy().into_owned()
+        } else {
+            let args = self
+                .args
+                .iter()
+                .map(|arg| arg.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("{} {args}", self.program.to_string_lossy())
+        }
+    }
+}
+
+pub(crate) fn run_in_current_terminal(cwd: &Path) -> Result<(), String> {
+    ensure_cwd_exists(cwd)?;
+
+    let invocations = shell_invocations();
+    let tried: Vec<String> = invocations.iter().map(ShellInvocation::label).collect();
+
+    print_shell_banner(cwd)?;
+    for invocation in invocations {
+        match Command::new(&invocation.program)
+            .args(&invocation.args)
+            .current_dir(cwd)
+            .env("ELIO_SHELL", "1")
+            .env(
+                "ELIO_LEVEL",
+                next_shell_level(std::env::var_os("ELIO_LEVEL")),
+            )
+            .status()
+        {
+            Ok(_) => return Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                ensure_cwd_exists(cwd)?;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Could not open shell in {}: {error}",
+                    cwd.display()
+                ));
+            }
+        }
+    }
+
+    Err(format!(
+        "Could not find a shell to open in {} (tried {})",
+        cwd.display(),
+        tried.join(", ")
+    ))
+}
+
+fn print_shell_banner(cwd: &Path) -> Result<(), String> {
+    let mut stdout = io::stdout();
+    let (label_style, value_style, dim_style, reset_style) = if shell_banner_color_enabled() {
+        ("\x1b[1;36m", "\x1b[1m", "\x1b[2m", "\x1b[0m")
+    } else {
+        ("", "", "", "")
+    };
+
+    writeln!(
+        stdout,
+        "{label_style}elio:{reset_style} opened shell in {value_style}{}{reset_style}",
+        cwd.display()
+    )
+    .and_then(|()| {
+        writeln!(
+            stdout,
+            "{dim_style}return:{reset_style} {}",
+            shell_return_hint()
+        )
+    })
+    .and_then(|()| writeln!(stdout))
+    .and_then(|()| stdout.flush())
+    .map_err(|error| format!("Could not prepare shell in {}: {error}", cwd.display()))
+}
+
+fn shell_banner_color_enabled() -> bool {
+    std::env::var_os("NO_COLOR").is_none()
+        && std::env::var_os("TERM").is_none_or(|term| term != "dumb")
+}
+
+fn shell_return_hint() -> &'static str {
+    #[cfg(windows)]
+    {
+        "exit"
+    }
+
+    #[cfg(not(windows))]
+    {
+        "exit or Ctrl-D"
+    }
+}
+
+pub(crate) fn shell_invocations() -> Vec<ShellInvocation> {
+    #[cfg(windows)]
+    {
+        windows_shell_invocations(std::env::var_os("COMSPEC"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        unix_shell_invocations(std::env::var_os("SHELL"))
+    }
+}
+
+#[cfg(any(not(windows), test))]
+fn unix_shell_invocations(shell: Option<OsString>) -> Vec<ShellInvocation> {
+    let fallback = ShellInvocation {
+        program: OsString::from("/bin/sh"),
+        args: Vec::new(),
+    };
+
+    let Some(program) = non_empty_env_value(shell) else {
+        return vec![fallback];
+    };
+
+    let configured = ShellInvocation {
+        program,
+        args: Vec::new(),
+    };
+    if configured.program == fallback.program {
+        vec![configured]
+    } else {
+        vec![configured, fallback]
+    }
+}
+
+#[cfg(any(windows, test))]
+fn windows_shell_invocations(comspec: Option<OsString>) -> Vec<ShellInvocation> {
+    let mut invocations = Vec::new();
+    if let Some(program) = non_empty_env_value(comspec) {
+        invocations.push(ShellInvocation {
+            program,
+            args: Vec::new(),
+        });
+    }
+
+    invocations.extend([
+        ShellInvocation {
+            program: OsString::from("pwsh"),
+            args: vec![OsString::from("-NoLogo")],
+        },
+        ShellInvocation {
+            program: OsString::from("powershell"),
+            args: vec![OsString::from("-NoLogo")],
+        },
+        ShellInvocation {
+            program: OsString::from("cmd"),
+            args: Vec::new(),
+        },
+    ]);
+    invocations
+}
+
+fn non_empty_env_value(value: Option<OsString>) -> Option<OsString> {
+    let value = value?;
+    (!value.to_string_lossy().trim().is_empty()).then_some(value)
+}
+
+fn next_shell_level(current: Option<OsString>) -> OsString {
+    let Some(current) = current else {
+        return OsString::from("1");
+    };
+    let Ok(level) = current.to_string_lossy().trim().parse::<u32>() else {
+        return OsString::from("1");
+    };
+    OsString::from(level.saturating_add(1).to_string())
+}
+
+fn ensure_cwd_exists(cwd: &Path) -> Result<(), String> {
+    match cwd.try_exists() {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(format!(
+            "Cannot open shell in {}: folder no longer exists",
+            cwd.display()
+        )),
+        Err(error) => Err(format!("Cannot open shell in {}: {error}", cwd.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_shell_uses_shell_env_then_sh_fallback() {
+        assert_eq!(
+            unix_shell_invocations(Some(OsString::from("/bin/bash"))),
+            vec![
+                ShellInvocation {
+                    program: OsString::from("/bin/bash"),
+                    args: Vec::new(),
+                },
+                ShellInvocation {
+                    program: OsString::from("/bin/sh"),
+                    args: Vec::new(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn unix_shell_uses_only_sh_when_shell_is_empty() {
+        assert_eq!(
+            unix_shell_invocations(Some(OsString::from(""))),
+            vec![ShellInvocation {
+                program: OsString::from("/bin/sh"),
+                args: Vec::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn unix_shell_does_not_duplicate_sh_fallback() {
+        assert_eq!(
+            unix_shell_invocations(Some(OsString::from("/bin/sh"))),
+            vec![ShellInvocation {
+                program: OsString::from("/bin/sh"),
+                args: Vec::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn windows_shell_uses_comspec_before_powershell_fallbacks() {
+        assert_eq!(
+            windows_shell_invocations(Some(OsString::from(r"C:\Windows\System32\cmd.exe"))),
+            vec![
+                ShellInvocation {
+                    program: OsString::from(r"C:\Windows\System32\cmd.exe"),
+                    args: Vec::new(),
+                },
+                ShellInvocation {
+                    program: OsString::from("pwsh"),
+                    args: vec![OsString::from("-NoLogo")],
+                },
+                ShellInvocation {
+                    program: OsString::from("powershell"),
+                    args: vec![OsString::from("-NoLogo")],
+                },
+                ShellInvocation {
+                    program: OsString::from("cmd"),
+                    args: Vec::new(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_shell_falls_back_when_comspec_is_empty() {
+        assert_eq!(
+            windows_shell_invocations(Some(OsString::from(" "))),
+            vec![
+                ShellInvocation {
+                    program: OsString::from("pwsh"),
+                    args: vec![OsString::from("-NoLogo")],
+                },
+                ShellInvocation {
+                    program: OsString::from("powershell"),
+                    args: vec![OsString::from("-NoLogo")],
+                },
+                ShellInvocation {
+                    program: OsString::from("cmd"),
+                    args: Vec::new(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn shell_level_starts_at_one() {
+        assert_eq!(next_shell_level(None), OsString::from("1"));
+        assert_eq!(
+            next_shell_level(Some(OsString::from(""))),
+            OsString::from("1")
+        );
+        assert_eq!(
+            next_shell_level(Some(OsString::from("not-a-number"))),
+            OsString::from("1")
+        );
+    }
+
+    #[test]
+    fn shell_level_increments_existing_level() {
+        assert_eq!(
+            next_shell_level(Some(OsString::from("1"))),
+            OsString::from("2")
+        );
+        assert_eq!(
+            next_shell_level(Some(OsString::from(" 41 "))),
+            OsString::from("42")
+        );
+    }
+
+    #[test]
+    fn cwd_check_reports_deleted_folder() {
+        let missing = std::env::temp_dir().join(format!(
+            "elio-missing-shell-cwd-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be after unix epoch")
+                .as_nanos()
+        ));
+
+        let error = ensure_cwd_exists(&missing).expect_err("missing cwd should fail");
+
+        assert!(
+            error.contains("folder no longer exists"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -187,13 +187,13 @@ pub(super) fn stable_path_label(path: &Path, max_chars: usize) -> String {
             if stripped.as_os_str().is_empty() {
                 "~".to_string()
             } else {
-                format!("~/{}", stripped.display())
+                format!("~/{}", crate::path_display::user_facing(stripped))
             }
         } else {
-            path.display().to_string()
+            crate::path_display::user_facing(path)
         }
     } else {
-        path.display().to_string()
+        crate::path_display::user_facing(path)
     };
     truncate_path_tail(&display, max_chars.max(8))
 }

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -53,6 +53,7 @@ pub(super) fn render_help(
         e(&kb.trash.to_string(), "trash (delete if in trash)"),
         e(&rename_key, "rename (bulk if selection)"),
         e(&rename_trash_key, "restore from trash"),
+        e(&kb.shell.to_string(), "open shell here"),
         e(&kb.open.to_string(), "open with default app"),
         e(&kb.open_with.to_string(), "open with"),
     ];


### PR DESCRIPTION
## Summary

Closes #112.

Adds a built-in shell action so users can press `!` to temporarily leave elio, run their shell in the current folder, then return to elio when the shell exits.

## What Changed

- Added `[keys] shell = "!"` as the default binding.
- Added a dedicated same-terminal shell task that suspends elio, runs the shell in the current folder, then resumes and refreshes elio.
- Resolves the shell per platform: `$SHELL` with `/bin/sh` fallback on Linux, macOS, BSD, and WSL; `COMSPEC` with `pwsh`, Windows PowerShell, and `cmd` fallbacks on Windows.
- Added `ELIO_SHELL=1` and `ELIO_LEVEL` for shell startup files and custom prompts.
- Added a short shell return hint before launching the child shell.
- Hid Windows verbatim path prefixes from user-facing path labels.
- Documented the shell action in the README, example config, help overlay, and changelog.

## User Impact

Users can now press `!` to open their shell in elio's current folder, run commands such as `zed .`, then return to elio with `exit`. On Linux, macOS, BSD, and WSL shells, `Ctrl+D` on an empty prompt usually works too.

## Notes

This opens a shell in the current terminal. It does not launch a separate GUI terminal window.

Changing directories inside the spawned shell only affects that shell session; when it exits, elio returns to the folder where the shell was opened.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested `!` on Linux.
- Tested `!` on Windows with `cmd`, including clean path display and `exit` returning to elio.
- Tested `!` on WSL, including `Ctrl+D`.
- Tested `!` on macOS, including `Ctrl+D`.
- Verified elio resumes after the shell exits.
- Verified the shell opens in the current folder.
- Verified Windows paths no longer show `\\?\` in the shell hint or TUI path labels.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
