### PR TITLE
feat(preview): simplify directory preview headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Simplified directory preview headers by hiding the `Contents` label. ([#125])
 - Updated the transparent theme example to make popups and path surfaces fully transparent, and removed comments from example themes.
 
 ### Fixed
@@ -188,3 +189,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#111]: https://github.com/elio-fm/elio/issues/111
 [#112]: https://github.com/elio-fm/elio/issues/112
 [#121]: https://github.com/elio-fm/elio/issues/121
+[#125]: https://github.com/elio-fm/elio/issues/125

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -49,7 +49,7 @@ pub(crate) fn loading_preview_for(
             .with_detail("Broken symlink");
     }
     if entry.is_dir() {
-        return PreviewContent::new(PreviewKind::Directory, Vec::new()).with_detail("Loading");
+        return PreviewContent::new(PreviewKind::Directory, Vec::new());
     }
     let facts = file_info::inspect_entry_cached(entry);
     let detail = facts

--- a/src/preview/tests/mod.rs
+++ b/src/preview/tests/mod.rs
@@ -55,6 +55,18 @@ fn truncated_directory_preview_omits_sampled_header_count() {
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
+#[test]
+fn directory_loading_preview_stays_silent() {
+    let preview = loading_preview_for(
+        &directory_entry(temp_path("directory-loading-preview")),
+        &PreviewRequestOptions::Default,
+    );
+
+    assert_eq!(preview.kind, PreviewKind::Directory);
+    assert_eq!(preview.detail, None);
+    assert!(preview.lines.is_empty());
+}
+
 #[cfg(unix)]
 #[test]
 fn directory_preview_marks_symlink_children_and_targets() {

--- a/src/ui/browser/preview.rs
+++ b/src/ui/browser/preview.rs
@@ -118,23 +118,20 @@ fn render_preview_body(
     state.preview_rows_visible = visible_rows;
     state.preview_cols_visible = text_area.width as usize;
     let section_label = app.preview_section_label();
-    let header_detail_width = sections[0]
-        .width
-        .saturating_sub(section_label.len() as u16 + 2) as usize;
+    let header_width = sections[0].width as usize;
+    let show_section_label = section_label != "Contents";
+    let header_detail_width = if show_section_label {
+        header_width.saturating_sub(helpers::display_width(section_label) + 2)
+    } else {
+        header_width
+    };
     let header_detail = app
         .preview_header_detail_for_width(visible_rows, header_detail_width)
         .as_deref()
-        .map(|detail| {
-            if header_detail_width == 0 {
-                String::new()
-            } else {
-                helpers::clamp_label(detail, header_detail_width)
-            }
-        })
+        .map(|detail| helpers::clamp_label(detail, header_detail_width))
         .unwrap_or_default();
-
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
+    let header_line = if show_section_label {
+        Line::from(vec![
             Span::styled(
                 section_label.to_string(),
                 Style::default()
@@ -143,8 +140,16 @@ fn render_preview_body(
             ),
             Span::styled("  ", Style::default().fg(palette.muted)),
             Span::styled(header_detail, Style::default().fg(palette.muted)),
-        ]))
-        .style(Style::default().bg(palette.panel).fg(palette.text)),
+        ])
+    } else {
+        Line::from(Span::styled(
+            header_detail,
+            Style::default().fg(palette.muted),
+        ))
+    };
+
+    frame.render_widget(
+        Paragraph::new(header_line).style(Style::default().bg(palette.panel).fg(palette.text)),
         sections[0],
     );
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1358,6 +1358,37 @@ fn preview_header_detail_uses_compact_labels_before_final_clamp() {
 }
 
 #[test]
+fn directory_preview_header_drops_contents_label_before_item_count() {
+    let root = temp_path("directory-preview-header-tight");
+    let folder = root.join("folder");
+    fs::create_dir_all(&folder).expect("failed to create folder");
+    for index in 0..27 {
+        fs::write(folder.join(format!("child-{index}.txt")), "x")
+            .expect("failed to write child file");
+    }
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    let mut narrow = Terminal::new(TestBackend::new(60, 24)).expect("terminal should init");
+    wait_for_background_preview(&mut app);
+
+    let state = draw_ui(&mut narrow, &mut app);
+    let preview_panel = state
+        .preview_panel
+        .expect("preview panel should be rendered");
+    let narrow_header = row_text(narrow.backend().buffer(), preview_panel.y + 1);
+    assert!(
+        narrow_header.contains("27 items"),
+        "expected tight directory header to keep the item count, got: {narrow_header:?}"
+    );
+    assert!(
+        !narrow_header.contains("Contents"),
+        "expected tight directory header to drop the less useful section label, got: {narrow_header:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn visible_directory_rows_show_cached_item_counts() {
     let root = temp_path("directory-counts");
     let photos = root.join("photos");


### PR DESCRIPTION
## Summary

Closes #125.

Simplifies directory preview headers by hiding the `Contents` label.

## What Changed

- Hide the `Contents` label for directory preview headers.
- Use the full header width for directory metadata like `6 items • 55.8 kB`.
- Keep directory loading placeholders quiet until metadata is ready.
- Add regression coverage for the header behavior and silent loading state.

## User Impact

Directory previews now give more space to folder metadata, especially in narrower layouts.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified the directory preview header visually with folder metadata visible and no `Contents` label.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed