### PR TITLE
fix(open): launch terminal default apps in the current terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `o` / `Enter` on Linux and BSD to open default terminal-based apps in the current terminal when opening a single file instead of a separate terminal window. ([#134])
 - Improved popup rendering over image previews, preventing preview content from showing through transparent overlay cells across Kitty/Ghostty, WezTerm/iTerm2, Foot, and Windows Terminal.
 - Fixed WezTerm and iTerm2 inline image previews during terminal resize, keeping previews and popups correctly layered.
 
@@ -190,3 +191,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/elio-fm/elio/issues/112
 [#121]: https://github.com/elio-fm/elio/issues/121
 [#125]: https://github.com/elio-fm/elio/issues/125
+[#134]: https://github.com/elio-fm/elio/issues/134

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -393,6 +393,20 @@ impl App {
     }
 
     pub(in crate::app) fn open_in_system(&mut self) -> Result<()> {
+        #[cfg(all(unix, not(target_os = "macos")))]
+        if let Some(app) = self
+            .single_file_open_target_entry()
+            .and_then(crate::app::open_with::default_open_with_app_for_entry)
+            .filter(|app| app.requires_terminal)
+        {
+            self.pending_terminal_task = Some(crate::app::PendingTerminalTask::Command {
+                program: app.program,
+                args: app.args,
+            });
+            self.status.clear();
+            return Ok(());
+        }
+
         let targets = self.open_in_system_targets();
         if targets.is_empty() {
             return Ok(());
@@ -418,6 +432,24 @@ impl App {
             }
         };
         Ok(())
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn single_file_open_target_entry(&self) -> Option<&Entry> {
+        if self.navigation.selected_paths.len() > 1 {
+            return None;
+        }
+
+        if let Some(path) = self.navigation.selected_paths.iter().next() {
+            return self
+                .navigation
+                .entries
+                .iter()
+                .find(|entry| &entry.path == path)
+                .filter(|entry| !entry.is_dir());
+        }
+
+        self.selected_entry().filter(|entry| !entry.is_dir())
     }
 
     fn open_in_system_targets(&self) -> Vec<PathBuf> {

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -25,6 +25,41 @@ impl Drop for OpenInSystemCaptureGuard {
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
+struct DefaultOpenWithAppGuard;
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl DefaultOpenWithAppGuard {
+    fn install(app: crate::app::state::OpenWithApp) -> Self {
+        crate::app::open_with::set_default_open_with_app_for_test(Some(app));
+        Self
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl Drop for DefaultOpenWithAppGuard {
+    fn drop(&mut self) {
+        crate::app::open_with::set_default_open_with_app_for_test(None);
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn fake_default_open_with_app(
+    display_name: &str,
+    program: &str,
+    args: Vec<String>,
+    requires_terminal: bool,
+) -> crate::app::state::OpenWithApp {
+    crate::app::state::OpenWithApp {
+        display_name: display_name.to_string(),
+        desktop_id: None,
+        program: program.to_string(),
+        args,
+        is_default: true,
+        requires_terminal,
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn read_open_capture(capture: &std::path::Path) -> String {
     let deadline = Instant::now() + Duration::from_millis(1000);
     while !capture.exists() && Instant::now() < deadline {
@@ -146,6 +181,77 @@ fn newline_key_event_also_opens_selected_file() {
 
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
+fn enter_queues_terminal_default_app_for_selected_file() {
+    let root = temp_path("enter-terminal-default");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let file_path = root.join("note.txt");
+    fs::write(&file_path, "hello").expect("failed to write temp file");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+    let _default_guard = DefaultOpenWithAppGuard::install(fake_default_open_with_app(
+        "Helix",
+        "hx",
+        vec![file_path.display().to_string()],
+        true,
+    ));
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should queue terminal default app");
+
+    assert_eq!(
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Command {
+            program: "hx".to_string(),
+            args: vec![file_path.display().to_string()],
+        })
+    );
+    assert!(app.status.is_empty());
+    assert!(
+        !capture.exists(),
+        "system opener should not run for terminal default app"
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn open_action_keeps_system_opener_for_gui_default_app() {
+    let root = temp_path("open-gui-default");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let file_path = root.join("note.txt");
+    fs::write(&file_path, "hello").expect("failed to write temp file");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+    let _default_guard = DefaultOpenWithAppGuard::install(fake_default_open_with_app(
+        "Text Editor",
+        "gedit",
+        vec![file_path.display().to_string()],
+        false,
+    ));
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('o'))))
+        .expect("o should use system opener for GUI defaults");
+
+    let opened = read_open_capture(&capture);
+    assert_eq!(opened, file_path.display().to_string());
+    assert_eq!(app.pending_terminal_task, None);
+    assert_eq!(app.status, format!("Opened {}", file_path.display()));
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
 fn enter_opens_selected_entries_with_system_opener() {
     let root = temp_path("enter-opens-selection");
     fs::create_dir_all(&root).expect("failed to create temp root");
@@ -213,6 +319,44 @@ fn open_action_opens_selected_entries_with_system_opener() {
         opened,
         vec![alpha.display().to_string(), beta.display().to_string()]
     );
+    assert_eq!(app.status, "Opened 2 items");
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn open_action_keeps_system_opener_for_multiple_selection_with_terminal_default() {
+    let root = temp_path("open-selection-terminal-default");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+    let _default_guard = DefaultOpenWithAppGuard::install(fake_default_open_with_app(
+        "Helix",
+        "hx",
+        vec![alpha.display().to_string()],
+        true,
+    ));
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('o'))))
+        .expect("o should use system opener for multiple selection");
+
+    let opened = read_open_capture(&capture);
+    let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
+    assert_eq!(
+        opened,
+        vec![alpha.display().to_string(), beta.display().to_string()]
+    );
+    assert_eq!(app.pending_terminal_task, None);
     assert_eq!(app.status, "Opened 2 items");
 
     fs::remove_dir_all(root).ok();

--- a/src/app/open_with/mod.rs
+++ b/src/app/open_with/mod.rs
@@ -4,12 +4,42 @@ mod overlay;
 #[cfg(test)]
 mod tests;
 
+#[cfg(all(test, unix, not(target_os = "macos")))]
+use std::cell::RefCell;
 use std::path::Path;
 
+#[cfg(all(unix, not(target_os = "macos")))]
+use super::state::OpenWithApp;
+#[cfg(all(unix, not(target_os = "macos")))]
+use crate::core::Entry;
 use crate::{
     core::{EntryKind, FileClass},
     file_info::{PreviewKind, inspect_path},
 };
+
+#[cfg(all(test, unix, not(target_os = "macos")))]
+thread_local! {
+    static TEST_DEFAULT_OPEN_WITH_APP: RefCell<Option<OpenWithApp>> = const { RefCell::new(None) };
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(in crate::app) fn default_open_with_app_for_entry(entry: &Entry) -> Option<OpenWithApp> {
+    #[cfg(test)]
+    {
+        let _ = entry;
+        TEST_DEFAULT_OPEN_WITH_APP.with(|slot| slot.borrow().clone())
+    }
+
+    #[cfg(not(test))]
+    discovery::discover_open_with_apps_for_entry(entry)
+        .into_iter()
+        .find(|app| app.is_default)
+}
+
+#[cfg(all(test, unix, not(target_os = "macos")))]
+pub(in crate::app) fn set_default_open_with_app_for_test(app: Option<OpenWithApp>) {
+    TEST_DEFAULT_OPEN_WITH_APP.with(|slot| *slot.borrow_mut() = app);
+}
 
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(super) fn path_is_text_like(path: &Path) -> bool {


### PR DESCRIPTION
## Summary

Makes `o` / `Enter` launch default terminal-based apps in the current terminal when opening a single file on Linux/BSD, instead of letting the desktop opener launch them in a separate terminal window.

Closes #134.

## What Changed

- Resolve the default Open With app before `o` / `Enter` delegates to the system opener on Linux/BSD.
- Queue default terminal-based apps through elio's existing current-terminal command path when opening a single file.
- Keep GUI defaults, directories, and bulk open on the existing system-opener path.
- Added regression coverage for terminal defaults, GUI defaults, and multi-select behavior.

## User Impact

Users whose default app is a terminal-based editor, such as Helix or Neovim, can now use `o` / `Enter` to open a single file in the current terminal instead of a separate terminal window.

Bulk open keeps using the system opener, matching the expected multi-file behavior.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Single-file open with a terminal app.
- Single-file open with a GUI app.
- Bulk open with terminal app files.
- Bulk open with GUI/default apps.

Result:

All checks passed locally, and manual open/bulk-open behavior matched the expected UX.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
