### PR TITLE
feat(keys): add configurable open-or-enter binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for assigning multiple single-character bindings to each configurable `[keys]` action, while keeping existing single-string key config compatible.
 - Added configurable navigation bindings for `nav_left`, `nav_down`, `nav_up`, and `nav_right`, including named arrow keys.
+- Added `open_or_enter` as a configurable binding for the existing `Enter` behavior: entering folders or opening files. ([#141])
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
 
 ## [1.7.0] - 2026-05-30
@@ -206,3 +207,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#134]: https://github.com/elio-fm/elio/issues/134
 [#138]: https://github.com/elio-fm/elio/pull/138
 [#140]: https://github.com/elio-fm/elio/issues/140
+[#141]: https://github.com/elio-fm/elio/issues/141

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept either one key or a list, such as `open_with = ["O", "w"]`. Navigation actions also accept `left`, `right`, `up`, and `down`. Setting an action replaces its full default key list.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept either one key or a list, such as `open_with = ["O", "w"]`. Named keys are supported for `left`, `right`, `up`, `down`, and `enter`. Setting an action replaces its full default key list.
 
 ### Navigation
 
@@ -268,7 +268,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `j` / `↓` `*` | Move down |
 | `h` / `←` `*` / `Backspace` | Go to parent directory |
 | `l` / `→` `*` | Enter folder |
-| `Enter` | Enter folder / open file or selection |
+| `Enter` `*` | Enter folder / open file or selection |
 | `g` | Go-to menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash) |
 | `G` | Jump to last item |
 | `PageUp` / `PageDown` | Page up / down |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -57,9 +57,9 @@
 # files = 45
 # preview = 45
 
-# Rebind browser action keys. Each value may be a single one-character string,
-# a list of one-character strings, or the named arrow keys "left", "right",
-# "up", and "down" for navigation actions.
+# Rebind browser action keys. Each value may be a single key or a list.
+# Keys may be one-character strings or named keys: "left", "right", "up",
+# "down", and "enter".
 # Example: open_with = ["O", "w"].
 # Setting a key replaces that action's full default list, not just one entry.
 # Example: nav_down = "j" removes the default "down" arrow binding.
@@ -85,6 +85,7 @@
 # shell                = "!"
 # open                 = "o"
 # open_with            = "O"
+# open_or_enter        = "enter"
 # sort                 = "s"
 # toggle_view          = "v"
 # toggle_hidden        = "."

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -214,7 +214,6 @@ impl App {
             KeyCode::End => self.select_last(),
             KeyCode::Char('g') => self.open_goto_overlay(),
             KeyCode::Char('G') => self.select_last(),
-            KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r') => self.open_selected()?,
             KeyCode::Backspace => self.go_parent()?,
             KeyCode::Char(' ') => self.toggle_selection(),
             KeyCode::Char('+') | KeyCode::Char('=')
@@ -287,6 +286,7 @@ impl App {
             }
             Action::Open => self.open_in_system()?,
             Action::OpenWith => self.open_open_with_overlay(),
+            Action::OpenOrEnter => self.open_selected()?,
             Action::Sort => self.cycle_sort_mode()?,
             Action::ToggleView => self.toggle_view_mode(),
             Action::ToggleHidden => self.toggle_hidden_files()?,
@@ -305,7 +305,8 @@ impl App {
                 } else if let Some(entry) = self.selected_entry().filter(|entry| entry.is_dir()) {
                     self.set_dir(entry.path.clone())?;
                 } else {
-                    self.status = "Press Enter to open files".to_string();
+                    let open_key = crate::config::keys().open_or_enter.to_string();
+                    self.status = format!("Press {open_key} to open files");
                 }
             }
             Action::ScrollPreviewLeft => {

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -966,6 +966,37 @@ fn rebound_quit_key_sets_should_quit() {
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn rebound_open_or_enter_key_opens_selected_file() {
+    use crate::config::KeyBindings;
+
+    let kb = KeyBindings::from_toml_str(
+        r#"[keys]
+nav_right = "right"
+open_or_enter = ["enter", "l"]"#,
+    );
+    assert_eq!(kb.action_for('l'), Some(Action::OpenOrEnter));
+
+    let root = temp_path("rebind-open-or-enter-file");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let file_path = root.join("note.txt");
+    fs::write(&file_path, "hello").expect("failed to write temp file");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.dispatch_action(kb.action_for('l').unwrap())
+        .expect("open_or_enter should open selected file");
+
+    let opened = read_open_capture(&capture);
+    assert_eq!(opened, file_path.display().to_string());
+
+    fs::remove_dir_all(root).ok();
+}
+
 #[test]
 fn zoxide_action_queues_pending_terminal_task() {
     let root = temp_path("zoxide-action");

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -19,6 +19,7 @@ pub(crate) enum Action {
     Shell,
     Open,
     OpenWith,
+    OpenOrEnter,
     Sort,
     ToggleView,
     ToggleHidden,
@@ -38,6 +39,7 @@ pub(crate) enum NamedKey {
     Right,
     Up,
     Down,
+    Enter,
 }
 
 impl NamedKey {
@@ -47,6 +49,7 @@ impl NamedKey {
             "right" => Some(Self::Right),
             "up" => Some(Self::Up),
             "down" => Some(Self::Down),
+            "enter" => Some(Self::Enter),
             _ => None,
         }
     }
@@ -58,6 +61,10 @@ impl NamedKey {
                 | (Self::Right, KeyCode::Right)
                 | (Self::Up, KeyCode::Up)
                 | (Self::Down, KeyCode::Down)
+                | (
+                    Self::Enter,
+                    KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r')
+                )
         )
     }
 }
@@ -69,6 +76,7 @@ impl std::fmt::Display for NamedKey {
             Self::Right => "→",
             Self::Up => "↑",
             Self::Down => "↓",
+            Self::Enter => "Enter",
         })
     }
 }
@@ -163,7 +171,7 @@ impl PartialEq<char> for KeyList {
 /// `config.toml` to override that binding. Values may be either a single
 /// string (`open = "o"`) or a list of strings (`open = ["o", "e"]`).
 /// Character bindings must be one character; named bindings currently support
-/// `left`, `right`, `up`, and `down`.
+/// `left`, `right`, `up`, `down`, and `enter`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct KeyBindings {
     pub quit: KeyList,
@@ -181,6 +189,7 @@ pub(crate) struct KeyBindings {
     pub shell: KeyList,
     pub open: KeyList,
     pub open_with: KeyList,
+    pub open_or_enter: KeyList,
     pub sort: KeyList,
     pub toggle_view: KeyList,
     pub toggle_hidden: KeyList,
@@ -222,6 +231,7 @@ impl Default for KeyBindings {
             shell: KeyList::one('!'),
             open: KeyList::one('o'),
             open_with: KeyList::one('O'),
+            open_or_enter: KeyList(vec![KeySpec::Named(NamedKey::Enter)]),
             sort: KeyList::one('s'),
             toggle_view: KeyList::one('v'),
             toggle_hidden: KeyList::one('.'),
@@ -261,6 +271,7 @@ pub(super) struct KeysConfigOverride {
     shell: Option<KeyConfigOverride>,
     open: Option<KeyConfigOverride>,
     open_with: Option<KeyConfigOverride>,
+    open_or_enter: Option<KeyConfigOverride>,
     sort: Option<KeyConfigOverride>,
     toggle_view: Option<KeyConfigOverride>,
     toggle_hidden: Option<KeyConfigOverride>,
@@ -299,6 +310,7 @@ impl KeyBindings {
             (&self.shell, Action::Shell),
             (&self.open, Action::Open),
             (&self.open_with, Action::OpenWith),
+            (&self.open_or_enter, Action::OpenOrEnter),
             (&self.sort, Action::Sort),
             (&self.toggle_view, Action::ToggleView),
             (&self.toggle_hidden, Action::ToggleHidden),
@@ -409,6 +421,11 @@ impl KeyBindings {
                 name: "open_with",
                 override_value: overrides.open_with,
                 default: defaults.open_with.clone(),
+            },
+            RawBinding {
+                name: "open_or_enter",
+                override_value: overrides.open_or_enter,
+                default: defaults.open_or_enter.clone(),
             },
             RawBinding {
                 name: "sort",
@@ -529,17 +546,18 @@ impl KeyBindings {
             shell: resolved(12),
             open: resolved(13),
             open_with: resolved(14),
-            sort: resolved(15),
-            toggle_view: resolved(16),
-            toggle_hidden: resolved(17),
-            nav_left: resolved(18),
-            nav_down: resolved(19),
-            nav_up: resolved(20),
-            nav_right: resolved(21),
-            scroll_preview_left: resolved(22),
-            scroll_preview_right: resolved(23),
-            scroll_preview_up: resolved(24),
-            scroll_preview_down: resolved(25),
+            open_or_enter: resolved(15),
+            sort: resolved(16),
+            toggle_view: resolved(17),
+            toggle_hidden: resolved(18),
+            nav_left: resolved(19),
+            nav_down: resolved(20),
+            nav_up: resolved(21),
+            nav_right: resolved(22),
+            scroll_preview_left: resolved(23),
+            scroll_preview_right: resolved(24),
+            scroll_preview_up: resolved(25),
+            scroll_preview_down: resolved(26),
         }
     }
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -74,7 +74,7 @@ fn keys_rejects_invalid_array_member_and_uses_default() {
     let config = Config::from_str(
         r#"
 [keys]
-open = ["e", "enter"]
+open = ["e", "space"]
 "#,
     )
     .expect("config should parse");
@@ -208,6 +208,13 @@ fn action_for_returns_correct_action_for_default_bindings() {
     assert_eq!(key_bindings.action_for('Q'), Some(Action::QuitWithoutCd));
     assert_eq!(key_bindings.action_for('o'), Some(Action::Open));
     assert_eq!(key_bindings.action_for('O'), Some(Action::OpenWith));
+    assert_eq!(
+        key_bindings.action_for_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        )),
+        Some(Action::OpenOrEnter)
+    );
     assert_eq!(key_bindings.action_for('z'), Some(Action::Zoxide));
     assert_eq!(key_bindings.action_for('!'), Some(Action::Shell));
     assert_eq!(key_bindings.action_for('h'), Some(Action::NavLeft));
@@ -374,6 +381,91 @@ open_with = "w"
     .expect("config should parse");
     assert_eq!(config.keys.action_for('w'), Some(Action::OpenWith));
     assert_eq!(config.keys.action_for('O'), None);
+}
+
+#[test]
+fn open_or_enter_defaults_to_enter() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let key_bindings = KeyBindings::default();
+    assert_eq!(key_bindings.open_or_enter.to_string(), "Enter");
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Char('\n'), KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+}
+
+#[test]
+fn open_or_enter_can_add_l_after_nav_right_frees_it() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_right = "right"
+open_or_enter = ["enter", "l"]
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('l'), Some(Action::OpenOrEnter));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        Some(Action::NavRight)
+    );
+}
+
+#[test]
+fn open_or_enter_rejects_l_while_nav_right_owns_it() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open_or_enter = ["enter", "l"]
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('l'), Some(Action::NavRight));
+    assert_eq!(config.keys.open_or_enter.to_string(), "Enter");
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+}
+
+#[test]
+fn enter_can_move_to_another_action_when_open_or_enter_frees_it() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open_or_enter = "b"
+open = "enter"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('b'), Some(Action::OpenOrEnter));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
 }
 
 #[test]

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -24,7 +24,7 @@ pub(super) fn render_help(
         e(&kb.nav_down.to_string(), "move down"),
         e(&parent_key, "parent folder"),
         e(&kb.nav_right.to_string(), "enter folder"),
-        e("Enter", "enter folder / open"),
+        e(&kb.open_or_enter.to_string(), "enter folder / open"),
         e("g", "go-to menu"),
         e("G", "last item"),
         e("PageUp / PageDown", "page up / down"),


### PR DESCRIPTION
## Summary

Adds `open_or_enter` as a configurable binding for the existing `Enter` behavior: entering folders or opening files/selections.

Closes #141.

## What Changed

- Added a new configurable `[keys]` action:
  - `open_or_enter`
- Added `enter` as a named key.
- Moved the existing hardcoded `Enter` behavior into normal key dispatch.
- Kept the default behavior unchanged:
  - `Enter` enters folders or opens files/selections
  - `l` / `right` still enter folders only
- Updated the help overlay to show the resolved `open_or_enter` binding.
- Updated the file-focused `nav_right` status message to use the configured `open_or_enter` key.
- Updated README, example config, and changelog.

## User Impact

Users can now assign the existing Enter behavior to other keys.

For example, to make `l` enter folders or open files while keeping `right` as folder navigation:

```toml
[keys]
nav_right = "right"
open_or_enter = ["enter", "l"]
```

This makes:

- `l` enter folders or open files
- `Enter` keep its existing behavior
- `right` enter folders only

The default behavior is unchanged for users who do not configure this.

## Notes

Empty bindings are still rejected. Setting a key replaces that action's full default list, not just one entry.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- [x] Default `Enter` behavior unchanged
- [x] Default `l` / `right` behavior unchanged
- [x] `nav_right = "right"` and `open_or_enter = ["enter", "l"]` makes `l` enter folders or open files
- [x] `Enter` still enters folders or opens files with custom `open_or_enter`
- [x] Help overlay reflects the resolved `open_or_enter` binding
- [x] Empty bindings remain rejected

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed

