### PR TITLE
feat(theme): support terminal ANSI colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `terminal-ansi` theme example and support for terminal ANSI colors in `theme.toml`. ([#84])
 - Added `--cwd-file` and installable bash, zsh, and fish shell integration for changing the parent shell directory to elio's final directory on quit, including quit-without-cd, current-shell detection, zsh `ZDOTDIR` support, symlink-aware config updates, and a matching uninstall command. ([#69])
 
 ### Changed
@@ -173,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
 [#86]: https://github.com/elio-fm/elio/issues/86
+[#84]: https://github.com/elio-fm/elio/issues/84
 [#79]: https://github.com/elio-fm/elio/issues/79
 [#77]: https://github.com/elio-fm/elio/pull/77
 [#75]: https://github.com/elio-fm/elio/issues/75

--- a/README.md
+++ b/README.md
@@ -377,7 +377,15 @@ Rules:
 
 **Built-in file classes:** `directory` · `symlink_directory` · `broken_symlink` · `code` · `config` · `document` · `license` · `image` · `audio` · `video` · `archive` · `font` · `data` · `file`
 
-Any color value also accepts `"none"` (alias: `"transparent"`) to reset that foreground or background to the terminal default. For background fields, this lets transparent terminals show through. See [`examples/themes/transparent/theme.toml`](examples/themes/transparent/theme.toml).
+Color values can be:
+
+- Hex RGB colors, such as `"#7aaeff"`.
+- `"none"` / `"transparent"` to reset that foreground or background to the terminal default. For background fields, this lets transparent terminals show through.
+- Terminal ANSI palette colors, such as `"ansi-blue"`, `"ansi-bright-blue"`, or `"indexed-12"`.
+
+Use `indexed-N` for terminal indexed colors from `0` to `255`.
+
+The `terminal-ansi` example uses ANSI colors and terminal-default backgrounds, while keeping the default RGB `selected_bg` for more reliable selection contrast. See [`examples/themes/transparent/theme.toml`](examples/themes/transparent/theme.toml) and [`examples/themes/terminal-ansi/theme.toml`](examples/themes/terminal-ansi/theme.toml).
 
 See [`assets/themes/default/theme.toml`](assets/themes/default/theme.toml) for the full default theme.
 

--- a/examples/themes/terminal-ansi/theme.toml
+++ b/examples/themes/terminal-ansi/theme.toml
@@ -1,0 +1,178 @@
+[palette]
+bg = "none"
+chrome = "none"
+chrome_alt = "none"
+chip_text = "ansi-black"
+panel = "none"
+panel_alt = "none"
+surface = "none"
+elevated = "none"
+button_bg = "none"
+button_disabled_bg = "none"
+sidebar_active = "none"
+accent_soft = "none"
+path_bg = "none"
+
+border = "ansi-bright-black"
+text = "ansi-white"
+muted = "ansi-bright-black"
+accent = "ansi-blue"
+accent_text = "ansi-bright-white"
+selected_bg = "#243758"
+selected_border = "ansi-blue"
+selection_bar = "ansi-yellow"
+yank_bar = "ansi-green"
+cut_bar = "ansi-red"
+grid_selection_band = "ansi-yellow"
+grid_yank_band = "ansi-green"
+grid_cut_band = "ansi-red"
+trash_bar = "ansi-red"
+restore_bar = "ansi-blue"
+
+[preview.code]
+fg = "ansi-white"
+bg = "none"
+selection_bg = "ansi-blue"
+selection_fg = "ansi-bright-white"
+caret = "ansi-cyan"
+line_highlight = "none"
+line_number = "ansi-bright-black"
+comment = "ansi-bright-black"
+string = "ansi-green"
+constant = "ansi-yellow"
+keyword = "ansi-blue"
+function = "ansi-cyan"
+type = "ansi-magenta"
+parameter = "ansi-yellow"
+tag = "ansi-green"
+operator = "ansi-cyan"
+macro = "ansi-red"
+invalid = "ansi-red"
+
+[classes.directory]
+color = "ansi-blue"
+
+[classes.code]
+color = "ansi-cyan"
+
+[classes.config]
+color = "ansi-magenta"
+
+[classes.document]
+color = "ansi-green"
+
+[classes.license]
+color = "ansi-yellow"
+
+[classes.image]
+color = "ansi-cyan"
+
+[classes.audio]
+color = "ansi-yellow"
+
+[classes.video]
+color = "ansi-magenta"
+
+[classes.archive]
+color = "ansi-red"
+
+[classes.font]
+color = "ansi-magenta"
+
+[classes.data]
+color = "ansi-green"
+
+[classes.file]
+color = "ansi-white"
+
+[directories."node_modules"]
+icon = "󰏗"
+color = "ansi-blue"
+
+[directories."tests"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."test"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."__tests__"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."scripts"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."build"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."dist"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories.".next"]
+icon = ""
+color = "ansi-blue"
+
+[directories.".nuxt"]
+icon = "󱄆"
+color = "ansi-blue"
+
+[directories.".svelte-kit"]
+icon = ""
+color = "ansi-blue"
+
+[directories.".astro"]
+icon = ""
+color = "ansi-blue"
+
+[directories."assets"]
+icon = "󰉏"
+color = "ansi-blue"
+
+[directories."coverage"]
+icon = "󰙨"
+color = "ansi-blue"
+
+[directories."tmp"]
+icon = "󰪺"
+color = "ansi-blue"
+
+[directories."temp"]
+icon = "󰪺"
+color = "ansi-blue"
+
+[directories."out"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."target"]
+icon = "󱧽"
+color = "ansi-blue"
+
+[directories."bin"]
+icon = "󱁿"
+color = "ansi-blue"
+
+[directories."lib"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."vendor"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."src"]
+icon = "󰉋"
+color = "ansi-blue"
+
+[directories."config"]
+icon = "󰒓"
+color = "ansi-blue"
+
+[directories."docs"]
+icon = "󱧷"
+color = "ansi-blue"

--- a/src/ui/theme/appearance/parsing.rs
+++ b/src/ui/theme/appearance/parsing.rs
@@ -319,9 +319,29 @@ pub(super) fn parse_class_name(name: &str) -> Option<FileClass> {
 
 pub(super) fn parse_color(value: &str) -> anyhow::Result<Color> {
     let trimmed = value.trim();
-    match trimmed.to_ascii_lowercase().as_str() {
+    let normalized = trimmed.to_ascii_lowercase();
+    match normalized.as_str() {
         "none" | "transparent" => return Ok(Color::Reset),
+        "ansi-black" => return Ok(Color::Black),
+        "ansi-red" => return Ok(Color::Red),
+        "ansi-green" => return Ok(Color::Green),
+        "ansi-yellow" => return Ok(Color::Yellow),
+        "ansi-blue" => return Ok(Color::Blue),
+        "ansi-magenta" => return Ok(Color::Magenta),
+        "ansi-cyan" => return Ok(Color::Cyan),
+        "ansi-white" => return Ok(Color::Gray),
+        "ansi-bright-black" => return Ok(Color::DarkGray),
+        "ansi-bright-red" => return Ok(Color::LightRed),
+        "ansi-bright-green" => return Ok(Color::LightGreen),
+        "ansi-bright-yellow" => return Ok(Color::LightYellow),
+        "ansi-bright-blue" => return Ok(Color::LightBlue),
+        "ansi-bright-magenta" => return Ok(Color::LightMagenta),
+        "ansi-bright-cyan" => return Ok(Color::LightCyan),
+        "ansi-bright-white" => return Ok(Color::White),
         _ => {}
+    }
+    if let Some(index) = normalized.strip_prefix("indexed-") {
+        return Ok(Color::Indexed(index.parse()?));
     }
 
     let hex = trimmed.trim_start_matches('#');

--- a/src/ui/theme/appearance/tests/examples.rs
+++ b/src/ui/theme/appearance/tests/examples.rs
@@ -9,6 +9,7 @@ const ALTERNATE_EXAMPLE_THEME_NAMES: &[&str] = &[
     "tokyo-night",
     "navi",
     "neon-cherry",
+    "terminal-ansi",
     "transparent",
 ];
 
@@ -49,6 +50,7 @@ fn alternate_example_theme_config(name: &str) -> &'static str {
         "tokyo-night" => include_str!("../../../../../examples/themes/tokyo-night/theme.toml"),
         "navi" => include_str!("../../../../../examples/themes/navi/theme.toml"),
         "neon-cherry" => include_str!("../../../../../examples/themes/neon-cherry/theme.toml"),
+        "terminal-ansi" => include_str!("../../../../../examples/themes/terminal-ansi/theme.toml"),
         "transparent" => include_str!("../../../../../examples/themes/transparent/theme.toml"),
         _ => panic!("unknown alternate example theme fixture: {name}"),
     }

--- a/src/ui/theme/appearance/tests/overrides.rs
+++ b/src/ui/theme/appearance/tests/overrides.rs
@@ -1,4 +1,4 @@
-use super::super::{loading::load_theme_from_disk, rules::rgb};
+use super::super::{loading::load_theme_from_disk, parsing::parse_color, rules::rgb};
 use super::*;
 use ratatui::style::Color;
 use std::{
@@ -265,6 +265,58 @@ bg = "none"
     let default_theme = Theme::default_theme();
     assert_eq!(theme.palette.chrome_alt, default_theme.palette.chrome_alt);
     assert_eq!(theme.palette.text, default_theme.palette.text);
+}
+
+#[test]
+fn parse_color_accepts_all_terminal_ansi_names() {
+    for (name, expected) in [
+        ("ansi-black", Color::Black),
+        ("ansi-red", Color::Red),
+        ("ansi-green", Color::Green),
+        ("ansi-yellow", Color::Yellow),
+        ("ansi-blue", Color::Blue),
+        ("ansi-magenta", Color::Magenta),
+        ("ansi-cyan", Color::Cyan),
+        ("ansi-white", Color::Gray),
+        ("ansi-bright-black", Color::DarkGray),
+        ("ansi-bright-red", Color::LightRed),
+        ("ansi-bright-green", Color::LightGreen),
+        ("ansi-bright-yellow", Color::LightYellow),
+        ("ansi-bright-blue", Color::LightBlue),
+        ("ansi-bright-magenta", Color::LightMagenta),
+        ("ansi-bright-cyan", Color::LightCyan),
+        ("ansi-bright-white", Color::White),
+    ] {
+        assert_eq!(parse_color(name).unwrap(), expected);
+    }
+}
+
+#[test]
+fn palette_accepts_terminal_ansi_colors() {
+    let theme = Theme::from_config_str(
+        r##"
+[palette]
+bg = "none"
+text = "ansi-white"
+muted = "  ANSI-BRIGHT-BLACK  "
+accent = "indexed-12"
+accent_text = "ansi-bright-white"
+
+[classes.code]
+color = "ansi-cyan"
+"##,
+    )
+    .expect("theme should parse");
+
+    assert_eq!(theme.palette.bg, Color::Reset);
+    assert_eq!(theme.palette.text, Color::Gray);
+    assert_eq!(theme.palette.muted, Color::DarkGray);
+    assert_eq!(theme.palette.accent, Color::Indexed(12));
+    assert_eq!(theme.palette.accent_text, Color::White);
+    assert_eq!(
+        theme.classes.get(&FileClass::Code).unwrap().color,
+        Color::Cyan
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds support for terminal ANSI palette colors in theme files and introduces a new `terminal-ansi` example theme for users who want elio to follow their terminal color palette more closely.

Closes #84.

## What Changed

- Added support for standard ANSI color names, such as `ansi-blue`.
- Added support for bright ANSI color names, such as `ansi-bright-blue`.
- Added support for indexed terminal colors from `indexed-0` to `indexed-255`.
- Added the `examples/themes/terminal-ansi` theme.
- Documented the new ANSI and indexed color formats.

## User Impact

Users can now configure themes with terminal ANSI palette colors, making it easier to keep elio visually aligned with their terminal color scheme.

The new `terminal-ansi` example theme uses ANSI colors together with existing `"none"` / `"transparent"` background support, allowing terminal-default backgrounds while keeping selection contrast reliable.

## Notes

This does not dynamically query terminal RGB values. Theme colors now support terminal ANSI palette references, which are resolved by the terminal according to the user's configured color scheme.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

Tested the `terminal-ansi` theme on GNOME Terminal, Alacritty, Kitty, WezTerm, Foot, Warp, and Konsole.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
