### PR TITLE
feat(keys): add modifier bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable navigation bindings for `nav_left`, `nav_down`, `nav_up`, and `nav_right`, including named arrow keys.
 - Added `open_or_enter` as a configurable binding for the existing `Enter` behavior: entering folders or opening files. ([#141])
 - Added `[]` support for unbinding configurable `[keys]` actions.
+- Added support for modifier `[keys]` bindings such as `ctrl+o`, `alt+o`, and `shift+right`.
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
 
 ## [1.7.0] - 2026-05-30

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for `left`, `right`, `up`, `down`, and `enter`. Setting an action replaces its full default key list.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for `left`, `right`, `up`, `down`, and `enter`; modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
 
 ### Navigation
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -57,15 +57,24 @@
 # files = 45
 # preview = 45
 
-# Rebind browser action keys. Each value may be a single key or a list.
-# Keys may be one-character strings or named keys: "left", "right", "up",
-# "down", and "enter".
-# Example: open_with = ["O", "w"].
+# Rebind browser action keys. Each value may be a single key, a list, or [].
+#
+# Keys may be one-character strings, named keys, or modifier bindings.
+# Supported named keys: "left", "right", "up", "down", "enter".
+# Supported modifiers: "ctrl", "alt", "shift" with lowercase names.
+#
+# Examples: open_with = ["O", "w"], open = "ctrl+o", nav_right = "shift+right".
+# For shifted letters, use uppercase characters: "O", not "shift+o".
+#
 # Setting a key replaces that action's full default list, not just one entry.
 # Example: nav_down = "j" removes the default "down" arrow binding.
+#
 # Use [] to unbind an action.
-# Example: nav_right = [] frees "l" and "right" for other actions.
-# Reserved (never rebindable): g G ? [ ] + = - _ Space
+# Example: nav_right = [] frees "l" and "right".
+# Then open_or_enter = ["enter", "l", "right"] can use them.
+#
+# Reserved bare keys: g G ? [ ] + = - _ Space
+# Reserved shortcuts: Ctrl+C, Ctrl+F, Ctrl+A, Ctrl+Plus/Minus, Alt+Left/Right
 # Omit any key to keep the built-in default shown in the comment.
 #
 # [keys]

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -128,16 +128,8 @@ impl App {
             && !key.modifiers.contains(KeyModifiers::CONTROL)
         {
             match key.code {
-                KeyCode::Left => {
-                    if self.handle_horizontal_navigation_key(-1) {
-                        return Ok(());
-                    }
-                }
-                KeyCode::Right => {
-                    if self.handle_horizontal_navigation_key(1) {
-                        return Ok(());
-                    }
-                }
+                KeyCode::Left if self.handle_horizontal_navigation_key(-1) => return Ok(()),
+                KeyCode::Right if self.handle_horizontal_navigation_key(1) => return Ok(()),
                 _ => {}
             }
         }
@@ -235,7 +227,15 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char(c) => {
+            KeyCode::Char(c)
+                if !key.modifiers.intersects(
+                    KeyModifiers::CONTROL
+                        | KeyModifiers::ALT
+                        | KeyModifiers::SUPER
+                        | KeyModifiers::HYPER
+                        | KeyModifiers::META,
+                ) =>
+            {
                 if let Some(action) = crate::config::keys().action_for(c) {
                     self.dispatch_action(action)?;
                 }

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -89,6 +89,30 @@ fn q_sets_should_quit() {
 }
 
 #[test]
+fn modified_plain_shortcut_does_not_trigger_plain_action() {
+    let root = temp_path("modified-plain-shortcut");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    assert!(!app.should_quit);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('q'),
+        KeyModifiers::CONTROL,
+    )))
+    .expect("Ctrl-Q should be ignored by the plain q binding");
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('q'),
+        KeyModifiers::ALT,
+    )))
+    .expect("Alt-Q should be ignored by the plain q binding");
+
+    assert!(!app.should_quit);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn capital_q_quits_without_changing_directory() {
     let root = temp_path("quit-without-cd-shortcut");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -82,39 +82,117 @@ impl std::fmt::Display for NamedKey {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) enum KeySpec {
+struct KeyModifierSpec {
+    ctrl: bool,
+    alt: bool,
+    shift: bool,
+    other: bool,
+}
+
+impl KeyModifierSpec {
+    const NONE: Self = Self {
+        ctrl: false,
+        alt: false,
+        shift: false,
+        other: false,
+    };
+
+    fn is_empty(self) -> bool {
+        !self.ctrl && !self.alt && !self.shift && !self.other
+    }
+
+    fn from_event(modifiers: KeyModifiers) -> Self {
+        let supported = KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT;
+        Self {
+            ctrl: modifiers.contains(KeyModifiers::CONTROL),
+            alt: modifiers.contains(KeyModifiers::ALT),
+            shift: modifiers.contains(KeyModifiers::SHIFT),
+            other: modifiers.intersects(!supported),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum KeyCodeSpec {
     Char(char),
     Named(NamedKey),
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct KeySpec {
+    code: KeyCodeSpec,
+    modifiers: KeyModifierSpec,
+}
+
 impl KeySpec {
+    fn char(c: char) -> Self {
+        Self {
+            code: KeyCodeSpec::Char(c),
+            modifiers: KeyModifierSpec::NONE,
+        }
+    }
+
+    fn named(named: NamedKey) -> Self {
+        Self {
+            code: KeyCodeSpec::Named(named),
+            modifiers: KeyModifierSpec::NONE,
+        }
+    }
+
     fn single_char(self) -> Option<char> {
-        match self {
-            Self::Char(c) => Some(c),
-            Self::Named(_) => None,
+        match (self.code, self.modifiers.is_empty()) {
+            (KeyCodeSpec::Char(c), true) => Some(c),
+            _ => None,
         }
     }
 
     fn matches_event(self, key: KeyEvent) -> bool {
-        if key
-            .modifiers
-            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-        {
+        let (event_code, event_modifiers) = normalize_key_event(key);
+        if event_modifiers != self.modifiers {
             return false;
         }
 
-        match self {
-            Self::Char(c) => matches!(key.code, KeyCode::Char(actual) if actual == c),
-            Self::Named(named) => named.matches(key.code),
+        match self.code {
+            KeyCodeSpec::Char(c) => matches!(event_code, KeyCode::Char(actual) if actual == c),
+            KeyCodeSpec::Named(named) => named.matches(event_code),
         }
     }
 }
 
+fn normalize_key_event(key: KeyEvent) -> (KeyCode, KeyModifierSpec) {
+    let mut modifiers = KeyModifierSpec::from_event(key.modifiers);
+    let code = match key.code {
+        KeyCode::Char(c) if modifiers.ctrl || modifiers.alt => {
+            modifiers.shift = false;
+            KeyCode::Char(c.to_ascii_lowercase())
+        }
+        KeyCode::Char(c) => {
+            modifiers.shift = false;
+            KeyCode::Char(c)
+        }
+        code => code,
+    };
+    (code, modifiers)
+}
+
 impl std::fmt::Display for KeySpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Char(c) => write!(f, "{c}"),
-            Self::Named(named) => write!(f, "{named}"),
+        if self.modifiers.ctrl {
+            f.write_str("Ctrl+")?;
+        }
+        if self.modifiers.alt {
+            f.write_str("Alt+")?;
+        }
+        if self.modifiers.shift {
+            f.write_str("Shift+")?;
+        }
+
+        match self.code {
+            KeyCodeSpec::Char(c) if self.modifiers.ctrl || self.modifiers.alt => {
+                write!(f, "{}", c.to_ascii_uppercase())
+            }
+            KeyCodeSpec::Char(c) => write!(f, "{c}"),
+            KeyCodeSpec::Named(named) => write!(f, "{named}"),
         }
     }
 }
@@ -125,7 +203,7 @@ pub(crate) struct KeyList(Vec<KeySpec>);
 
 impl KeyList {
     fn one(c: char) -> Self {
-        Self(vec![KeySpec::Char(c)])
+        Self(vec![KeySpec::char(c)])
     }
 
     fn contains(&self, key: KeySpec) -> bool {
@@ -162,7 +240,7 @@ impl std::fmt::Display for KeyList {
 
 impl PartialEq<char> for KeyList {
     fn eq(&self, other: &char) -> bool {
-        self.0.as_slice() == [KeySpec::Char(*other)]
+        self.0.as_slice() == [KeySpec::char(*other)]
     }
 }
 
@@ -214,6 +292,14 @@ const RESERVED_CHARS: &[char] = &[
     ' ', // toggle selection
 ];
 
+/// Modified keys that are still hard-wired before configurable browser actions.
+const RESERVED_MODIFIED_CHARS: &[char] = &[
+    'c', // cancel/clear
+    'f', // file search
+    'a', // select all
+    '+', '=', '-', '_', // grid zoom
+];
+
 impl Default for KeyBindings {
     fn default() -> Self {
         Self {
@@ -232,14 +318,14 @@ impl Default for KeyBindings {
             shell: KeyList::one('!'),
             open: KeyList::one('o'),
             open_with: KeyList::one('O'),
-            open_or_enter: KeyList(vec![KeySpec::Named(NamedKey::Enter)]),
+            open_or_enter: KeyList(vec![KeySpec::named(NamedKey::Enter)]),
             sort: KeyList::one('s'),
             toggle_view: KeyList::one('v'),
             toggle_hidden: KeyList::one('.'),
-            nav_left: KeyList(vec![KeySpec::Char('h'), KeySpec::Named(NamedKey::Left)]),
-            nav_down: KeyList(vec![KeySpec::Char('j'), KeySpec::Named(NamedKey::Down)]),
-            nav_up: KeyList(vec![KeySpec::Char('k'), KeySpec::Named(NamedKey::Up)]),
-            nav_right: KeyList(vec![KeySpec::Char('l'), KeySpec::Named(NamedKey::Right)]),
+            nav_left: KeyList(vec![KeySpec::char('h'), KeySpec::named(NamedKey::Left)]),
+            nav_down: KeyList(vec![KeySpec::char('j'), KeySpec::named(NamedKey::Down)]),
+            nav_up: KeyList(vec![KeySpec::char('k'), KeySpec::named(NamedKey::Up)]),
+            nav_right: KeyList(vec![KeySpec::char('l'), KeySpec::named(NamedKey::Right)]),
             scroll_preview_left: KeyList::one('H'),
             scroll_preview_right: KeyList::one('L'),
             scroll_preview_up: KeyList::one('K'),
@@ -585,12 +671,38 @@ fn parse_key_override(name: &str, value: &KeyConfigOverride, default: &KeyList) 
 }
 
 fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec> {
-    if let Some(named) = NamedKey::parse(value) {
-        return Some(KeySpec::Named(named));
+    let (modifiers, key_name) = parse_key_modifiers(name, value, default)?;
+
+    if modifiers.shift && key_name.len() == 1 {
+        let c = key_name.chars().next().expect("single-char key");
+        let suggestion = if c.is_ascii_alphabetic() {
+            format!("; use {:?} instead", c.to_ascii_uppercase().to_string())
+        } else {
+            String::new()
+        };
+        eprintln!(
+            "elio: keys.{name}: {value:?} uses shift with a character{suggestion}; using default '{default}'"
+        );
+        return None;
     }
 
-    let mut chars = value.chars();
-    let Some(c) = chars.next() else {
+    if key_name == "shift" || key_name == "ctrl" || key_name == "alt" {
+        eprintln!(
+            "elio: keys.{name}: {value:?} is missing a key after modifiers; using default '{default}'"
+        );
+        return None;
+    }
+
+    if let Some(named) = NamedKey::parse(key_name) {
+        let spec = KeySpec {
+            code: KeyCodeSpec::Named(named),
+            modifiers,
+        };
+        return validate_key_spec(name, spec, default);
+    }
+
+    let mut chars = key_name.chars();
+    let Some(mut c) = chars.next() else {
         eprintln!(
             "elio: keys.{name}: empty strings cannot be used as key bindings; use [] to unbind this action; using default '{default}'"
         );
@@ -598,11 +710,11 @@ fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec>
     };
     if chars.next().is_some() {
         eprintln!(
-            "elio: keys.{name}: {value:?} is not a single character or supported named key; using default '{default}'"
+            "elio: keys.{name}: {value:?} is not a single character, modifier binding, or supported named key; using default '{default}'"
         );
         return None;
     }
-    if RESERVED_CHARS.contains(&c) {
+    if RESERVED_CHARS.contains(&c) && modifiers.is_empty() {
         eprintln!(
             "elio: keys.{name}: '{c}' is reserved and cannot be rebound; using default '{default}'"
         );
@@ -615,5 +727,113 @@ fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec>
         return None;
     }
 
-    Some(KeySpec::Char(c))
+    if (modifiers.ctrl || modifiers.alt) && c.is_ascii_alphabetic() {
+        c = c.to_ascii_lowercase();
+    }
+
+    validate_key_spec(
+        name,
+        KeySpec {
+            code: KeyCodeSpec::Char(c),
+            modifiers,
+        },
+        default,
+    )
+}
+
+fn validate_key_spec(name: &str, spec: KeySpec, default: &KeyList) -> Option<KeySpec> {
+    if is_reserved_key_spec(spec) {
+        eprintln!(
+            "elio: keys.{name}: '{spec}' is reserved and cannot be rebound; using default '{default}'"
+        );
+        return None;
+    }
+
+    Some(spec)
+}
+
+fn is_reserved_key_spec(spec: KeySpec) -> bool {
+    match spec.code {
+        KeyCodeSpec::Char(c) if spec.modifiers.is_empty() => RESERVED_CHARS.contains(&c),
+        KeyCodeSpec::Char(c) if spec.modifiers.ctrl => {
+            RESERVED_MODIFIED_CHARS.contains(&c.to_ascii_lowercase())
+        }
+        KeyCodeSpec::Named(NamedKey::Left | NamedKey::Right) if spec.modifiers.alt => true,
+        _ => false,
+    }
+}
+
+fn parse_key_modifiers<'a>(
+    name: &str,
+    value: &'a str,
+    default: &KeyList,
+) -> Option<(KeyModifierSpec, &'a str)> {
+    let mut parts = value.split('+').peekable();
+    let mut modifiers = KeyModifierSpec::NONE;
+    let mut key = None;
+
+    while let Some(part) = parts.next() {
+        if part.is_empty() {
+            if value.is_empty() {
+                eprintln!(
+                    "elio: keys.{name}: empty strings cannot be used as key bindings; use [] to unbind this action; using default '{default}'"
+                );
+            } else {
+                eprintln!(
+                    "elio: keys.{name}: {value:?} contains an empty key component; using default '{default}'"
+                );
+            }
+            return None;
+        }
+
+        if parts.peek().is_none() {
+            key = Some(part);
+            break;
+        }
+
+        match part {
+            "ctrl" => {
+                if modifiers.ctrl {
+                    eprintln!(
+                        "elio: keys.{name}: duplicate modifier 'ctrl' in {value:?}; using default '{default}'"
+                    );
+                    return None;
+                }
+                modifiers.ctrl = true;
+            }
+            "alt" => {
+                if modifiers.alt {
+                    eprintln!(
+                        "elio: keys.{name}: duplicate modifier 'alt' in {value:?}; using default '{default}'"
+                    );
+                    return None;
+                }
+                modifiers.alt = true;
+            }
+            "shift" => {
+                if modifiers.shift {
+                    eprintln!(
+                        "elio: keys.{name}: duplicate modifier 'shift' in {value:?}; using default '{default}'"
+                    );
+                    return None;
+                }
+                modifiers.shift = true;
+            }
+            _ => {
+                eprintln!(
+                    "elio: keys.{name}: unknown modifier {part:?} in {value:?}; supported modifiers are ctrl, alt, and shift; using default '{default}'"
+                );
+                return None;
+            }
+        }
+    }
+
+    let Some(key) = key else {
+        eprintln!(
+            "elio: keys.{name}: {value:?} is missing a key after modifiers; using default '{default}'"
+        );
+        return None;
+    };
+
+    Some((modifiers, key))
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -123,6 +123,306 @@ open = ["o", "e"]
 }
 
 #[test]
+fn keys_accept_modifier_bindings() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "ctrl+o"
+open_with = "alt+o"
+open_or_enter = ["enter", "ctrl+enter"]
+nav_right = "shift+right"
+nav_left = "ctrl+alt+up"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.open.to_string(), "Ctrl+O");
+    assert_eq!(config.keys.open_with.to_string(), "Alt+O");
+    assert_eq!(config.keys.open_or_enter.to_string(), "Enter/Ctrl+Enter");
+    assert_eq!(config.keys.nav_right.to_string(), "Shift+→");
+    assert_eq!(config.keys.nav_left.to_string(), "Ctrl+Alt+↑");
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT)),
+        Some(Action::OpenWith)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::SHIFT)),
+        Some(Action::NavRight)
+    );
+    assert_eq!(
+        config.keys.action_for_key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::CONTROL | KeyModifiers::ALT
+        )),
+        Some(Action::NavLeft)
+    );
+}
+
+#[test]
+fn keys_match_modifiers_exactly() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_right = "right"
+open = "shift+right"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        Some(Action::NavRight)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::SHIFT)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL)),
+        None
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::SUPER)),
+        None
+    );
+}
+
+#[test]
+fn modified_and_plain_bindings_do_not_collide() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_right = []
+open = "e"
+search_folders = "ctrl+e"
+open_or_enter = "right"
+nav_left = "shift+right"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.action_for('e'), Some(Action::Open));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL)),
+        Some(Action::SearchFolders)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::SHIFT)),
+        Some(Action::NavLeft)
+    );
+}
+
+#[test]
+fn modified_bindings_detect_collisions() {
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "ctrl+e"
+search_folders = "ctrl+e"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.open.to_string(), "Ctrl+E");
+    assert_eq!(config.keys.search_folders.to_string(), "f");
+}
+
+#[test]
+fn shifted_char_events_match_uppercase_char_bindings() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let key_bindings = KeyBindings::default();
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Char('O'), KeyModifiers::SHIFT)),
+        Some(Action::OpenWith)
+    );
+}
+
+#[test]
+fn keys_reject_invalid_modifier_bindings_and_use_default() {
+    let cases = [
+        "open = \"ctrl+\"",
+        "open = \"ctrl++f\"",
+        "open = \"ctrl+ctrl+f\"",
+        "open = \"cmd+f\"",
+        "open = \"ctrl+spacebar\"",
+        "open = \"ctrl+f\"",
+        "open = \"ctrl+c\"",
+        "open = \"ctrl+a\"",
+        "open = \"ctrl+=\"",
+        "open = \"ctrl+-\"",
+        "open = \"alt+right\"",
+        "open = \"alt+left\"",
+    ];
+
+    for override_toml in cases {
+        let config =
+            Config::from_str(&format!("[keys]\n{override_toml}")).expect("config should parse");
+        assert_eq!(config.keys.open.to_string(), "o");
+    }
+
+    let config = Config::from_str("[keys]\nopen_with = \"shift+o\"").expect("config should parse");
+    assert_eq!(config.keys.open_with.to_string(), "O");
+}
+
+#[test]
+fn modified_bindings_accept_case_and_order_variants_safely() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "CTRL+O"
+open_with = "alt+ctrl+e"
+"#,
+    )
+    .expect("config should parse");
+
+    // Modifiers are intentionally lower-case only; uppercase aliases fall back
+    // instead of being accepted ambiguously.
+    assert_eq!(config.keys.open.to_string(), "o");
+    assert_eq!(config.keys.open_with.to_string(), "Ctrl+Alt+E");
+    assert_eq!(
+        config.keys.action_for_key(KeyEvent::new(
+            KeyCode::Char('e'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT
+        )),
+        Some(Action::OpenWith)
+    );
+    assert_eq!(
+        config.keys.action_for_key(KeyEvent::new(
+            KeyCode::Char('e'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER
+        )),
+        None,
+        "extra terminal modifiers must not accidentally match"
+    );
+}
+
+#[test]
+fn ctrl_alt_character_bindings_match_shifted_terminal_events_without_leaking_plain() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "ctrl+o"
+open_with = "alt+o"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config.keys.action_for_key(KeyEvent::new(
+            KeyCode::Char('O'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT
+        )),
+        Some(Action::Open),
+        "terminals may report Ctrl+Shift+letter as an uppercase char plus Shift"
+    );
+    assert_eq!(
+        config.keys.action_for_key(KeyEvent::new(
+            KeyCode::Char('O'),
+            KeyModifiers::ALT | KeyModifiers::SHIFT
+        )),
+        Some(Action::OpenWith)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)),
+        None,
+        "plain o must stay unbound after open moves to Ctrl+O"
+    );
+}
+
+#[test]
+fn parser_edge_cases_fall_back_without_panicking() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let suspicious_values = [
+        "",
+        "+",
+        "++",
+        "ctrl+",
+        "+ctrl+o",
+        "ctrl++o",
+        "ctrl+alt+",
+        "ctrl+alt+shift",
+        "ctrl+shift+o",
+        "shift++",
+        "super+o",
+        "cmd+o",
+        "ctrl+spacebar",
+        "right+ctrl",
+        "ctrl+alt+right+extra",
+        "enter+ctrl",
+        "\t",
+        "\n",
+        "🔥🔥",
+    ];
+
+    for value in suspicious_values {
+        let escaped = value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\t', "\\t")
+            .replace('\n', "\\n");
+        let config = Config::from_str(&format!("[keys]\nopen = \"{escaped}\""))
+            .expect("config should parse or safely fall back");
+        assert!(
+            config.keys.open.to_string() == "o"
+                || config.keys.action_for_key(KeyEvent::new(
+                    KeyCode::Right,
+                    KeyModifiers::CONTROL | KeyModifiers::ALT,
+                )) == Some(Action::Open),
+            "unexpected parse result for {value:?}: {}",
+            config.keys.open
+        );
+    }
+}
+
+#[test]
 fn keys_rejects_multi_char_string_and_uses_default() {
     let config = Config::from_str(
         r#"


### PR DESCRIPTION
## Summary

Adds modifier-aware bindings for configurable `[keys]` actions.

Users can now bind actions to shortcuts like `ctrl+o`, `alt+o`, `ctrl+enter`, and `shift+right`.

## What Changed

- Added `ctrl`, `alt`, and `shift` modifier parsing for configurable key bindings.
- Added modifier support for both character keys and named keys.
- Kept shifted letters as uppercase character bindings, such as `O` instead of `shift+o`.
- Reserved hard-wired shortcuts like `Ctrl+C`, `Ctrl+F`, `Ctrl+A`, zoom keys, and `Alt+Left` / `Alt+Right`.
- Prevented modified key events from falling through to plain character bindings.

## User Impact

Users can configure modifier shortcuts while keeping existing single-key, multi-key, named-key, and `[]` unbind behavior.

Invalid, duplicate, or reserved bindings fall back to defaults instead of creating ambiguous mappings.

## Notes

Modifier and named-key names are lowercase. Shifted letters remain uppercase character bindings for terminal compatibility.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Manually tested modifier key configs.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
