### PR TITLE
feat(keys): add configurable browser control keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for assigning multiple single-character bindings to each configurable `[keys]` action, while keeping existing single-string key config compatible.
+- Added support for assigning multiple bindings to each configurable `[keys]` action, while keeping existing single-string key config compatible.
 - Added configurable navigation bindings for `nav_left`, `nav_down`, `nav_up`, and `nav_right`, including named arrow keys.
 - Added `open_or_enter` as a configurable binding for the existing `Enter` behavior: entering folders or opening files. ([#141])
 - Added `[]` support for unbinding configurable `[keys]` actions.
 - Added support for modifier `[keys]` bindings such as `ctrl+o`, `alt+o`, and `shift+right`.
+- Added named `[keys]` values for `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`.
+- Added configurable browser control bindings for `go_to`, `toggle_selection`, `cycle_places_next`, `cycle_places_previous`, `go_parent`, `page_up`, `page_down`, `select_first`, and `select_last`.
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
+
+### Changed
+
+- Updated the help overlay to reflect the new configurable bindings.
 
 ## [1.7.0] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for `left`, `right`, `up`, `down`, and `enter`; modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for arrows, `enter`, `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`; modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
 
 ### Navigation
 
@@ -266,13 +266,14 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 |---|---|
 | `k` / `↑` `*` | Move up |
 | `j` / `↓` `*` | Move down |
-| `h` / `←` `*` / `Backspace` | Go to parent directory |
+| `h` / `←` / `Backspace` `*` | Go to parent directory |
 | `l` / `→` `*` | Enter folder |
 | `Enter` `*` | Enter folder / open file or selection |
-| `g` | Go-to menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash) |
-| `G` | Jump to last item |
-| `PageUp` / `PageDown` | Page up / down |
-| `Tab` / `Shift+Tab` | Cycle places |
+| `g` `*` | Go-to menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash) |
+| `Home` `*` | Jump to first item |
+| `G` / `End` `*` | Jump to last item |
+| `PageUp` / `PageDown` `*` | Page up / down |
+| `Tab` / `Shift+Tab` `*` | Cycle places |
 | `Alt+←` / `Alt+→` | Back / forward in history |
 
 ### Search
@@ -317,7 +318,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 
 | Key | Action |
 |---|---|
-| `Space` | Toggle selection |
+| `Space` `*` | Toggle selection |
 | `Ctrl+A` | Select all |
 | `y` `*` | Yank (copy) |
 | `x` `*` | Cut |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -60,7 +60,8 @@
 # Rebind browser action keys. Each value may be a single key, a list, or [].
 #
 # Keys may be one-character strings, named keys, or modifier bindings.
-# Supported named keys: "left", "right", "up", "down", "enter".
+# Supported named keys: "left", "right", "up", "down", "enter", "space",
+# "tab", "backtab", "shift+tab", "backspace", "pageup", "pagedown", "home", "end".
 # Supported modifiers: "ctrl", "alt", "shift" with lowercase names.
 #
 # Examples: open_with = ["O", "w"], open = "ctrl+o", nav_right = "shift+right".
@@ -73,7 +74,7 @@
 # Example: nav_right = [] frees "l" and "right".
 # Then open_or_enter = ["enter", "l", "right"] can use them.
 #
-# Reserved bare keys: g G ? [ ] + = - _ Space
+# Reserved bare keys: ? [ ] + = - _
 # Reserved shortcuts: Ctrl+C, Ctrl+F, Ctrl+A, Ctrl+Plus/Minus, Alt+Left/Right
 # Omit any key to keep the built-in default shown in the comment.
 #
@@ -97,6 +98,15 @@
 # open                 = "o"
 # open_with            = "O"
 # open_or_enter        = "enter"
+# go_to                = "g"
+# toggle_selection     = "space"
+# cycle_places_next    = "tab"
+# cycle_places_previous = "backtab"
+# go_parent            = "backspace"
+# page_up              = "pageup"
+# page_down            = "pagedown"
+# select_first         = "home"
+# select_last          = ["G", "end"]
 # sort                 = "s"
 # toggle_view          = "v"
 # toggle_hidden        = "."

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -192,22 +192,12 @@ impl App {
                 self.clear_wheel_scroll();
                 self.overlays.help = true;
             }
-            KeyCode::Tab => self.step_sidebar_place(1)?,
-            KeyCode::BackTab => self.step_sidebar_place(-1)?,
             _ if crate::config::keys().action_for_key(key).is_some() => {
                 let action = crate::config::keys()
                     .action_for_key(key)
                     .expect("action was checked above");
                 self.dispatch_action(action)?;
             }
-            KeyCode::PageUp => self.page(-1),
-            KeyCode::PageDown => self.page(1),
-            KeyCode::Home => self.select_index(0),
-            KeyCode::End => self.select_last(),
-            KeyCode::Char('g') => self.open_goto_overlay(),
-            KeyCode::Char('G') => self.select_last(),
-            KeyCode::Backspace => self.go_parent()?,
-            KeyCode::Char(' ') => self.toggle_selection(),
             KeyCode::Char('+') | KeyCode::Char('=')
                 if self.navigation.view_mode == ViewMode::Grid =>
             {
@@ -287,6 +277,15 @@ impl App {
             Action::Open => self.open_in_system()?,
             Action::OpenWith => self.open_open_with_overlay(),
             Action::OpenOrEnter => self.open_selected()?,
+            Action::GoTo => self.open_goto_overlay(),
+            Action::ToggleSelection => self.toggle_selection(),
+            Action::CyclePlacesNext => self.step_sidebar_place(1)?,
+            Action::CyclePlacesPrevious => self.step_sidebar_place(-1)?,
+            Action::GoParent => self.go_parent()?,
+            Action::PageUp => self.page(-1),
+            Action::PageDown => self.page(1),
+            Action::SelectFirst => self.select_index(0),
+            Action::SelectLast => self.select_last(),
             Action::Sort => self.cycle_sort_mode()?,
             Action::ToggleView => self.toggle_view_mode(),
             Action::ToggleHidden => self.toggle_hidden_files()?,
@@ -367,13 +366,11 @@ impl App {
             Some(crate::config::Action::NavDown) => Some(NavigationRepeatKey::Down),
             Some(crate::config::Action::NavLeft) => Some(NavigationRepeatKey::Left),
             Some(crate::config::Action::NavRight) => Some(NavigationRepeatKey::Right),
-            _ => match key.code {
-                KeyCode::PageUp => Some(NavigationRepeatKey::PageUp),
-                KeyCode::PageDown => Some(NavigationRepeatKey::PageDown),
-                KeyCode::Home => Some(NavigationRepeatKey::Home),
-                KeyCode::End | KeyCode::Char('G') => Some(NavigationRepeatKey::End),
-                _ => None,
-            },
+            Some(crate::config::Action::PageUp) => Some(NavigationRepeatKey::PageUp),
+            Some(crate::config::Action::PageDown) => Some(NavigationRepeatKey::PageDown),
+            Some(crate::config::Action::SelectFirst) => Some(NavigationRepeatKey::Home),
+            Some(crate::config::Action::SelectLast) => Some(NavigationRepeatKey::End),
+            _ => None,
         }
     }
 

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -20,6 +20,15 @@ pub(crate) enum Action {
     Open,
     OpenWith,
     OpenOrEnter,
+    GoTo,
+    ToggleSelection,
+    CyclePlacesNext,
+    CyclePlacesPrevious,
+    GoParent,
+    PageUp,
+    PageDown,
+    SelectFirst,
+    SelectLast,
     Sort,
     ToggleView,
     ToggleHidden,
@@ -40,6 +49,14 @@ pub(crate) enum NamedKey {
     Up,
     Down,
     Enter,
+    Space,
+    Tab,
+    BackTab,
+    Backspace,
+    PageUp,
+    PageDown,
+    Home,
+    End,
 }
 
 impl NamedKey {
@@ -50,6 +67,14 @@ impl NamedKey {
             "up" => Some(Self::Up),
             "down" => Some(Self::Down),
             "enter" => Some(Self::Enter),
+            "space" => Some(Self::Space),
+            "tab" => Some(Self::Tab),
+            "backtab" => Some(Self::BackTab),
+            "backspace" => Some(Self::Backspace),
+            "pageup" => Some(Self::PageUp),
+            "pagedown" => Some(Self::PageDown),
+            "home" => Some(Self::Home),
+            "end" => Some(Self::End),
             _ => None,
         }
     }
@@ -65,6 +90,14 @@ impl NamedKey {
                     Self::Enter,
                     KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r')
                 )
+                | (Self::Space, KeyCode::Char(' '))
+                | (Self::Tab, KeyCode::Tab)
+                | (Self::BackTab, KeyCode::BackTab)
+                | (Self::Backspace, KeyCode::Backspace)
+                | (Self::PageUp, KeyCode::PageUp)
+                | (Self::PageDown, KeyCode::PageDown)
+                | (Self::Home, KeyCode::Home)
+                | (Self::End, KeyCode::End)
         )
     }
 }
@@ -77,6 +110,14 @@ impl std::fmt::Display for NamedKey {
             Self::Up => "↑",
             Self::Down => "↓",
             Self::Enter => "Enter",
+            Self::Space => "Space",
+            Self::Tab => "Tab",
+            Self::BackTab => "Shift+Tab",
+            Self::Backspace => "Backspace",
+            Self::PageUp => "PageUp",
+            Self::PageDown => "PageDown",
+            Self::Home => "Home",
+            Self::End => "End",
         })
     }
 }
@@ -170,6 +211,10 @@ fn normalize_key_event(key: KeyEvent) -> (KeyCode, KeyModifierSpec) {
             modifiers.shift = false;
             KeyCode::Char(c)
         }
+        KeyCode::BackTab => {
+            modifiers.shift = false;
+            KeyCode::BackTab
+        }
         code => code,
     };
     (code, modifiers)
@@ -250,7 +295,8 @@ impl PartialEq<char> for KeyList {
 /// string (`open = "o"`) or a list of strings (`open = ["o", "e"]`).
 /// Empty lists unbind the action (`open = []`).
 /// Character bindings must be one character; named bindings currently support
-/// `left`, `right`, `up`, `down`, and `enter`.
+/// `left`, `right`, `up`, `down`, `enter`, `space`, `tab`, `backtab`,
+/// `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct KeyBindings {
     pub quit: KeyList,
@@ -269,6 +315,15 @@ pub(crate) struct KeyBindings {
     pub open: KeyList,
     pub open_with: KeyList,
     pub open_or_enter: KeyList,
+    pub go_to: KeyList,
+    pub toggle_selection: KeyList,
+    pub cycle_places_next: KeyList,
+    pub cycle_places_previous: KeyList,
+    pub go_parent: KeyList,
+    pub page_up: KeyList,
+    pub page_down: KeyList,
+    pub select_first: KeyList,
+    pub select_last: KeyList,
     pub sort: KeyList,
     pub toggle_view: KeyList,
     pub toggle_hidden: KeyList,
@@ -285,11 +340,9 @@ pub(crate) struct KeyBindings {
 /// Characters that are hard-wired to non-configurable actions and may not be
 /// used as key binding values.
 const RESERVED_CHARS: &[char] = &[
-    'g', 'G', // go-to overlay / jump to last
     '?', // help
     '[', ']', // page stepping (epub / comic / pdf)
     '+', '=', '-', '_', // grid zoom
-    ' ', // toggle selection
 ];
 
 /// Modified keys that are still hard-wired before configurable browser actions.
@@ -319,6 +372,15 @@ impl Default for KeyBindings {
             open: KeyList::one('o'),
             open_with: KeyList::one('O'),
             open_or_enter: KeyList(vec![KeySpec::named(NamedKey::Enter)]),
+            go_to: KeyList::one('g'),
+            toggle_selection: KeyList(vec![KeySpec::named(NamedKey::Space)]),
+            cycle_places_next: KeyList(vec![KeySpec::named(NamedKey::Tab)]),
+            cycle_places_previous: KeyList(vec![KeySpec::named(NamedKey::BackTab)]),
+            go_parent: KeyList(vec![KeySpec::named(NamedKey::Backspace)]),
+            page_up: KeyList(vec![KeySpec::named(NamedKey::PageUp)]),
+            page_down: KeyList(vec![KeySpec::named(NamedKey::PageDown)]),
+            select_first: KeyList(vec![KeySpec::named(NamedKey::Home)]),
+            select_last: KeyList(vec![KeySpec::char('G'), KeySpec::named(NamedKey::End)]),
             sort: KeyList::one('s'),
             toggle_view: KeyList::one('v'),
             toggle_hidden: KeyList::one('.'),
@@ -359,6 +421,15 @@ pub(super) struct KeysConfigOverride {
     open: Option<KeyConfigOverride>,
     open_with: Option<KeyConfigOverride>,
     open_or_enter: Option<KeyConfigOverride>,
+    go_to: Option<KeyConfigOverride>,
+    toggle_selection: Option<KeyConfigOverride>,
+    cycle_places_next: Option<KeyConfigOverride>,
+    cycle_places_previous: Option<KeyConfigOverride>,
+    go_parent: Option<KeyConfigOverride>,
+    page_up: Option<KeyConfigOverride>,
+    page_down: Option<KeyConfigOverride>,
+    select_first: Option<KeyConfigOverride>,
+    select_last: Option<KeyConfigOverride>,
     sort: Option<KeyConfigOverride>,
     toggle_view: Option<KeyConfigOverride>,
     toggle_hidden: Option<KeyConfigOverride>,
@@ -398,6 +469,15 @@ impl KeyBindings {
             (&self.open, Action::Open),
             (&self.open_with, Action::OpenWith),
             (&self.open_or_enter, Action::OpenOrEnter),
+            (&self.go_to, Action::GoTo),
+            (&self.toggle_selection, Action::ToggleSelection),
+            (&self.cycle_places_next, Action::CyclePlacesNext),
+            (&self.cycle_places_previous, Action::CyclePlacesPrevious),
+            (&self.go_parent, Action::GoParent),
+            (&self.page_up, Action::PageUp),
+            (&self.page_down, Action::PageDown),
+            (&self.select_first, Action::SelectFirst),
+            (&self.select_last, Action::SelectLast),
             (&self.sort, Action::Sort),
             (&self.toggle_view, Action::ToggleView),
             (&self.toggle_hidden, Action::ToggleHidden),
@@ -513,6 +593,51 @@ impl KeyBindings {
                 name: "open_or_enter",
                 override_value: overrides.open_or_enter,
                 default: defaults.open_or_enter.clone(),
+            },
+            RawBinding {
+                name: "go_to",
+                override_value: overrides.go_to,
+                default: defaults.go_to.clone(),
+            },
+            RawBinding {
+                name: "toggle_selection",
+                override_value: overrides.toggle_selection,
+                default: defaults.toggle_selection.clone(),
+            },
+            RawBinding {
+                name: "cycle_places_next",
+                override_value: overrides.cycle_places_next,
+                default: defaults.cycle_places_next.clone(),
+            },
+            RawBinding {
+                name: "cycle_places_previous",
+                override_value: overrides.cycle_places_previous,
+                default: defaults.cycle_places_previous.clone(),
+            },
+            RawBinding {
+                name: "go_parent",
+                override_value: overrides.go_parent,
+                default: defaults.go_parent.clone(),
+            },
+            RawBinding {
+                name: "page_up",
+                override_value: overrides.page_up,
+                default: defaults.page_up.clone(),
+            },
+            RawBinding {
+                name: "page_down",
+                override_value: overrides.page_down,
+                default: defaults.page_down.clone(),
+            },
+            RawBinding {
+                name: "select_first",
+                override_value: overrides.select_first,
+                default: defaults.select_first.clone(),
+            },
+            RawBinding {
+                name: "select_last",
+                override_value: overrides.select_last,
+                default: defaults.select_last.clone(),
             },
             RawBinding {
                 name: "sort",
@@ -634,17 +759,26 @@ impl KeyBindings {
             open: resolved(13),
             open_with: resolved(14),
             open_or_enter: resolved(15),
-            sort: resolved(16),
-            toggle_view: resolved(17),
-            toggle_hidden: resolved(18),
-            nav_left: resolved(19),
-            nav_down: resolved(20),
-            nav_up: resolved(21),
-            nav_right: resolved(22),
-            scroll_preview_left: resolved(23),
-            scroll_preview_right: resolved(24),
-            scroll_preview_up: resolved(25),
-            scroll_preview_down: resolved(26),
+            go_to: resolved(16),
+            toggle_selection: resolved(17),
+            cycle_places_next: resolved(18),
+            cycle_places_previous: resolved(19),
+            go_parent: resolved(20),
+            page_up: resolved(21),
+            page_down: resolved(22),
+            select_first: resolved(23),
+            select_last: resolved(24),
+            sort: resolved(25),
+            toggle_view: resolved(26),
+            toggle_hidden: resolved(27),
+            nav_left: resolved(28),
+            nav_down: resolved(29),
+            nav_up: resolved(30),
+            nav_right: resolved(31),
+            scroll_preview_left: resolved(32),
+            scroll_preview_right: resolved(33),
+            scroll_preview_up: resolved(34),
+            scroll_preview_down: resolved(35),
         }
     }
 }
@@ -671,7 +805,26 @@ fn parse_key_override(name: &str, value: &KeyConfigOverride, default: &KeyList) 
 }
 
 fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec> {
-    let (modifiers, key_name) = parse_key_modifiers(name, value, default)?;
+    let (mut modifiers, key_name) = parse_key_modifiers(name, value, default)?;
+
+    if modifiers.shift && key_name == "tab" {
+        modifiers.shift = false;
+        return validate_key_spec(
+            name,
+            KeySpec {
+                code: KeyCodeSpec::Named(NamedKey::BackTab),
+                modifiers,
+            },
+            default,
+        );
+    }
+
+    if modifiers.shift && key_name == "space" {
+        eprintln!(
+            "elio: keys.{name}: {value:?} uses shift with space, which terminals do not report reliably; using default '{default}'"
+        );
+        return None;
+    }
 
     if modifiers.shift && key_name.len() == 1 {
         let c = key_name.chars().next().expect("single-char key");
@@ -725,6 +878,16 @@ fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec>
             "elio: keys.{name}: control characters cannot be used as key bindings; using default '{default}'"
         );
         return None;
+    }
+    if c == ' ' && modifiers.is_empty() {
+        return validate_key_spec(
+            name,
+            KeySpec {
+                code: KeyCodeSpec::Named(NamedKey::Space),
+                modifiers,
+            },
+            default,
+        );
     }
 
     if (modifiers.ctrl || modifiers.alt) && c.is_ascii_alphabetic() {

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -286,6 +286,7 @@ fn keys_reject_invalid_modifier_bindings_and_use_default() {
         "open = \"ctrl+ctrl+f\"",
         "open = \"cmd+f\"",
         "open = \"ctrl+spacebar\"",
+        "open = \"shift+space\"",
         "open = \"ctrl+f\"",
         "open = \"ctrl+c\"",
         "open = \"ctrl+a\"",
@@ -394,6 +395,7 @@ fn parser_edge_cases_fall_back_without_panicking() {
         "super+o",
         "cmd+o",
         "ctrl+spacebar",
+        "shift+space",
         "right+ctrl",
         "ctrl+alt+right+extra",
         "enter+ctrl",
@@ -420,6 +422,19 @@ fn parser_edge_cases_fall_back_without_panicking() {
             config.keys.open
         );
     }
+}
+
+#[test]
+fn literal_space_collides_with_space_named_key() {
+    let config = Config::from_str(
+        r#"
+[keys]
+open = " "
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(config.keys.action_for(' '), Some(Action::ToggleSelection));
+    assert_eq!(config.keys.action_for('o'), Some(Action::Open));
 }
 
 #[test]
@@ -900,5 +915,204 @@ scroll_preview_down = "U"
         config.keys.action_for('J'),
         None,
         "default 'J' is no longer bound because scroll_preview_down was overridden to 'U'"
+    );
+}
+
+#[test]
+fn browser_control_defaults_are_configurable_actions() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let key_bindings = KeyBindings::default();
+    assert_eq!(key_bindings.action_for('g'), Some(Action::GoTo));
+    assert_eq!(key_bindings.action_for('G'), Some(Action::SelectLast));
+    assert_eq!(key_bindings.action_for(' '), Some(Action::ToggleSelection));
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        Some(Action::CyclePlacesNext)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::CyclePlacesPrevious)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
+        Some(Action::CyclePlacesPrevious)
+    );
+
+    let shift_tab = Config::from_str("[keys]\ncycle_places_previous = \"shift+tab\"")
+        .expect("config should parse");
+    assert_eq!(
+        shift_tab
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::CyclePlacesPrevious)
+    );
+    assert_eq!(
+        shift_tab
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
+        Some(Action::CyclePlacesPrevious)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        Some(Action::GoParent)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+        Some(Action::PageUp)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+        Some(Action::PageDown)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE)),
+        Some(Action::SelectFirst)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE)),
+        Some(Action::SelectLast)
+    );
+}
+
+#[test]
+fn browser_control_defaults_can_be_freed_for_other_actions() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+go_to = []
+toggle_selection = []
+cycle_places_next = []
+cycle_places_previous = []
+go_parent = []
+page_up = []
+page_down = []
+select_first = []
+select_last = []
+open = ["o", "g", "G", "space", "tab", "backtab", "backspace", "pageup", "pagedown", "home", "end"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.action_for('g'), Some(Action::Open));
+    assert_eq!(config.keys.action_for('G'), Some(Action::Open));
+    assert_eq!(config.keys.action_for(' '), Some(Action::Open));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
+        Some(Action::Open)
+    );
+
+    let nav_right = Config::from_str(
+        r#"
+[keys]
+cycle_places_previous = []
+nav_right = "backtab"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(
+        nav_right
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::NavRight)
+    );
+    assert_eq!(
+        nav_right
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
+        Some(Action::NavRight)
+    );
+
+    let shift_tab_nav_right = Config::from_str(
+        r#"
+[keys]
+cycle_places_previous = []
+nav_right = "shift+tab"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(
+        shift_tab_nav_right
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::NavRight)
+    );
+    assert_eq!(
+        shift_tab_nav_right
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
+        Some(Action::NavRight)
+    );
+
+    let default_keys = KeyBindings::default();
+    assert_eq!(
+        default_keys.action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::CyclePlacesPrevious)
+    );
+    assert_eq!(
+        default_keys.action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
+        Some(Action::CyclePlacesPrevious)
+    );
+
+    let literal_space = Config::from_str(
+        r#"
+[keys]
+toggle_selection = []
+open = " "
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(literal_space.keys.action_for(' '), Some(Action::Open));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE)),
+        Some(Action::Open)
     );
 }

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -1,4 +1,5 @@
 use crate::app::FrameState;
+use crate::config::KeyBindings;
 use crate::ui::{helpers, theme::Palette};
 use ratatui::{
     Frame,
@@ -17,20 +18,7 @@ pub(super) fn render_help(
 ) {
     let kb = crate::config::keys();
 
-    let parent_key = format!("{} / Backspace", kb.nav_left);
-
-    let navigation_entries = vec![
-        e(&kb.nav_up.to_string(), "move up"),
-        e(&kb.nav_down.to_string(), "move down"),
-        e(&parent_key, "parent folder"),
-        e(&kb.nav_right.to_string(), "enter folder"),
-        e(&kb.open_or_enter.to_string(), "enter folder / open"),
-        e("g", "go-to menu"),
-        e("G", "last item"),
-        e("PageUp / PageDown", "page up / down"),
-        e("Tab / Shift+Tab", "cycle places"),
-        e("Alt+← / Alt+→", "back / forward"),
-    ];
+    let navigation_entries = navigation_entries(kb);
     let search_entries = vec![
         e(&kb.zoxide.to_string(), "zoxide history"),
         e(&kb.search_folders.to_string(), "search folders"),
@@ -40,15 +28,7 @@ pub(super) fn render_help(
         e("Ctrl+Del", "delete next word"),
         e("Ctrl+W / Alt+D", "fallback word delete"),
     ];
-    let clipboard_entries = vec![
-        e("Space", "toggle selection"),
-        e("Ctrl+A", "select all"),
-        e("Esc", "clear selection"),
-        e(&kb.yank.to_string(), "yank (copy)"),
-        e(&kb.copy_path.to_string(), "copy path details"),
-        e(&kb.cut.to_string(), "cut"),
-        e(&kb.paste.to_string(), "paste"),
-    ];
+    let clipboard_entries = clipboard_entries(kb);
     let rename_key = format!("{} / F2", kb.rename);
     let rename_trash_key = format!("{} (in trash)", kb.rename);
     let files_entries = vec![
@@ -224,6 +204,46 @@ pub(super) fn render_help(
     );
 }
 
+fn navigation_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
+    let parent_key = format_key_pair(&kb.nav_left, &kb.go_parent);
+    let page_key = format_key_pair(&kb.page_up, &kb.page_down);
+    let place_key = format_key_pair(&kb.cycle_places_next, &kb.cycle_places_previous);
+
+    vec![
+        e(&kb.nav_up.to_string(), "move up"),
+        e(&kb.nav_down.to_string(), "move down"),
+        e(&parent_key, "parent folder"),
+        e(&kb.nav_right.to_string(), "enter folder"),
+        e(&kb.open_or_enter.to_string(), "enter folder / open"),
+        e(&kb.go_to.to_string(), "go-to menu"),
+        e(&kb.select_first.to_string(), "first item"),
+        e(&kb.select_last.to_string(), "last item"),
+        e(&page_key, "page up / down"),
+        e(&place_key, "cycle places"),
+        e("Alt+← / Alt+→", "back / forward"),
+    ]
+}
+
+fn clipboard_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
+    vec![
+        e(&kb.toggle_selection.to_string(), "toggle selection"),
+        e("Ctrl+A", "select all"),
+        e("Esc", "clear selection"),
+        e(&kb.yank.to_string(), "yank (copy)"),
+        e(&kb.copy_path.to_string(), "copy path details"),
+        e(&kb.cut.to_string(), "cut"),
+        e(&kb.paste.to_string(), "paste"),
+    ]
+}
+
+fn format_key_pair(first: &crate::config::KeyList, second: &crate::config::KeyList) -> String {
+    match (first.to_string(), second.to_string()) {
+        (first, second) if first.is_empty() => second,
+        (first, second) if second.is_empty() => first,
+        (first, second) => format!("{first} / {second}"),
+    }
+}
+
 /// Render a preview-scroll key pair: defaults like 'H'/'L' show as "Shift+H / Shift+L";
 /// overrides such as '<'/'>' show as "< / >".
 fn format_preview_scroll_key(
@@ -368,4 +388,60 @@ fn wrap_help_action(text: &str, width: usize) -> Vec<String> {
     }
 
     lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry_key(entries: &[HelpEntry], action: &str) -> String {
+        entries
+            .iter()
+            .find(|entry| entry.action == action)
+            .unwrap_or_else(|| panic!("missing help entry for {action:?}"))
+            .key
+            .clone()
+    }
+
+    #[test]
+    fn help_uses_configurable_browser_control_defaults() {
+        let kb = KeyBindings::default();
+        let navigation = navigation_entries(&kb);
+        let clipboard = clipboard_entries(&kb);
+
+        assert_eq!(entry_key(&navigation, "go-to menu"), "g");
+        assert_eq!(entry_key(&navigation, "first item"), "Home");
+        assert_eq!(entry_key(&navigation, "last item"), "G/End");
+        assert_eq!(
+            entry_key(&navigation, "page up / down"),
+            "PageUp / PageDown"
+        );
+        assert_eq!(entry_key(&navigation, "cycle places"), "Tab / Shift+Tab");
+        assert_eq!(entry_key(&clipboard, "toggle selection"), "Space");
+    }
+
+    #[test]
+    fn help_reflects_rebound_browser_controls() {
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+go_to = "u"
+toggle_selection = "t"
+cycle_places_next = "n"
+cycle_places_previous = "P"
+page_up = "<"
+page_down = ">"
+select_first = "1"
+select_last = "2"
+"#,
+        );
+        let navigation = navigation_entries(&kb);
+        let clipboard = clipboard_entries(&kb);
+
+        assert_eq!(entry_key(&navigation, "go-to menu"), "u");
+        assert_eq!(entry_key(&navigation, "first item"), "1");
+        assert_eq!(entry_key(&navigation, "last item"), "2");
+        assert_eq!(entry_key(&navigation, "page up / down"), "< / >");
+        assert_eq!(entry_key(&navigation, "cycle places"), "n / P");
+        assert_eq!(entry_key(&clipboard, "toggle selection"), "t");
+    }
 }


