### PR TITLE
chore: clean up Windows CI warnings

### DIFF
--- a/src/preview/container/archive/external.rs
+++ b/src/preview/container/archive/external.rs
@@ -232,11 +232,9 @@ fn parse_unrar_bare_listing(output: &str) -> Vec<ArchiveEntry> {
 #[cfg(test)]
 mod tests {
     use super::{parse_7z_listing, parse_unrar_bare_listing, run_archive_listing_command};
-    use std::{
-        fs,
-        path::PathBuf,
-        time::{Duration, Instant},
-    };
+    #[cfg(unix)]
+    use std::time::{Duration, Instant};
+    use std::{fs, path::PathBuf};
 
     #[test]
     fn parse_7z_listing_collects_external_fallback_metadata_and_entries() {

--- a/src/shell_integration/mod.rs
+++ b/src/shell_integration/mod.rs
@@ -50,6 +50,7 @@ impl ShellIntegrationAction {
         }
     }
 
+    #[cfg(any(unix, test))]
     fn active_shell_description(self) -> &'static str {
         match self {
             Self::Install => "installs integration for",
@@ -60,7 +61,9 @@ impl ShellIntegrationAction {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ShellDetection {
+    #[cfg(any(unix, test))]
     Supported(Shell),
+    #[cfg(any(unix, test))]
     Unsupported(String),
     Unknown,
 }
@@ -81,7 +84,9 @@ pub(crate) struct UninstallReport {
 
 pub(crate) fn detect_shell(action: ShellIntegrationAction) -> Result<Shell> {
     match detect_parent_shell() {
+        #[cfg(any(unix, test))]
         ShellDetection::Supported(shell) => Ok(shell),
+        #[cfg(any(unix, test))]
         ShellDetection::Unsupported(shell) => Err(anyhow::anyhow!(
             unsupported_active_shell_message(action, &shell)
         )),
@@ -128,6 +133,7 @@ fn detect_parent_shell() -> ShellDetection {
     ShellDetection::Unknown
 }
 
+#[cfg(any(unix, test))]
 fn detect_shell_from_command(command: &str) -> ShellDetection {
     let Some(name) = shell_name_from_command(command) else {
         return ShellDetection::Unknown;
@@ -140,6 +146,7 @@ fn detect_shell_from_command(command: &str) -> ShellDetection {
     }
 }
 
+#[cfg(any(unix, test))]
 fn is_known_unsupported_shell(name: &str) -> bool {
     matches!(
         name,
@@ -163,6 +170,7 @@ fn is_known_unsupported_shell(name: &str) -> bool {
     )
 }
 
+#[cfg(any(unix, test))]
 fn unsupported_active_shell_message(action: ShellIntegrationAction, shell: &str) -> String {
     format!(
         "error: unsupported active shell '{shell}'\n\n`elio shell {}` {} the active shell.\nsupported shells: bash, zsh, fish\n\n{}",

--- a/src/shell_integration/tests.rs
+++ b/src/shell_integration/tests.rs
@@ -1,7 +1,9 @@
+#[cfg(unix)]
+use super::resolve_write_path;
 use super::{
     MANAGED_END, MANAGED_START, Shell, ShellDetection, binary_command, detect_shell_from_command,
-    init_script, managed_script, remove_managed_blocks, resolve_write_path,
-    shell_name_from_command, uninstall_reload_command, upsert_managed_block, write_text_atomic,
+    init_script, managed_script, remove_managed_blocks, shell_name_from_command,
+    uninstall_reload_command, upsert_managed_block, write_text_atomic,
 };
 use std::{
     fs,


### PR DESCRIPTION
## Summary

Cleans up Windows-only unused/dead-code warnings from shell integration and archive tests.

## What Changed

- Gated Unix/test-only shell detection paths with `#[cfg(any(unix, test))]`.
- Gated Unix-only shell integration test imports.
- Gated Unix-only archive cancellation test time imports.

## User Impact

No user-visible behavior change.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Windows:
  - `cargo build --locked`
  - `cargo test --locked`

Result:

All checks passed locally and on Windows.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed
