### PR TITLE
fix(preview): prevent images showing through transparent popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `--cwd-file` and installable bash, zsh, and fish shell integration for changing the parent shell directory to elio's final directory on quit, including quit-without-cd, current-shell detection, zsh `ZDOTDIR` support, symlink-aware config updates, and a matching uninstall command. ([#69])
 
+### Fixed
+
+- Improved popup rendering over inline image previews, preventing images from showing through transparent overlay cells.
+
 ## [1.6.0] - 2026-05-22
 
 ### Added

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -124,12 +124,13 @@ mod tests {
         ImageProtocol, OverlayPresentState, RenderedImageDimensions, TerminalWindowSize,
     };
     use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
-    use ratatui::layout::Rect;
+    use ratatui::{buffer::Buffer, layout::Rect};
     use std::{
         fs,
         path::{Path, PathBuf},
         sync::Arc,
-        time::{Duration, SystemTime, UNIX_EPOCH},
+        thread,
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     };
 
     fn temp_root(label: &str) -> PathBuf {
@@ -149,6 +150,15 @@ mod tests {
             pixels_width: 1920,
             pixels_height: 1080,
         });
+    }
+
+    fn blank_frame_buffer() -> Buffer {
+        Buffer::empty(Rect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 40,
+        })
     }
 
     fn write_test_raster_image(path: &Path, format: ImageFormat, width_px: u32, height_px: u32) {
@@ -782,6 +792,11 @@ mod tests {
             width: 12,
             height: 4,
         };
+        let erase = app.modal_image_post_draw_erase(&[popup], &blank_frame_buffer());
+        assert!(
+            !erase.is_empty(),
+            "opening a transparent popup over a Kitty placeholder image should erase covered cells"
+        );
         app.input.frame_state.open_with_panel = Some(popup);
 
         let with_popup = String::from_utf8(
@@ -811,6 +826,65 @@ mod tests {
             app.preview.image.displayed_excluded.is_empty(),
             "closing the popup should remove kitty exclusions"
         );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn sixel_popup_skips_post_draw_masking_for_foot_performance() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("sixel-popup-mask", "demo.png");
+        let request = ready_static_image_overlay(&mut app);
+        app.preview.terminal_images.protocol = ImageProtocol::Sixel;
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+            &request,
+            request.area,
+            request.area,
+        ));
+        assert!(app.static_image_overlay_displayed());
+
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+        let popup = Rect {
+            x: request.area.x.saturating_add(1),
+            y: request.area.y.saturating_add(1),
+            width: request.area.width.saturating_sub(2).max(1),
+            height: request.area.height.saturating_sub(2).max(1),
+        };
+        let erase = app.modal_image_post_draw_erase(&[popup], &blank_frame_buffer());
+        assert!(
+            erase.is_empty(),
+            "Sixel should not use post-draw modal masking because Foot processes those erases slowly"
+        );
+
+        let out = app
+            .present_preview_overlay()
+            .expect("Sixel popup redraw should not fail");
+        assert!(
+            out.is_empty(),
+            "Sixel should not repaint raster image bytes while the popup is open"
+        );
+        assert!(app.static_image_overlay_displayed());
+
+        app.overlays.open_with = None;
+        app.input.frame_state.open_with_panel = None;
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut restored = Vec::new();
+        while Instant::now() < deadline {
+            let _ = app.process_background_jobs();
+            restored = app
+                .present_preview_overlay()
+                .expect("closing the popup should repaint the Sixel image");
+            if !restored.is_empty() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !restored.is_empty(),
+            "closing the popup should repaint the masked Sixel image"
+        );
+        assert!(app.static_image_overlay_displayed());
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -8,7 +8,7 @@ mod tmux;
 mod window;
 
 use anyhow::{Context, Result};
-use ratatui::layout::Rect;
+use ratatui::{buffer::Buffer, layout::Rect};
 use std::{env, io::Write as _, path::Path};
 
 use crate::app::App;
@@ -247,6 +247,53 @@ impl App {
             .unwrap_or_default()
     }
 
+    /// Erases blank modal cells that would otherwise show terminal image content
+    /// through transparent popup surfaces. The tracked image remains logically
+    /// displayed; raster protocols repaint it after the modal closes, while Kitty
+    /// placeholders are redrawn with popup exclusions after the frame render.
+    pub(crate) fn modal_image_post_draw_erase(
+        &mut self,
+        modal_rects: &[Rect],
+        frame_buffer: &Buffer,
+    ) -> Vec<u8> {
+        let protocol = self.preview.terminal_images.protocol;
+        if modal_rects.is_empty()
+            || !matches!(
+                protocol,
+                ImageProtocol::KittyGraphics | ImageProtocol::ItermInline
+            )
+        {
+            return Vec::new();
+        }
+
+        let image_rects = [
+            self.displayed_static_image_clear_area(),
+            self.displayed_pdf_overlay_area(),
+        ];
+        if image_rects.iter().all(Option::is_none) {
+            return Vec::new();
+        }
+
+        let mut to_erase = Vec::new();
+        for popup in modal_rects {
+            for image in image_rects.iter().flatten() {
+                if let Some(mask) = geometry::intersect_rect(*popup, *image) {
+                    push_blank_cell_runs(&mut to_erase, mask, frame_buffer);
+                }
+            }
+        }
+
+        if to_erase.is_empty() {
+            return Vec::new();
+        }
+
+        if protocol.is_raster() {
+            self.preview.terminal_images.pending_iterm_popup_restore = true;
+        }
+
+        to_erase.into_iter().flat_map(iterm::erase_cells).collect()
+    }
+
     /// Returns iTerm2 erase bytes that must be written to the terminal **before**
     /// `terminal.draw()` when an image is about to be replaced or cleared.
     ///