### PR DESCRIPTION
## Summary

Adds configurable `[keys]` bindings for the remaining browser control shortcuts.

Users can now rebind or unbind controls like go-to, selection, place cycling, parent navigation, paging, and first/last item jumps.

## What Changed

- Added configurable `[keys]` actions:
  - `go_to`
  - `toggle_selection`
  - `cycle_places_next`
  - `cycle_places_previous`
  - `go_parent`
  - `page_up`
  - `page_down`
  - `select_first`
  - `select_last`
- Added named key support for:
  - `space`
  - `tab`
  - `backtab` / `shift+tab`
  - `backspace`
  - `pageup`
  - `pagedown`
  - `home`
  - `end`
- Moved the existing hardcoded browser controls through normal configurable key dispatch.
- Kept default behavior unchanged:
  - `g` opens the go-to overlay
  - `Space` toggles selection
  - `Tab` / `Shift+Tab` cycle places
  - `Backspace` goes to the parent directory
  - `PageUp` / `PageDown` page through entries
  - `Home` jumps to the first item
  - `G` / `End` jump to the last item
- Updated repeat-key handling so configurable paging and first/last-item bindings still repeat correctly.
- Updated the help overlay to show resolved configurable bindings.
- Updated README, example config, and changelog.

## User Impact

Users can now customize or disable browser control shortcuts that were previously hardcoded.

For example:

```toml
[keys]
go_to = []
toggle_selection = "tab"
cycle_places_next = "space"
select_last = ["G", "end"]
```

Existing configs keep their current behavior because all new actions default to the previous built-in shortcuts.

## Notes

`shift+tab` is accepted as an alias for `backtab`.

`shift+space` remains rejected because terminals do not report it reliably.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings -A clippy::unnecessary_sort_by -A clippy::collapsible_match -A clippy::manual_checked_ops`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Checked default browser control dispatch for `g`, `Space`, `Tab`, `Shift+Tab`, `Backspace`, `PageUp`, `PageDown`, `Home`, `G`, and `End`.
- Checked browser control defaults can be unbinded and their freed keys reused by another action.
- Checked `backtab` and `shift+tab` both resolve to the same BackTab behavior.
- Checked literal `" "` is treated as the `space` named key and collides correctly with `toggle_selection`.
- Checked `shift+space` is rejected instead of creating an unreliable binding.
- Checked the help overlay uses the default browser control bindings.
- Checked the help overlay reflects rebinded browser control bindings.
- Checked `examples/config.toml` matches the supported named keys, reserved bare keys, and new default bindings from source.
- Checked the README controls table marks the newly configurable browser controls correctly.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
