### PR TITLE
fix(preview): prevent hangs from special files and archive previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed quit stalls after browsing special files or large archives by avoiding blocking special-file reads, canceling archive listing commands, and sending oversized ZIP/CBZ archives through the bounded external listing path. ([#121])
 - Improved fuzzy search for large directory trees: matches now appear while scanning continues, stale scans are canceled automatically, the scan cap is much higher, and the overlay reports `scan limit reached` when the cap is hit.
 - Fixed fuzzy search so symlinked folders, symlinked files, and broken symlinks appear as searchable entries. Linked directories are listed but not descended into.
 - Fixed `Tab` / `Shift+Tab` cycling and the active highlight for symlinked Places entries, which previously reset to Home after opening the symlink target. ([#109])
@@ -167,3 +168,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#109]: https://github.com/elio-fm/elio/issues/109
 [#111]: https://github.com/elio-fm/elio/issues/111
 [#112]: https://github.com/elio-fm/elio/issues/112
+[#121]: https://github.com/elio-fm/elio/issues/121

--- a/src/file_info/classify.rs
+++ b/src/file_info/classify.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
-use std::{fs::File, io::Read};
+use std::{fs, fs::File, io::Read};
 
 const CONFIG_SNIFF_BYTE_LIMIT: usize = 16 * 1024;
 const CONFIG_SNIFF_LINE_LIMIT: usize = 80;
@@ -191,11 +191,21 @@ fn normalize_key(input: &str) -> String {
 }
 
 fn sniff_extensionless_file_type(path: &Path) -> Option<FileFacts> {
+    if !is_regular_file(path) {
+        return None;
+    }
+
     let mut file = File::open(path).ok()?;
     let mut buffer = [0_u8; 512];
     let bytes_read = file.read(&mut buffer).ok()?;
     let prefix = &buffer[..bytes_read];
     sniff_image_type(prefix).or_else(|| sniff_shebang_script_type(prefix))
+}
+
+fn is_regular_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
 }
 
 fn sniff_image_type(buffer: &[u8]) -> Option<FileFacts> {
@@ -300,6 +310,10 @@ fn sniff_config_file_type(path: &Path) -> Option<FileFacts> {
 }
 
 fn read_text_prefix(path: &Path) -> Option<String> {
+    if !is_regular_file(path) {
+        return None;
+    }
+
     let mut file = File::open(path).ok()?;
     let mut buffer = vec![0_u8; CONFIG_SNIFF_BYTE_LIMIT];
     let bytes_read = file.read(&mut buffer).ok()?;

--- a/src/file_info/license.rs
+++ b/src/file_info/license.rs
@@ -1,6 +1,6 @@
 use super::{FileFacts, PreviewKind};
 use crate::core::FileClass;
-use std::{fs::File, io::Read, path::Path};
+use std::{fs, fs::File, io::Read, path::Path};
 
 const FAST_LICENSE_SNIFF_BYTE_LIMIT: usize = 4 * 1024;
 const LICENSE_SNIFF_BYTE_LIMIT: usize = 64 * 1024;
@@ -182,6 +182,10 @@ fn can_sniff_license_markers(ext: &str, base_facts: FileFacts) -> bool {
 }
 
 fn read_license_text_prefix(path: &Path, byte_limit: usize) -> Option<String> {
+    if !is_regular_file(path) {
+        return None;
+    }
+
     let mut file = File::open(path).ok()?;
     let mut buffer = vec![0_u8; byte_limit];
     let bytes_read = file.read(&mut buffer).ok()?;
@@ -194,6 +198,12 @@ fn read_license_text_prefix(path: &Path, byte_limit: usize) -> Option<String> {
 
 fn read_license_text(path: &Path) -> Option<String> {
     read_license_text_prefix(path, LICENSE_SNIFF_BYTE_LIMIT)
+}
+
+fn is_regular_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
 }
 
 fn license_file_facts(detection: LicenseDetection, base_facts: FileFacts) -> FileFacts {

--- a/src/file_info/tests/classify.rs
+++ b/src/file_info/tests/classify.rs
@@ -259,3 +259,35 @@ fn extensionless_svg_is_detected_from_contents() {
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
+
+#[cfg(unix)]
+#[test]
+fn extensionless_fifo_is_not_opened_for_content_sniffing() {
+    let root = temp_path("extensionless-fifo");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("hidraw-like");
+    make_fifo(&path);
+
+    let facts = inspect_path(&path, EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::File);
+    assert_eq!(facts.specific_type_label, None);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(unix)]
+#[test]
+fn config_fifo_is_not_opened_for_content_sniffing() {
+    let root = temp_path("config-fifo");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("settings.conf");
+    make_fifo(&path);
+
+    let facts = inspect_path(&path, EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::Config);
+    assert_eq!(facts.specific_type_label, Some("Config file"));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}

--- a/src/file_info/tests/license.rs
+++ b/src/file_info/tests/license.rs
@@ -212,6 +212,22 @@ fn inspect_entry_fast_rejects_non_license_text_without_canonical_filename() {
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
+#[cfg(unix)]
+#[test]
+fn license_fifo_is_not_opened_for_content_sniffing() {
+    let root = temp_path("license-fifo");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("LICENSE");
+    make_fifo(&path);
+
+    let facts = inspect_path(&path, EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::File);
+    assert_eq!(facts.specific_type_label, None);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
 #[test]
 fn additional_spdx_license_ids_are_classified_explicitly() {
     let cases = [

--- a/src/file_info/tests/mod.rs
+++ b/src/file_info/tests/mod.rs
@@ -6,6 +6,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(unix)]
+use std::{ffi::CString, os::unix::ffi::OsStrExt};
+
 fn temp_path(label: &str) -> PathBuf {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -29,6 +32,20 @@ fn assert_code_spec(
 ) {
     assert_eq!(preview.code_syntax, code_syntax);
     assert_eq!(preview.code_backend, code_backend);
+}
+
+#[cfg(unix)]
+fn make_fifo(path: &Path) {
+    let c_path =
+        CString::new(path.as_os_str().as_bytes()).expect("fifo path should not contain NUL");
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+    assert_eq!(
+        result,
+        0,
+        "failed to create fifo at {}: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
 }
 
 mod classify;

--- a/src/preview/container/archive/comic.rs
+++ b/src/preview/container/archive/comic.rs
@@ -1226,8 +1226,20 @@ fn parse_zip_comic_archive<F>(path: &Path, canceled: &F) -> Option<CachedComicAr
 where
     F: Fn() -> bool,
 {
+    let physical_size = fs::metadata(path).ok().map(|metadata| metadata.len());
+    if canceled() || physical_size.is_some_and(|size| size > super::ZIP_INTERNAL_PREVIEW_MAX_BYTES)
+    {
+        return None;
+    }
+
     let file = File::open(path).ok()?;
+    if canceled() {
+        return None;
+    }
     let mut archive = ZipArchive::new(file).ok()?;
+    if canceled() {
+        return None;
+    }
     let mut page_entries = Vec::new();
     let mut metadata_entry = None;
 
@@ -1560,7 +1572,16 @@ where
         }
         let bytes = match comic.backend {
             ComicArchiveBackend::Zip => {
+                let physical_size = fs::metadata(archive_path)
+                    .ok()
+                    .map(|metadata| metadata.len());
+                if physical_size.is_some_and(|size| size > super::ZIP_INTERNAL_PREVIEW_MAX_BYTES) {
+                    return None;
+                }
                 let file = File::open(archive_path).ok()?;
+                if canceled() {
+                    return None;
+                }
                 let mut archive = ZipArchive::new(file).ok()?;
                 read_zip_entry_bytes_limited(
                     &mut archive,

--- a/src/preview/container/archive/comic/tests.rs
+++ b/src/preview/container/archive/comic/tests.rs
@@ -1,5 +1,5 @@
-use super::super::ArchiveFormat;
 use super::super::build_archive_preview;
+use super::super::{ArchiveFormat, ZIP_INTERNAL_PREVIEW_MAX_BYTES};
 use super::{
     ComicArchiveBackend, ComicArchiveSignature, build_comic_archive_preview,
     parse_comic_archive_from_7z_output, parse_comic_book_info_comment, parse_unrar_archive_comment,
@@ -14,7 +14,7 @@ use std::{
     path::PathBuf,
     process::Command,
     sync::atomic::{AtomicBool, Ordering},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 fn temp_path(label: &str) -> PathBuf {
@@ -247,6 +247,29 @@ fn parse_zip_comic_archive_returns_none_when_canceled() {
     let canceled = AtomicBool::new(true);
     let parsed = parse_zip_comic_archive(&archive, &|| canceled.load(Ordering::Relaxed));
     assert!(parsed.is_none(), "canceled zip parsing should stop early");
+
+    fs::remove_dir_all(&root).expect("failed to remove temp root");
+}
+
+#[test]
+fn oversized_cbz_skips_internal_zip_reader() {
+    let root = temp_path("oversized-cbz-internal-skip");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let archive = root.join("huge.cbz");
+    let mut file = File::create(&archive).expect("failed to create sparse cbz fixture");
+    file.write_all(b"PK\x03\x04")
+        .expect("failed to write zip signature");
+    file.set_len(ZIP_INTERNAL_PREVIEW_MAX_BYTES + 1)
+        .expect("failed to size sparse cbz fixture");
+
+    let started_at = Instant::now();
+    let parsed = parse_zip_comic_archive(&archive, &|| false);
+
+    assert!(parsed.is_none());
+    assert!(
+        started_at.elapsed().as_millis() < 100,
+        "oversized CBZ files should skip the uncancellable zip reader"
+    );
 
     fs::remove_dir_all(&root).expect("failed to remove temp root");
 }

--- a/src/preview/container/archive/external.rs
+++ b/src/preview/container/archive/external.rs
@@ -1,6 +1,40 @@
 use super::common::{normalize_archive_path, parse_key_value_line, parse_u64};
 use super::*;
-use std::{collections::BTreeMap, path::Path, process::Command};
+use std::{
+    collections::BTreeMap,
+    fs::{self, File},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+const ARCHIVE_EXTERNAL_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const ARCHIVE_EXTERNAL_COMMAND_POLL: Duration = Duration::from_millis(20);
+
+static ARCHIVE_OUTPUT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+struct ArchiveCommandOutputFile {
+    path: PathBuf,
+}
+
+impl ArchiveCommandOutputFile {
+    fn create(program: &str) -> Option<(Self, File)> {
+        let path = archive_command_output_path(program);
+        let file = File::create(&path).ok()?;
+        Some((Self { path }, file))
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ArchiveCommandOutputFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
 
 pub(super) fn fallback_single_file_archive_entry(
     path: &Path,
@@ -21,40 +55,96 @@ pub(super) fn fallback_single_file_archive_entry(
     })
 }
 
-pub(super) fn collect_archive_entries_with_bsdtar(path: &Path) -> Option<Vec<ArchiveEntry>> {
-    let output = Command::new("bsdtar").arg("-tf").arg(path).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
+pub(super) fn collect_archive_entries_with_bsdtar<F>(
+    path: &Path,
+    canceled: &F,
+) -> Option<Vec<ArchiveEntry>>
+where
+    F: Fn() -> bool,
+{
+    let output = run_archive_listing_command("bsdtar", &["-tf"], path, canceled)?;
     Some(normalize_archive_entries(
-        String::from_utf8_lossy(&output.stdout).lines(),
+        String::from_utf8_lossy(&output).lines(),
         false,
     ))
 }
 
-pub(super) fn collect_archive_entries_with_unrar(path: &Path) -> Option<Vec<ArchiveEntry>> {
-    let output = Command::new("unrar").arg("lb").arg(path).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(parse_unrar_bare_listing(&String::from_utf8_lossy(
-        &output.stdout,
-    )))
+pub(super) fn collect_archive_entries_with_unrar<F>(
+    path: &Path,
+    canceled: &F,
+) -> Option<Vec<ArchiveEntry>>
+where
+    F: Fn() -> bool,
+{
+    let output = run_archive_listing_command("unrar", &["lb"], path, canceled)?;
+    Some(parse_unrar_bare_listing(&String::from_utf8_lossy(&output)))
 }
 
-pub(super) fn collect_archive_listing_with_7z(
+pub(super) fn collect_archive_listing_with_7z<F>(
     path: &Path,
-) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>)> {
-    let output = Command::new("7z")
-        .arg("l")
-        .arg("-slt")
-        .arg(path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
+    canceled: &F,
+) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>)>
+where
+    F: Fn() -> bool,
+{
+    let output = run_archive_listing_command("7z", &["l", "-slt"], path, canceled)?;
+    parse_7z_listing(&String::from_utf8_lossy(&output))
+}
+
+fn run_archive_listing_command<F>(
+    program: &str,
+    args: &[&str],
+    path: &Path,
+    canceled: &F,
+) -> Option<Vec<u8>>
+where
+    F: Fn() -> bool,
+{
+    if canceled() {
         return None;
     }
-    parse_7z_listing(&String::from_utf8_lossy(&output.stdout))
+
+    let (output_guard, output_file) = ArchiveCommandOutputFile::create(program)?;
+    let mut child = Command::new(program)
+        .args(args)
+        .arg(path)
+        .stdout(Stdio::from(output_file))
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = Instant::now() + ARCHIVE_EXTERNAL_COMMAND_TIMEOUT;
+    loop {
+        if canceled() || Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
+                let output = fs::read(output_guard.path()).ok()?;
+                return Some(output);
+            }
+            Ok(None) => std::thread::sleep(ARCHIVE_EXTERNAL_COMMAND_POLL),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+fn archive_command_output_path(program: &str) -> PathBuf {
+    let counter = ARCHIVE_OUTPUT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "elio-archive-{program}-{}-{counter}.out",
+        std::process::id()
+    ))
 }
 
 fn parse_7z_listing(output: &str) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>)> {
@@ -141,7 +231,12 @@ fn parse_unrar_bare_listing(output: &str) -> Vec<ArchiveEntry> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_7z_listing, parse_unrar_bare_listing};
+    use super::{parse_7z_listing, parse_unrar_bare_listing, run_archive_listing_command};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{Duration, Instant},
+    };
 
     #[test]
     fn parse_7z_listing_collects_external_fallback_metadata_and_entries() {
@@ -221,5 +316,61 @@ images/
                 .any(|entry| entry.path == "images" && entry.is_dir)
         );
         assert!(!entries.iter().any(|entry| entry.path.contains("ignored")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_archive_command_observes_cancellation_while_running() {
+        let started_at = Instant::now();
+        let output = run_archive_listing_command(
+            "sh",
+            &["-c", "sleep 5", "sh"],
+            std::path::Path::new("ignored.zip"),
+            &|| started_at.elapsed() >= Duration::from_millis(40),
+        );
+
+        assert!(output.is_none());
+        assert!(
+            started_at.elapsed() < Duration::from_secs(1),
+            "canceled archive command should not wait for the child process to finish"
+        );
+    }
+
+    #[test]
+    fn external_archive_command_cleans_temp_file_when_spawn_fails() {
+        let program = "elio-definitely-missing-archive-tool-for-cleanup-test";
+        remove_archive_temp_outputs(program);
+
+        let output =
+            run_archive_listing_command(program, &[], std::path::Path::new("ignored.zip"), &|| {
+                false
+            });
+
+        assert!(output.is_none());
+        assert!(
+            archive_temp_outputs(program).is_empty(),
+            "failed spawn should clean up its temp output file"
+        );
+    }
+
+    fn archive_temp_outputs(program: &str) -> Vec<PathBuf> {
+        let prefix = format!("elio-archive-{program}-{}-", std::process::id());
+        fs::read_dir(std::env::temp_dir())
+            .into_iter()
+            .flatten()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".out"))
+            })
+            .collect()
+    }
+
+    fn remove_archive_temp_outputs(program: &str) {
+        for path in archive_temp_outputs(program) {
+            let _ = fs::remove_file(path);
+        }
     }
 }

--- a/src/preview/container/archive/internal.rs
+++ b/src/preview/container/archive/internal.rs
@@ -29,12 +29,13 @@ pub(super) fn collect_internal_archive_listing(
 pub(super) fn collect_preferred_archive_entries(
     path: &Path,
     format: ArchiveFormat,
+    canceled: &impl Fn() -> bool,
 ) -> Option<Vec<ArchiveEntry>> {
     if prefers_internal_listing(format) {
         // If internal TAR parsing fails, keep bsdtar as the only tar-family CLI fallback.
         return collect_internal_archive_listing(path, format)
             .map(|(_, entries, _, _)| entries)
-            .or_else(|| collect_archive_entries_with_bsdtar(path));
+            .or_else(|| collect_archive_entries_with_bsdtar(path, canceled));
     }
 
     None

--- a/src/preview/container/archive/mod.rs
+++ b/src/preview/container/archive/mod.rs
@@ -8,6 +8,7 @@ mod render;
 
 const ARCHIVE_ENTRY_SCAN_LIMIT: usize = 50_000;
 const ZIP_MANIFEST_LIMIT_BYTES: u64 = 64 * 1024;
+const ZIP_INTERNAL_PREVIEW_MAX_BYTES: u64 = 256 * 1024 * 1024;
 
 pub(super) use self::common::{ArchiveEntry, ArchiveTreeNode};
 pub(in crate::preview) use self::format::ArchiveFormat;
@@ -57,36 +58,54 @@ where
     {
         return Some(preview);
     }
-    if let Some(preview) = build_zip_archive_preview(path, format, type_detail) {
+    if let Some(preview) = build_zip_archive_preview(path, format, type_detail, canceled) {
         return Some(preview);
     }
     if let Some(preview) = build_tar_archive_preview(path, format, type_detail) {
         return Some(preview);
     }
-    build_external_archive_preview(path, format, type_detail)
+    build_external_archive_preview(path, format, type_detail, canceled)
 }
 
-fn build_zip_archive_preview(
+fn build_zip_archive_preview<F>(
     path: &Path,
     format: ArchiveFormat,
     type_detail: Option<&'static str>,
-) -> Option<PreviewContent> {
+    canceled: &F,
+) -> Option<PreviewContent>
+where
+    F: Fn() -> bool,
+{
     if !matches!(format, ArchiveFormat::Zip | ArchiveFormat::ComicZip) {
         return None;
     }
 
+    let physical_size = fs::metadata(path).ok().map(|metadata| metadata.len());
+    if canceled() || physical_size.is_some_and(|size| size > ZIP_INTERNAL_PREVIEW_MAX_BYTES) {
+        return None;
+    }
+
     let file = File::open(path).ok()?;
+    if canceled() {
+        return None;
+    }
     let mut archive = ZipArchive::new(file).ok()?;
+    if canceled() {
+        return None;
+    }
     let total_entries = archive.len();
     let mut entries = Vec::with_capacity(total_entries.min(ARCHIVE_ENTRY_SCAN_LIMIT));
     let mut metadata = ArchiveMetadata {
         format_label: Some(archive_format_name(format).to_string()),
-        physical_size: fs::metadata(path).ok().map(|metadata| metadata.len()),
+        physical_size,
         ..ArchiveMetadata::default()
     };
     let mut manifest = ZipManifestMetadata::default();
 
     for index in 0..total_entries.min(ARCHIVE_ENTRY_SCAN_LIMIT) {
+        if canceled() {
+            return None;
+        }
         let entry = archive.by_index(index).ok()?;
         let is_dir = entry.is_dir();
         let name = entry.name().to_string();
@@ -164,16 +183,23 @@ fn build_tar_archive_preview(
     }))
 }
 
-fn build_external_archive_preview(
+fn build_external_archive_preview<F>(
     path: &Path,
     format: ArchiveFormat,
     type_detail: Option<&'static str>,
-) -> Option<PreviewContent> {
+    canceled: &F,
+) -> Option<PreviewContent>
+where
+    F: Fn() -> bool,
+{
     // Common ZIP and TAR previews are handled internally above. This path is for
     // recovery and uncommon archive types, where 7z provides the broadest coverage
     // and bsdtar remains a final generic fallback.
     let detail = type_detail.unwrap_or(archive_default_label(format));
-    if let Some(entries) = collect_preferred_archive_entries(path, format) {
+    if canceled() {
+        return None;
+    }
+    if let Some(entries) = collect_preferred_archive_entries(path, format, canceled) {
         return Some(render_archive_preview(ArchiveRenderConfig {
             detail: detail.to_string(),
             metadata: ArchiveMetadata {
@@ -189,7 +215,10 @@ fn build_external_archive_preview(
         }));
     }
 
-    if let Some((metadata, mut entries)) = collect_archive_listing_with_7z(path) {
+    if canceled() {
+        return None;
+    }
+    if let Some((metadata, mut entries)) = collect_archive_listing_with_7z(path, canceled) {
         if entries.is_empty()
             && let Some(entry) = fallback_single_file_archive_entry(path, format)
         {
@@ -208,7 +237,7 @@ fn build_external_archive_preview(
     }
 
     if matches!(format, ArchiveFormat::Rar)
-        && let Some(entries) = collect_archive_entries_with_unrar(path)
+        && let Some(entries) = collect_archive_entries_with_unrar(path, canceled)
     {
         return Some(render_archive_preview(ArchiveRenderConfig {
             detail: detail.to_string(),
@@ -226,7 +255,10 @@ fn build_external_archive_preview(
         }));
     }
 
-    let entries = collect_archive_entries_with_bsdtar(path)?;
+    if canceled() {
+        return None;
+    }
+    let entries = collect_archive_entries_with_bsdtar(path, canceled)?;
 
     Some(render_archive_preview(ArchiveRenderConfig {
         detail: detail.to_string(),
@@ -241,4 +273,41 @@ fn build_external_archive_preview(
         extra_sections: Vec::new(),
         scan_truncated: false,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ArchiveFormat, ZIP_INTERNAL_PREVIEW_MAX_BYTES, build_zip_archive_preview};
+    use std::{
+        fs,
+        time::{Instant, SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn oversized_zip_skips_internal_reader() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "elio-oversized-zip-internal-skip-{unique}-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("huge.zip");
+        let file = fs::File::create(&path).expect("failed to create sparse zip fixture");
+        file.set_len(ZIP_INTERNAL_PREVIEW_MAX_BYTES + 1)
+            .expect("failed to size sparse zip fixture");
+
+        let started_at = Instant::now();
+        let preview = build_zip_archive_preview(&path, ArchiveFormat::Zip, None, &|| false);
+
+        assert!(preview.is_none());
+        assert!(
+            started_at.elapsed().as_millis() < 100,
+            "oversized ZIP files should skip the uncancellable zip reader"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
 }

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -7,6 +7,7 @@ use ratatui::{
     style::Style,
     text::{Line, Span},
 };
+use std::fs;
 
 pub(crate) fn should_build_preview_in_background(entry: &Entry) -> bool {
     // Any selected file preview may touch the filesystem or decode enough content to
@@ -188,6 +189,12 @@ where
     let facts = file_info::inspect_entry_cached(entry);
     let preview_spec = facts.preview;
     let type_detail = facts.specific_type_label;
+    if !is_regular_file_for_preview(entry) {
+        return apply_type_detail(
+            PreviewContent::new(PreviewKind::Unavailable, Vec::new()).with_detail("Special file"),
+            type_detail,
+        );
+    }
     if preview_spec.kind == file_info::PreviewKind::Iso
         && let Some(preview) = container::build_iso_preview(&entry.path)
     {
@@ -406,6 +413,12 @@ fn apply_type_detail(
         preview.detail = Some(detail.to_string());
     }
     preview
+}
+
+fn is_regular_file_for_preview(entry: &Entry) -> bool {
+    fs::metadata(&entry.path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
 }
 
 fn source_preview_detail(

--- a/src/preview/tests/helpers.rs
+++ b/src/preview/tests/helpers.rs
@@ -4,6 +4,8 @@ use flate2::{Compression, write::GzEncoder};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use ratatui::style::Color;
 use ratatui::text::Line;
+#[cfg(unix)]
+use std::{ffi::CString, os::unix::ffi::OsStrExt};
 use std::{
     fs,
     fs::File,
@@ -47,6 +49,20 @@ pub(super) fn directory_entry(path: PathBuf) -> Entry {
         modified: None,
         readonly: false,
     }
+}
+
+#[cfg(unix)]
+pub(super) fn make_fifo(path: &Path) {
+    let c_path =
+        CString::new(path.as_os_str().as_bytes()).expect("fifo path should not contain NUL");
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+    assert_eq!(
+        result,
+        0,
+        "failed to create fifo at {}: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
 }
 
 pub(super) fn line_text(line: &Line<'_>) -> String {

--- a/src/preview/tests/text.rs
+++ b/src/preview/tests/text.rs
@@ -332,3 +332,19 @@ The fixture notice should stay in the same paragraph after reflowing.
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
+
+#[cfg(unix)]
+#[test]
+fn fifo_preview_is_not_opened_as_text() {
+    let root = temp_path("fifo-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("hidraw-like");
+    make_fifo(&path);
+
+    let preview = build_preview(&file_entry(path));
+
+    assert_eq!(preview.kind, PreviewKind::Unavailable);
+    assert_eq!(preview.detail.as_deref(), Some("Special file"));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}


### PR DESCRIPTION
## Summary

Fixes #121.

This PR fixes quit stalls caused by preview work that could block after cancellation, especially after browsing special files, large archive-heavy directories, or oversized ZIP and CBZ files.

## What Changed

- Avoid content sniffing and direct preview reads for non-regular files such as FIFOs and character devices.
- Show a safe unavailable preview for special files instead of trying text, archive, or media preview paths.
- Make external archive listing commands cancellable and timeout-bound.
- Clean up temporary archive command output files on cancellation, timeout, spawn failure, read failure, and non-zero exit.
- Skip the uncancellable internal ZIP reader for oversized ZIP and CBZ files, falling back to the bounded external listing path instead.
- Thread preview cancellation through archive, tar fallback, and comic ZIP and CBZ preview paths.
- Add regression tests for special-file preview safety, cancellable archive commands, temp cleanup, oversized ZIPs, and oversized CBZs.

## User Impact

Quitting elio should remain responsive after browsing paths like `/`, `/dev`, `/usr/bin`, and directories containing large or slow archive previews.

Normal small ZIP and CBZ previews still use the existing internal preview path.

## Notes

Diagnosis used process/thread state and `gdb` backtraces from frozen runs. The backtraces showed the main thread waiting for preview worker shutdown while preview workers were blocked in special-file reads, external archive listing commands, and large ZIP parsing. The same oversized-archive protection is also applied to CBZ.

Oversized ZIP/CBZ previews now prioritize responsiveness by avoiding the internal ZIP parser path that cannot observe cancellation while opening very large archives.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

Reproduction and fix verification:

- [x] CachyOS: reproduced `/` quit freeze on `v1.5.1` / `main`; no longer reproduces on this branch.
- [x] CachyOS: reproduced `/usr/bin` scroll-then-quit stall on `v1.5.1`; no longer reproduces on this branch.
- [x] Ubuntu 26.04 VM: reproduced `/usr/bin` scroll-then-quit stall on `v1.5.1`; no longer reproduces on this branch.

Cross-platform smoke testing:

- [x] Windows: tested fast navigation and quit; no hang.
- [x] WSL: tested fast navigation, holding `Tab` then quitting, `/usr/bin`, and `/`; no hang.
- [x] macOS: tested the same fast-navigation and quit stress cases; no hang.

Preview and archive regression testing:

- [x] Tested repeated `/usr/bin` scroll-then-quit runs.
- [x] Tested repeated `/dev` special-file browsing and quit.
- [x] Tested real ZIP preview directories.
- [x] Tested oversized sparse `huge.zip` and `huge.cbz` fixtures.
- [x] Verified normal small ZIP and CBZ previews still render after the cancellation changes.
- [x] Tested comic archive previews across several CBZ/CBR files.

Result:

All automated checks passed locally, and the reproduced quit stalls no longer reproduce on this branch.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
