### PR TITLE
fix(preview): keep iTerm inline previews layered during resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improved popup rendering over inline image previews, preventing images from showing through transparent overlay cells.
+- Fixed WezTerm and iTerm inline image previews during terminal resize, keeping previews and popups correctly layered.
 
 ## [1.6.0] - 2026-05-22
 

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -664,9 +664,9 @@ mod tests {
     }
 
     #[test]
-    fn iterm_resize_does_not_request_full_screen_clear() {
+    fn iterm_resize_requests_full_screen_clear_for_displayed_overlay() {
         let (mut app, root, _image_path) =
-            build_selected_static_image_app("iterm-resize-no-clear", "demo.png");
+            build_selected_static_image_app("iterm-resize-clear", "demo.png");
         let request = ready_static_image_overlay(&mut app);
         app.preview.terminal_images.protocol = ImageProtocol::ItermInline;
         app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
@@ -677,8 +677,9 @@ mod tests {
 
         app.handle_terminal_image_resize();
 
+        assert!(app.take_pending_resize_clear());
+        assert!(!app.static_image_overlay_displayed());
         assert!(!app.take_pending_resize_clear());
-        assert!(app.static_image_overlay_displayed());
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -153,11 +153,12 @@ impl App {
         self.refresh_terminal_image_window_size();
         if matches!(
             self.preview.terminal_images.protocol,
-            ImageProtocol::KittyGraphics | ImageProtocol::Sixel
+            ImageProtocol::KittyGraphics | ImageProtocol::ItermInline | ImageProtocol::Sixel
         ) && (self.static_image_overlay_displayed() || self.pdf_overlay_displayed())
         {
-            // Kitty unicode placeholders can reflow on resize, while Sixel can
-            // leave stale framebuffer pixels outside the new bounds in Foot.
+            // Kitty unicode placeholders can reflow on resize, iTerm inline
+            // images can stale against old geometry in WezTerm, and Sixel can
+            // leave framebuffer pixels outside the new bounds in Foot.
             // Force a full-screen clear on the next draw so ratatui repaints
             // the entire alt screen before the image is re-rendered.
             self.preview.terminal_images.pending_resize_clear = true;
@@ -341,7 +342,41 @@ impl App {
             .collect()
     }
 
+    pub(crate) fn should_repaint_iterm_inline_under_modal(&self, modal_rects: &[Rect]) -> bool {
+        let active_static_image = self.active_static_image_overlay_request().is_some()
+            || self
+                .active_preview_visual_overlay_request_unchecked()
+                .is_some();
+        let active_pdf_overlay = self.active_pdf_overlay_requested();
+        self.preview.terminal_images.protocol == ImageProtocol::ItermInline
+            && !modal_rects.is_empty()
+            && self.any_modal_overlay_open()
+            && ((active_static_image
+                && ((!self.displayed_static_image_matches_active()
+                    && !self.keep_displayed_static_image_overlay_while_pending())
+                    || self.preview.terminal_images.pending_iterm_popup_restore))
+                || (active_pdf_overlay && !self.displayed_pdf_overlay_matches_active()))
+    }
+
     pub(crate) fn present_preview_overlay(&mut self) -> Result<Vec<u8>> {
+        self.present_preview_overlay_inner(false)
+    }
+
+    pub(crate) fn present_preview_overlay_behind_modal(&mut self) -> Result<Vec<u8>> {
+        let out = self.present_preview_overlay_inner(true)?;
+        if !out.is_empty()
+            && self.preview.terminal_images.protocol == ImageProtocol::ItermInline
+            && self.any_modal_overlay_open()
+        {
+            self.preview.terminal_images.pending_iterm_popup_restore = true;
+        }
+        Ok(out)
+    }
+
+    fn present_preview_overlay_inner(
+        &mut self,
+        allow_iterm_modal_repaint: bool,
+    ) -> Result<Vec<u8>> {
         if self.browser_wheel_burst_active() || self.preview.state.deferred_refresh_at.is_some() {
             return Ok(Vec::new());
         }
@@ -360,7 +395,7 @@ impl App {
             return Ok(Vec::new());
         }
 
-        if protocol == ImageProtocol::ItermInline && popup_open {
+        if protocol == ImageProtocol::ItermInline && popup_open && !allow_iterm_modal_repaint {
             if self.static_image_overlay_displayed() || self.pdf_overlay_displayed() {
                 self.preview.terminal_images.pending_iterm_popup_restore = true;
             }
@@ -376,7 +411,7 @@ impl App {
             && std::mem::take(&mut self.preview.terminal_images.pending_sixel_repaint);
         let force_iterm_popup_repaint = protocol.is_raster()
             && self.preview.terminal_images.pending_iterm_popup_restore
-            && !popup_open;
+            && (!popup_open || allow_iterm_modal_repaint);
         let force_protocol_repaint = force_iterm_popup_repaint || force_sixel_repaint;
 
         // For Kitty, collect rects occupied by open popups so the image can be

--- a/src/app/overlays/pdf/session.rs
+++ b/src/app/overlays/pdf/session.rs
@@ -210,6 +210,10 @@ impl App {
         })
     }
 
+    pub(in crate::app) fn active_pdf_overlay_requested(&self) -> bool {
+        self.active_pdf_overlay_request().is_some()
+    }
+
     pub(in crate::app) fn apply_pdf_probe_build(&mut self, build: jobs::PdfProbeBuild) -> bool {
         let key = PdfPageKey {
             path: build.path.clone(),

--- a/src/app/overlays/pdf/tests/session.rs
+++ b/src/app/overlays/pdf/tests/session.rs
@@ -79,6 +79,58 @@ fn present_pdf_overlay_queues_current_probe_only_once() {
 }
 
 #[test]
+fn iterm_modal_pdf_resize_requeues_render_after_display_state_clear() {
+    let (mut app, root) = build_pdf_overlay_test_app("iterm-modal-resize-render");
+    configure_iterm_image_support(&mut app);
+    let request = app
+        .active_pdf_overlay_request()
+        .expect("PDF overlay request should be available");
+    app.preview.pdf.page_dimensions.insert(
+        PdfPageKey::from_request(&request),
+        PdfPageDimensions {
+            width_pts: 612.0,
+            height_pts: 792.0,
+        },
+    );
+    let placement = app
+        .overlay_placement_for_request(&request)
+        .expect("PDF placement should be available");
+    app.preview.pdf.displayed = Some(DisplayedPdfPreview::from_request(&request, placement));
+    app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+
+    app.handle_terminal_image_resize();
+    configure_iterm_image_support(&mut app);
+    assert!(
+        app.take_pending_resize_clear(),
+        "iTerm resize should clear stale PDF image geometry before redraw"
+    );
+    assert!(!app.pdf_overlay_displayed());
+
+    let popup = Rect {
+        x: 4,
+        y: 5,
+        width: 24,
+        height: 8,
+    };
+    assert!(app.should_repaint_iterm_inline_under_modal(&[popup]));
+    let out = app
+        .present_preview_overlay_behind_modal()
+        .expect("controlled PDF repaint should not fail");
+
+    assert!(
+        out.is_empty(),
+        "PDF render is not cached yet, so the modal path should queue work"
+    );
+    let render_key = app
+        .active_pdf_render_key()
+        .expect("active PDF render key should be available");
+    assert!(app.preview.pdf.pending_renders.contains(&render_key));
+    assert!(app.jobs.scheduler.has_pending_work());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn process_pdf_preview_timers_releases_selection_activation_once() {
     let (mut app, root) = build_pdf_overlay_test_app("activation-timer");
     app.preview.pdf.activation_ready_at = Some(Instant::now() - Duration::from_millis(1));

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -22,6 +22,54 @@ fn blank_frame_buffer() -> Buffer {
     })
 }
 
+fn build_displayed_iterm_inline_image_app(label: &str) -> (App, PathBuf) {
+    let root = temp_root(label);
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let page = root.join("page.png");
+    write_test_raster_image(&page, ImageFormat::Png, 640, 360);
+    let page_metadata = fs::metadata(&page).expect("page metadata should exist");
+
+    let mut app = App::new_at(root.clone()).expect("app should initialize");
+    configure_iterm_image_support(&mut app);
+    app.navigation.entries = vec![Entry {
+        path: page.clone(),
+        name: "page.png".to_string(),
+        name_key: "page.png".to_string(),
+        kind: EntryKind::File,
+        symlink: None,
+        size: page_metadata.len(),
+        modified: page_metadata.modified().ok(),
+        readonly: false,
+    }];
+    app.navigation.selected = 0;
+    app.preview.image.selection_activation_delay = Duration::ZERO;
+    app.input.frame_state.preview_media_area = Some(Rect {
+        x: 2,
+        y: 3,
+        width: 48,
+        height: 12,
+    });
+    app.input.frame_state.preview_content_area = Some(Rect {
+        x: 2,
+        y: 15,
+        width: 48,
+        height: 8,
+    });
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+        .with_preview_visual(PreviewVisual {
+            kind: PreviewVisualKind::PageImage,
+            layout: PreviewVisualLayout::Inline,
+            path: page,
+            size: page_metadata.len(),
+            modified: page_metadata.modified().ok(),
+        });
+
+    app.refresh_static_image_preloads();
+    wait_for_displayed_preview_overlay(&mut app);
+    assert!(app.static_image_overlay_displayed());
+    (app, root)
+}
+
 #[test]
 fn page_image_visual_uses_full_preview_height() {
     let root = temp_root("full-height");
@@ -465,50 +513,7 @@ fn iterm_popup_masks_displayed_image_until_close() {
 
 #[test]
 fn closing_open_with_popup_restores_iterm_inline_image() {
-    let root = temp_root("iterm-open-with-popup");
-    fs::create_dir_all(&root).expect("failed to create temp root");
-    let page = root.join("page.png");
-    write_test_raster_image(&page, ImageFormat::Png, 640, 360);
-    let page_metadata = fs::metadata(&page).expect("page metadata should exist");
-
-    let mut app = App::new_at(root.clone()).expect("app should initialize");
-    configure_iterm_image_support(&mut app);
-    app.navigation.entries = vec![Entry {
-        path: page.clone(),
-        name: "page.png".to_string(),
-        name_key: "page.png".to_string(),
-        kind: EntryKind::File,
-        symlink: None,
-        size: page_metadata.len(),
-        modified: page_metadata.modified().ok(),
-        readonly: false,
-    }];
-    app.navigation.selected = 0;
-    app.preview.image.selection_activation_delay = Duration::ZERO;
-    app.input.frame_state.preview_media_area = Some(Rect {
-        x: 2,
-        y: 3,
-        width: 48,
-        height: 12,
-    });
-    app.input.frame_state.preview_content_area = Some(Rect {
-        x: 2,
-        y: 15,
-        width: 48,
-        height: 8,
-    });
-    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
-        .with_preview_visual(PreviewVisual {
-            kind: PreviewVisualKind::PageImage,
-            layout: PreviewVisualLayout::Inline,
-            path: page,
-            size: page_metadata.len(),
-            modified: page_metadata.modified().ok(),
-        });
-
-    app.refresh_static_image_preloads();
-    wait_for_displayed_preview_overlay(&mut app);
-    assert!(app.static_image_overlay_displayed());
+    let (mut app, root) = build_displayed_iterm_inline_image_app("iterm-open-with-popup");
 
     app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
     let popup = app
@@ -543,6 +548,144 @@ fn closing_open_with_popup_restores_iterm_inline_image() {
             .expect("steady-state redraw should succeed")
             .is_empty()
     );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn iterm_modal_layout_change_repaints_image_behind_popup() {
+    let (mut app, root) = build_displayed_iterm_inline_image_app("iterm-modal-layout-repaint");
+
+    app.input.frame_state.preview_media_area = Some(Rect {
+        x: 2,
+        y: 3,
+        width: 36,
+        height: 10,
+    });
+    app.input.frame_state.preview_content_area = Some(Rect {
+        x: 2,
+        y: 13,
+        width: 36,
+        height: 8,
+    });
+    assert!(
+        !app.displayed_static_image_matches_active(),
+        "resized preview layout should no longer match the displayed iTerm image"
+    );
+
+    let next_request = app
+        .active_static_image_overlay_request()
+        .expect("resized static preview should request a new image target");
+    let next_key = StaticImageKey::from_request(&next_request);
+    app.refresh_static_image_preloads();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while app.preview.image.pending_prepares.contains(&next_key) && Instant::now() < deadline {
+        let _ = app.process_background_jobs();
+        let _ = app.process_image_preview_timers();
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        !app.preview.image.pending_prepares.contains(&next_key),
+        "resized iTerm image target should be prepared before the modal repaint"
+    );
+
+    app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+    let popup = app
+        .displayed_static_image_clear_area()
+        .expect("displayed image should have a clear area");
+    assert!(app.should_repaint_iterm_inline_under_modal(&[popup]));
+
+    let blocked = app
+        .present_preview_overlay()
+        .expect("normal iTerm modal presentation should not fail");
+    assert!(
+        blocked.is_empty(),
+        "normal iTerm presentation must stay blocked while a modal is open"
+    );
+
+    let repaint = String::from_utf8(
+        app.present_preview_overlay_behind_modal()
+            .expect("controlled iTerm modal repaint should not fail"),
+    )
+    .expect("controlled iTerm repaint output should be valid utf8");
+    assert!(repaint.contains("\x1b]1337;File=inline=1;"));
+    assert!(app.static_image_overlay_displayed());
+    assert!(app.displayed_static_image_matches_active());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Esc)))
+        .expect("Esc should close the open-with overlay");
+    let restore = String::from_utf8(
+        app.present_preview_overlay()
+            .expect("closing the popup should repaint the covered iTerm image"),
+    )
+    .expect("restored iTerm image output should be valid utf8");
+    assert!(restore.contains("\x1b]1337;File=inline=1;"));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn iterm_modal_repaints_image_when_preview_pane_reappears() {
+    let (mut app, root) = build_displayed_iterm_inline_image_app("iterm-modal-preview-reappears");
+
+    app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+    app.handle_terminal_image_resize();
+    configure_iterm_image_support(&mut app);
+    assert!(
+        app.take_pending_resize_clear(),
+        "iTerm resize should clear stale image geometry before redraw"
+    );
+    assert!(
+        !app.static_image_overlay_displayed(),
+        "resize clear should drop the stale logical image target"
+    );
+
+    app.input.frame_state.preview_media_area = None;
+    app.input.frame_state.preview_content_area = None;
+    assert!(
+        app.active_static_image_overlay_request().is_none(),
+        "hidden preview pane should remove the active static image target"
+    );
+    assert!(
+        app.present_preview_overlay()
+            .expect("hidden pane with popup should not repaint directly")
+            .is_empty()
+    );
+
+    app.input.frame_state.preview_media_area = Some(Rect {
+        x: 2,
+        y: 3,
+        width: 48,
+        height: 12,
+    });
+    app.input.frame_state.preview_content_area = Some(Rect {
+        x: 2,
+        y: 15,
+        width: 48,
+        height: 8,
+    });
+    let popup = Rect {
+        x: 4,
+        y: 5,
+        width: 24,
+        height: 8,
+    };
+
+    assert!(app.active_static_image_overlay_request().is_some());
+    assert!(
+        !app.displayed_static_image_matches_active(),
+        "restored pane should need a fresh iTerm image placement"
+    );
+    assert!(app.should_repaint_iterm_inline_under_modal(&[popup]));
+    let repaint = String::from_utf8(
+        app.present_preview_overlay_behind_modal()
+            .expect("controlled iTerm modal repaint should not fail"),
+    )
+    .expect("controlled iTerm repaint output should be valid utf8");
+
+    assert!(repaint.contains("\x1b]1337;File=inline=1;"));
+    assert!(app.static_image_overlay_displayed());
+    assert!(app.displayed_static_image_matches_active());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,12 @@ use crossterm::{
         disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement,
     },
 };
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    buffer::{Buffer, Cell},
+    layout::Rect,
+};
 use std::{
     fs as std_fs,
     io::{self, ErrorKind, Write},
@@ -557,15 +562,26 @@ fn draw_terminal_frame(
             terminal.backend_mut().write_all(&kitty_erase)?;
         }
         let mut frame_state = app::FrameState::default();
-        let (dirty, modal_erase) = {
+        let (dirty, image_behind_modal, popup_restore, modal_erase, skip_overlay_present) = {
             let completed = terminal.draw(|frame| ui::render(frame, app, &mut frame_state))?;
             let dirty = app.set_frame_state(frame_state);
             let modal_rects = app.collect_popup_rects();
-            let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
-            (dirty, modal_erase)
+            if !app.browser_wheel_burst_active()
+                && app.should_repaint_iterm_inline_under_modal(&modal_rects)
+            {
+                let image_behind_modal = app.present_preview_overlay_behind_modal()?;
+                let popup_restore = collect_buffer_cells(&modal_rects, completed.buffer);
+                let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
+                (dirty, image_behind_modal, popup_restore, modal_erase, true)
+            } else {
+                let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
+                (dirty, Vec::new(), Vec::new(), modal_erase, false)
+            }
         };
+        write_bytes_preserving_cursor(terminal.backend_mut(), &image_behind_modal)?;
+        draw_cells_preserving_cursor(terminal.backend_mut(), &popup_restore)?;
         write_bytes_preserving_cursor(terminal.backend_mut(), &modal_erase)?;
-        if !app.browser_wheel_burst_active() {
+        if !skip_overlay_present && !app.browser_wheel_burst_active() {
             let overlay_bytes = app.present_preview_overlay()?;
             write_bytes_preserving_cursor(terminal.backend_mut(), &overlay_bytes)?;
         }
@@ -592,6 +608,56 @@ fn write_bytes_preserving_cursor<W: Write>(writer: &mut W, bytes: &[u8]) -> io::
     Ok(())
 }
 
+fn draw_cells_preserving_cursor<W: Write>(
+    backend: &mut CrosstermBackend<W>,
+    cells: &[(u16, u16, Cell)],
+) -> io::Result<()> {
+    if cells.is_empty() {
+        return Ok(());
+    }
+    execute!(backend, SavePosition)?;
+    ratatui::backend::Backend::draw(backend, cells.iter().map(|(x, y, cell)| (*x, *y, cell)))?;
+    execute!(backend, RestorePosition)?;
+    Ok(())
+}
+
+fn collect_buffer_cells(rects: &[Rect], buffer: &Buffer) -> Vec<(u16, u16, Cell)> {
+    let bounds = *buffer.area();
+    let mut cells = Vec::new();
+    for rect in rects {
+        let Some(area) = intersect_rect(*rect, bounds) else {
+            continue;
+        };
+        for y in area.y..area.y.saturating_add(area.height) {
+            for x in area.x..area.x.saturating_add(area.width) {
+                let Some(cell) = buffer.cell((x, y)) else {
+                    continue;
+                };
+                if cell.skip {
+                    continue;
+                }
+                cells.push((x, y, cell.clone()));
+            }
+        }
+    }
+    cells
+}
+
+fn intersect_rect(a: Rect, b: Rect) -> Option<Rect> {
+    let x1 = a.x.max(b.x);
+    let y1 = a.y.max(b.y);
+    let x2 = a.x.saturating_add(a.width).min(b.x.saturating_add(b.width));
+    let y2 =
+        a.y.saturating_add(a.height)
+            .min(b.y.saturating_add(b.height));
+    (x2 > x1 && y2 > y1).then_some(Rect {
+        x: x1,
+        y: y1,
+        width: x2.saturating_sub(x1),
+        height: y2.saturating_sub(y1),
+    })
+}
+
 fn event_poll_interval<I>(
     base_poll_interval: Duration,
     terminal_focused: bool,
@@ -614,8 +680,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, event_poll_interval};
-    use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+    use crate::{
+        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, collect_buffer_cells, event_poll_interval,
+    };
+    use ratatui::{
+        buffer::Buffer,
+        layout::Rect,
+        style::{Color, Modifier, Style},
+    };
     use std::{
         fs, io,
         path::{Path, PathBuf},
@@ -671,6 +743,29 @@ mod tests {
                 .map(|(x, y, cell)| (*x, *y, cell.symbol().to_string()))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn collect_buffer_cells_captures_popup_cells_with_styles() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 4));
+        buffer.set_string(
+            2,
+            1,
+            "OK",
+            Style::default()
+                .fg(Color::LightGreen)
+                .bg(Color::Rgb(1, 2, 3))
+                .add_modifier(Modifier::BOLD),
+        );
+
+        let cells = collect_buffer_cells(&[Rect::new(2, 1, 2, 1)], &buffer);
+
+        assert_eq!(cells.len(), 2);
+        assert_eq!((cells[0].0, cells[0].1, cells[0].2.symbol()), (2, 1, "O"));
+        assert_eq!((cells[1].0, cells[1].1, cells[1].2.symbol()), (3, 1, "K"));
+        assert_eq!(cells[0].2.fg, Color::LightGreen);
+        assert_eq!(cells[0].2.bg, Color::Rgb(1, 2, 3));
+        assert!(cells[0].2.modifier.contains(Modifier::BOLD));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes WezTerm/iTerm inline preview behavior when resizing the terminal with a popup open. Inline previews now stay correctly layered with modal popups and recover when the preview pane disappears and reappears during resize.

## What Changed

- Added a controlled iTerm inline repaint path for modal resize cases.
- Clears stale iTerm inline preview state on terminal resize so old image geometry cannot affect the UI.
- Handles image and PDF preview repainting while a popup remains open.
- Added regression coverage for modal resize, preview pane reappearing, and PDF preview repainting.

## User Impact

WezTerm and iTerm users should no longer see inline previews disappear, draw over popups, or interfere with popup/UI layering during terminal resize.

## Notes

Kitty was smoke-tested as a regression check. The iTerm inline behavior was tested both inside and outside tmux.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- WezTerm outside tmux
- WezTerm inside tmux
- iTerm2 outside tmux
- iTerm2 inside tmux
- Kitty regression check

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
