### PR TITLE
feat(keys): add configurable navigation bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for assigning multiple single-character bindings to each configurable `[keys]` action, while keeping existing single-string key config compatible.
+- Added configurable navigation bindings for `nav_left`, `nav_down`, `nav_up`, and `nav_right`, including named arrow keys.
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
 
 ## [1.7.0] - 2026-05-30

--- a/README.md
+++ b/README.md
@@ -258,15 +258,16 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept either a single one-character string or a list, such as `open_with = ["O", "w"]`.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept either one key or a list, such as `open_with = ["O", "w"]`. Navigation actions also accept `left`, `right`, `up`, and `down`. Setting an action replaces its full default key list.
 
 ### Navigation
 
 | Key | Action |
 |---|---|
-| `↑` / `↓` · `j` / `k` | Move selection |
-| `←` · `h` · `Backspace` | Go to parent directory |
-| `→` · `l` | Enter folder |
+| `k` / `↑` `*` | Move up |
+| `j` / `↓` `*` | Move down |
+| `h` / `←` `*` / `Backspace` | Go to parent directory |
+| `l` / `→` `*` | Enter folder |
 | `Enter` | Enter folder / open file or selection |
 | `g` | Go-to menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash) |
 | `G` | Jump to last item |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,7 +1,7 @@
 # Copy to ~/.config/elio/config.toml to customize Elio's behavior.
 
-[ui]
-show_top_bar = false
+# [ui]
+# show_top_bar = false
 # grid_zoom = 1    # starting zoom level for grid view: 0, 1, or 2 (clamped)
 # show_hidden = false  # show dotfiles and hidden files on startup (toggle with .)
 # start_in_grid = false  # open in grid view on startup (toggle with v)
@@ -57,12 +57,20 @@ show_top_bar = false
 # files = 45
 # preview = 45
 
-# Rebind browser action keys. Each value may be a single one-character string
-# or a list of one-character strings, e.g. open_with = ["O", "w"].
-# Reserved (never rebindable): h j k l g G ? [ ] + = - _ Space
+# Rebind browser action keys. Each value may be a single one-character string,
+# a list of one-character strings, or the named arrow keys "left", "right",
+# "up", and "down" for navigation actions.
+# Example: open_with = ["O", "w"].
+# Setting a key replaces that action's full default list, not just one entry.
+# Example: nav_down = "j" removes the default "down" arrow binding.
+# Reserved (never rebindable): g G ? [ ] + = - _ Space
 # Omit any key to keep the built-in default shown in the comment.
 #
 # [keys]
+# nav_left            = ["h", "left"]
+# nav_down            = ["j", "down"]
+# nav_up              = ["k", "up"]
+# nav_right           = ["l", "right"]
 # quit                 = "q"
 # yank                 = "y"
 # cut                  = "x"

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -202,23 +202,11 @@ impl App {
             }
             KeyCode::Tab => self.step_sidebar_place(1)?,
             KeyCode::BackTab => self.step_sidebar_place(-1)?,
