### PR TITLE
fix(input): double-click item with active selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved mouse double-click behavior when a selection is active.
 - Fixed `o` / `Enter` on Linux and BSD to open default terminal-based apps in the current terminal when opening a single file instead of a separate terminal window. ([#134])
 - Improved popup rendering over image previews, preventing preview content from showing through transparent overlay cells across Kitty/Ghostty, WezTerm/iTerm2, Foot, and Windows Terminal.
 - Fixed WezTerm and iTerm2 inline image previews during terminal resize, keeping previews and popups correctly layered.

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -392,22 +392,58 @@ impl App {
         )
     }
 
+    pub(in crate::app) fn open_entry_at_index(&mut self, index: usize) -> Result<()> {
+        let Some(entry) = self.navigation.entries.get(index).cloned() else {
+            return Ok(());
+        };
+
+        if entry.is_dir() {
+            self.set_dir(entry.path)
+        } else {
+            self.open_entry_in_system(&entry)
+        }
+    }
+
     pub(in crate::app) fn open_in_system(&mut self) -> Result<()> {
         #[cfg(all(unix, not(target_os = "macos")))]
-        if let Some(app) = self
+        if self
             .single_file_open_target_entry()
-            .and_then(crate::app::open_with::default_open_with_app_for_entry)
-            .filter(|app| app.requires_terminal)
+            .cloned()
+            .is_some_and(|entry| self.queue_terminal_default_open_if_needed(&entry))
         {
-            self.pending_terminal_task = Some(crate::app::PendingTerminalTask::Command {
-                program: app.program,
-                args: app.args,
-            });
-            self.status.clear();
             return Ok(());
         }
 
         let targets = self.open_in_system_targets();
+        self.open_paths_in_system(targets)
+    }
+
+    fn open_entry_in_system(&mut self, entry: &Entry) -> Result<()> {
+        #[cfg(all(unix, not(target_os = "macos")))]
+        if self.queue_terminal_default_open_if_needed(entry) {
+            return Ok(());
+        }
+
+        self.open_paths_in_system(vec![entry.path.clone()])
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn queue_terminal_default_open_if_needed(&mut self, entry: &Entry) -> bool {
+        let Some(app) = crate::app::open_with::default_open_with_app_for_entry(entry)
+            .filter(|app| app.requires_terminal)
+        else {
+            return false;
+        };
+
+        self.pending_terminal_task = Some(crate::app::PendingTerminalTask::Command {
+            program: app.program,
+            args: app.args,
+        });
+        self.status.clear();
+        true
+    }
+
+    fn open_paths_in_system(&mut self, targets: Vec<PathBuf>) -> Result<()> {
         if targets.is_empty() {
             return Ok(());
         }

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -106,7 +106,7 @@ impl App {
                     };
                     self.select_index(hit.index);
                     if self.is_double_click(&path) {
-                        self.open_selected()?;
+                        self.open_entry_at_index(hit.index)?;
                     }
                     self.input.last_click = Some(ClickState {
                         path,

--- a/src/app/input/tests/helpers.rs
+++ b/src/app/input/tests/helpers.rs
@@ -1,11 +1,11 @@
 use super::super::*;
 use std::{
-    env,
+    env, fs,
     fs::File,
     io::Write,
     path::{Path, PathBuf},
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
@@ -42,6 +42,31 @@ pub(super) fn wait_for_background_preview(app: &mut App) {
         thread::sleep(Duration::from_millis(10));
     }
     panic!("timed out waiting for background preview");
+}
+
+pub(super) struct OpenInSystemCaptureGuard;
+
+impl OpenInSystemCaptureGuard {
+    pub(super) fn install(path: PathBuf) -> Self {
+        let _ = fs::remove_file(&path);
+        crate::fs::set_open_in_system_capture_for_test(Some(path));
+        Self
+    }
+}
+
+impl Drop for OpenInSystemCaptureGuard {
+    fn drop(&mut self) {
+        crate::fs::set_open_in_system_capture_for_test(None);
+    }
+}
+
+pub(super) fn read_open_capture(capture: &Path) -> String {
+    let deadline = Instant::now() + Duration::from_millis(1000);
+    while !capture.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    fs::read_to_string(capture).expect("capture should exist")
 }
 
 pub(super) fn write_binary_zip_entries(path: &Path, entries: &[(&str, &[u8])]) {

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -1,28 +1,13 @@
 use super::super::*;
 use super::helpers::{
-    temp_path, wait_for_background_preview, wait_for_directory_load, write_epub_fixture,
+    OpenInSystemCaptureGuard, read_open_capture, temp_path, wait_for_background_preview,
+    wait_for_directory_load, write_epub_fixture,
 };
 use crate::config::Action;
 use std::{
     fs, thread,
     time::{Duration, Instant},
 };
-
-struct OpenInSystemCaptureGuard;
-
-impl OpenInSystemCaptureGuard {
-    fn install(path: std::path::PathBuf) -> Self {
-        let _ = fs::remove_file(&path);
-        crate::fs::set_open_in_system_capture_for_test(Some(path));
-        Self
-    }
-}
-
-impl Drop for OpenInSystemCaptureGuard {
-    fn drop(&mut self) {
-        crate::fs::set_open_in_system_capture_for_test(None);
-    }
-}
 
 #[cfg(all(unix, not(target_os = "macos")))]
 struct DefaultOpenWithAppGuard;
@@ -57,16 +42,6 @@ fn fake_default_open_with_app(
         is_default: true,
         requires_terminal,
     }
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-fn read_open_capture(capture: &std::path::Path) -> String {
-    let deadline = Instant::now() + Duration::from_millis(1000);
-    while !capture.exists() && Instant::now() < deadline {
-        thread::sleep(Duration::from_millis(10));
-    }
-
-    fs::read_to_string(capture).expect("capture should exist")
 }
 
 #[test]

--- a/src/app/input/tests/mod.rs
+++ b/src/app/input/tests/mod.rs
@@ -2,6 +2,7 @@ mod browser_wheel;
 mod errors;
 mod helpers;
 mod keyboard;
+mod mouse;
 mod navigation;
 mod preview;
 mod preview_wheel;

--- a/src/app/input/tests/mouse.rs
+++ b/src/app/input/tests/mouse.rs
@@ -1,0 +1,105 @@
+use super::super::*;
+use super::helpers::{
+    OpenInSystemCaptureGuard, read_open_capture, temp_path, wait_for_directory_load,
+};
+use std::fs;
+
+fn left_click(column: u16, row: u16) -> Event {
+    Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    })
+}
+
+fn entry_hit(index: usize, row: u16) -> EntryHit {
+    EntryHit {
+        rect: Rect {
+            x: 0,
+            y: row,
+            width: 20,
+            height: 1,
+        },
+        index,
+    }
+}
+
+#[test]
+fn double_click_opens_clicked_file_not_multi_selection() {
+    let root = temp_path("mouse-double-click-file-selection");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    let gamma = root.join("gamma.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    fs::write(&gamma, "gamma").expect("failed to write gamma");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(gamma.clone());
+    let beta_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == beta)
+        .expect("beta should be visible");
+    app.set_frame_state(FrameState {
+        entry_hits: vec![entry_hit(beta_index, 1)],
+        ..FrameState::default()
+    });
+
+    app.handle_event(left_click(1, 1))
+        .expect("first click should focus clicked file");
+    assert!(!capture.exists());
+
+    app.handle_event(left_click(1, 1))
+        .expect("second click should open clicked file");
+
+    let opened = read_open_capture(&capture);
+    let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
+    assert_eq!(opened, vec![beta.display().to_string()]);
+    assert_eq!(app.status, format!("Opened {}", beta.display()));
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn double_click_enters_clicked_directory_not_multi_selection() {
+    let root = temp_path("mouse-double-click-dir-selection");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let child = root.join("child");
+    let selected = root.join("selected.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&selected, "selected").expect("failed to write selected file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(selected);
+    let child_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == child)
+        .expect("child should be visible");
+    app.set_frame_state(FrameState {
+        entry_hits: vec![entry_hit(child_index, 1)],
+        ..FrameState::default()
+    });
+
+    app.handle_event(left_click(1, 1))
+        .expect("first click should focus clicked directory");
+    assert_eq!(app.navigation.cwd, root);
+
+    app.handle_event(left_click(1, 1))
+        .expect("second click should enter clicked directory");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, child);
+
+    fs::remove_dir_all(root).ok();
+}


### PR DESCRIPTION
## Summary

Fixes mouse double-click behavior when a selection is active, so double-clicking a row acts on the clicked item instead of the current selected set.

## What Changed

- Added a direct entry-opening path for mouse double-clicks.
- Kept keyboard `Enter` / `o` selection-aware, including multi-selection opens.
- Reused the existing system/default-opener logic for single-file mouse opens.
- Added regression tests for double-clicking files and directories while a selection is active.

## User Impact

Mouse double-click now behaves as direct manipulation: it opens or enters the clicked row even when other items are selected.

Keyboard open behavior is unchanged.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Selected multiple files, then double-clicked another file.
- Selected one or more items, then double-clicked a directory.
- Confirmed keyboard `Enter` / `o` still opens the active selection.

Result:

All checks passed locally, and manual double-click behavior matched the expected UX.

## Documentation and Changelog

- [ ] Documentation updated
- [x] Changelog updated
- [ ] Docs and changelog are not needed
