### PR TITLE
docs(theme): update transparent theme example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `--cwd-file` and installable bash, zsh, and fish shell integration for changing the parent shell directory to elio's final directory on quit, including quit-without-cd, current-shell detection, zsh `ZDOTDIR` support, symlink-aware config updates, and a matching uninstall command. ([#69])
 
+### Changed
+
+- Updated the transparent theme example to make popups and path surfaces fully transparent, and removed comments from example themes.
+
 ### Fixed
 
 - Improved popup rendering over inline image previews, preventing images from showing through transparent overlay cells.

--- a/examples/themes/amber-dusk/theme.toml
+++ b/examples/themes/amber-dusk/theme.toml
@@ -1,5 +1,3 @@
-# Copy to ~/.config/elio/theme.toml to use a warm dark Elio theme.
-
 [palette]
 bg = "#120f0d"
 chrome = "#181310"

--- a/examples/themes/catppuccin-mocha/theme.toml
+++ b/examples/themes/catppuccin-mocha/theme.toml
@@ -1,5 +1,3 @@
-# Copy to ~/.config/elio/theme.toml to use a Catppuccin Mocha-inspired Elio theme.
-
 [palette]
 bg = "#1e1e2e"
 chrome = "#181825"

--- a/examples/themes/default-light/theme.toml
+++ b/examples/themes/default-light/theme.toml
@@ -1,5 +1,3 @@
-# Copy to ~/.config/elio/theme.toml to use a light take on Elio's built-in default theme.
-
 [palette]
 bg = "#eff2f5"
 chrome = "#e4e8ed"

--- a/examples/themes/navi/theme.toml
+++ b/examples/themes/navi/theme.toml
@@ -1,5 +1,3 @@
-# Copy to ~/.config/elio/theme.toml to use the original blue-heavy Elio theme.
-
 [palette]
 bg = "#02050c"
 chrome = "#070d16"

--- a/examples/themes/tokyo-night/theme.toml
+++ b/examples/themes/tokyo-night/theme.toml
@@ -1,5 +1,3 @@
-# Copy to ~/.config/elio/theme.toml to use a Tokyo Night-inspired Elio theme.
-
 [palette]
 bg = "#1a1b26"
 chrome = "#16161e"

--- a/examples/themes/transparent/theme.toml
+++ b/examples/themes/transparent/theme.toml
@@ -1,10 +1,7 @@
-# Copy to ~/.config/elio/theme.toml to inherit your terminal's own background
-# instead of Elio's dark surfaces. Selection bars and yank/cut bands stay opaque.
-
 [palette]
 bg = "none"
 chrome = "none"
-# chrome_alt and path_bg stay opaque to keep popups readable over images.
+chrome_alt = "none"
 border = "#6f7d8d"
 panel = "none"
 panel_alt = "none"
@@ -14,6 +11,7 @@ button_bg = "none"
 button_disabled_bg = "none"
 sidebar_active = "none"
 accent_soft = "none"
+path_bg = "none"
 
 [preview.code]
 bg = "none"


### PR DESCRIPTION
## Summary

Updates the transparent example theme now that transparent popup rendering works properly, and removes redundant copy-path comments from example theme files.

## What Changed

- Made the transparent theme use `none` for `chrome_alt` and `path_bg`.
- Removed top-level copy-path comments from example theme files.
- Added a changelog entry.

## User Impact

Users copying the transparent theme now get fully transparent popup and path surfaces.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Manually checked the transparent theme.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
