### PR TITLE
feat(trash): add permanent delete shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
+
 ## [1.7.0] - 2026-05-30
 
 ### Added
@@ -199,3 +203,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#129]: https://github.com/elio-fm/elio/issues/129
 [#134]: https://github.com/elio-fm/elio/issues/134
 [#138]: https://github.com/elio-fm/elio/pull/138
+[#140]: https://github.com/elio-fm/elio/issues/140

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ elio supports common file-manager actions directly from the keyboard:
 - `O` opens files through the Open With flow when supported, including terminal apps.
 - `c` copies names, paths, or directory paths using OSC52 or the platform clipboard.
 - `g` opens quick jumps for common locations such as Home, Downloads, config, and Trash.
-- `d` moves files to Trash; in the Trash view, `d` deletes permanently and `r` restores.
+- `d` moves files to Trash; `D` deletes permanently; in the Trash view, `d` also deletes permanently and `r` restores.
 - `f` searches folders, while `Ctrl+F` searches files in the current tree.
 - `z` jumps through zoxide history when `zoxide` is installed.
 - `!` opens a shell in the current folder and returns to elio when the shell exits.
@@ -291,6 +291,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `!` `*` | Open shell in current folder |
 | `a` `*` | Create file or folder |
 | `d` `*` | Trash; permanently delete if already in trash |
+| `D` `*` | Delete permanently |
 | `r` `*` | Rename / bulk rename / restore from trash |
 | `F2` | Rename / bulk rename |
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -67,6 +67,7 @@ show_top_bar = false
 # cut                  = "x"
 # paste                = "p"
 # trash                = "d"
+# delete_permanently   = "D"   # Shift+D
 # create               = "a"
 # rename               = "r"
 # copy_path            = "c"

--- a/src/app/create/tests.rs
+++ b/src/app/create/tests.rs
@@ -313,6 +313,32 @@ fn confirm_trash_permanently_deletes_selected_items_inside_trash() {
 }
 
 #[test]
+fn confirm_delete_permanently_removes_selected_items_outside_trash() {
+    let root = temp_path("delete-permanent-outside-trash");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("gone.txt"), "bye").expect("failed to write file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(root.join("gone.txt"));
+    app.open_delete_permanently_prompt();
+
+    assert_eq!(app.trash_title(), "Delete permanently 1 selected file?");
+    app.confirm_trash().expect("delete should succeed");
+
+    assert!(app.overlays.trash.is_none());
+    assert!(app.navigation.selected_paths.is_empty());
+
+    wait_for_trash_and_reload(&mut app);
+
+    assert!(!root.join("gone.txt").exists());
+    assert_eq!(app.status_message(), "Permanently deleted \"gone.txt\"");
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn after_delete_cursor_moves_to_next_surviving_entry() {
     // Deleting a middle entry should leave the cursor on what was the
     // entry immediately below it (now occupying the same visual row).

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -71,7 +71,20 @@ impl App {
             return;
         }
 
-        let permanent = self.cwd_is_trash();
+        self.open_trash_prompt_for_targets(targets, self.cwd_is_trash());
+    }
+
+    pub(in crate::app) fn open_delete_permanently_prompt(&mut self) {
+        let targets = self.selected_trash_targets();
+
+        if targets.is_empty() {
+            return;
+        }
+
+        self.open_trash_prompt_for_targets(targets, true);
+    }
+
+    fn open_trash_prompt_for_targets(&mut self, targets: Vec<TrashTarget>, permanent: bool) {
         self.overlays.help = false;
         self.overlays.search = None;
         self.overlays.create = None;

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -270,6 +270,7 @@ impl App {
             Action::Cut => self.cut(),
             Action::Paste => self.paste()?,
             Action::Trash => self.open_trash_prompt(),
+            Action::DeletePermanently => self.open_delete_permanently_prompt(),
             Action::Create => self.open_create_prompt(),
             Action::Rename => {
                 if self.navigation.in_trash {

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -106,6 +106,47 @@ fn capital_q_quits_without_changing_directory() {
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
+#[test]
+fn capital_d_opens_permanent_delete_prompt_outside_trash() {
+    let root = temp_path("delete-permanently-shortcut");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("gone.txt"), "bye").expect("failed to write file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('D'))))
+        .expect("D should open permanent delete prompt");
+
+    assert!(app.trash_is_open());
+    assert_eq!(app.trash_title(), "Delete permanently 1 selected file?");
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn capital_d_permanent_delete_prompt_uses_selection() {
+    let root = temp_path("delete-permanently-selection-shortcut");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha);
+    app.navigation.selected_paths.insert(beta);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('D'))))
+        .expect("D should open permanent delete prompt");
+
+    assert!(app.trash_is_open());
+    assert_eq!(app.trash_title(), "Delete permanently 2 files?");
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn enter_opens_selected_file_with_system_opener() {

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -9,6 +9,7 @@ pub(crate) enum Action {
     Cut,
     Paste,
     Trash,
+    DeletePermanently,
     Create,
     Rename,
     CopyPath,
@@ -37,6 +38,7 @@ pub(crate) struct KeyBindings {
     pub cut: char,
     pub paste: char,
     pub trash: char,
+    pub delete_permanently: char,
     pub create: char,
     pub rename: char,
     pub copy_path: char,
@@ -74,6 +76,7 @@ impl Default for KeyBindings {
             cut: 'x',
             paste: 'p',
             trash: 'd',
+            delete_permanently: 'D',
             create: 'a',
             rename: 'r',
             copy_path: 'c',
@@ -101,6 +104,7 @@ pub(super) struct KeysConfigOverride {
     cut: Option<String>,
     paste: Option<String>,
     trash: Option<String>,
+    delete_permanently: Option<String>,
     create: Option<String>,
     rename: Option<String>,
     copy_path: Option<String>,
@@ -128,6 +132,7 @@ impl KeyBindings {
             _ if c == self.cut => Some(Action::Cut),
             _ if c == self.paste => Some(Action::Paste),
             _ if c == self.trash => Some(Action::Trash),
+            _ if c == self.delete_permanently => Some(Action::DeletePermanently),
             _ if c == self.create => Some(Action::Create),
             _ if c == self.rename => Some(Action::Rename),
             _ if c == self.copy_path => Some(Action::CopyPath),
@@ -160,7 +165,7 @@ impl KeyBindings {
 
     pub(super) fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
         // Each entry: (field_name, user_override_string, default_char)
-        let raw: [(&str, Option<String>, char); 21] = [
+        let raw: [(&str, Option<String>, char); 22] = [
             ("quit", overrides.quit, defaults.quit),
             (
                 "quit_without_cd",
@@ -171,6 +176,11 @@ impl KeyBindings {
             ("cut", overrides.cut, defaults.cut),
             ("paste", overrides.paste, defaults.paste),
             ("trash", overrides.trash, defaults.trash),
+            (
+                "delete_permanently",
+                overrides.delete_permanently,
+                defaults.delete_permanently,
+            ),
             ("create", overrides.create, defaults.create),
             ("rename", overrides.rename, defaults.rename),
             ("copy_path", overrides.copy_path, defaults.copy_path),
@@ -215,7 +225,7 @@ impl KeyBindings {
         // Step 1: parse each override string independently, falling back to
         // default on any format or reserved-char error.
         // (resolved_char, is_user_set)
-        let mut candidates: [(char, bool); 21] = [(' ', false); 21];
+        let mut candidates: [(char, bool); 22] = [(' ', false); 22];
         for (index, (name, override_str, default)) in raw.iter().enumerate() {
             candidates[index] = match override_str {
                 None => (*default, false),
@@ -254,12 +264,12 @@ impl KeyBindings {
         // binding does not silently leave a conflict with another.
         loop {
             let mut changed = false;
-            for index in 0..21 {
+            for index in 0..22 {
                 if !candidates[index].1 {
                     continue;
                 }
                 let candidate = candidates[index].0;
-                let collision = (0..21)
+                let collision = (0..22)
                     .filter(|&other_index| other_index != index)
                     .any(|other_index| candidates[other_index].0 == candidate);
                 if collision {
@@ -295,21 +305,22 @@ impl KeyBindings {
             cut: resolved(3),
             paste: resolved(4),
             trash: resolved(5),
-            create: resolved(6),
-            rename: resolved(7),
-            copy_path: resolved(8),
-            search_folders: resolved(9),
-            zoxide: resolved(10),
-            shell: resolved(11),
-            open: resolved(12),
-            open_with: resolved(13),
-            sort: resolved(14),
-            toggle_view: resolved(15),
-            toggle_hidden: resolved(16),
-            scroll_preview_left: resolved(17),
-            scroll_preview_right: resolved(18),
-            scroll_preview_up: resolved(19),
-            scroll_preview_down: resolved(20),
+            delete_permanently: resolved(6),
+            create: resolved(7),
+            rename: resolved(8),
+            copy_path: resolved(9),
+            search_folders: resolved(10),
+            zoxide: resolved(11),
+            shell: resolved(12),
+            open: resolved(13),
+            open_with: resolved(14),
+            sort: resolved(15),
+            toggle_view: resolved(16),
+            toggle_hidden: resolved(17),
+            scroll_preview_left: resolved(18),
+            scroll_preview_right: resolved(19),
+            scroll_preview_up: resolved(20),
+            scroll_preview_down: resolved(21),
         }
     }
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -6,6 +6,7 @@ fn keys_default_bindings_are_sane() {
     assert_eq!(config.keys.yank, 'y');
     assert_eq!(config.keys.cut, 'x');
     assert_eq!(config.keys.paste, 'p');
+    assert_eq!(config.keys.delete_permanently, 'D');
     assert_eq!(config.keys.quit, 'q');
     assert_eq!(config.keys.quit_without_cd, 'Q');
     assert_eq!(config.keys.zoxide, 'z');
@@ -119,6 +120,10 @@ fn action_for_returns_correct_action_for_default_bindings() {
     assert_eq!(key_bindings.action_for('y'), Some(Action::Yank));
     assert_eq!(key_bindings.action_for('x'), Some(Action::Cut));
     assert_eq!(key_bindings.action_for('p'), Some(Action::Paste));
+    assert_eq!(
+        key_bindings.action_for('D'),
+        Some(Action::DeletePermanently)
+    );
     assert_eq!(key_bindings.action_for('q'), Some(Action::Quit));
     assert_eq!(key_bindings.action_for('Q'), Some(Action::QuitWithoutCd));
     assert_eq!(key_bindings.action_for('o'), Some(Action::Open));
@@ -139,6 +144,19 @@ yank = "Y"
     .expect("config should parse");
     assert_eq!(config.keys.action_for('Y'), Some(Action::Yank));
     assert_eq!(config.keys.action_for('y'), None);
+}
+
+#[test]
+fn delete_permanently_can_be_overridden() {
+    let config = Config::from_str(
+        r#"
+[keys]
+delete_permanently = "X"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('X'), Some(Action::DeletePermanently));
+    assert_eq!(config.keys.action_for('D'), None);
 }
 
 #[test]

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1251,6 +1251,10 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
         "expected help overlay to show the current create prompt newline hint, got: {rendered:?}"
     );
     assert!(
+        rendered.contains("delete permanently"),
+        "expected help overlay to list the permanent delete shortcut, got: {rendered:?}"
+    );
+    assert!(
         rendered.contains("Wheel              scroll"),
         "expected help overlay to describe wheel routing accurately, got: {rendered:?}"
     );

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -51,6 +51,7 @@ pub(super) fn render_help(
         e(&kb.create.to_string(), "create file or folder"),
         e("Alt/Shift+Enter", "add line in create prompt"),
         e(&kb.trash.to_string(), "trash (delete if in trash)"),
+        e(&kb.delete_permanently.to_string(), "delete permanently"),
         e(&rename_key, "rename (bulk if selection)"),
         e(&rename_trash_key, "restore from trash"),
         e(&kb.shell.to_string(), "open shell here"),


### PR DESCRIPTION
## Summary

Adds a configurable permanent delete shortcut for focused or selected entries.

Closes #140.

## What Changed

- Added `delete_permanently` to configurable key bindings, defaulting to `D`.
- Routed `D` through the existing destructive delete confirmation flow.
- Kept `d` as move-to-Trash outside Trash.
- Kept existing Trash-view behavior where `d` permanently deletes and `r` restores.
- Preserved selection-aware behavior: selected entries win over the focused entry.
- Updated the help overlay, README, example config, and changelog.
- Added regression coverage for the key binding, prompt routing, selection behavior, actual deletion, and help text.

## User Impact

Users can now permanently delete files or folders directly with `D` / `Shift+D`, while `d` remains the safer move-to-Trash action.

Because the new action is destructive, it still requires confirmation before deleting.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested permanent delete for a focused entry.
- Tested bulk permanent delete for selected entries.

Result:

All checks passed locally, and permanent delete behavior matched the expected UX.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