-            KeyCode::Up | KeyCode::Char('k') => self.move_vertical_keyboard(-1),
-            KeyCode::Down | KeyCode::Char('j') => self.move_vertical_keyboard(1),
-            KeyCode::Left | KeyCode::Char('h') => {
-                if self.navigation.view_mode == ViewMode::Grid {
-                    self.move_by_keyboard(-1);
-                } else {
-                    self.go_parent()?;
-                }
-            }
-            KeyCode::Right | KeyCode::Char('l') => {
-                if self.navigation.view_mode == ViewMode::Grid {
-                    self.move_by_keyboard(1);
-                } else if let Some(entry) = self.selected_entry().filter(|entry| entry.is_dir()) {
-                    self.set_dir(entry.path.clone())?;
-                } else {
-                    self.status = "Press Enter to open files".to_string();
-                }
+            _ if crate::config::keys().action_for_key(key).is_some() => {
+                let action = crate::config::keys()
+                    .action_for_key(key)
+                    .expect("action was checked above");
+                self.dispatch_action(action)?;
             }
             KeyCode::PageUp => self.page(-1),
             KeyCode::PageDown => self.page(1),
@@ -302,6 +290,24 @@ impl App {
             Action::Sort => self.cycle_sort_mode()?,
             Action::ToggleView => self.toggle_view_mode(),
             Action::ToggleHidden => self.toggle_hidden_files()?,
+            Action::NavLeft => {
+                if self.navigation.view_mode == ViewMode::Grid {
+                    self.move_by_keyboard(-1);
+                } else {
+                    self.go_parent()?;
+                }
+            }
+            Action::NavDown => self.move_vertical_keyboard(1),
+            Action::NavUp => self.move_vertical_keyboard(-1),
+            Action::NavRight => {
+                if self.navigation.view_mode == ViewMode::Grid {
+                    self.move_by_keyboard(1);
+                } else if let Some(entry) = self.selected_entry().filter(|entry| entry.is_dir()) {
+                    self.set_dir(entry.path.clone())?;
+                } else {
+                    self.status = "Press Enter to open files".to_string();
+                }
+            }
             Action::ScrollPreviewLeft => {
                 let _ = self.scroll_preview_columns(-1);
             }
@@ -355,16 +361,18 @@ impl App {
             return None;
         }
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') => Some(NavigationRepeatKey::Up),
-            KeyCode::Down | KeyCode::Char('j') => Some(NavigationRepeatKey::Down),
-            KeyCode::Left | KeyCode::Char('h') => Some(NavigationRepeatKey::Left),
-            KeyCode::Right | KeyCode::Char('l') => Some(NavigationRepeatKey::Right),
-            KeyCode::PageUp => Some(NavigationRepeatKey::PageUp),
-            KeyCode::PageDown => Some(NavigationRepeatKey::PageDown),
-            KeyCode::Home => Some(NavigationRepeatKey::Home),
-            KeyCode::End | KeyCode::Char('G') => Some(NavigationRepeatKey::End),
-            _ => None,
+        match crate::config::keys().action_for_key(key) {
+            Some(crate::config::Action::NavUp) => Some(NavigationRepeatKey::Up),
+            Some(crate::config::Action::NavDown) => Some(NavigationRepeatKey::Down),
+            Some(crate::config::Action::NavLeft) => Some(NavigationRepeatKey::Left),
+            Some(crate::config::Action::NavRight) => Some(NavigationRepeatKey::Right),
+            _ => match key.code {
+                KeyCode::PageUp => Some(NavigationRepeatKey::PageUp),
+                KeyCode::PageDown => Some(NavigationRepeatKey::PageDown),
+                KeyCode::Home => Some(NavigationRepeatKey::Home),
+                KeyCode::End | KeyCode::Char('G') => Some(NavigationRepeatKey::End),
+                _ => None,
+            },
         }
     }
 

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -1,3 +1,4 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::Deserialize;
 
 /// A browser action that can be triggered by a configurable key binding.
@@ -21,41 +22,131 @@ pub(crate) enum Action {
     Sort,
     ToggleView,
     ToggleHidden,
+    NavLeft,
+    NavDown,
+    NavUp,
+    NavRight,
     ScrollPreviewLeft,
     ScrollPreviewRight,
     ScrollPreviewUp,
     ScrollPreviewDown,
 }
 
-/// One or more single-character key bindings for a browser action.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum NamedKey {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl NamedKey {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "left" => Some(Self::Left),
+            "right" => Some(Self::Right),
+            "up" => Some(Self::Up),
+            "down" => Some(Self::Down),
+            _ => None,
+        }
+    }
+
+    fn matches(self, code: KeyCode) -> bool {
+        matches!(
+            (self, code),
+            (Self::Left, KeyCode::Left)
+                | (Self::Right, KeyCode::Right)
+                | (Self::Up, KeyCode::Up)
+                | (Self::Down, KeyCode::Down)
+        )
+    }
+}
+
+impl std::fmt::Display for NamedKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Left => "←",
+            Self::Right => "→",
+            Self::Up => "↑",
+            Self::Down => "↓",
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum KeySpec {
+    Char(char),
+    Named(NamedKey),
+}
+
+impl KeySpec {
+    fn single_char(self) -> Option<char> {
+        match self {
+            Self::Char(c) => Some(c),
+            Self::Named(_) => None,
+        }
+    }
+
+    fn matches_event(self, key: KeyEvent) -> bool {
+        if key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            return false;
+        }
+
+        match self {
+            Self::Char(c) => matches!(key.code, KeyCode::Char(actual) if actual == c),
+            Self::Named(named) => named.matches(key.code),
+        }
+    }
+}
+
+impl std::fmt::Display for KeySpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Char(c) => write!(f, "{c}"),
+            Self::Named(named) => write!(f, "{named}"),
+        }
+    }
+}
+
+/// One or more key bindings for a browser action.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct KeyList(Vec<char>);
+pub(crate) struct KeyList(Vec<KeySpec>);
 
 impl KeyList {
     fn one(c: char) -> Self {
-        Self(vec![c])
+        Self(vec![KeySpec::Char(c)])
     }
 
-    fn contains(&self, c: char) -> bool {
-        self.0.contains(&c)
+    fn contains(&self, key: KeySpec) -> bool {
+        self.0.contains(&key)
     }
 
-    fn chars(&self) -> impl Iterator<Item = char> + '_ {
+    fn matches_event(&self, key: KeyEvent) -> bool {
+        self.0.iter().any(|spec| spec.matches_event(key))
+    }
+
+    fn keys(&self) -> impl Iterator<Item = KeySpec> + '_ {
         self.0.iter().copied()
     }
 
-    pub(crate) fn as_slice(&self) -> &[char] {
-        &self.0
+    pub(crate) fn single_char(&self) -> Option<char> {
+        match self.0.as_slice() {
+            [spec] => spec.single_char(),
+            _ => None,
+        }
     }
 }
 
 impl std::fmt::Display for KeyList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (index, c) in self.0.iter().enumerate() {
+        for (index, key) in self.0.iter().enumerate() {
             if index > 0 {
                 f.write_str("/")?;
             }
-            write!(f, "{c}")?;
+            write!(f, "{key}")?;
         }
         Ok(())
     }
@@ -63,15 +154,16 @@ impl std::fmt::Display for KeyList {
 
 impl PartialEq<char> for KeyList {
     fn eq(&self, other: &char) -> bool {
-        self.0.as_slice() == [*other]
+        self.0.as_slice() == [KeySpec::Char(*other)]
     }
 }
 
-/// Single-character key bindings for browser actions.
+/// Key bindings for browser actions.
 /// All fields default to the built-in keys; set any field in `[keys]` in
 /// `config.toml` to override that binding. Values may be either a single
-/// one-character string (`open = "o"`) or a list of one-character strings
-/// (`open = ["o", "e"]`).
+/// string (`open = "o"`) or a list of strings (`open = ["o", "e"]`).
+/// Character bindings must be one character; named bindings currently support
+/// `left`, `right`, `up`, and `down`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct KeyBindings {
     pub quit: KeyList,
@@ -92,6 +184,10 @@ pub(crate) struct KeyBindings {
     pub sort: KeyList,
     pub toggle_view: KeyList,
     pub toggle_hidden: KeyList,
+    pub nav_left: KeyList,
+    pub nav_down: KeyList,
+    pub nav_up: KeyList,
+    pub nav_right: KeyList,
     pub scroll_preview_left: KeyList,
     pub scroll_preview_right: KeyList,
     pub scroll_preview_up: KeyList,
@@ -101,7 +197,6 @@ pub(crate) struct KeyBindings {
 /// Characters that are hard-wired to non-configurable actions and may not be
 /// used as key binding values.
 const RESERVED_CHARS: &[char] = &[
-    'h', 'j', 'k', 'l', // navigation (vim keys)
     'g', 'G', // go-to overlay / jump to last
     '?', // help
     '[', ']', // page stepping (epub / comic / pdf)
@@ -130,6 +225,10 @@ impl Default for KeyBindings {
             sort: KeyList::one('s'),
             toggle_view: KeyList::one('v'),
             toggle_hidden: KeyList::one('.'),
+            nav_left: KeyList(vec![KeySpec::Char('h'), KeySpec::Named(NamedKey::Left)]),
+            nav_down: KeyList(vec![KeySpec::Char('j'), KeySpec::Named(NamedKey::Down)]),
+            nav_up: KeyList(vec![KeySpec::Char('k'), KeySpec::Named(NamedKey::Up)]),
+            nav_right: KeyList(vec![KeySpec::Char('l'), KeySpec::Named(NamedKey::Right)]),
             scroll_preview_left: KeyList::one('H'),
             scroll_preview_right: KeyList::one('L'),
             scroll_preview_up: KeyList::one('K'),
@@ -165,6 +264,10 @@ pub(super) struct KeysConfigOverride {
     sort: Option<KeyConfigOverride>,
     toggle_view: Option<KeyConfigOverride>,
     toggle_hidden: Option<KeyConfigOverride>,
+    nav_left: Option<KeyConfigOverride>,
+    nav_down: Option<KeyConfigOverride>,
+    nav_up: Option<KeyConfigOverride>,
+    nav_right: Option<KeyConfigOverride>,
     scroll_preview_left: Option<KeyConfigOverride>,
     scroll_preview_right: Option<KeyConfigOverride>,
     scroll_preview_up: Option<KeyConfigOverride>,
@@ -178,33 +281,45 @@ struct RawBinding {
 }
 
 impl KeyBindings {
+    /// Returns the action bound to `key`, if any.
+    pub(crate) fn action_for_key(&self, key: KeyEvent) -> Option<Action> {
+        let bindings = [
+            (&self.quit, Action::Quit),
+            (&self.quit_without_cd, Action::QuitWithoutCd),
+            (&self.yank, Action::Yank),
+            (&self.cut, Action::Cut),
+            (&self.paste, Action::Paste),
+            (&self.trash, Action::Trash),
+            (&self.delete_permanently, Action::DeletePermanently),
+            (&self.create, Action::Create),
+            (&self.rename, Action::Rename),
+            (&self.copy_path, Action::CopyPath),
+            (&self.search_folders, Action::SearchFolders),
+            (&self.zoxide, Action::Zoxide),
+            (&self.shell, Action::Shell),
+            (&self.open, Action::Open),
+            (&self.open_with, Action::OpenWith),
+            (&self.sort, Action::Sort),
+            (&self.toggle_view, Action::ToggleView),
+            (&self.toggle_hidden, Action::ToggleHidden),
+            (&self.nav_left, Action::NavLeft),
+            (&self.nav_down, Action::NavDown),
+            (&self.nav_up, Action::NavUp),
+            (&self.nav_right, Action::NavRight),
+            (&self.scroll_preview_left, Action::ScrollPreviewLeft),
+            (&self.scroll_preview_right, Action::ScrollPreviewRight),
+            (&self.scroll_preview_up, Action::ScrollPreviewUp),
+            (&self.scroll_preview_down, Action::ScrollPreviewDown),
+        ];
+
+        bindings
+            .iter()
+            .find_map(|(keys, action)| keys.matches_event(key).then_some(*action))
+    }
+
     /// Returns the action bound to `c`, if any.
     pub(crate) fn action_for(&self, c: char) -> Option<Action> {
-        match c {
-            _ if self.quit.contains(c) => Some(Action::Quit),
-            _ if self.quit_without_cd.contains(c) => Some(Action::QuitWithoutCd),
-            _ if self.yank.contains(c) => Some(Action::Yank),
-            _ if self.cut.contains(c) => Some(Action::Cut),
-            _ if self.paste.contains(c) => Some(Action::Paste),
-            _ if self.trash.contains(c) => Some(Action::Trash),
-            _ if self.delete_permanently.contains(c) => Some(Action::DeletePermanently),
-            _ if self.create.contains(c) => Some(Action::Create),
-            _ if self.rename.contains(c) => Some(Action::Rename),
-            _ if self.copy_path.contains(c) => Some(Action::CopyPath),
-            _ if self.search_folders.contains(c) => Some(Action::SearchFolders),
-            _ if self.zoxide.contains(c) => Some(Action::Zoxide),
-            _ if self.shell.contains(c) => Some(Action::Shell),
-            _ if self.open.contains(c) => Some(Action::Open),
-            _ if self.open_with.contains(c) => Some(Action::OpenWith),
-            _ if self.sort.contains(c) => Some(Action::Sort),
-            _ if self.toggle_view.contains(c) => Some(Action::ToggleView),
-            _ if self.toggle_hidden.contains(c) => Some(Action::ToggleHidden),
-            _ if self.scroll_preview_left.contains(c) => Some(Action::ScrollPreviewLeft),
-            _ if self.scroll_preview_right.contains(c) => Some(Action::ScrollPreviewRight),
-            _ if self.scroll_preview_up.contains(c) => Some(Action::ScrollPreviewUp),
-            _ if self.scroll_preview_down.contains(c) => Some(Action::ScrollPreviewDown),
-            _ => None,
-        }
+        self.action_for_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
     }
 
     /// Parse a full config TOML string and return only the resolved key
@@ -311,6 +426,26 @@ impl KeyBindings {
                 default: defaults.toggle_hidden.clone(),
             },
             RawBinding {
+                name: "nav_left",
+                override_value: overrides.nav_left,
+                default: defaults.nav_left.clone(),
+            },
+            RawBinding {
+                name: "nav_down",
+                override_value: overrides.nav_down,
+                default: defaults.nav_down.clone(),
+            },
+            RawBinding {
+                name: "nav_up",
+                override_value: overrides.nav_up,
+                default: defaults.nav_up.clone(),
+            },
+            RawBinding {
+                name: "nav_right",
+                override_value: overrides.nav_right,
+                default: defaults.nav_right.clone(),
+            },
+            RawBinding {
                 name: "scroll_preview_left",
                 override_value: overrides.scroll_preview_left,
                 default: defaults.scroll_preview_left.clone(),
@@ -355,7 +490,7 @@ impl KeyBindings {
                 if !candidates[index].1 {
                     continue;
                 }
-                let collision = candidates[index].0.chars().find_map(|candidate| {
+                let collision = candidates[index].0.keys().find_map(|candidate| {
                     (0..raw.len())
                         .filter(|&other_index| other_index != index)
                         .find(|&other_index| candidates[other_index].0.contains(candidate))
@@ -397,10 +532,14 @@ impl KeyBindings {
             sort: resolved(15),
             toggle_view: resolved(16),
             toggle_hidden: resolved(17),
-            scroll_preview_left: resolved(18),
-            scroll_preview_right: resolved(19),
-            scroll_preview_up: resolved(20),
-            scroll_preview_down: resolved(21),
+            nav_left: resolved(18),
+            nav_down: resolved(19),
+            nav_up: resolved(20),
+            nav_right: resolved(21),
+            scroll_preview_left: resolved(22),
+            scroll_preview_right: resolved(23),
+            scroll_preview_up: resolved(24),
+            scroll_preview_down: resolved(25),
         }
     }
 }
@@ -420,39 +559,49 @@ fn parse_key_override(name: &str, value: &KeyConfigOverride, default: &KeyList) 
 
     let mut parsed = Vec::with_capacity(values.len());
     for value in values {
-        let mut chars = value.chars();
-        let Some(c) = chars.next() else {
+        let spec = parse_key_spec(name, value, default)?;
+        if parsed.contains(&spec) {
             eprintln!(
-                "elio: keys.{name}: empty strings cannot be used as key bindings; using default '{default}'"
-            );
-            return None;
-        };
-        if chars.next().is_some() {
-            eprintln!(
-                "elio: keys.{name}: {value:?} is not a single character; using default '{default}'"
+                "elio: keys.{name}: '{spec}' is listed more than once; using default '{default}'"
             );
             return None;
         }
-        if RESERVED_CHARS.contains(&c) {
-            eprintln!(
-                "elio: keys.{name}: '{c}' is reserved and cannot be rebound; using default '{default}'"
-            );
-            return None;
-        }
-        if c.is_control() {
-            eprintln!(
-                "elio: keys.{name}: control characters cannot be used as key bindings; using default '{default}'"
-            );
-            return None;
-        }
-        if parsed.contains(&c) {
-            eprintln!(
-                "elio: keys.{name}: '{c}' is listed more than once; using default '{default}'"
-            );
-            return None;
-        }
-        parsed.push(c);
+        parsed.push(spec);
     }
 
     Some(KeyList(parsed))
+}
+
+fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec> {
+    if let Some(named) = NamedKey::parse(value) {
+        return Some(KeySpec::Named(named));
+    }
+
+    let mut chars = value.chars();
+    let Some(c) = chars.next() else {
+        eprintln!(
+            "elio: keys.{name}: empty strings cannot be used as key bindings; using default '{default}'"
+        );
+        return None;
+    };
+    if chars.next().is_some() {
+        eprintln!(
+            "elio: keys.{name}: {value:?} is not a single character or supported named key; using default '{default}'"
+        );
+        return None;
+    }
+    if RESERVED_CHARS.contains(&c) {
+        eprintln!(
+            "elio: keys.{name}: '{c}' is reserved and cannot be rebound; using default '{default}'"
+        );
+        return None;
+    }
+    if c.is_control() {
+        eprintln!(
+            "elio: keys.{name}: control characters cannot be used as key bindings; using default '{default}'"
+        );
+        return None;
+    }
+
+    Some(KeySpec::Char(c))
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -137,7 +137,7 @@ fn keys_rejects_reserved_char_and_uses_default() {
     let config = Config::from_str(
         r#"
 [keys]
-yank = "j"
+yank = "?"
 "#,
     )
     .expect("config should parse");
@@ -210,7 +210,111 @@ fn action_for_returns_correct_action_for_default_bindings() {
     assert_eq!(key_bindings.action_for('O'), Some(Action::OpenWith));
     assert_eq!(key_bindings.action_for('z'), Some(Action::Zoxide));
     assert_eq!(key_bindings.action_for('!'), Some(Action::Shell));
-    assert_eq!(key_bindings.action_for('j'), None);
+    assert_eq!(key_bindings.action_for('h'), Some(Action::NavLeft));
+    assert_eq!(key_bindings.action_for('j'), Some(Action::NavDown));
+    assert_eq!(key_bindings.action_for('k'), Some(Action::NavUp));
+    assert_eq!(key_bindings.action_for('l'), Some(Action::NavRight));
+}
+
+#[test]
+fn nav_defaults_include_vim_keys_and_arrow_keys() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let key_bindings = KeyBindings::default();
+    assert_eq!(key_bindings.nav_left.to_string(), "h/←");
+    assert_eq!(key_bindings.nav_down.to_string(), "j/↓");
+    assert_eq!(key_bindings.nav_up.to_string(), "k/↑");
+    assert_eq!(key_bindings.nav_right.to_string(), "l/→");
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)),
+        Some(Action::NavLeft)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+        Some(Action::NavDown)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+        Some(Action::NavUp)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        Some(Action::NavRight)
+    );
+}
+
+#[test]
+fn nav_keys_can_be_overridden_with_chars_and_arrows() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_down = ["n", "down"]
+nav_up = "u"
+nav_right = "b"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('n'), Some(Action::NavDown));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+        Some(Action::NavDown)
+    );
+    assert_eq!(config.keys.action_for('u'), Some(Action::NavUp));
+    assert_eq!(config.keys.action_for('b'), Some(Action::NavRight));
+    assert_eq!(config.keys.action_for('j'), None);
+    assert_eq!(config.keys.action_for('k'), None);
+    assert_eq!(config.keys.action_for('l'), None);
+}
+
+#[test]
+fn overriding_nav_right_frees_l_for_another_action() {
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_right = "right"
+open = ["o", "l"]
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('l'), Some(Action::Open));
+    assert_eq!(config.keys.action_for('o'), Some(Action::Open));
+}
+
+#[test]
+fn keys_rejects_collision_with_default_nav_key() {
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "l"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('l'), Some(Action::NavRight));
+    assert_eq!(config.keys.action_for('o'), Some(Action::Open));
+}
+
+#[test]
+fn keys_rejects_collision_with_default_arrow_key() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "right"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        Some(Action::NavRight)
+    );
+    assert_eq!(config.keys.action_for('o'), Some(Action::Open));
 }
 
 #[test]

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -17,10 +17,14 @@ pub(super) fn render_help(
 ) {
     let kb = crate::config::keys();
 
+    let parent_key = format!("{} / Backspace", kb.nav_left);
+
     let navigation_entries = vec![
-        e("↑↓ / jk", "move selection"),
-        e("← / h / Backspace", "parent folder"),
-        e("→ / l / Enter", "enter folder / open"),
+        e(&kb.nav_up.to_string(), "move up"),
+        e(&kb.nav_down.to_string(), "move down"),
+        e(&parent_key, "parent folder"),
+        e(&kb.nav_right.to_string(), "enter folder"),
+        e("Enter", "enter folder / open"),
         e("g", "go-to menu"),
         e("G", "last item"),
         e("PageUp / PageDown", "page up / down"),
@@ -226,8 +230,8 @@ fn format_preview_scroll_key(
     low: &crate::config::KeyList,
     high: &crate::config::KeyList,
 ) -> String {
-    match (low.as_slice(), high.as_slice()) {
-        ([low], [high]) if low.is_ascii_uppercase() && high.is_ascii_uppercase() => {
+    match (low.single_char(), high.single_char()) {
+        (Some(low), Some(high)) if low.is_ascii_uppercase() && high.is_ascii_uppercase() => {
             format!("Shift+{low} / Shift+{high}")
         }
         _ => format!("{low} / {high}"),


### PR DESCRIPTION
## Summary

Adds configurable navigation bindings for browser movement while preserving the existing default `h`/`j`/`k`/`l` and arrow-key behavior.

## What Changed

- Added configurable `[keys]` actions:
  - `nav_left`
  - `nav_down`
  - `nav_up`
  - `nav_right`
- Added named arrow-key bindings for navigation:
  - `left`
  - `right`
  - `up`
  - `down`
- Kept default navigation behavior unchanged:
  - `h` / `left`
  - `j` / `down`
  - `k` / `up`
  - `l` / `right`
- Removed `h`, `j`, `k`, and `l` from the reserved key list.
- Kept `Backspace` and `Enter` as fixed shortcuts.
- Updated navigation dispatch and repeat handling to use resolved key bindings.
- Updated the help overlay to show resolved navigation bindings.
- Made `examples/config.toml` inert by default by commenting the initial `[ui]` example.

## User Impact

Users can now rebind navigation keys and free `h`, `j`, `k`, or `l` for other actions.

For example:

```toml
[keys]
nav_right = "right"
open = ["o", "l"]
```

This makes `right` enter folders while `l` opens files or folders through the system opener.

Setting an action replaces its full default key list, so:

```toml
[keys]
nav_down = "j"
```

removes the default `down` arrow binding for `nav_down`.

Invalid or colliding bindings still fall back to defaults.

## Notes

`Enter` and `Backspace` remain fixed shortcuts.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- [x] Default nav behavior unchanged for `h`/`j`/`k`/`l`, arrow keys, `Enter`, and `Backspace`
- [x] Held/repeated `j`, `↓`, `l`, and `→` still navigate as expected
- [x] `nav_down = "j"` removes the default `down` arrow binding while keeping other defaults
- [x] `nav_right = "right"` frees `l` for `open = ["o", "l"]`
- [x] `l` as `open` opens files and directories through the system opener
- [x] Help overlay reflects resolved `open` and `nav_right` bindings
- [x] `open = "l"` falls back to `o` while `l` remains `nav_right`

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
