### PR TITLE
fix(shell): require explicit target for unsupported active shells

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::shell_integration::{self, Shell};
+use crate::shell_integration::{self, Shell, ShellIntegrationAction};
 use anyhow::Result;
 use std::{
     env, fs, io,
@@ -29,7 +29,7 @@ pub(crate) fn run() -> Result<()> {
             let binary = shell_integration::binary_command(invocation.as_deref(), &executable);
             let shell = match shell {
                 Some(shell) => shell,
-                None => shell_integration::detect_shell()?,
+                None => shell_integration::detect_shell(ShellIntegrationAction::Install)?,
             };
             let report = shell_integration::install(shell, &binary)?;
             println!(
@@ -48,7 +48,7 @@ pub(crate) fn run() -> Result<()> {
         Command::UninstallShellIntegration(shell) => {
             let shell = match shell {
                 Some(shell) => shell,
-                None => shell_integration::detect_shell()?,
+                None => shell_integration::detect_shell(ShellIntegrationAction::Uninstall)?,
             };
             let report = shell_integration::uninstall(shell)?;
             println!(

--- a/src/shell_integration/mod.rs
+++ b/src/shell_integration/mod.rs
@@ -36,6 +36,35 @@ impl Shell {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum ShellIntegrationAction {
+    Install,
+    Uninstall,
+}
+
+impl ShellIntegrationAction {
+    fn command(self) -> &'static str {
+        match self {
+            Self::Install => "install",
+            Self::Uninstall => "uninstall",
+        }
+    }
+
+    fn active_shell_description(self) -> &'static str {
+        match self {
+            Self::Install => "installs integration for",
+            Self::Uninstall => "removes integration from",
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum ShellDetection {
+    Supported(Shell),
+    Unsupported(String),
+    Unknown,
+}
+
 pub(crate) struct InstallReport {
     pub(crate) shell: Shell,
     pub(crate) path: PathBuf,
@@ -50,43 +79,104 @@ pub(crate) struct UninstallReport {
     pub(crate) removed_file: bool,
 }
 
-pub(crate) fn detect_shell() -> Result<Shell> {
-    if let Some(shell) = detect_parent_shell() {
-        return Ok(shell);
+pub(crate) fn detect_shell(action: ShellIntegrationAction) -> Result<Shell> {
+    match detect_parent_shell() {
+        ShellDetection::Supported(shell) => Ok(shell),
+        ShellDetection::Unsupported(shell) => Err(anyhow::anyhow!(
+            unsupported_active_shell_message(action, &shell)
+        )),
+        ShellDetection::Unknown => detect_shell_from_environment(action),
     }
-
-    detect_shell_from_environment()
 }
 
-fn detect_shell_from_environment() -> Result<Shell> {
-    let shell = env::var("SHELL").context(
-        "error: could not detect your shell from the parent process or $SHELL\n\nRun 'elio shell install fish', 'elio shell install bash', or 'elio shell install zsh' instead.",
-    )?;
+fn detect_shell_from_environment(action: ShellIntegrationAction) -> Result<Shell> {
+    let shell = env::var("SHELL").with_context(|| {
+        format!(
+            "error: could not detect your shell from the parent process or $SHELL\n\n{}",
+            explicit_shell_guidance(action)
+        )
+    })?;
     let name = shell_name_from_command(&shell).unwrap_or(shell);
 
     Shell::parse(&name).map_err(anyhow::Error::msg)
 }
 
 #[cfg(unix)]
-fn detect_parent_shell() -> Option<Shell> {
+fn detect_parent_shell() -> ShellDetection {
     let parent_pid = unsafe { libc::getppid() }.to_string();
     let output = std::process::Command::new("ps")
         .args(["-p", &parent_pid, "-o", "comm="])
         .output()
-        .ok()?;
+        .ok();
+    let Some(output) = output else {
+        return ShellDetection::Unknown;
+    };
 
     if !output.status.success() {
-        return None;
+        return ShellDetection::Unknown;
     }
 
-    let command = String::from_utf8(output.stdout).ok()?;
-    let name = shell_name_from_command(&command)?;
-    Shell::parse(&name).ok()
+    let Ok(command) = String::from_utf8(output.stdout) else {
+        return ShellDetection::Unknown;
+    };
+
+    detect_shell_from_command(&command)
 }
 
 #[cfg(not(unix))]
-fn detect_parent_shell() -> Option<Shell> {
-    None
+fn detect_parent_shell() -> ShellDetection {
+    ShellDetection::Unknown
+}
+
+fn detect_shell_from_command(command: &str) -> ShellDetection {
+    let Some(name) = shell_name_from_command(command) else {
+        return ShellDetection::Unknown;
+    };
+
+    match Shell::parse(&name) {
+        Ok(shell) => ShellDetection::Supported(shell),
+        Err(_) if is_known_unsupported_shell(&name) => ShellDetection::Unsupported(name),
+        Err(_) => ShellDetection::Unknown,
+    }
+}
+
+fn is_known_unsupported_shell(name: &str) -> bool {
+    matches!(
+        name,
+        "sh" | "dash"
+            | "ash"
+            | "ksh"
+            | "mksh"
+            | "pdksh"
+            | "yash"
+            | "csh"
+            | "tcsh"
+            | "nu"
+            | "nushell"
+            | "xonsh"
+            | "elvish"
+            | "ion"
+            | "oil"
+            | "osh"
+            | "pwsh"
+            | "powershell"
+    )
+}
+
+fn unsupported_active_shell_message(action: ShellIntegrationAction, shell: &str) -> String {
+    format!(
+        "error: unsupported active shell '{shell}'\n\n`elio shell {}` {} the active shell.\nsupported shells: bash, zsh, fish\n\n{}",
+        action.command(),
+        action.active_shell_description(),
+        explicit_shell_guidance(action)
+    )
+}
+
+fn explicit_shell_guidance(action: ShellIntegrationAction) -> String {
+    let command = action.command();
+    format!(
+        "Run one of these explicitly if you want to target another shell:\n  elio shell {command} fish\n  elio shell {command} bash\n  elio shell {command} zsh"
+    )
 }
 
 fn shell_name_from_command(command: &str) -> Option<String> {

--- a/src/shell_integration/tests.rs
+++ b/src/shell_integration/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    MANAGED_END, MANAGED_START, Shell, binary_command, init_script, managed_script,
-    remove_managed_blocks, resolve_write_path, shell_name_from_command, uninstall_reload_command,
-    upsert_managed_block, write_text_atomic,
+    MANAGED_END, MANAGED_START, Shell, ShellDetection, binary_command, detect_shell_from_command,
+    init_script, managed_script, remove_managed_blocks, resolve_write_path,
+    shell_name_from_command, uninstall_reload_command, upsert_managed_block, write_text_atomic,
 };
 use std::{
     fs,
@@ -92,6 +92,22 @@ fn shell_name_from_command_handles_paths_login_shells_and_arguments() {
         Some("fish")
     );
     assert_eq!(shell_name_from_command("  "), None);
+}
+
+#[test]
+fn detect_shell_from_command_distinguishes_supported_unsupported_and_unknown() {
+    assert_eq!(
+        detect_shell_from_command("/usr/bin/fish\n"),
+        ShellDetection::Supported(Shell::Fish)
+    );
+    assert_eq!(
+        detect_shell_from_command("/usr/bin/nu --login\n"),
+        ShellDetection::Unsupported("nu".to_string())
+    );
+    assert_eq!(
+        detect_shell_from_command("shell_integration_cli\n"),
+        ShellDetection::Unknown
+    );
 }
 
 #[test]

--- a/tests/shell_integration_cli.rs
+++ b/tests/shell_integration_cli.rs
@@ -552,6 +552,116 @@ fn shell_install_detects_current_parent_shell_before_login_shell_environment() {
     fs::remove_dir_all(root).expect("temp directory should be removed");
 }
 
+#[cfg(unix)]
+#[test]
+fn shell_install_rejects_unsupported_current_shell_before_login_shell_environment() {
+    if Command::new("sh").arg("-c").arg(":").status().is_err() {
+        return;
+    }
+
+    let root = temp_path("reject-unsupported-parent-install");
+    let config_home = root.join("config");
+    fs::create_dir_all(&root).expect("temp directory should be created");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg("\"$ELIO_TEST_BIN\" shell install; status=$?; exit \"$status\"")
+        .env("ELIO_TEST_BIN", env!("CARGO_BIN_EXE_elio"))
+        .env("SHELL", "/usr/bin/fish")
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install from sh");
+
+    assert_failure("sh -c elio shell install", &output);
+    assert_no_stdout("sh -c elio shell install", &output);
+    assert_stderr_contains(
+        "sh -c elio shell install",
+        &output,
+        "error: unsupported active shell 'sh'",
+    );
+    assert_stderr_contains(
+        "sh -c elio shell install",
+        &output,
+        "elio shell install fish",
+    );
+    assert!(!config_home.join("fish/conf.d/elio.fish").exists());
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_install_explicit_target_works_from_unsupported_current_shell() {
+    if Command::new("sh").arg("-c").arg(":").status().is_err() {
+        return;
+    }
+
+    let root = temp_path("explicit-install-from-unsupported-parent");
+    let config_home = root.join("config");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg("\"$ELIO_TEST_BIN\" shell install fish; status=$?; exit \"$status\"")
+        .env("ELIO_TEST_BIN", env!("CARGO_BIN_EXE_elio"))
+        .env("SHELL", "/bin/sh")
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install fish from sh");
+
+    assert_success("sh -c elio shell install fish", &output);
+    assert_no_stderr("sh -c elio shell install fish", &output);
+    assert!(config_home.join("fish/conf.d/elio.fish").exists());
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_uninstall_rejects_unsupported_current_shell_before_login_shell_environment() {
+    if Command::new("sh").arg("-c").arg(":").status().is_err() {
+        return;
+    }
+
+    let root = temp_path("reject-unsupported-parent-uninstall");
+    let config_home = root.join("config");
+    let conf_d = config_home.join("fish/conf.d");
+    let integration = conf_d.join("elio.fish");
+    fs::create_dir_all(&conf_d).expect("fish conf.d should be created");
+    fs::write(
+        &integration,
+        "# >>> elio shell integration >>>\nfunction elio\nend\n# <<< elio shell integration <<<\n",
+    )
+    .expect("fish integration should be written");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg("\"$ELIO_TEST_BIN\" shell uninstall; status=$?; exit \"$status\"")
+        .env("ELIO_TEST_BIN", env!("CARGO_BIN_EXE_elio"))
+        .env("SHELL", "/usr/bin/fish")
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell uninstall from sh");
+
+    assert_failure("sh -c elio shell uninstall", &output);
+    assert_no_stdout("sh -c elio shell uninstall", &output);
+    assert_stderr_contains(
+        "sh -c elio shell uninstall",
+        &output,
+        "error: unsupported active shell 'sh'",
+    );
+    assert_stderr_contains(
+        "sh -c elio shell uninstall",
+        &output,
+        "elio shell uninstall fish",
+    );
+    assert!(
+        integration.exists(),
+        "uninstall should not fall back to the login shell"
+    );
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
 #[test]
 fn shell_uninstall_bash_removes_managed_block_idempotently() {
     let root = temp_path("bash-uninstall");


### PR DESCRIPTION
## Summary

Require no-arg shell integration commands to target the active supported shell instead of silently falling back to `$SHELL` when the active shell is known but unsupported.

## What Changed

- Distinguish supported, unsupported, and unknown active shell detection results.
- Make `elio shell install` fail clearly when the active shell is unsupported.
- Apply the same behavior to `elio shell uninstall`.
- Keep explicit targets working as overrides, like `elio shell install fish`.
- Keep `$SHELL` fallback only when the active shell cannot be detected.
- Add regression coverage for unsupported active shells and explicit targets.

## User Impact

Users running from unsupported shells like Nushell now get a clear error for bare `elio shell install` or `elio shell uninstall` instead of unexpectedly modifying config for their login shell.

Explicit commands still work:

```sh
elio shell install fish
elio shell uninstall fish
```

## Notes

This avoids surprising edits when `$SHELL` points to a supported login shell but the current active shell is different and unsupported.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Nushell: verified bare `elio shell install` now rejects unsupported active shell `nu` instead of falling back to `$SHELL=fish`.

All automated checks and manual smoke tests passed.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed