### PR TITLE
feat(shell): add Nushell cwd integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a `terminal-ansi` theme example and support for terminal ANSI colors in `theme.toml`. ([#84])
-- Added `--cwd-file` and installable bash, zsh, and fish shell integration for changing the parent shell directory to elio's final directory on quit, including quit-without-cd, current-shell detection, zsh `ZDOTDIR` support, symlink-aware config updates, and a matching uninstall command. ([#69])
+- Added `--cwd-file` and installable bash, zsh, fish, and Nushell integration for changing the parent shell directory to elio's final directory on quit, including quit-without-cd, current-shell detection, zsh `ZDOTDIR` support, symlink-aware config updates, and a matching uninstall command. ([#69], [#129])
 
 ### Changed
 
@@ -192,4 +192,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#112]: https://github.com/elio-fm/elio/issues/112
 [#121]: https://github.com/elio-fm/elio/issues/121
 [#125]: https://github.com/elio-fm/elio/issues/125
+[#129]: https://github.com/elio-fm/elio/issues/129
 [#134]: https://github.com/elio-fm/elio/issues/134

--- a/README.md
+++ b/README.md
@@ -276,9 +276,16 @@ elio shell install fish
 elio shell uninstall fish
 ```
 
-Replace `fish` with `bash` or `zsh` as needed.
+Replace `fish` with `bash`, `zsh`, or `nu` as needed.
 
-The installer writes a managed block to `~/.bashrc` for bash, to `$ZDOTDIR/.zshrc` or `~/.zshrc` for zsh, and to `$XDG_CONFIG_HOME/fish/conf.d/elio.fish` or `~/.config/fish/conf.d/elio.fish` for fish. Existing bash and zsh files are preserved, including symlinks used by dotfile managers. Fish `conf.d` directories managed through symlinks are preserved too, and elio refuses to overwrite an existing `elio.fish` unless it was previously managed by elio.
+The installer writes elio-managed shell integration to:
+
+- `~/.bashrc` for bash
+- `$ZDOTDIR/.zshrc` or `~/.zshrc` for zsh
+- `$XDG_CONFIG_HOME/fish/conf.d/elio.fish` or `~/.config/fish/conf.d/elio.fish` for fish
+- `$XDG_CONFIG_HOME/nushell/autoload/elio.nu` or `~/.config/nushell/autoload/elio.nu` for Nushell
+
+Existing bash and zsh startup files are preserved: elio only adds, updates, or removes its marked integration block, leaving other user config intact, including symlinks used by dotfile managers. Symlinked Fish `conf.d` and Nushell `autoload` directories are preserved too, and elio refuses to overwrite an existing `elio.fish` or `elio.nu` unless it was previously managed by elio.
 
 If you prefer to manage your shell files yourself, use `elio shell init` instead. It prints the integration snippet without editing any files:
 
@@ -286,6 +293,7 @@ If you prefer to manage your shell files yourself, use `elio shell init` instead
 elio shell init fish
 elio shell init bash
 elio shell init zsh
+elio shell init nu
 ```
 
 For custom wrappers, elio also exposes the file handoff used by the shell integration:

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -1,7 +1,9 @@
 use super::super::*;
+#[cfg(all(unix, not(target_os = "macos")))]
+use super::helpers::read_open_capture;
 use super::helpers::{
-    OpenInSystemCaptureGuard, read_open_capture, temp_path, wait_for_background_preview,
-    wait_for_directory_load, write_epub_fixture,
+    OpenInSystemCaptureGuard, temp_path, wait_for_background_preview, wait_for_directory_load,
+    write_epub_fixture,
 };
 use crate::config::Action;
 use std::{

--- a/src/app/overlays/images/mod.rs
+++ b/src/app/overlays/images/mod.rs
@@ -222,6 +222,29 @@ mod tests {
             .expect("static image overlay request should exist")
     }
 
+    fn displayed_sixel_static_image_overlay(
+        app: &mut App,
+        identity: TerminalIdentity,
+    ) -> StaticImageOverlayRequest {
+        let request = ready_static_image_overlay(app);
+        app.set_terminal_image_protocol_for_tests(ImageProtocol::Sixel, identity);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            let _ = app.process_background_jobs();
+            let _ = app.process_image_preview_timers();
+            let output = app
+                .present_preview_overlay()
+                .expect("initial Sixel image presentation should succeed");
+            if !output.is_empty() && app.static_image_overlay_displayed() {
+                return request;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        panic!("timed out waiting for initial Sixel image presentation");
+    }
+
     #[test]
     fn kitty_png_overlay_uses_source_path_for_direct_display() {
         let (mut app, root, image_path) =
@@ -836,13 +859,7 @@ mod tests {
     fn sixel_popup_skips_post_draw_masking_for_foot_performance() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("sixel-popup-mask", "demo.png");
-        let request = ready_static_image_overlay(&mut app);
-        app.preview.terminal_images.protocol = ImageProtocol::Sixel;
-        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
-            &request,
-            request.area,
-            request.area,
-        ));
+        let request = displayed_sixel_static_image_overlay(&mut app, TerminalIdentity::Foot);
         assert!(app.static_image_overlay_displayed());
 
         app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
@@ -895,13 +912,7 @@ mod tests {
     fn foot_sixel_popup_erases_collision_and_repaints_after_close() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("foot-sixel-popup-collision", "demo.png");
-        let request = ready_static_image_overlay(&mut app);
-        app.set_terminal_image_protocol_for_tests(ImageProtocol::Sixel, TerminalIdentity::Foot);
-        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
-            &request,
-            request.area,
-            request.area,
-        ));
+        let request = displayed_sixel_static_image_overlay(&mut app, TerminalIdentity::Foot);
         assert!(app.static_image_overlay_displayed());
 
         app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);
@@ -963,16 +974,8 @@ mod tests {
     fn windows_terminal_sixel_popup_erases_collision_and_repaints_after_close() {
         let (mut app, root, _image_path) =
             build_selected_static_image_app("wt-sixel-popup-collision", "demo.png");
-        let request = ready_static_image_overlay(&mut app);
-        app.set_terminal_image_protocol_for_tests(
-            ImageProtocol::Sixel,
-            TerminalIdentity::WindowsTerminal,
-        );
-        app.preview.image.displayed = Some(types::DisplayedStaticImagePreview::from_request(
-            &request,
-            request.area,
-            request.area,
-        ));
+        let request =
+            displayed_sixel_static_image_overlay(&mut app, TerminalIdentity::WindowsTerminal);
         assert!(app.static_image_overlay_displayed());
 
         app.inject_open_with_for_test("Preview", "/usr/bin/true", vec![], false);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,18 +19,20 @@ pub(crate) fn run() -> Result<()> {
         Command::PrintShellInit(shell) => {
             let executable = env::current_exe()?;
             let invocation = env::args().next();
-            let binary = shell_integration::binary_command(invocation.as_deref(), &executable);
+            let binary =
+                shell_integration::binary_command(shell, invocation.as_deref(), &executable);
             print!("{}", shell_integration::init_script(shell, &binary));
             Ok(())
         }
         Command::InstallShellIntegration(shell) => {
             let executable = env::current_exe()?;
             let invocation = env::args().next();
-            let binary = shell_integration::binary_command(invocation.as_deref(), &executable);
             let shell = match shell {
                 Some(shell) => shell,
                 None => shell_integration::detect_shell(ShellIntegrationAction::Install)?,
             };
+            let binary =
+                shell_integration::binary_command(shell, invocation.as_deref(), &executable);
             let report = shell_integration::install(shell, &binary)?;
             println!(
                 "Installed elio shell integration for {}.",
@@ -154,7 +156,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
         }
         [command, subcommand] if command == "shell" && subcommand == "init" => {
             return Err(anyhow::anyhow!(
-                "error: expected a shell after 'elio shell init'\n\nsupported shells: bash, zsh, fish"
+                "error: expected a shell after 'elio shell init'\n\nsupported shells: bash, zsh, fish, nu"
             ));
         }
         [command, ..] if command == "shell" => {
@@ -245,9 +247,9 @@ fn print_help() {
     println!("  -V, --version        Print version");
     println!();
     println!("Commands:");
-    println!("  shell init <SHELL>        Print shell integration for bash, zsh, or fish");
-    println!("  shell install [SHELL]    Install shell integration for bash, zsh, or fish");
-    println!("  shell uninstall [SHELL]  Remove shell integration for bash, zsh, or fish");
+    println!("  shell init <SHELL>        Print shell integration for bash, zsh, fish, or nu");
+    println!("  shell install [SHELL]    Install shell integration for bash, zsh, fish, or nu");
+    println!("  shell uninstall [SHELL]  Remove shell integration for bash, zsh, fish, or nu");
 }
 
 fn resolve_startup_directory(arg: &str) -> Result<PathBuf> {

--- a/src/shell_integration/install.rs
+++ b/src/shell_integration/install.rs
@@ -1,0 +1,376 @@
+use anyhow::{Context, Result};
+use std::{
+    env, fs, io,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use super::scripts::{init_script, nu_string_literal, shell_quote};
+use super::{InstallReport, Shell, UninstallReport};
+
+pub(crate) const MANAGED_START: &str = "# >>> elio shell integration >>>";
+pub(crate) const MANAGED_END: &str = "# <<< elio shell integration <<<";
+
+pub(crate) fn install(shell: Shell, binary: &str) -> Result<InstallReport> {
+    let script = managed_script(shell, binary);
+    let path = integration_path(shell)?;
+
+    match shell {
+        Shell::Fish | Shell::Nu => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("failed to create {}", parent.display()))?;
+            }
+            if let Some(existing) = read_utf8_if_exists(&path)?
+                && !has_managed_block(&existing)?
+            {
+                anyhow::bail!(
+                    "error: refusing to overwrite {} because it is not managed by elio",
+                    path.display()
+                );
+            }
+            write_text_atomic(&path, &script)?;
+        }
+        Shell::Bash | Shell::Zsh => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("failed to create {}", parent.display()))?;
+            }
+            let existing = read_utf8_if_exists(&path)?.unwrap_or_default();
+            let updated = upsert_managed_block(&existing, &script)?;
+            write_text_atomic(&path, &updated)?;
+        }
+    }
+
+    Ok(InstallReport {
+        shell,
+        reload_command: reload_command(shell, &path),
+        path,
+    })
+}
+
+pub(crate) fn uninstall(shell: Shell) -> Result<UninstallReport> {
+    let path = integration_path(shell)?;
+    let changed = match shell {
+        Shell::Fish | Shell::Nu => uninstall_managed_file(&path)?,
+        Shell::Bash | Shell::Zsh => uninstall_posix(&path)?,
+    };
+
+    Ok(UninstallReport {
+        shell,
+        reload_command: uninstall_reload_command(shell),
+        path,
+        changed,
+        removed_file: matches!(shell, Shell::Fish | Shell::Nu) && changed,
+    })
+}
+
+fn integration_path(shell: Shell) -> Result<PathBuf> {
+    match shell {
+        Shell::Fish => Ok(config_home_for_shell("fish")?.join("fish/conf.d/elio.fish")),
+        Shell::Nu => Ok(config_home_for_shell("nu")?.join("nushell/autoload/elio.nu")),
+        Shell::Bash => Ok(home_dir()?.join(".bashrc")),
+        Shell::Zsh => Ok(zsh_config_dir()?.join(".zshrc")),
+    }
+}
+
+fn config_home_for_shell(shell: &str) -> Result<PathBuf> {
+    env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .with_context(|| {
+            format!("error: could not find $XDG_CONFIG_HOME or $HOME for {shell} integration")
+        })
+}
+
+fn zsh_config_dir() -> Result<PathBuf> {
+    match env::var_os("ZDOTDIR") {
+        Some(zdotdir) if !zdotdir.is_empty() => Ok(PathBuf::from(zdotdir)),
+        _ => home_dir(),
+    }
+}
+
+fn home_dir() -> Result<PathBuf> {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .context("error: could not find $HOME for shell integration")
+}
+
+fn reload_command(shell: Shell, path: &Path) -> String {
+    match shell {
+        Shell::Fish => format!("source {}", shell_quote(path)),
+        Shell::Bash | Shell::Zsh => format!("source {}", shell_quote(path)),
+        Shell::Nu => format!("source {}", nu_string_literal(path)),
+    }
+}
+
+pub(super) fn uninstall_reload_command(shell: Shell) -> String {
+    match shell {
+        Shell::Bash => "unset -f elio".to_string(),
+        Shell::Zsh => "unfunction elio 2>/dev/null || true".to_string(),
+        Shell::Fish => "functions --erase elio".to_string(),
+        Shell::Nu => "hide elio".to_string(),
+    }
+}
+
+pub(super) fn managed_script(shell: Shell, binary: &str) -> String {
+    format!(
+        "{MANAGED_START}\n{}\n{MANAGED_END}\n",
+        init_script(shell, binary).trim_end()
+    )
+}
+
+pub(super) fn upsert_managed_block(existing: &str, block: &str) -> Result<String> {
+    if let Some(start) = existing.find(MANAGED_START) {
+        if let Some(relative_end) = existing[start..].find(MANAGED_END) {
+            let end = start + relative_end + MANAGED_END.len();
+            let after = remove_managed_blocks(&existing[end..])?
+                .unwrap_or_else(|| existing[end..].to_string());
+            let mut updated = String::new();
+            updated.push_str(existing[..start].trim_end_matches('\n'));
+            if !updated.is_empty() {
+                updated.push_str("\n\n");
+            }
+            updated.push_str(block.trim_end());
+            updated.push_str(after.trim_start_matches('\n'));
+            if !updated.ends_with('\n') {
+                updated.push('\n');
+            }
+            return Ok(updated);
+        }
+
+        anyhow::bail!("error: found elio shell integration start marker without end marker");
+    }
+
+    let mut updated = existing.trim_end_matches('\n').to_string();
+    if !updated.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(block.trim_end());
+    updated.push('\n');
+    Ok(updated)
+}
+
+fn uninstall_posix(path: &Path) -> Result<bool> {
+    let Some(existing) = read_utf8_if_exists(path)? else {
+        return Ok(false);
+    };
+
+    let Some(updated) = remove_managed_blocks(&existing)? else {
+        return Ok(false);
+    };
+
+    write_text_atomic(path, &updated)?;
+    Ok(true)
+}
+
+fn uninstall_managed_file(path: &Path) -> Result<bool> {
+    let Some(existing) = read_utf8_if_exists(path)? else {
+        return Ok(false);
+    };
+
+    if !has_managed_block(&existing)? {
+        anyhow::bail!(
+            "error: refusing to remove {} because it is not managed by elio",
+            path.display()
+        );
+    }
+
+    fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))?;
+    Ok(true)
+}
+
+fn read_utf8_if_exists(path: &Path) -> Result<Option<String>> {
+    match fs::read(path) {
+        Ok(bytes) => String::from_utf8(bytes)
+            .with_context(|| format!("failed to read {} as UTF-8", path.display()))
+            .map(Some),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+pub(super) fn write_text_atomic(path: &Path, contents: &str) -> Result<()> {
+    let write_path = resolve_write_path(path)?;
+    let parent = write_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let (temp_path, mut temp_file) = create_atomic_temp(&write_path, parent)?;
+
+    let result = (|| -> Result<()> {
+        match fs::metadata(&write_path) {
+            Ok(metadata) => temp_file
+                .set_permissions(metadata.permissions())
+                .with_context(|| format!("failed to set permissions on {}", temp_path.display()))?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to inspect {}", write_path.display()));
+            }
+        }
+
+        temp_file
+            .write_all(contents.as_bytes())
+            .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        temp_file
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", temp_path.display()))?;
+        drop(temp_file);
+
+        replace_with_temp(&temp_path, &write_path)
+            .with_context(|| format!("failed to replace {}", write_path.display()))?;
+        sync_parent_dir(parent).with_context(|| format!("failed to sync {}", parent.display()))?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    result
+}
+
+pub(super) fn resolve_write_path(path: &Path) -> Result<PathBuf> {
+    let mut current = path.to_path_buf();
+
+    for _ in 0..16 {
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(current),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to inspect {}", current.display()));
+            }
+        };
+
+        if !metadata.file_type().is_symlink() {
+            return Ok(current);
+        }
+
+        let target = fs::read_link(&current)
+            .with_context(|| format!("failed to read symlink {}", current.display()))?;
+        current = if target.is_absolute() {
+            target
+        } else {
+            current
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."))
+                .join(target)
+        };
+    }
+
+    anyhow::bail!(
+        "failed to resolve shell integration symlink chain for {}",
+        path.display()
+    )
+}
+
+fn create_atomic_temp(path: &Path, parent: &Path) -> Result<(PathBuf, fs::File)> {
+    let file_name = path
+        .file_name()
+        .context("failed to build temporary shell integration path")?
+        .to_string_lossy();
+    let process_id = std::process::id();
+
+    for attempt in 0..100 {
+        let temp_path = parent.join(format!(".{file_name}.elio-tmp-{process_id}-{attempt}"));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => return Ok((temp_path, file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to create {}", temp_path.display()));
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "failed to create a temporary shell integration file beside {}",
+        path.display()
+    )
+}
+
+#[cfg(windows)]
+fn replace_with_temp(temp_path: &Path, write_path: &Path) -> io::Result<()> {
+    if write_path.exists() {
+        fs::remove_file(write_path)?;
+    }
+    fs::rename(temp_path, write_path)
+}
+
+#[cfg(not(windows))]
+fn replace_with_temp(temp_path: &Path, write_path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, write_path)
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(parent: &Path) -> io::Result<()> {
+    match fs::File::open(parent)?.sync_all() {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::InvalidInput | io::ErrorKind::Unsupported
+            ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_parent: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+pub(super) fn remove_managed_blocks(existing: &str) -> Result<Option<String>> {
+    let mut updated = existing.to_string();
+    let mut changed = false;
+
+    while let Some(next) = remove_first_managed_block(&updated)? {
+        updated = next;
+        changed = true;
+    }
+
+    Ok(changed.then_some(updated))
+}
+
+fn remove_first_managed_block(existing: &str) -> Result<Option<String>> {
+    let Some(start) = existing.find(MANAGED_START) else {
+        return Ok(None);
+    };
+    let Some(relative_end) = existing[start..].find(MANAGED_END) else {
+        anyhow::bail!("error: found elio shell integration start marker without end marker");
+    };
+
+    let end = start + relative_end + MANAGED_END.len();
+    let before = existing[..start].trim_end_matches('\n');
+    let after = existing[end..].trim_start_matches('\n');
+    let mut updated = String::new();
+    updated.push_str(before);
+    if !before.is_empty() && !after.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(after);
+    if !updated.is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    Ok(Some(updated))
+}
+
+fn has_managed_block(existing: &str) -> Result<bool> {
+    let Some(start) = existing.find(MANAGED_START) else {
+        return Ok(false);
+    };
+    if !existing[start..].contains(MANAGED_END) {
+        anyhow::bail!("error: found elio shell integration start marker without end marker");
+    }
+    Ok(true)
+}

--- a/src/shell_integration/mod.rs
+++ b/src/shell_integration/mod.rs
@@ -1,18 +1,29 @@
 use anyhow::{Context, Result};
 use std::{
-    env, fs, io,
-    io::Write,
+    env,
     path::{Path, PathBuf},
 };
 
-const MANAGED_START: &str = "# >>> elio shell integration >>>";
-const MANAGED_END: &str = "# <<< elio shell integration <<<";
+mod install;
+mod scripts;
+
+pub(crate) use install::{install, uninstall};
+pub(crate) use scripts::{binary_command, init_script};
+
+#[cfg(test)]
+use install::{
+    MANAGED_END, MANAGED_START, managed_script, remove_managed_blocks, resolve_write_path,
+    uninstall_reload_command, upsert_managed_block, write_text_atomic,
+};
+#[cfg(test)]
+use scripts::nu_string_literal;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Shell {
     Bash,
     Zsh,
     Fish,
+    Nu,
 }
 
 impl Shell {
@@ -21,8 +32,11 @@ impl Shell {
             "bash" => Ok(Self::Bash),
             "zsh" => Ok(Self::Zsh),
             "fish" => Ok(Self::Fish),
+            "nu" | "nushell" => Ok(Self::Nu),
             shell => Err(format!(
-                "error: unsupported shell '{shell}'\n\nsupported shells: bash, zsh, fish"
+                "error: unsupported shell '{shell}'
+
+supported shells: bash, zsh, fish, nu"
             )),
         }
     }
@@ -32,6 +46,7 @@ impl Shell {
             Self::Bash => "bash",
             Self::Zsh => "zsh",
             Self::Fish => "fish",
+            Self::Nu => "nu",
         }
     }
 }
@@ -158,8 +173,6 @@ fn is_known_unsupported_shell(name: &str) -> bool {
             | "yash"
             | "csh"
             | "tcsh"
-            | "nu"
-            | "nushell"
             | "xonsh"
             | "elvish"
             | "ion"
@@ -173,7 +186,7 @@ fn is_known_unsupported_shell(name: &str) -> bool {
 #[cfg(any(unix, test))]
 fn unsupported_active_shell_message(action: ShellIntegrationAction, shell: &str) -> String {
     format!(
-        "error: unsupported active shell '{shell}'\n\n`elio shell {}` {} the active shell.\nsupported shells: bash, zsh, fish\n\n{}",
+        "error: unsupported active shell '{shell}'\n\n`elio shell {}` {} the active shell.\nsupported shells: bash, zsh, fish, nu\n\n{}",
         action.command(),
         action.active_shell_description(),
         explicit_shell_guidance(action)
@@ -183,7 +196,7 @@ fn unsupported_active_shell_message(action: ShellIntegrationAction, shell: &str)
 fn explicit_shell_guidance(action: ShellIntegrationAction) -> String {
     let command = action.command();
     format!(
-        "Run one of these explicitly if you want to target another shell:\n  elio shell {command} fish\n  elio shell {command} bash\n  elio shell {command} zsh"
+        "Run one of these explicitly if you want to target another shell:\n  elio shell {command} fish\n  elio shell {command} bash\n  elio shell {command} zsh\n  elio shell {command} nu"
     )
 }
 
@@ -199,450 +212,6 @@ fn shell_name_from_command(command: &str) -> Option<String> {
         .file_name()
         .and_then(|name| name.to_str())?;
     Some(file_name.strip_prefix('-').unwrap_or(file_name).to_string())
-}
-
-pub(crate) fn binary_command(invocation: Option<&str>, executable: &Path) -> String {
-    let Some(invocation) = invocation else {
-        return shell_quote(executable);
-    };
-
-    if invocation.contains('/') || invocation.contains('\\') || invocation.starts_with('.') {
-        shell_quote(executable)
-    } else {
-        "command elio".to_string()
-    }
-}
-
-pub(crate) fn init_script(shell: Shell, binary: &str) -> String {
-    match shell {
-        Shell::Bash | Shell::Zsh => posix_init_script(binary),
-        Shell::Fish => fish_init_script(binary),
-    }
-}
-
-pub(crate) fn install(shell: Shell, binary: &str) -> Result<InstallReport> {
-    let script = managed_script(shell, binary);
-    let path = integration_path(shell)?;
-
-    match shell {
-        Shell::Fish => {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)
-                    .with_context(|| format!("failed to create {}", parent.display()))?;
-            }
-            if let Some(existing) = read_utf8_if_exists(&path)?
-                && !has_managed_block(&existing)?
-            {
-                anyhow::bail!(
-                    "error: refusing to overwrite {} because it is not managed by elio",
-                    path.display()
-                );
-            }
-            write_text_atomic(&path, &script)?;
-        }
-        Shell::Bash | Shell::Zsh => {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)
-                    .with_context(|| format!("failed to create {}", parent.display()))?;
-            }
-            let existing = read_utf8_if_exists(&path)?.unwrap_or_default();
-            let updated = upsert_managed_block(&existing, &script)?;
-            write_text_atomic(&path, &updated)?;
-        }
-    }
-
-    Ok(InstallReport {
-        shell,
-        reload_command: reload_command(shell, &path),
-        path,
-    })
-}
-
-pub(crate) fn uninstall(shell: Shell) -> Result<UninstallReport> {
-    let path = integration_path(shell)?;
-    let changed = match shell {
-        Shell::Fish => uninstall_fish(&path)?,
-        Shell::Bash | Shell::Zsh => uninstall_posix(&path)?,
-    };
-
-    Ok(UninstallReport {
-        shell,
-        reload_command: uninstall_reload_command(shell),
-        path,
-        changed,
-        removed_file: shell == Shell::Fish && changed,
-    })
-}
-
-fn integration_path(shell: Shell) -> Result<PathBuf> {
-    match shell {
-        Shell::Fish => {
-            let config_home = env::var_os("XDG_CONFIG_HOME")
-                .map(PathBuf::from)
-                .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
-                .context("error: could not find $XDG_CONFIG_HOME or $HOME for fish integration")?;
-            Ok(config_home.join("fish/conf.d/elio.fish"))
-        }
-        Shell::Bash => Ok(home_dir()?.join(".bashrc")),
-        Shell::Zsh => Ok(zsh_config_dir()?.join(".zshrc")),
-    }
-}
-
-fn zsh_config_dir() -> Result<PathBuf> {
-    match env::var_os("ZDOTDIR") {
-        Some(zdotdir) if !zdotdir.is_empty() => Ok(PathBuf::from(zdotdir)),
-        _ => home_dir(),
-    }
-}
-
-fn home_dir() -> Result<PathBuf> {
-    env::var_os("HOME")
-        .map(PathBuf::from)
-        .context("error: could not find $HOME for shell integration")
-}
-
-fn reload_command(shell: Shell, path: &Path) -> String {
-    match shell {
-        Shell::Fish => format!("source {}", shell_quote(path)),
-        Shell::Bash | Shell::Zsh => format!("source {}", shell_quote(path)),
-    }
-}
-
-fn uninstall_reload_command(shell: Shell) -> String {
-    match shell {
-        Shell::Bash => "unset -f elio".to_string(),
-        Shell::Zsh => "unfunction elio 2>/dev/null || true".to_string(),
-        Shell::Fish => "functions --erase elio".to_string(),
-    }
-}
-
-fn managed_script(shell: Shell, binary: &str) -> String {
-    format!(
-        "{MANAGED_START}\n{}\n{MANAGED_END}\n",
-        init_script(shell, binary).trim_end()
-    )
-}
-
-fn upsert_managed_block(existing: &str, block: &str) -> Result<String> {
-    if let Some(start) = existing.find(MANAGED_START) {
-        if let Some(relative_end) = existing[start..].find(MANAGED_END) {
-            let end = start + relative_end + MANAGED_END.len();
-            let after = remove_managed_blocks(&existing[end..])?
-                .unwrap_or_else(|| existing[end..].to_string());
-            let mut updated = String::new();
-            updated.push_str(existing[..start].trim_end_matches('\n'));
-            if !updated.is_empty() {
-                updated.push_str("\n\n");
-            }
-            updated.push_str(block.trim_end());
-            updated.push_str(after.trim_start_matches('\n'));
-            if !updated.ends_with('\n') {
-                updated.push('\n');
-            }
-            return Ok(updated);
-        }
-
-        anyhow::bail!("error: found elio shell integration start marker without end marker");
-    }
-
-    let mut updated = existing.trim_end_matches('\n').to_string();
-    if !updated.is_empty() {
-        updated.push_str("\n\n");
-    }
-    updated.push_str(block.trim_end());
-    updated.push('\n');
-    Ok(updated)
-}
-
-fn uninstall_posix(path: &Path) -> Result<bool> {
-    let Some(existing) = read_utf8_if_exists(path)? else {
-        return Ok(false);
-    };
-
-    let Some(updated) = remove_managed_blocks(&existing)? else {
-        return Ok(false);
-    };
-
-    write_text_atomic(path, &updated)?;
-    Ok(true)
-}
-
-fn uninstall_fish(path: &Path) -> Result<bool> {
-    let Some(existing) = read_utf8_if_exists(path)? else {
-        return Ok(false);
-    };
-
-    if !has_managed_block(&existing)? {
-        anyhow::bail!(
-            "error: refusing to remove {} because it is not managed by elio",
-            path.display()
-        );
-    }
-
-    fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))?;
-    Ok(true)
-}
-
-fn read_utf8_if_exists(path: &Path) -> Result<Option<String>> {
-    match fs::read(path) {
-        Ok(bytes) => String::from_utf8(bytes)
-            .with_context(|| format!("failed to read {} as UTF-8", path.display()))
-            .map(Some),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
-    }
-}
-
-fn write_text_atomic(path: &Path, contents: &str) -> Result<()> {
-    let write_path = resolve_write_path(path)?;
-    let parent = write_path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let (temp_path, mut temp_file) = create_atomic_temp(&write_path, parent)?;
-
-    let result = (|| -> Result<()> {
-        match fs::metadata(&write_path) {
-            Ok(metadata) => temp_file
-                .set_permissions(metadata.permissions())
-                .with_context(|| format!("failed to set permissions on {}", temp_path.display()))?,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(error)
-                    .with_context(|| format!("failed to inspect {}", write_path.display()));
-            }
-        }
-
-        temp_file
-            .write_all(contents.as_bytes())
-            .with_context(|| format!("failed to write {}", temp_path.display()))?;
-        temp_file
-            .sync_all()
-            .with_context(|| format!("failed to sync {}", temp_path.display()))?;
-        drop(temp_file);
-
-        replace_with_temp(&temp_path, &write_path)
-            .with_context(|| format!("failed to replace {}", write_path.display()))?;
-        sync_parent_dir(parent).with_context(|| format!("failed to sync {}", parent.display()))?;
-        Ok(())
-    })();
-
-    if result.is_err() {
-        let _ = fs::remove_file(&temp_path);
-    }
-
-    result
-}
-
-fn resolve_write_path(path: &Path) -> Result<PathBuf> {
-    let mut current = path.to_path_buf();
-
-    for _ in 0..16 {
-        let metadata = match fs::symlink_metadata(&current) {
-            Ok(metadata) => metadata,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(current),
-            Err(error) => {
-                return Err(error)
-                    .with_context(|| format!("failed to inspect {}", current.display()));
-            }
-        };
-
-        if !metadata.file_type().is_symlink() {
-            return Ok(current);
-        }
-
-        let target = fs::read_link(&current)
-            .with_context(|| format!("failed to read symlink {}", current.display()))?;
-        current = if target.is_absolute() {
-            target
-        } else {
-            current
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty())
-                .unwrap_or_else(|| Path::new("."))
-                .join(target)
-        };
-    }
-
-    anyhow::bail!(
-        "failed to resolve shell integration symlink chain for {}",
-        path.display()
-    )
-}
-
-fn create_atomic_temp(path: &Path, parent: &Path) -> Result<(PathBuf, fs::File)> {
-    let file_name = path
-        .file_name()
-        .context("failed to build temporary shell integration path")?
-        .to_string_lossy();
-    let process_id = std::process::id();
-
-    for attempt in 0..100 {
-        let temp_path = parent.join(format!(".{file_name}.elio-tmp-{process_id}-{attempt}"));
-        match fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp_path)
-        {
-            Ok(file) => return Ok((temp_path, file)),
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
-            Err(error) => {
-                return Err(error)
-                    .with_context(|| format!("failed to create {}", temp_path.display()));
-            }
-        }
-    }
-
-    anyhow::bail!(
-        "failed to create a temporary shell integration file beside {}",
-        path.display()
-    )
-}
-
-#[cfg(windows)]
-fn replace_with_temp(temp_path: &Path, write_path: &Path) -> io::Result<()> {
-    if write_path.exists() {
-        fs::remove_file(write_path)?;
-    }
-    fs::rename(temp_path, write_path)
-}
-
-#[cfg(not(windows))]
-fn replace_with_temp(temp_path: &Path, write_path: &Path) -> io::Result<()> {
-    fs::rename(temp_path, write_path)
-}
-
-#[cfg(unix)]
-fn sync_parent_dir(parent: &Path) -> io::Result<()> {
-    match fs::File::open(parent)?.sync_all() {
-        Ok(()) => Ok(()),
-        Err(error)
-            if matches!(
-                error.kind(),
-                io::ErrorKind::InvalidInput | io::ErrorKind::Unsupported
-            ) =>
-        {
-            Ok(())
-        }
-        Err(error) => Err(error),
-    }
-}
-
-#[cfg(not(unix))]
-fn sync_parent_dir(_parent: &Path) -> io::Result<()> {
-    Ok(())
-}
-
-fn remove_managed_blocks(existing: &str) -> Result<Option<String>> {
-    let mut updated = existing.to_string();
-    let mut changed = false;
-
-    while let Some(next) = remove_first_managed_block(&updated)? {
-        updated = next;
-        changed = true;
-    }
-
-    Ok(changed.then_some(updated))
-}
-
-fn remove_first_managed_block(existing: &str) -> Result<Option<String>> {
-    let Some(start) = existing.find(MANAGED_START) else {
-        return Ok(None);
-    };
-    let Some(relative_end) = existing[start..].find(MANAGED_END) else {
-        anyhow::bail!("error: found elio shell integration start marker without end marker");
-    };
-
-    let end = start + relative_end + MANAGED_END.len();
-    let before = existing[..start].trim_end_matches('\n');
-    let after = existing[end..].trim_start_matches('\n');
-    let mut updated = String::new();
-    updated.push_str(before);
-    if !before.is_empty() && !after.is_empty() {
-        updated.push_str("\n\n");
-    }
-    updated.push_str(after);
-    if !updated.is_empty() && !updated.ends_with('\n') {
-        updated.push('\n');
-    }
-    Ok(Some(updated))
-}
-
-fn has_managed_block(existing: &str) -> Result<bool> {
-    let Some(start) = existing.find(MANAGED_START) else {
-        return Ok(false);
-    };
-    if !existing[start..].contains(MANAGED_END) {
-        anyhow::bail!("error: found elio shell integration start marker without end marker");
-    }
-    Ok(true)
-}
-
-fn posix_init_script(executable: &str) -> String {
-    format!(
-        r#"elio() {{
-    case "${{1-}}" in
-        shell|-*)
-            {executable} "$@"
-            return $?
-            ;;
-    esac
-
-    local tmp cwd status_code
-    tmp="$(mktemp -t "elio-cwd.XXXXXX")" || return
-    {executable} --cwd-file "$tmp" "$@"
-    status_code=$?
-
-    if [ -s "$tmp" ]; then
-        cwd="$(cat -- "$tmp")"
-        rm -f -- "$tmp"
-        if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && [ -d "$cwd" ]; then
-            cd -- "$cwd" || return $?
-        fi
-    else
-        rm -f -- "$tmp"
-    fi
-
-    return "$status_code"
-}}
-"#
-    )
-}
-
-fn fish_init_script(executable: &str) -> String {
-    format!(
-        r#"function elio
-    switch "$argv[1]"
-        case shell '-*'
-            {executable} $argv
-            return $status
-    end
-
-    set -l tmp (mktemp -t "elio-cwd.XXXXXX")
-    or return
-
-    {executable} --cwd-file "$tmp" $argv
-    set -l status_code $status
-
-    if test -s "$tmp"
-        set -l cwd (string collect < "$tmp")
-        rm -f "$tmp"
-        if test -n "$cwd"; and test "$cwd" != "$PWD"; and test -d "$cwd"
-            cd "$cwd"; or return $status
-        end
-    else
-        rm -f "$tmp"
-    end
-
-    return $status_code
-end
-"#
-    )
-}
-
-fn shell_quote(path: &Path) -> String {
-    let value = path.to_string_lossy();
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]

--- a/src/shell_integration/mod.rs
+++ b/src/shell_integration/mod.rs
@@ -10,10 +10,12 @@ mod scripts;
 pub(crate) use install::{install, uninstall};
 pub(crate) use scripts::{binary_command, init_script};
 
+#[cfg(all(test, unix))]
+use install::resolve_write_path;
 #[cfg(test)]
 use install::{
-    MANAGED_END, MANAGED_START, managed_script, remove_managed_blocks, resolve_write_path,
-    uninstall_reload_command, upsert_managed_block, write_text_atomic,
+    MANAGED_END, MANAGED_START, managed_script, remove_managed_blocks, uninstall_reload_command,
+    upsert_managed_block, write_text_atomic,
 };
 #[cfg(test)]
 use scripts::nu_string_literal;

--- a/src/shell_integration/scripts.rs
+++ b/src/shell_integration/scripts.rs
@@ -1,0 +1,165 @@
+use std::path::Path;
+
+use super::Shell;
+
+pub(crate) fn binary_command(shell: Shell, invocation: Option<&str>, executable: &Path) -> String {
+    match shell {
+        Shell::Bash | Shell::Zsh | Shell::Fish => posix_binary_command(invocation, executable),
+        Shell::Nu => nu_binary_command(invocation, executable),
+    }
+}
+
+fn posix_binary_command(invocation: Option<&str>, executable: &Path) -> String {
+    let Some(invocation) = invocation else {
+        return shell_quote(executable);
+    };
+
+    if invocation.contains('/') || invocation.contains('\\') || invocation.starts_with('.') {
+        shell_quote(executable)
+    } else {
+        "command elio".to_string()
+    }
+}
+
+fn nu_binary_command(invocation: Option<&str>, executable: &Path) -> String {
+    let Some(invocation) = invocation else {
+        return nu_string_literal(executable);
+    };
+
+    if invocation.contains('/') || invocation.contains('\\') || invocation.starts_with('.') {
+        nu_string_literal(executable)
+    } else {
+        r#""elio""#.to_string()
+    }
+}
+
+pub(crate) fn init_script(shell: Shell, binary: &str) -> String {
+    match shell {
+        Shell::Bash | Shell::Zsh => posix_init_script(binary),
+        Shell::Fish => fish_init_script(binary),
+        Shell::Nu => nu_init_script(binary),
+    }
+}
+fn posix_init_script(executable: &str) -> String {
+    format!(
+        r#"elio() {{
+    case "${{1-}}" in
+        shell|-*)
+            {executable} "$@"
+            return $?
+            ;;
+    esac
+
+    local tmp cwd status_code
+    tmp="$(mktemp -t "elio-cwd.XXXXXX")" || return
+    {executable} --cwd-file "$tmp" "$@"
+    status_code=$?
+
+    if [ -s "$tmp" ]; then
+        cwd="$(cat -- "$tmp")"
+        rm -f -- "$tmp"
+        if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && [ -d "$cwd" ]; then
+            cd -- "$cwd" || return $?
+        fi
+    else
+        rm -f -- "$tmp"
+    fi
+
+    return "$status_code"
+}}
+"#
+    )
+}
+
+fn fish_init_script(executable: &str) -> String {
+    format!(
+        r#"function elio
+    switch "$argv[1]"
+        case shell '-*'
+            {executable} $argv
+            return $status
+    end
+
+    set -l tmp (mktemp -t "elio-cwd.XXXXXX")
+    or return
+
+    {executable} --cwd-file "$tmp" $argv
+    set -l status_code $status
+
+    if test -s "$tmp"
+        set -l cwd (string collect < "$tmp")
+        rm -f "$tmp"
+        if test -n "$cwd"; and test "$cwd" != "$PWD"; and test -d "$cwd"
+            cd "$cwd"; or return $status
+        end
+    else
+        rm -f "$tmp"
+    end
+
+    return $status_code
+end
+"#
+    )
+}
+
+fn nu_init_script(executable: &str) -> String {
+    format!(
+        r#"def --env --wrapped elio [...args] {{
+  if (($args | length) > 0) and (
+    (($args.0 | into string) == 'shell') or
+    (($args.0 | into string) | str starts-with '-')
+  ) {{
+    let result = (
+      try {{
+        run-external {executable} ...$args | complete
+      }} catch {{|e| {{ stdout: "", stderr: ($e.msg? | default ""), exit_code: ($e.exit_code? | default 127) }} }}
+    )
+
+    if ($result.stderr | is-not-empty) {{
+      print -e --no-newline $result.stderr
+    }}
+
+    $env.LAST_EXIT_CODE = $result.exit_code
+
+    if (is-terminal --stdout) {{
+      if ($result.stdout | is-not-empty) {{
+        print --no-newline $result.stdout
+      }}
+      return
+    }}
+
+    return $result.stdout
+  }}
+
+  let tmp = (mktemp -t "elio-cwd.XXXXXX")
+  let command_args = (["--cwd-file", $tmp] ++ $args)
+
+  let status_code = (
+    try {{
+      run-external {executable} ...$command_args
+      $env.LAST_EXIT_CODE
+    }} catch {{|e| ($e.exit_code? | default 127) }}
+  )
+
+  let cwd = if ($tmp | path exists) {{ open --raw $tmp }} else {{ "" }}
+  rm -f $tmp
+
+  if ($cwd | is-not-empty) and ($cwd != $env.PWD) and (($cwd | path type) == 'dir') {{
+    cd $cwd
+  }}
+
+  $env.LAST_EXIT_CODE = $status_code
+}}
+"#
+    )
+}
+
+pub(super) fn shell_quote(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub(super) fn nu_string_literal(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}

--- a/src/shell_integration/tests.rs
+++ b/src/shell_integration/tests.rs
@@ -2,7 +2,7 @@
 use super::resolve_write_path;
 use super::{
     MANAGED_END, MANAGED_START, Shell, ShellDetection, binary_command, detect_shell_from_command,
-    init_script, managed_script, remove_managed_blocks, shell_name_from_command,
+    init_script, managed_script, nu_string_literal, remove_managed_blocks, shell_name_from_command,
     uninstall_reload_command, upsert_managed_block, write_text_atomic,
 };
 use std::{
@@ -23,6 +23,7 @@ fn temp_path(label: &str) -> PathBuf {
 fn binary_command_uses_path_for_local_invocations() {
     assert_eq!(
         binary_command(
+            Shell::Bash,
             Some("target/debug/elio"),
             Path::new("/repo/target/debug/elio")
         ),
@@ -33,7 +34,11 @@ fn binary_command_uses_path_for_local_invocations() {
 #[test]
 fn binary_command_uses_path_for_absolute_invocations() {
     assert_eq!(
-        binary_command(Some("/opt/elio/bin/elio"), Path::new("/opt/elio/bin/elio")),
+        binary_command(
+            Shell::Bash,
+            Some("/opt/elio/bin/elio"),
+            Path::new("/opt/elio/bin/elio")
+        ),
         "'/opt/elio/bin/elio'"
     );
 }
@@ -42,6 +47,7 @@ fn binary_command_uses_path_for_absolute_invocations() {
 fn binary_command_uses_path_for_windows_invocations() {
     assert_eq!(
         binary_command(
+            Shell::Bash,
             Some(r"C:\repo\target\debug\elio.exe"),
             Path::new(r"C:\repo\target\debug\elio.exe")
         ),
@@ -52,8 +58,32 @@ fn binary_command_uses_path_for_windows_invocations() {
 #[test]
 fn binary_command_uses_path_lookup_for_normal_invocations() {
     assert_eq!(
-        binary_command(Some("elio"), Path::new("/versioned/path/elio")),
+        binary_command(Shell::Bash, Some("elio"), Path::new("/versioned/path/elio")),
         "command elio"
+    );
+}
+
+#[test]
+fn binary_command_formats_nu_invocations_for_run_external() {
+    assert_eq!(
+        binary_command(Shell::Nu, Some("elio"), Path::new("/versioned/path/elio")),
+        r#""elio""#
+    );
+    assert_eq!(
+        binary_command(
+            Shell::Nu,
+            Some("target/debug/elio"),
+            Path::new("/repo/target/debug/elio")
+        ),
+        r#""/repo/target/debug/elio""#
+    );
+}
+
+#[test]
+fn nu_string_literal_escapes_backslashes_and_quotes() {
+    assert_eq!(
+        nu_string_literal(Path::new(r#"/tmp/path with spaces/eli"o\bin"#)),
+        r#""/tmp/path with spaces/eli\"o\\bin""#
     );
 }
 
@@ -83,6 +113,24 @@ fn fish_init_script_passes_cli_commands_through() {
 }
 
 #[test]
+fn nu_init_script_passes_cli_commands_through_without_posix_syntax() {
+    let script = init_script(Shell::Nu, r#""elio""#);
+
+    assert!(script.contains("def --env --wrapped elio [...args]"));
+    assert!(script.contains("run-external \"elio\" ...$args"));
+    assert!(script.contains("mktemp -t \"elio-cwd.XXXXXX\""));
+    assert!(script.contains("let command_args = ([\"--cwd-file\", $tmp] ++ $args)"));
+    assert!(script.contains("run-external \"elio\" ...$command_args"));
+    assert!(script.contains("$env.LAST_EXIT_CODE = $status_code"));
+    assert!(script.contains("$e.exit_code? | default 127"));
+    assert!(script.contains("cd $cwd"));
+    assert!(!script.contains("local tmp"));
+    assert!(!script.contains("case \"${1-}\""));
+    assert!(!script.contains("command elio"));
+    assert!(!script.contains("return $status_code"));
+}
+
+#[test]
 fn shell_name_from_command_handles_paths_login_shells_and_arguments() {
     assert_eq!(
         shell_name_from_command("/usr/bin/zsh\n").as_deref(),
@@ -104,7 +152,11 @@ fn detect_shell_from_command_distinguishes_supported_unsupported_and_unknown() {
     );
     assert_eq!(
         detect_shell_from_command("/usr/bin/nu --login\n"),
-        ShellDetection::Unsupported("nu".to_string())
+        ShellDetection::Supported(Shell::Nu)
+    );
+    assert_eq!(
+        detect_shell_from_command("-nushell\n"),
+        ShellDetection::Supported(Shell::Nu)
     );
     assert_eq!(
         detect_shell_from_command("shell_integration_cli\n"),
@@ -123,6 +175,7 @@ fn uninstall_reload_command_removes_loaded_function() {
         uninstall_reload_command(Shell::Fish),
         "functions --erase elio"
     );
+    assert_eq!(uninstall_reload_command(Shell::Nu), "hide elio");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -37,14 +37,19 @@ fn help_prints_usage() {
     assert!(stdout.contains("-V, --version        Print version"));
     assert!(stdout.contains("Commands:"));
     assert!(
-        stdout.contains("shell init <SHELL>        Print shell integration for bash, zsh, or fish")
+        stdout.contains(
+            "shell init <SHELL>        Print shell integration for bash, zsh, fish, or nu"
+        )
     );
     assert!(
-        stdout
-            .contains("shell install [SHELL]    Install shell integration for bash, zsh, or fish")
+        stdout.contains(
+            "shell install [SHELL]    Install shell integration for bash, zsh, fish, or nu"
+        )
     );
     assert!(
-        stdout.contains("shell uninstall [SHELL]  Remove shell integration for bash, zsh, or fish")
+        stdout.contains(
+            "shell uninstall [SHELL]  Remove shell integration for bash, zsh, fish, or nu"
+        )
     );
     assert!(output.stderr.is_empty());
 }

--- a/tests/shell_integration_cli.rs
+++ b/tests/shell_integration_cli.rs
@@ -57,6 +57,10 @@ fn assert_stderr_contains(command: &str, output: &Output, expected: &str) {
     );
 }
 
+fn nu_literal(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
 #[test]
 fn shell_init_fish_prints_sourceable_function() {
     let output = elio()
@@ -133,7 +137,7 @@ fn shell_init_nu_prints_sourceable_command() {
     assert_no_stderr("elio shell init nu", &output);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("def --env --wrapped elio [...args]"));
-    assert!(stdout.contains(env!("CARGO_BIN_EXE_elio")));
+    assert!(stdout.contains(&nu_literal(env!("CARGO_BIN_EXE_elio"))));
     assert!(stdout.contains("run-external"));
     assert!(stdout.contains("--cwd-file"));
     assert!(stdout.contains("$env.LAST_EXIT_CODE = $status_code"));
@@ -162,7 +166,7 @@ fn shell_install_nu_writes_autoload_file() {
     let integration = config_home.join("nushell/autoload/elio.nu");
     let script = fs::read_to_string(&integration).expect("nu integration should be written");
     assert!(script.contains("def --env --wrapped elio"));
-    assert!(script.contains(env!("CARGO_BIN_EXE_elio")));
+    assert!(script.contains(&nu_literal(env!("CARGO_BIN_EXE_elio"))));
     assert!(script.contains("run-external"));
     assert!(script.contains("--cwd-file"));
 

--- a/tests/shell_integration_cli.rs
+++ b/tests/shell_integration_cli.rs
@@ -123,6 +123,204 @@ fn shell_init_zsh_prints_function() {
 }
 
 #[test]
+fn shell_init_nu_prints_sourceable_command() {
+    let output = elio()
+        .args(["shell", "init", "nu"])
+        .output()
+        .expect("failed to run elio shell init nu");
+
+    assert_success("elio shell init nu", &output);
+    assert_no_stderr("elio shell init nu", &output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("def --env --wrapped elio [...args]"));
+    assert!(stdout.contains(env!("CARGO_BIN_EXE_elio")));
+    assert!(stdout.contains("run-external"));
+    assert!(stdout.contains("--cwd-file"));
+    assert!(stdout.contains("$env.LAST_EXIT_CODE = $status_code"));
+    assert!(!stdout.contains("command elio"));
+    assert!(!stdout.contains("local tmp"));
+}
+
+#[test]
+fn shell_install_nu_writes_autoload_file() {
+    let root = temp_path("nu-install");
+    let config_home = root.join("config");
+
+    let output = elio()
+        .args(["shell", "install", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install nu");
+
+    assert_success("elio shell install nu", &output);
+    assert_no_stderr("elio shell install nu", &output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Installed elio shell integration for nu"));
+    assert!(stdout.contains("nushell/autoload/elio.nu"));
+    assert!(stdout.contains(r#"source ""#));
+
+    let integration = config_home.join("nushell/autoload/elio.nu");
+    let script = fs::read_to_string(&integration).expect("nu integration should be written");
+    assert!(script.contains("def --env --wrapped elio"));
+    assert!(script.contains(env!("CARGO_BIN_EXE_elio")));
+    assert!(script.contains("run-external"));
+    assert!(script.contains("--cwd-file"));
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[test]
+fn shell_install_nu_refuses_unmanaged_autoload_file() {
+    let root = temp_path("nu-install-unmanaged");
+    let config_home = root.join("config");
+    let integration = config_home.join("nushell/autoload/elio.nu");
+    fs::create_dir_all(
+        integration
+            .parent()
+            .expect("integration should have a parent"),
+    )
+    .expect("nu autoload directory should be created");
+    fs::write(
+        &integration,
+        "def elio [] {}
+",
+    )
+    .expect("unmanaged file should be written");
+
+    let output = elio()
+        .args(["shell", "install", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install nu");
+
+    assert_failure("elio shell install nu", &output);
+    assert_no_stdout("elio shell install nu", &output);
+    assert_stderr_contains("elio shell install nu", &output, "not managed by elio");
+    assert_eq!(
+        fs::read_to_string(&integration).expect("unmanaged file should be readable"),
+        "def elio [] {}
+"
+    );
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[test]
+fn shell_uninstall_nu_removes_managed_autoload_file_idempotently() {
+    let root = temp_path("nu-uninstall");
+    let config_home = root.join("config");
+    let integration = config_home.join("nushell/autoload/elio.nu");
+
+    let install = elio()
+        .args(["shell", "install", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install nu");
+    assert_success("elio shell install nu", &install);
+
+    let uninstall = elio()
+        .args(["shell", "uninstall", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell uninstall nu");
+
+    assert_success("elio shell uninstall nu", &uninstall);
+    assert_no_stderr("elio shell uninstall nu", &uninstall);
+    let stdout = String::from_utf8_lossy(&uninstall.stdout);
+    assert!(stdout.contains("Uninstalled elio shell integration for nu"));
+    assert!(stdout.contains("Removed:"));
+    assert!(stdout.contains("hide elio"));
+    assert!(!integration.exists());
+
+    let uninstall_again = elio()
+        .args(["shell", "uninstall", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell uninstall nu again");
+    assert_success("elio shell uninstall nu", &uninstall_again);
+    assert_no_stderr("elio shell uninstall nu", &uninstall_again);
+    assert!(String::from_utf8_lossy(&uninstall_again.stdout).contains("No integration found at:"));
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_install_nu_preserves_symlinked_autoload_directory() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_path("nu-install-autoload-symlink");
+    let config_home = root.join("config");
+    let nushell_dir = config_home.join("nushell");
+    let dotfiles_autoload = root.join("dotfiles/nushell/autoload");
+    fs::create_dir_all(&nushell_dir).expect("nushell directory should be created");
+    fs::create_dir_all(&dotfiles_autoload).expect("dotfiles autoload should be created");
+    symlink(&dotfiles_autoload, nushell_dir.join("autoload"))
+        .expect("autoload symlink should be created");
+
+    let output = elio()
+        .args(["shell", "install", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install nu");
+
+    assert_success("elio shell install nu", &output);
+    assert_no_stderr("elio shell install nu", &output);
+    assert!(dotfiles_autoload.join("elio.nu").exists());
+    assert!(config_home.join("nushell/autoload/elio.nu").exists());
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_install_nu_preserves_symlinked_autoload_file() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_path("nu-install-file-symlink");
+    let config_home = root.join("config");
+    let autoload = config_home.join("nushell/autoload");
+    let dotfiles = root.join("dotfiles");
+    fs::create_dir_all(&autoload).expect("autoload should be created");
+    fs::create_dir_all(&dotfiles).expect("dotfiles should be created");
+    let target = dotfiles.join("elio.nu");
+    let link = autoload.join("elio.nu");
+    fs::write(
+        &target,
+        "# >>> elio shell integration >>>
+def elio [] {}
+# <<< elio shell integration <<<
+",
+    )
+    .expect("target should be written");
+    symlink(&target, &link).expect("autoload file symlink should be created");
+
+    let output = elio()
+        .args(["shell", "install", "nu"])
+        .env("XDG_CONFIG_HOME", &config_home)
+        .output()
+        .expect("failed to run elio shell install nu");
+
+    assert_success("elio shell install nu", &output);
+    assert_no_stderr("elio shell install nu", &output);
+    assert!(
+        fs::symlink_metadata(&link)
+            .expect("link metadata should be readable")
+            .file_type()
+            .is_symlink(),
+        "install should preserve symlinked elio.nu"
+    );
+    let target_contents = fs::read_to_string(&target).expect("target should be readable");
+    assert!(target_contents.contains("def --env --wrapped elio"));
+    assert_eq!(
+        fs::read_to_string(&link).expect("link should resolve"),
+        target_contents
+    );
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}
+
+#[test]
 fn shell_install_fish_writes_conf_d_file() {
     let root = temp_path("fish-install");
     let config_home = root.join("config");
@@ -917,7 +1115,7 @@ fn shell_init_rejects_unsupported_shell() {
     assert_stderr_contains(
         "elio shell init powershell",
         &output,
-        "supported shells: bash, zsh, fish",
+        "supported shells: bash, zsh, fish, nu",
     );
 }
 

--- a/tests/shell_runtime_cli.rs
+++ b/tests/shell_runtime_cli.rs
@@ -74,6 +74,7 @@ struct RuntimeFixture {
 enum ShellSyntax {
     Posix,
     Fish,
+    Nu,
 }
 
 #[test]
@@ -91,6 +92,11 @@ fn generated_fish_function_runs_when_executed() -> Result<(), Box<dyn Error>> {
     run_generated_function("fish", ShellSyntax::Fish)
 }
 
+#[test]
+fn generated_nu_function_runs_when_executed() -> Result<(), Box<dyn Error>> {
+    run_generated_function("nu", ShellSyntax::Nu)
+}
+
 fn run_generated_function(shell: &str, syntax: ShellSyntax) -> Result<(), Box<dyn Error>> {
     if !shell_available(shell) {
         return Ok(());
@@ -100,11 +106,15 @@ fn run_generated_function(shell: &str, syntax: ShellSyntax) -> Result<(), Box<dy
     let runtime_script = match syntax {
         ShellSyntax::Posix => posix_runtime_script(&fixture.init_script, &fixture.start_dir),
         ShellSyntax::Fish => fish_runtime_script(&fixture.init_script, &fixture.start_dir),
+        ShellSyntax::Nu => nu_runtime_script(&fixture.init_script, &fixture.start_dir),
     };
 
     let mut command = Command::new(shell);
     if matches!(syntax, ShellSyntax::Fish) {
         command.arg("--no-config");
+    }
+    if matches!(syntax, ShellSyntax::Nu) {
+        command.arg("--no-config-file");
     }
     command.arg("-c").arg(runtime_script);
     configure_runtime_environment(&mut command, &fixture)?;
@@ -150,8 +160,13 @@ fn runtime_fixture(shell: &str) -> Result<RuntimeFixture, Box<dyn Error>> {
     );
 
     let script = String::from_utf8(output.stdout)?;
+    let expected_path_call = if shell == "nu" {
+        r#"run-external "elio""#
+    } else {
+        "command elio"
+    };
     assert!(
-        script.contains("command elio"),
+        script.contains(expected_path_call),
         "official-install {shell} init script should call elio from PATH:\n{script}"
     );
     assert!(
@@ -254,6 +269,39 @@ printf 'shell_code=%s\n' "$status"
     )
 }
 
+fn nu_runtime_script(init_script: &Path, start_dir: &Path) -> String {
+    let pipeline_output = start_dir.join("nu-shell-pipeline.txt");
+    format!(
+        r#"source {}
+mkdir {}
+cd {}
+
+elio
+print $"cwd=($env.PWD) code=($env.LAST_EXIT_CODE)"
+
+cd {}
+elio empty
+print $"empty_cwd=($env.PWD) empty_code=($env.LAST_EXIT_CODE)"
+
+elio --help
+print $"help_code=($env.LAST_EXIT_CODE)"
+
+elio shell status
+print $"shell_code=($env.LAST_EXIT_CODE)"
+
+elio shell status | save -f {}
+print $"shell_pipeline_code=($env.LAST_EXIT_CODE)"
+print $"shell_pipeline=(open --raw {})"
+"#,
+        nu_quote(init_script),
+        nu_quote(start_dir),
+        nu_quote(start_dir),
+        nu_quote(start_dir),
+        nu_quote(&pipeline_output),
+        nu_quote(&pipeline_output),
+    )
+}
+
 fn assert_runtime_output(output: std::process::Output, start_dir: &Path) {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -274,22 +322,37 @@ fn assert_runtime_output(output: std::process::Output, start_dir: &Path) {
         stdout.contains(&format!("empty_cwd={} empty_code=9", start_dir.display())),
         "empty cwd file should leave the shell in the original directory\nstdout:\n{stdout}"
     );
-    assert!(
-        stdout.contains("HELP-PASSTHROUGH"),
-        "--help should pass through to the real executable\nstdout:\n{stdout}"
-    );
+    let has_nu_pipeline_checks = stdout.contains("shell_pipeline_code=");
+    if !has_nu_pipeline_checks {
+        assert!(
+            stdout.contains("HELP-PASSTHROUGH"),
+            "--help should pass through to the real executable\nstdout:\n{stdout}"
+        );
+    }
     assert!(
         stdout.contains("help_code=3"),
         "--help should preserve the real executable status\nstdout:\n{stdout}"
     );
-    assert!(
-        stdout.contains("SHELL-PASSTHROUGH"),
-        "shell subcommands should pass through to the real executable\nstdout:\n{stdout}"
-    );
+    if !has_nu_pipeline_checks {
+        assert!(
+            stdout.contains("SHELL-PASSTHROUGH"),
+            "shell subcommands should pass through to the real executable\nstdout:\n{stdout}"
+        );
+    }
     assert!(
         stdout.contains("shell_code=4"),
         "shell subcommands should preserve the real executable status\nstdout:\n{stdout}"
     );
+    if has_nu_pipeline_checks {
+        assert!(
+            stdout.contains("shell_pipeline_code=4"),
+            "Nu shell subcommand pipelines should preserve the real executable status\nstdout:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("shell_pipeline=SHELL-PASSTHROUGH"),
+            "Nu shell subcommand pipelines should receive the real executable stdout\nstdout:\n{stdout}"
+        );
+    }
 }
 
 fn shell_available(shell: &str) -> bool {
@@ -313,4 +376,9 @@ fn path_with_prefix(prefix: &Path) -> Result<OsString, Box<dyn Error>> {
 fn shell_quote(path: &Path) -> String {
     let value = path.to_string_lossy();
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn nu_quote(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }


### PR DESCRIPTION
## Summary

Adds Nushell support for elio’s shell integration, including cwd propagation on quit, install/uninstall support, docs, and tests.

Closes #129.

## What Changed

- Added Nushell support for:
  - `elio shell init nu`
  - `elio shell install nu`
  - `elio shell uninstall nu`
- Added Nu autoload installation at:
  - `~/.config/nushell/autoload/elio.nu`
- Added a Nu-native wrapper using `def --env --wrapped elio [...args]`.
- Preserved cwd propagation on quit through `--cwd-file`.
- Preserved passthrough behavior for:
  - `elio shell ...`
  - flag-like commands such as `elio --help` / `elio --version`
- Preserved stdout/stderr/status behavior for CLI commands and Nu pipelines.
- Refactored shell integration code into dedicated script/install modules.
- Expanded shell integration test coverage across init/install/uninstall and runtime behavior.
- Included a test-only Sixel overlay adjustment needed to keep the full test suite green.

## User Impact

Nushell users can now install elio’s shell integration and have their parent shell change directory after quitting elio, matching the existing Bash/Zsh/Fish behavior.

The Nu integration uses Nushell autoload instead of editing `config.nu`, so install/uninstall stays targeted and reversible.

Existing Bash, Zsh, and Fish integrations should behave the same as before.

## Notes

The Nu wrapper intentionally uses `run-external` and an autoloaded `def --env --wrapped` function so it can call the installed binary correctly, preserve CLI command behavior, and update `$env.PWD` in the parent Nu session.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual testing:

- CachyOS:
  - Installed with `cargo install --path .`.
  - Tested Nushell init/install/source/uninstall/hide flow.
  - Tested real Nushell cwd propagation after quitting elio.
  - Smoke-tested Fish integration.
- Ubuntu VM:
  - Installed with `cargo install --path .`.
  - Tested Nushell init/install/source/uninstall/hide flow.
  - Tested real Nushell cwd propagation after quitting elio.
  - Smoke-tested Bash integration.

## Documentation and Changelog

- [x] Documentation updated
- [x] Changelog updated
- [ ] Docs and changelog are not needed