@@ -313,7 +360,13 @@ impl App {
             return Ok(Vec::new());
         }
 
-        if protocol.is_raster()
+        if protocol == ImageProtocol::ItermInline && popup_open {
+            if self.static_image_overlay_displayed() || self.pdf_overlay_displayed() {
+                self.preview.terminal_images.pending_iterm_popup_restore = true;
+            }
+            return Ok(Vec::new());
+        }
+        if protocol == ImageProtocol::Sixel
             && popup_open
             && (self.static_image_overlay_displayed() || self.pdf_overlay_displayed())
         {
@@ -392,7 +445,7 @@ impl App {
         }
     }
 
-    fn collect_popup_rects(&self) -> Vec<Rect> {
+    pub(crate) fn collect_popup_rects(&self) -> Vec<Rect> {
         let mut rects = Vec::new();
         if let Some(r) = self.input.frame_state.trash_panel {
             rects.push(r);
@@ -499,6 +552,48 @@ impl App {
     }
 }
 
+fn push_blank_cell_runs(rects: &mut Vec<Rect>, area: Rect, frame_buffer: &Buffer) {
+    let Some(area) = geometry::intersect_rect(area, *frame_buffer.area()) else {
+        return;
+    };
+
+    for y in area.y..area.y.saturating_add(area.height) {
+        let mut run_start = None;
+        for x in area.x..area.x.saturating_add(area.width) {
+            let transparent_blank = frame_buffer.cell((x, y)).is_some_and(|cell| {
+                cell.symbol() == " " && cell.bg == ratatui::style::Color::Reset
+            });
+            match (transparent_blank, run_start) {
+                (true, None) => run_start = Some(x),
+                (false, Some(start)) => {
+                    geometry::push_unique_rect(
+                        rects,
+                        Rect {
+                            x: start,
+                            y,
+                            width: x.saturating_sub(start),
+                            height: 1,
+                        },
+                    );
+                    run_start = None;
+                }
+                _ => {}
+            }
+        }
+        if let Some(start) = run_start {
+            geometry::push_unique_rect(
+                rects,
+                Rect {
+                    x: start,
+                    y,
+                    width: area.x.saturating_add(area.width).saturating_sub(start),
+                    height: 1,
+                },
+            );
+        }
+    }
+}
+
 pub(in crate::app) fn place_terminal_image(
     protocol: ImageProtocol,
     path: &Path,
@@ -538,5 +633,53 @@ pub(in crate::app) fn clear_terminal_images(protocol: ImageProtocol) -> Result<V
         ImageProtocol::ItermInline | ImageProtocol::None => Ok(Vec::new()),
         // Sixel also has no clear primitive (same as iTerm2).
         ImageProtocol::Sixel => sixel::clear_terminal_images_with_sixel_protocol(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::{Color, Style};
+
+    #[test]
+    fn modal_mask_only_targets_reset_background_blank_cells() {
+        let mut buffer = Buffer::empty(Rect {
+            x: 0,
+            y: 0,
+            width: 5,
+            height: 1,
+        });
+        buffer.set_string(1, 0, "  ", Style::default().bg(Color::Blue));
+        buffer.set_string(3, 0, "x", Style::default());
+
+        let mut rects = Vec::new();
+        push_blank_cell_runs(
+            &mut rects,
+            Rect {
+                x: 0,
+                y: 0,
+                width: 5,
+                height: 1,
+            },
+            &buffer,
+        );
+
+        assert_eq!(
+            rects,
+            vec![
+                Rect {
+                    x: 0,
+                    y: 0,
+                    width: 1,
+                    height: 1,
+                },
+                Rect {
+                    x: 4,
+                    y: 0,
+                    width: 1,
+                    height: 1,
+                },
+            ]
+        );
     }
 }

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crossterm::event::{Event, KeyCode, KeyEvent};
-use ratatui::text::Line;
+use ratatui::{buffer::Buffer, text::Line};
 
 fn configure_iterm_image_support(app: &mut App) {
     let (cells_width, cells_height) = crossterm::terminal::size().unwrap_or((120, 40));
@@ -11,6 +11,15 @@ fn configure_iterm_image_support(app: &mut App) {
         pixels_width: 1920,
         pixels_height: 1080,
     });
+}
+
+fn blank_frame_buffer() -> Buffer {
+    Buffer::empty(Rect {
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 40,
+    })
 }
 
 #[test]
@@ -368,7 +377,7 @@ fn document_overlay_keeps_previous_page_visible_while_next_page_waits() {
 }
 
 #[test]
-fn iterm_popup_keeps_the_displayed_image_visible() {
+fn iterm_popup_masks_displayed_image_until_close() {
     let root = temp_root("iterm-popup-deferred-erase");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let page = root.join("page.png");
@@ -412,8 +421,22 @@ fn iterm_popup_keeps_the_displayed_image_visible() {
     wait_for_displayed_preview_overlay(&mut app);
     assert!(app.static_image_overlay_displayed());
 
+    let image_area = app
+        .displayed_static_image_clear_area()
+        .expect("displayed image should have a clear area");
+    let popup = Rect {
+        x: image_area.x.saturating_add(1),
+        y: image_area.y.saturating_add(1),
+        width: image_area.width.saturating_sub(2).max(1),
+        height: image_area.height.saturating_sub(2).max(1),
+    };
     app.overlays.help = true;
-    assert!(app.iterm_pre_draw_erase().is_empty());
+    let frame_buffer = blank_frame_buffer();
+    let erase = app.modal_image_post_draw_erase(&[popup], &frame_buffer);
+    assert!(
+        !erase.is_empty(),
+        "opening a transparent popup over an iTerm image should erase the covered image cells"
+    );
     let out = app
         .present_preview_overlay()
         .expect("iTerm popup redraw should not fail");
@@ -488,7 +511,15 @@ fn closing_open_with_popup_restores_iterm_inline_image() {
     assert!(app.static_image_overlay_displayed());
 
     app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
-    assert!(app.iterm_pre_draw_erase().is_empty());
+    let popup = app
+        .displayed_static_image_clear_area()
+        .expect("displayed image should have a clear area");
+    let frame_buffer = blank_frame_buffer();
+    let erase = app.modal_image_post_draw_erase(&[popup], &frame_buffer);
+    assert!(
+        !erase.is_empty(),
+        "opening the open-with popup should erase the covered iTerm image cells"
+    );
 
     let out = app
         .present_preview_overlay()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod zoxide;
 use crate::app::{App, PendingTerminalTask};
 use anyhow::Result;
 use crossterm::{
-    cursor::SetCursorStyle,
+    cursor::{RestorePosition, SavePosition, SetCursorStyle},
     event::{
         self, DisableFocusChange, EnableFocusChange, Event, KeyboardEnhancementFlags, MouseEvent,
         MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
@@ -557,13 +557,17 @@ fn draw_terminal_frame(
             terminal.backend_mut().write_all(&kitty_erase)?;
         }
         let mut frame_state = app::FrameState::default();
-        terminal.draw(|frame| ui::render(frame, app, &mut frame_state))?;
-        let dirty = app.set_frame_state(frame_state);
+        let (dirty, modal_erase) = {
+            let completed = terminal.draw(|frame| ui::render(frame, app, &mut frame_state))?;
+            let dirty = app.set_frame_state(frame_state);
+            let modal_rects = app.collect_popup_rects();
+            let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
+            (dirty, modal_erase)
+        };
+        write_bytes_preserving_cursor(terminal.backend_mut(), &modal_erase)?;
         if !app.browser_wheel_burst_active() {
             let overlay_bytes = app.present_preview_overlay()?;
-            if !overlay_bytes.is_empty() {
-                terminal.backend_mut().write_all(&overlay_bytes)?;
-            }
+            write_bytes_preserving_cursor(terminal.backend_mut(), &overlay_bytes)?;
         }
         terminal.backend_mut().flush()?;
         Ok(dirty)
@@ -576,6 +580,16 @@ fn draw_terminal_frame(
         (Ok(_), Err(error)) => Err(error.into()),
         (Err(error), Err(_)) => Err(error),
     }
+}
+
+fn write_bytes_preserving_cursor<W: Write>(writer: &mut W, bytes: &[u8]) -> io::Result<()> {
+    if bytes.is_empty() {
+        return Ok(());
+    }
+    execute!(writer, SavePosition)?;
+    writer.write_all(bytes)?;
+    execute!(writer, RestorePosition)?;
+    Ok(())
 }
 
 fn event_poll_interval<I>(


### PR DESCRIPTION
## Summary

Fix transparent popup rendering over terminal image previews so `none`/transparent theme surfaces reveal the terminal background instead of stale image pixels.

## What Changed

- Added a post-draw erase pass for modal popup cells that overlap terminal image preview areas.
- Only erases blank popup cells, preserving popup text, borders, and controls.
- Keeps Kitty placeholder exclusions working while also covering raster protocols like iTerm inline and Sixel.
- Added regression coverage for Kitty, iTerm/WezTerm-style inline images, and Sixel popup behavior.

## User Impact

Transparent popup surfaces are now usable over image previews. Themes can set popup-related colors like `chrome_alt = "none"` and `path_bg = "none"` without image previews leaking through the popup.

## Notes

Scoped to popup/image masking. WezTerm/iTerm inline resize behavior with a modal open should be handled separately.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested image previews with transparent popups in Konsole, Warp, Kitty, Ghostty, and WezTerm.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed