### PR TITLE
fix(preview): prevent Sixel previews leaking through transparent popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improved popup rendering over inline image previews, preventing images from showing through transparent overlay cells.
-- Fixed WezTerm and iTerm inline image previews during terminal resize, keeping previews and popups correctly layered.
+- Improved popup rendering over image previews, preventing preview content from showing through transparent overlay cells across Kitty/Ghostty, WezTerm/iTerm2, Foot, and Windows Terminal.
+- Fixed WezTerm and iTerm2 inline image previews during terminal resize, keeping previews and popups correctly layered.
 
 ## [1.6.0] - 2026-05-22
 

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -917,7 +917,7 @@ mod tests {
             "Foot Sixel should avoid fragile transparent-cell post-draw masking"
         );
 
-        let (collisions, erase) = app.foot_sixel_modal_collision_erase(&[popup]);
+        let (collisions, erase) = app.sixel_modal_collision_erase(&[popup]);
         assert_eq!(collisions, vec![popup]);
         assert!(
             !erase.is_empty(),
@@ -953,6 +953,77 @@ mod tests {
         assert!(
             !restored.is_empty(),
             "closing the popup should repaint the erased Foot Sixel collision"
+        );
+        assert!(app.static_image_overlay_displayed());
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn windows_terminal_sixel_popup_erases_collision_and_repaints_after_close() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("wt-sixel-popup-collision", "demo.png");
+        let request = ready_static_image_overlay(&mut app);
+        app.set_terminal_image_protocol_for_tests(
+            ImageProtocol::Sixel,
+            TerminalIdentity::WindowsTerminal,
+        );
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+            &request,
+            request.area,
+            request.area,
+        ));
+        assert!(app.static_image_overlay_displayed());
+
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+        let popup = Rect {
+            x: request.area.x.saturating_add(1),
+            y: request.area.y.saturating_add(1),
+            width: request.area.width.saturating_sub(2).max(1),
+            height: request.area.height.saturating_sub(2).max(1),
+        };
+        let mask = app.modal_image_post_draw_erase(&[popup], &blank_frame_buffer());
+        assert!(
+            mask.is_empty(),
+            "Windows Terminal Sixel should avoid fragile transparent-cell post-draw masking"
+        );
+
+        let (collisions, erase) = app.sixel_modal_collision_erase(&[popup]);
+        assert_eq!(collisions, vec![popup]);
+        assert!(
+            !erase.is_empty(),
+            "Windows Terminal Sixel should erase the popup/image collision like Yazi's Clear widget"
+        );
+        assert!(
+            app.static_image_overlay_displayed(),
+            "the image remains logically displayed so only the popup intersection is punched out"
+        );
+        assert!(
+            app.present_preview_overlay()
+                .expect("Windows Terminal Sixel popup redraw should not fail")
+                .is_empty(),
+            "Windows Terminal Sixel should not repaint image bytes over an open popup"
+        );
+
+        app.overlays.open_with = None;
+        app.input.frame_state.open_with_panel = None;
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut restored = Vec::new();
+        while Instant::now() < deadline {
+            let _ = app.process_background_jobs();
+            let _ = app.process_image_preview_timers();
+            restored = app
+                .present_preview_overlay()
+                .expect("closing the popup should repaint the Sixel image");
+            if !restored.is_empty() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !restored.is_empty(),
+            "closing the popup should repaint the erased Windows Terminal Sixel collision"
         );
         assert!(app.static_image_overlay_displayed());
 
@@ -1020,7 +1091,7 @@ mod tests {
             "resize clear removes stale Sixel geometry before redraw"
         );
         assert!(
-            app.should_repaint_foot_sixel_under_modal(&[popup]),
+            app.should_repaint_sixel_under_modal(&[popup]),
             "Foot Sixel should repaint the resized image behind an open popup"
         );
 
@@ -1043,7 +1114,7 @@ mod tests {
         );
         assert!(app.static_image_overlay_displayed());
 
-        let (collisions, erase) = app.foot_sixel_modal_collision_erase(&[popup]);
+        let (collisions, erase) = app.sixel_modal_collision_erase(&[popup]);
         assert_eq!(collisions, vec![popup]);
         assert!(
             !erase.is_empty(),

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -121,7 +121,8 @@ impl App {
 mod tests {
     use super::*;
     use crate::app::overlays::inline_image::{
-        ImageProtocol, OverlayPresentState, RenderedImageDimensions, TerminalWindowSize,
+        ImageProtocol, OverlayPresentState, RenderedImageDimensions, TerminalIdentity,
+        TerminalWindowSize,
     };
     use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
     use ratatui::{buffer::Buffer, layout::Rect};
@@ -886,6 +887,174 @@ mod tests {
             "closing the popup should repaint the masked Sixel image"
         );
         assert!(app.static_image_overlay_displayed());
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn foot_sixel_popup_erases_collision_and_repaints_after_close() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("foot-sixel-popup-collision", "demo.png");
+        let request = ready_static_image_overlay(&mut app);
+        app.set_terminal_image_protocol_for_tests(ImageProtocol::Sixel, TerminalIdentity::Foot);
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+            &request,
+            request.area,
+            request.area,
+        ));
+        assert!(app.static_image_overlay_displayed());
+
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+        let popup = Rect {
+            x: request.area.x.saturating_add(1),
+            y: request.area.y.saturating_add(1),
+            width: request.area.width.saturating_sub(2).max(1),
+            height: request.area.height.saturating_sub(2).max(1),
+        };
+        let mask = app.modal_image_post_draw_erase(&[popup], &blank_frame_buffer());
+        assert!(
+            mask.is_empty(),
+            "Foot Sixel should avoid fragile transparent-cell post-draw masking"
+        );
+
+        let (collisions, erase) = app.foot_sixel_modal_collision_erase(&[popup]);
+        assert_eq!(collisions, vec![popup]);
+        assert!(
+            !erase.is_empty(),
+            "Foot Sixel should erase the popup/image collision like Yazi's Clear widget"
+        );
+        assert!(
+            app.static_image_overlay_displayed(),
+            "the image remains logically displayed so only the popup intersection is punched out"
+        );
+        assert!(
+            app.present_preview_overlay()
+                .expect("Sixel popup redraw should not fail")
+                .is_empty(),
+            "Foot Sixel should not repaint image bytes over an open popup"
+        );
+
+        app.overlays.open_with = None;
+        app.input.frame_state.open_with_panel = None;
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut restored = Vec::new();
+        while Instant::now() < deadline {
+            let _ = app.process_background_jobs();
+            let _ = app.process_image_preview_timers();
+            restored = app
+                .present_preview_overlay()
+                .expect("closing the popup should repaint the Sixel image");
+            if !restored.is_empty() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !restored.is_empty(),
+            "closing the popup should repaint the erased Foot Sixel collision"
+        );
+        assert!(app.static_image_overlay_displayed());
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn foot_sixel_focus_gain_with_popup_does_not_clear_displayed_image_without_resize() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("foot-sixel-focus-popup", "demo.png");
+        let request = ready_static_image_overlay(&mut app);
+        app.set_terminal_image_protocol_for_tests(ImageProtocol::Sixel, TerminalIdentity::Foot);
+        app.handle_terminal_image_focus_gained();
+        assert!(!app.take_pending_resize_clear());
+
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+            &request,
+            request.area,
+            request.area,
+        ));
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+
+        app.handle_terminal_image_focus_gained();
+        assert!(
+            !app.take_pending_resize_clear(),
+            "focus gained without a terminal-size change must not take the resize-clear path"
+        );
+        assert!(
+            app.static_image_overlay_displayed(),
+            "Foot Sixel image state should survive focus refocus while a popup is open"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn foot_sixel_resize_under_popup_repaints_image_behind_modal() {
+        let (mut app, root, _image_path) =
+            build_selected_static_image_app("foot-sixel-resize-popup", "demo.png");
+        let request = ready_static_image_overlay(&mut app);
+        app.set_terminal_image_protocol_for_tests(ImageProtocol::Sixel, TerminalIdentity::Foot);
+        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
+            &request,
+            request.area,
+            request.area,
+        ));
+        app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
+        let popup = Rect {
+            x: request.area.x.saturating_add(1),
+            y: request.area.y.saturating_add(1),
+            width: request.area.width.saturating_sub(2).max(1),
+            height: request.area.height.saturating_sub(2).max(1),
+        };
+
+        app.handle_terminal_image_resize();
+        app.preview.terminal_images.window = Some(TerminalWindowSize {
+            cells_width: 120,
+            cells_height: 40,
+            pixels_width: 1920,
+            pixels_height: 1080,
+        });
+        assert!(app.take_pending_resize_clear());
+        assert!(
+            !app.static_image_overlay_displayed(),
+            "resize clear removes stale Sixel geometry before redraw"
+        );
+        assert!(
+            app.should_repaint_foot_sixel_under_modal(&[popup]),
+            "Foot Sixel should repaint the resized image behind an open popup"
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut image_bytes = Vec::new();
+        while Instant::now() < deadline {
+            let _ = app.process_background_jobs();
+            let _ = app.process_image_preview_timers();
+            image_bytes = app
+                .present_preview_overlay_behind_modal()
+                .expect("resize-under-popup repaint should not fail");
+            if !image_bytes.is_empty() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !image_bytes.is_empty(),
+            "resize-under-popup should emit fresh Sixel bytes before collision masking"
+        );
+        assert!(app.static_image_overlay_displayed());
+
+        let (collisions, erase) = app.foot_sixel_modal_collision_erase(&[popup]);
+        assert_eq!(collisions, vec![popup]);
+        assert!(
+            !erase.is_empty(),
+            "the freshly repainted image should still be punched out under the popup"
+        );
+        assert!(
+            app.present_preview_overlay()
+                .expect("normal popup redraw should not fail")
+                .is_empty(),
+            "normal Foot Sixel presentation remains blocked while the popup is open"
+        );
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -208,7 +208,10 @@ impl App {
 
     pub(in crate::app) fn needs_sixel_repaint_workaround(&self) -> bool {
         self.preview.terminal_images.protocol == ImageProtocol::Sixel
-            && self.preview.terminal_images.identity == TerminalIdentity::Foot
+            && matches!(
+                self.preview.terminal_images.identity,
+                TerminalIdentity::Foot | TerminalIdentity::WindowsTerminal
+            )
     }
 
     pub(in crate::app) fn needs_slow_sixel_navigation_workaround(&self) -> bool {
@@ -371,7 +374,7 @@ impl App {
                 || (active_pdf_overlay && !self.displayed_pdf_overlay_matches_active()))
     }
 
-    pub(crate) fn should_repaint_foot_sixel_under_modal(&self, modal_rects: &[Rect]) -> bool {
+    pub(crate) fn should_repaint_sixel_under_modal(&self, modal_rects: &[Rect]) -> bool {
         let active_static_image = self.active_static_image_overlay_request().is_some()
             || self
                 .active_preview_visual_overlay_request_unchecked()
@@ -589,7 +592,7 @@ impl App {
         Ok(bytes)
     }
 
-    pub(crate) fn foot_sixel_modal_collision_erase(
+    pub(crate) fn sixel_modal_collision_erase(
         &mut self,
         modal_rects: &[Rect],
     ) -> (Vec<Rect>, Vec<u8>) {

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -151,6 +151,20 @@ impl App {
 
     pub(crate) fn handle_terminal_image_resize(&mut self) {
         self.refresh_terminal_image_window_size();
+        self.queue_terminal_image_resize_clear();
+        self.handle_pdf_overlay_resize();
+    }
+
+    pub(crate) fn handle_terminal_image_focus_gained(&mut self) {
+        let previous_window = self.preview.terminal_images.window;
+        self.refresh_terminal_image_window_size();
+        if self.preview.terminal_images.window != previous_window {
+            self.queue_terminal_image_resize_clear();
+            self.handle_pdf_overlay_resize();
+        }
+    }
+
+    fn queue_terminal_image_resize_clear(&mut self) {
         if matches!(
             self.preview.terminal_images.protocol,
             ImageProtocol::KittyGraphics | ImageProtocol::ItermInline | ImageProtocol::Sixel
@@ -163,7 +177,6 @@ impl App {
             // the entire alt screen before the image is re-rendered.
             self.preview.terminal_images.pending_resize_clear = true;
         }
-        self.handle_pdf_overlay_resize();
     }
 
     pub(crate) fn take_pending_resize_clear(&mut self) -> bool {
@@ -358,6 +371,21 @@ impl App {
                 || (active_pdf_overlay && !self.displayed_pdf_overlay_matches_active()))
     }
 
+    pub(crate) fn should_repaint_foot_sixel_under_modal(&self, modal_rects: &[Rect]) -> bool {
+        let active_static_image = self.active_static_image_overlay_request().is_some()
+            || self
+                .active_preview_visual_overlay_request_unchecked()
+                .is_some();
+        let active_pdf_overlay = self.active_pdf_overlay_requested();
+        self.needs_sixel_repaint_workaround()
+            && !modal_rects.is_empty()
+            && self.any_modal_overlay_open()
+            && ((active_static_image
+                && !self.displayed_static_image_matches_active()
+                && !self.keep_displayed_static_image_overlay_while_pending())
+                || (active_pdf_overlay && !self.displayed_pdf_overlay_matches_active()))
+    }
+
     pub(crate) fn present_preview_overlay(&mut self) -> Result<Vec<u8>> {
         self.present_preview_overlay_inner(false)
     }
@@ -399,6 +427,9 @@ impl App {
             if self.static_image_overlay_displayed() || self.pdf_overlay_displayed() {
                 self.preview.terminal_images.pending_iterm_popup_restore = true;
             }
+            return Ok(Vec::new());
+        }
+        if self.needs_sixel_repaint_workaround() && popup_open && !allow_iterm_modal_repaint {
             return Ok(Vec::new());
         }
         if protocol == ImageProtocol::Sixel
@@ -556,6 +587,43 @@ impl App {
         self.clear_displayed_static_image();
         self.clear_displayed_pdf_overlay();
         Ok(bytes)
+    }
+
+    pub(crate) fn foot_sixel_modal_collision_erase(
+        &mut self,
+        modal_rects: &[Rect],
+    ) -> (Vec<Rect>, Vec<u8>) {
+        if !self.needs_sixel_repaint_workaround() || modal_rects.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+
+        let image_rects = [
+            self.displayed_static_image_clear_area(),
+            self.displayed_pdf_overlay_area(),
+        ];
+        if image_rects.iter().all(Option::is_none) {
+            return (Vec::new(), Vec::new());
+        }
+
+        let mut collisions = Vec::new();
+        for popup in modal_rects {
+            for image in image_rects.iter().flatten() {
+                if let Some(collision) = geometry::intersect_rect(*popup, *image) {
+                    geometry::push_unique_rect(&mut collisions, collision);
+                }
+            }
+        }
+        if collisions.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+
+        self.preview.terminal_images.pending_sixel_repaint = true;
+        let erase = collisions
+            .iter()
+            .copied()
+            .flat_map(iterm::erase_cells)
+            .collect();
+        (collisions, erase)
     }
 
     pub(crate) fn queue_forced_iterm_preview_erase(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,7 @@ fn run_app(
                     terminal_focused = false;
                 } else if matches!(event, Event::FocusGained) {
                     terminal_focused = true;
-                    app.handle_terminal_image_resize();
+                    app.handle_terminal_image_focus_gained();
                     dirty = true;
                 } else if matches!(event, Event::Resize(_, _)) {
                     app.handle_terminal_image_resize();
@@ -549,6 +549,7 @@ fn draw_terminal_frame(
         if app.take_pending_resize_clear() {
             terminal.clear()?;
         }
+
         // Erase stale image cells before terminal.draw() so ratatui can
         // overpaint them with the correct panel background in the same pass.
         // - iTerm2: images are drawn at pixel level; erasing prevents ghost pixels.
@@ -562,7 +563,14 @@ fn draw_terminal_frame(
             terminal.backend_mut().write_all(&kitty_erase)?;
         }
         let mut frame_state = app::FrameState::default();
-        let (dirty, image_behind_modal, popup_restore, modal_erase, skip_overlay_present) = {
+        let (
+            dirty,
+            image_behind_modal,
+            sixel_collision_erase,
+            popup_restore,
+            modal_erase,
+            skip_overlay_present,
+        ) = {
             let completed = terminal.draw(|frame| ui::render(frame, app, &mut frame_state))?;
             let dirty = app.set_frame_state(frame_state);
             let modal_rects = app.collect_popup_rects();
@@ -572,13 +580,47 @@ fn draw_terminal_frame(
                 let image_behind_modal = app.present_preview_overlay_behind_modal()?;
                 let popup_restore = collect_buffer_cells(&modal_rects, completed.buffer);
                 let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
-                (dirty, image_behind_modal, popup_restore, modal_erase, true)
-            } else {
+                (
+                    dirty,
+                    image_behind_modal,
+                    Vec::new(),
+                    popup_restore,
+                    modal_erase,
+                    true,
+                )
+            } else if !app.browser_wheel_burst_active()
+                && app.should_repaint_foot_sixel_under_modal(&modal_rects)
+            {
+                let image_behind_modal = app.present_preview_overlay_behind_modal()?;
+                let (sixel_collision_rects, sixel_collision_erase) =
+                    app.foot_sixel_modal_collision_erase(&modal_rects);
+                let popup_restore = collect_buffer_cells(&sixel_collision_rects, completed.buffer);
                 let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
-                (dirty, Vec::new(), Vec::new(), modal_erase, false)
+                (
+                    dirty,
+                    image_behind_modal,
+                    sixel_collision_erase,
+                    popup_restore,
+                    modal_erase,
+                    true,
+                )
+            } else {
+                let (sixel_collision_rects, sixel_collision_erase) =
+                    app.foot_sixel_modal_collision_erase(&modal_rects);
+                let popup_restore = collect_buffer_cells(&sixel_collision_rects, completed.buffer);
+                let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
+                (
+                    dirty,
+                    Vec::new(),
+                    sixel_collision_erase,
+                    popup_restore,
+                    modal_erase,
+                    false,
+                )
             }
         };
         write_bytes_preserving_cursor(terminal.backend_mut(), &image_behind_modal)?;
+        write_bytes_preserving_cursor(terminal.backend_mut(), &sixel_collision_erase)?;
         draw_cells_preserving_cursor(terminal.backend_mut(), &popup_restore)?;
         write_bytes_preserving_cursor(terminal.backend_mut(), &modal_erase)?;
         if !skip_overlay_present && !app.browser_wheel_burst_active() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,11 +589,11 @@ fn draw_terminal_frame(
                     true,
                 )
             } else if !app.browser_wheel_burst_active()
-                && app.should_repaint_foot_sixel_under_modal(&modal_rects)
+                && app.should_repaint_sixel_under_modal(&modal_rects)
             {
                 let image_behind_modal = app.present_preview_overlay_behind_modal()?;
                 let (sixel_collision_rects, sixel_collision_erase) =
-                    app.foot_sixel_modal_collision_erase(&modal_rects);
+                    app.sixel_modal_collision_erase(&modal_rects);
                 let popup_restore = collect_buffer_cells(&sixel_collision_rects, completed.buffer);
                 let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
                 (
@@ -606,7 +606,7 @@ fn draw_terminal_frame(
                 )
             } else {
                 let (sixel_collision_rects, sixel_collision_erase) =
-                    app.foot_sixel_modal_collision_erase(&modal_rects);
+                    app.sixel_modal_collision_erase(&modal_rects);
                 let popup_restore = collect_buffer_cells(&sixel_collision_rects, completed.buffer);
                 let modal_erase = app.modal_image_post_draw_erase(&modal_rects, completed.buffer);
                 (


### PR DESCRIPTION
## Summary

Fixes Sixel image preview layering with transparent popup/theme surfaces, so modal popups render cleanly over image previews instead of letting stale preview pixels show through.

## What Changed

- Added Sixel modal masking for popup/image intersections.
- Suppressed normal Sixel presentation while a modal is open, then repainted the preview after the modal closes.
- Kept the behavior scoped to Sixel terminals so existing Kitty/iTerm-style image paths are not changed.
- Added regression coverage for the modal image overlay path.

## User Impact

Transparent themes can now use transparent popup/path surfaces over Sixel image previews without preview content bleeding through the popup.

This fixes the behavior on terminals such as Foot and Windows Terminal.

## Notes

The popup remains visually transparent to the terminal background, but not to stale image preview pixels underneath it.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Foot: tested popups over Sixel image previews with the transparent theme.
- Foot: tested terminal resizing while a popup was open over an image preview.
- Windows Terminal: tested popups over Sixel image previews with the transparent theme.
- Windows Terminal: tested terminal resizing while a popup was open over an image preview.
- Kitty: smoke-tested image preview/popup behavior to check for regressions.

Result:

All automated checks passed locally, and manual popup-over-image behavior looked correct on Foot and Windows Terminal.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
