### PR TITLE
Allow unbinding configurable key actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for assigning multiple single-character bindings to each configurable `[keys]` action, while keeping existing single-string key config compatible.
 - Added configurable navigation bindings for `nav_left`, `nav_down`, `nav_up`, and `nav_right`, including named arrow keys.
 - Added `open_or_enter` as a configurable binding for the existing `Enter` behavior: entering folders or opening files. ([#141])
+- Added `[]` support for unbinding configurable `[keys]` actions.
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
 
 ## [1.7.0] - 2026-05-30

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept either one key or a list, such as `open_with = ["O", "w"]`. Named keys are supported for `left`, `right`, `up`, `down`, and `enter`. Setting an action replaces its full default key list.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for `left`, `right`, `up`, `down`, and `enter`. Setting an action replaces its full default key list.
 
 ### Navigation
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -63,6 +63,8 @@
 # Example: open_with = ["O", "w"].
 # Setting a key replaces that action's full default list, not just one entry.
 # Example: nav_down = "j" removes the default "down" arrow binding.
+# Use [] to unbind an action.
+# Example: nav_right = [] frees "l" and "right" for other actions.
 # Reserved (never rebindable): g G ? [ ] + = - _ Space
 # Omit any key to keep the built-in default shown in the comment.
 #
@@ -93,3 +95,7 @@
 # scroll_preview_down  = "J"   # Shift+J
 # scroll_preview_left  = "H"   # Shift+H
 # scroll_preview_right = "L"   # Shift+L
+#
+# Example: make l/Enter/Right all open or enter.
+# nav_right     = []
+# open_or_enter = ["enter", "l", "right"]

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -170,6 +170,7 @@ impl PartialEq<char> for KeyList {
 /// All fields default to the built-in keys; set any field in `[keys]` in
 /// `config.toml` to override that binding. Values may be either a single
 /// string (`open = "o"`) or a list of strings (`open = ["o", "e"]`).
+/// Empty lists unbind the action (`open = []`).
 /// Character bindings must be one character; named bindings currently support
 /// `left`, `right`, `up`, `down`, and `enter`.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -485,7 +486,7 @@ impl KeyBindings {
         ];
 
         // Step 1: parse each override independently, falling back to default on
-        // any format or reserved-char error.
+        // any format or reserved-char error. Empty lists are valid unbinds.
         // (resolved_keys, is_user_set)
         let mut candidates: Vec<(KeyList, bool)> = raw
             .iter()
@@ -568,13 +569,6 @@ fn parse_key_override(name: &str, value: &KeyConfigOverride, default: &KeyList) 
         KeyConfigOverride::Many(values) => values.iter().map(String::as_str).collect(),
     };
 
-    if values.is_empty() {
-        eprintln!(
-            "elio: keys.{name}: key binding lists cannot be empty; using default '{default}'"
-        );
-        return None;
-    }
-
     let mut parsed = Vec::with_capacity(values.len());
     for value in values {
         let spec = parse_key_spec(name, value, default)?;
@@ -598,7 +592,7 @@ fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec>
     let mut chars = value.chars();
     let Some(c) = chars.next() else {
         eprintln!(
-            "elio: keys.{name}: empty strings cannot be used as key bindings; using default '{default}'"
+            "elio: keys.{name}: empty strings cannot be used as key bindings; use [] to unbind this action; using default '{default}'"
         );
         return None;
     };

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -44,7 +44,7 @@ open_with = ["O"]
 }
 
 #[test]
-fn keys_rejects_empty_array_and_uses_default() {
+fn keys_accepts_empty_array_to_unbind_action() {
     let config = Config::from_str(
         r#"
 [keys]
@@ -52,8 +52,22 @@ open = []
 "#,
     )
     .expect("config should parse");
-    assert_eq!(config.keys.open, 'o');
-    assert_eq!(config.keys.action_for('o'), Some(Action::Open));
+    assert_eq!(config.keys.open.to_string(), "");
+    assert_eq!(config.keys.action_for('o'), None);
+}
+
+#[test]
+fn unbound_action_frees_its_default_key_for_another_action() {
+    let config = Config::from_str(
+        r#"
+[keys]
+open = []
+shell = "o"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for('o'), Some(Action::Shell));
+    assert_eq!(config.keys.action_for('!'), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Allow configurable `[keys]` actions to be unbound by setting them to an empty list.

## What Changed

- Treat `action = []` as a valid empty key list instead of falling back to the built-in default.
- Keep empty strings invalid and point users to `[]` for unbinding.
- Add focused tests for unbinding an action and reusing its former default key.
- Document the syntax in the README, annotated config, and changelog.

## User Impact

Users can disable individual key actions or free their default keys for other actions:

```toml
[keys]
nav_right = []
open_or_enter = ["enter", "l", "right"]
```

This removes the need for dummy bindings when users want to release keys like `l` or `right`.

## Notes

Empty lists are intentionally action-based: they unbind an action without adding a separate `unmap` syntax or accepting empty strings as key names.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Checked `shell = ""` reports an understandable error and points to `[]`.
- Checked `nav_right = []` with `open_or_enter = ["enter", "l", "right"]` works as intended.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
