### PR TITLE
chore: clean platform-specific warnings

### DIFF
--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -1,16 +1,19 @@
 use super::super::App;
 use crate::app::ClipOp;
 use std::{
-    env,
-    ffi::OsString,
     fs,
     path::PathBuf,
-    sync::{Mutex, OnceLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::{
+    env,
+    ffi::OsString,
+    sync::{Mutex, OnceLock},
+};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -49,6 +52,7 @@ fn wait_for_paste_and_reload(app: &mut App) {
     panic!("timed out waiting for paste and directory reload to complete");
 }
 
+#[cfg(unix)]
 fn clipboard_env_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))

--- a/src/app/input/tests/errors.rs
+++ b/src/app/input/tests/errors.rs
@@ -1,5 +1,7 @@
 use super::super::*;
-use super::helpers::{temp_path, wait_for_directory_load};
+use super::helpers::temp_path;
+#[cfg(unix)]
+use super::helpers::wait_for_directory_load;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -8,10 +8,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(all(unix, not(target_os = "macos")))]
 struct OpenInSystemCaptureGuard;
 
-#[cfg(all(unix, not(target_os = "macos")))]
 impl OpenInSystemCaptureGuard {
     fn install(path: std::path::PathBuf) -> Self {
         let _ = fs::remove_file(&path);
@@ -20,7 +18,6 @@ impl OpenInSystemCaptureGuard {
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
 impl Drop for OpenInSystemCaptureGuard {
     fn drop(&mut self) {
         crate::fs::set_open_in_system_capture_for_test(None);
@@ -875,7 +872,6 @@ fn missing_zoxide_selection_reports_error() {
 fn capital_o_opens_open_with_overlay_for_selected_file() {
     let root = temp_path("open-with-overlay-file");
     fs::write(root.join("document.txt"), "hello").expect("failed to write temp file");
-    #[cfg(all(unix, not(target_os = "macos")))]
     let _capture_guard = OpenInSystemCaptureGuard::install(root.join("open-capture.txt"));
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");

--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -266,6 +266,7 @@ fn read_process_env(_: u32, _: &str) -> Option<String> {
     None
 }
 
+#[cfg(any(target_os = "linux", test))]
 fn parse_proc_environ(environ: &[u8], name: &str) -> Option<String> {
     let mut prefix = name.as_bytes().to_vec();
     prefix.push(b'=');
@@ -381,12 +382,17 @@ mod tests {
     use super::*;
     use std::{
         ffi::OsString,
+        sync::{Mutex, OnceLock},
+    };
+
+    #[cfg(unix)]
+    use std::{
         fs,
         path::PathBuf,
-        sync::{Mutex, OnceLock},
         time::{SystemTime, UNIX_EPOCH},
     };
 
+    #[cfg(unix)]
     fn temp_root(label: &str) -> PathBuf {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/src/fs/opener.rs
+++ b/src/fs/opener.rs
@@ -168,7 +168,7 @@ fn spawn_with_deadline(
     Ok(())
 }
 
-#[cfg(any(test, target_os = "macos", all(unix, not(target_os = "macos"))))]
+#[cfg(unix)]
 pub(crate) fn detached_open(program: &str, args: &[&str], target: &Path) -> io::Result<()> {
     let mut command = Command::new(program);
     command.args(args);
@@ -220,7 +220,7 @@ fn status_spawn(command: &mut Command) -> io::Result<()> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/src/preview/tests/mod.rs
+++ b/src/preview/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::{appearance as theme, *};
+#[cfg(unix)]
 use crate::core::{EntryKind, SymlinkInfo};
 use image::ImageFormat;
 use ratatui::{style::Modifier, text::Line};

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1,6 +1,8 @@
 use super::super::helpers;
 use super::super::theme;
-use super::entries::{browser_symlink_target_detail, render_compact_list_row};
+#[cfg(unix)]
+use super::entries::browser_symlink_target_detail;
+use super::entries::render_compact_list_row;
 use super::layout::resolve_body_layout;
 use super::scrollbar::split_scrollbar_area;
 use super::sidebar::render_sidebar;

--- a/src/zoxide.rs
+++ b/src/zoxide.rs
@@ -87,6 +87,17 @@ fn stderr_mentions_missing_fzf(stderr: &[u8]) -> bool {
 }
 
 fn fzf_options() -> String {
+    let defaults = fzf_default_options().join(" ");
+
+    match (env::var("FZF_DEFAULT_OPTS"), env::var("ELIO_ZOXIDE_OPTS")) {
+        (Ok(base), Ok(extra)) => format!("{base} {defaults} {extra}"),
+        (Ok(base), Err(_)) => format!("{base} {defaults}"),
+        (Err(_), Ok(extra)) => format!("{defaults} {extra}"),
+        (Err(_), Err(_)) => defaults,
+    }
+}
+
+fn fzf_default_options() -> Vec<&'static str> {
     let mut defaults = vec![
         "--exact",
         "--no-sort",
@@ -100,27 +111,29 @@ fn fzf_options() -> String {
         "--tabstop=1",
         "--exit-0",
     ];
+    defaults.extend_from_slice(fzf_preview_options());
+    defaults
+}
 
-    #[cfg(target_os = "linux")]
-    {
-        defaults.push("--preview-window=down,30%,sharp");
-        defaults
-            .push("--preview='\\command -p ls -Cp --color=always --group-directories-first {2..}'");
-    }
-    #[cfg(all(unix, not(target_os = "linux")))]
-    {
-        defaults.push("--preview-window=down,30%,sharp");
-        defaults.push("--preview='\\command -p ls -Cp {2..}'");
-    }
+#[cfg(target_os = "linux")]
+fn fzf_preview_options() -> &'static [&'static str] {
+    &[
+        "--preview-window=down,30%,sharp",
+        "--preview='\\command -p ls -Cp --color=always --group-directories-first {2..}'",
+    ]
+}
 
-    let defaults = defaults.join(" ");
+#[cfg(all(unix, not(target_os = "linux")))]
+fn fzf_preview_options() -> &'static [&'static str] {
+    &[
+        "--preview-window=down,30%,sharp",
+        "--preview='\\command -p ls -Cp {2..}'",
+    ]
+}
 
-    match (env::var("FZF_DEFAULT_OPTS"), env::var("ELIO_ZOXIDE_OPTS")) {
-        (Ok(base), Ok(extra)) => format!("{base} {defaults} {extra}"),
-        (Ok(base), Err(_)) => format!("{base} {defaults}"),
-        (Err(_), Ok(extra)) => format!("{defaults} {extra}"),
-        (Err(_), Err(_)) => defaults,
-    }
+#[cfg(not(unix))]
+fn fzf_preview_options() -> &'static [&'static str] {
+    &[]
 }
 
 fn path_from_command_stdout(mut stdout: Vec<u8>) -> Option<PathBuf> {
@@ -138,5 +151,37 @@ fn path_from_command_stdout(mut stdout: Vec<u8>) -> Option<PathBuf> {
     #[cfg(not(unix))]
     {
         String::from_utf8(stdout).ok().map(PathBuf::from)
+    }
+}
+
+#[cfg(test)]
+mod fzf_tests {
+    use super::fzf_default_options;
+
+    #[test]
+    fn fzf_options_include_base_picker_flags() {
+        let options = fzf_default_options();
+        assert!(options.contains(&"--exact"));
+        assert!(options.contains(&"--exit-0"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_fzf_options_include_colored_preview() {
+        let options = fzf_default_options();
+        assert!(options.contains(&"--preview-window=down,30%,sharp"));
+        assert!(
+            options
+                .iter()
+                .any(|option| option.contains("--color=always --group-directories-first"))
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    #[test]
+    fn non_linux_unix_fzf_options_include_plain_preview() {
+        let options = fzf_default_options();
+        assert!(options.contains(&"--preview-window=down,30%,sharp"));
+        assert!(options.contains(&"--preview='\\command -p ls -Cp {2..}'"));
     }
 }


### PR DESCRIPTION
## Summary

Cleans up platform-specific Rust warnings seen on macOS and Windows CI without changing runtime behavior.

## What Changed

- Added targeted `#[cfg(...)]` gates for platform-specific test helpers and imports.
- Gated Linux-only `/proc/.../environ` parsing so it does not compile as dead code on non-Linux platforms.
- Refactored zoxide fzf option construction to avoid Windows `unused_mut` warnings without using `#[allow(unused_mut)]`.
- Narrowed test-only desktop opener capture helpers to the platforms where those tests actually use them.

## Notes

This is intentionally limited to warning cleanup. It does not include the Windows EPUB cache race and does not add stricter macOS/Windows warning enforcement yet.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual/platform checks:

- [x] Windows `cargo build --locked`
- [x] Windows `cargo test --locked`

Result:

All checks passed locally. CI should confirm macOS and Windows warning output is clean.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed
