### PR TITLE
feat(keys): add context-aware restore binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `restore_from_trash` and function-key bindings such as `F2`, letting restore and rename be configured separately while keeping the default `r` restore behavior in Trash and `r`/`F2` rename behavior elsewhere.
 - Added support for assigning multiple bindings to each configurable `[keys]` action, while keeping existing single-string key config compatible.
 - Added configurable navigation bindings for `nav_left`, `nav_down`, `nav_up`, and `nav_right`, including named arrow keys.
 - Added `open_or_enter` as a configurable binding for the existing `Enter` behavior: entering folders or opening files. ([#141])

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for arrows, `enter`, `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`; modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for arrows, `enter`, `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, `end`, and `F1`–`F12`; named keys and modifiers are case-insensitive, so `F2`, `PageUp`, and `Ctrl+O` work. Modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
 
 ### Navigation
 
@@ -294,8 +294,8 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `a` `*` | Create file or folder |
 | `d` `*` | Trash; permanently delete if already in trash |
 | `D` `*` | Delete permanently |
-| `r` `*` | Rename / bulk rename / restore from trash |
-| `F2` | Rename / bulk rename |
+| `r` / `F2` `*` | Rename / bulk rename |
+| `r` `*` (in Trash) | Restore from trash |
 
 ### View
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -61,8 +61,9 @@
 #
 # Keys may be one-character strings, named keys, or modifier bindings.
 # Supported named keys: "left", "right", "up", "down", "enter", "space",
-# "tab", "backtab", "shift+tab", "backspace", "pageup", "pagedown", "home", "end".
-# Supported modifiers: "ctrl", "alt", "shift" with lowercase names.
+# "tab", "backtab", "shift+tab", "backspace", "pageup", "pagedown", "home",
+# "end", "f1".."f12".
+# Named keys and modifiers are case-insensitive: "F2", "PageUp", "Ctrl+O".
 #
 # Examples: open_with = ["O", "w"], open = "ctrl+o", nav_right = "shift+right".
 # For shifted letters, use uppercase characters: "O", not "shift+o".
@@ -90,7 +91,8 @@
 # trash                = "d"
 # delete_permanently   = "D"   # Shift+D
 # create               = "a"
-# rename               = "r"
+# rename               = ["r", "F2"]
+# restore_from_trash   = "r"
 # copy_path            = "c"
 # search_folders       = "f"
 # zoxide               = "z"

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -169,6 +169,9 @@ impl App {
             }
         }
 
+        let configured_action =
+            crate::config::keys().action_for_key_in_context(key, self.key_context());
+
         match key.code {
             KeyCode::Esc => {
                 if let Some(prog) = &self.jobs.trash_progress {
@@ -192,10 +195,8 @@ impl App {
                 self.clear_wheel_scroll();
                 self.overlays.help = true;
             }
-            _ if crate::config::keys().action_for_key(key).is_some() => {
-                let action = crate::config::keys()
-                    .action_for_key(key)
-                    .expect("action was checked above");
+            _ if configured_action.is_some() => {
+                let action = configured_action.expect("action was checked above");
                 self.dispatch_action(action)?;
             }
             KeyCode::Char('+') | KeyCode::Char('=')
@@ -207,28 +208,6 @@ impl App {
                 if self.navigation.view_mode == ViewMode::Grid =>
             {
                 self.adjust_zoom(-1);
-            }
-            KeyCode::F(2) => {
-                if !self.navigation.in_trash && !self.cwd_is_inside_trash_subfolder() {
-                    if !self.navigation.selected_paths.is_empty() {
-                        self.open_bulk_rename_prompt();
-                    } else {
-                        self.open_rename_prompt();
-                    }
-                }
-            }
-            KeyCode::Char(c)
-                if !key.modifiers.intersects(
-                    KeyModifiers::CONTROL
-                        | KeyModifiers::ALT
-                        | KeyModifiers::SUPER
-                        | KeyModifiers::HYPER
-                        | KeyModifiers::META,
-                ) =>
-            {
-                if let Some(action) = crate::config::keys().action_for(c) {
-                    self.dispatch_action(action)?;
-                }
             }
             _ => {}
         }
@@ -250,16 +229,21 @@ impl App {
             Action::DeletePermanently => self.open_delete_permanently_prompt(),
             Action::Create => self.open_create_prompt(),
             Action::Rename => {
+                if !self.navigation.in_trash && !self.cwd_is_inside_trash_subfolder() {
+                    if !self.navigation.selected_paths.is_empty() {
+                        self.open_bulk_rename_prompt();
+                    } else {
+                        self.open_rename_prompt();
+                    }
+                }
+            }
+            Action::RestoreFromTrash => {
                 if self.navigation.in_trash {
                     self.open_restore_prompt();
                 } else if self.cwd_is_inside_trash_subfolder() {
                     self.status = "Cannot restore from inside a trashed folder \
                                    — go up to the trash to restore the folder itself"
                         .to_string();
-                } else if !self.navigation.selected_paths.is_empty() {
-                    self.open_bulk_rename_prompt();
-                } else {
-                    self.open_rename_prompt();
                 }
             }
             Action::CopyPath => self.open_copy_overlay(),
@@ -330,6 +314,14 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    fn key_context(&self) -> crate::config::KeyContext {
+        if self.navigation.in_trash || self.cwd_is_inside_trash_subfolder() {
+            crate::config::KeyContext::Trash
+        } else {
+            crate::config::KeyContext::Normal
+        }
     }
 
     fn should_debounce_navigation_key(&mut self, key: KeyEvent) -> bool {

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -47,6 +47,52 @@ fn fake_default_open_with_app(
 }
 
 #[test]
+fn f2_renames_outside_trash_but_not_inside_trash() {
+    let root = temp_path("f2-rename-not-restore");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("note.txt"), "hello").expect("failed to write file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::F(2))))
+        .expect("F2 should open rename outside trash");
+    assert!(app.rename_is_open());
+    app.overlays.rename = None;
+
+    app.navigation.in_trash = true;
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::F(2))))
+        .expect("F2 should be ignored in trash");
+    assert!(!app.rename_is_open());
+    assert!(!app.restore_is_open());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn r_renames_outside_trash_and_restores_inside_trash() {
+    let root = temp_path("r-rename-restore-context");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("note.txt"), "hello").expect("failed to write file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('r'))))
+        .expect("r should open rename outside trash");
+    assert!(app.rename_is_open());
+    app.overlays.rename = None;
+
+    app.navigation.in_trash = true;
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('r'))))
+        .expect("r should open restore inside trash");
+    assert!(!app.rename_is_open());
+    assert!(app.restore_is_open());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn shift_slash_opens_and_closes_help_overlay() {
     let root = temp_path("help-shift-slash");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -13,6 +13,7 @@ pub(crate) enum Action {
     DeletePermanently,
     Create,
     Rename,
+    RestoreFromTrash,
     CopyPath,
     SearchFolders,
     Zoxide,
@@ -57,11 +58,14 @@ pub(crate) enum NamedKey {
     PageDown,
     Home,
     End,
+    Function(u8),
 }
 
 impl NamedKey {
     fn parse(value: &str) -> Option<Self> {
-        match value {
+        let normalized = value.to_ascii_lowercase();
+
+        match normalized.as_str() {
             "left" => Some(Self::Left),
             "right" => Some(Self::Right),
             "up" => Some(Self::Up),
@@ -75,30 +79,33 @@ impl NamedKey {
             "pagedown" => Some(Self::PageDown),
             "home" => Some(Self::Home),
             "end" => Some(Self::End),
+            value if value.len() >= 2 && value.starts_with('f') => value[1..]
+                .parse::<u8>()
+                .ok()
+                .filter(|number| (1..=12).contains(number))
+                .map(Self::Function),
             _ => None,
         }
     }
 
     fn matches(self, code: KeyCode) -> bool {
-        matches!(
-            (self, code),
+        match (self, code) {
             (Self::Left, KeyCode::Left)
-                | (Self::Right, KeyCode::Right)
-                | (Self::Up, KeyCode::Up)
-                | (Self::Down, KeyCode::Down)
-                | (
-                    Self::Enter,
-                    KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r')
-                )
-                | (Self::Space, KeyCode::Char(' '))
-                | (Self::Tab, KeyCode::Tab)
-                | (Self::BackTab, KeyCode::BackTab)
-                | (Self::Backspace, KeyCode::Backspace)
-                | (Self::PageUp, KeyCode::PageUp)
-                | (Self::PageDown, KeyCode::PageDown)
-                | (Self::Home, KeyCode::Home)
-                | (Self::End, KeyCode::End)
-        )
+            | (Self::Right, KeyCode::Right)
+            | (Self::Up, KeyCode::Up)
+            | (Self::Down, KeyCode::Down)
+            | (Self::Enter, KeyCode::Enter | KeyCode::Char('\n') | KeyCode::Char('\r'))
+            | (Self::Space, KeyCode::Char(' '))
+            | (Self::Tab, KeyCode::Tab)
+            | (Self::BackTab, KeyCode::BackTab)
+            | (Self::Backspace, KeyCode::Backspace)
+            | (Self::PageUp, KeyCode::PageUp)
+            | (Self::PageDown, KeyCode::PageDown)
+            | (Self::Home, KeyCode::Home)
+            | (Self::End, KeyCode::End) => true,
+            (Self::Function(expected), KeyCode::F(actual)) => expected == actual,
+            _ => false,
+        }
     }
 }
 
@@ -118,7 +125,45 @@ impl std::fmt::Display for NamedKey {
             Self::PageDown => "PageDown",
             Self::Home => "Home",
             Self::End => "End",
+            Self::Function(number) => return write!(f, "F{number}"),
         })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum KeyContext {
+    Normal,
+    Trash,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct KeyContexts(u8);
+
+impl KeyContexts {
+    const NORMAL: Self = Self(0b01);
+    const TRASH: Self = Self(0b10);
+    const ALL: Self = Self(Self::NORMAL.0 | Self::TRASH.0);
+
+    fn contains(self, context: KeyContext) -> bool {
+        let mask = match context {
+            KeyContext::Normal => Self::NORMAL,
+            KeyContext::Trash => Self::TRASH,
+        };
+        self.intersects(mask)
+    }
+
+    fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+}
+
+impl Action {
+    fn key_contexts(self) -> KeyContexts {
+        match self {
+            Self::Rename => KeyContexts::NORMAL,
+            Self::RestoreFromTrash => KeyContexts::TRASH,
+            _ => KeyContexts::ALL,
+        }
     }
 }
 
@@ -296,7 +341,7 @@ impl PartialEq<char> for KeyList {
 /// Empty lists unbind the action (`open = []`).
 /// Character bindings must be one character; named bindings currently support
 /// `left`, `right`, `up`, `down`, `enter`, `space`, `tab`, `backtab`,
-/// `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`.
+/// `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, `end`, and `f1`..`f12`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct KeyBindings {
     pub quit: KeyList,
@@ -308,6 +353,7 @@ pub(crate) struct KeyBindings {
     pub delete_permanently: KeyList,
     pub create: KeyList,
     pub rename: KeyList,
+    pub restore_from_trash: KeyList,
     pub copy_path: KeyList,
     pub search_folders: KeyList,
     pub zoxide: KeyList,
@@ -364,7 +410,11 @@ impl Default for KeyBindings {
             trash: KeyList::one('d'),
             delete_permanently: KeyList::one('D'),
             create: KeyList::one('a'),
-            rename: KeyList::one('r'),
+            rename: KeyList(vec![
+                KeySpec::char('r'),
+                KeySpec::named(NamedKey::Function(2)),
+            ]),
+            restore_from_trash: KeyList::one('r'),
             copy_path: KeyList::one('c'),
             search_folders: KeyList::one('f'),
             zoxide: KeyList::one('z'),
@@ -414,6 +464,7 @@ pub(super) struct KeysConfigOverride {
     delete_permanently: Option<KeyConfigOverride>,
     create: Option<KeyConfigOverride>,
     rename: Option<KeyConfigOverride>,
+    restore_from_trash: Option<KeyConfigOverride>,
     copy_path: Option<KeyConfigOverride>,
     search_folders: Option<KeyConfigOverride>,
     zoxide: Option<KeyConfigOverride>,
@@ -445,14 +496,35 @@ pub(super) struct KeysConfigOverride {
 
 struct RawBinding {
     name: &'static str,
+    action: Action,
     override_value: Option<KeyConfigOverride>,
     default: KeyList,
 }
 
 impl KeyBindings {
-    /// Returns the action bound to `key`, if any.
+    /// Returns the normal-browser action bound to `key`, if any.
     pub(crate) fn action_for_key(&self, key: KeyEvent) -> Option<Action> {
-        let bindings = [
+        self.action_for_key_in_context(key, KeyContext::Normal)
+    }
+
+    /// Returns the action bound to `key` in the active browser context, if any.
+    pub(crate) fn action_for_key_in_context(
+        &self,
+        key: KeyEvent,
+        context: KeyContext,
+    ) -> Option<Action> {
+        self.bindings().iter().find_map(|(keys, action)| {
+            action
+                .key_contexts()
+                .contains(context)
+                .then_some(())
+                .filter(|_| keys.matches_event(key))
+                .map(|_| *action)
+        })
+    }
+
+    fn bindings(&self) -> [(&KeyList, Action); 37] {
+        [
             (&self.quit, Action::Quit),
             (&self.quit_without_cd, Action::QuitWithoutCd),
             (&self.yank, Action::Yank),
@@ -462,6 +534,7 @@ impl KeyBindings {
             (&self.delete_permanently, Action::DeletePermanently),
             (&self.create, Action::Create),
             (&self.rename, Action::Rename),
+            (&self.restore_from_trash, Action::RestoreFromTrash),
             (&self.copy_path, Action::CopyPath),
             (&self.search_folders, Action::SearchFolders),
             (&self.zoxide, Action::Zoxide),
@@ -489,14 +562,11 @@ impl KeyBindings {
             (&self.scroll_preview_right, Action::ScrollPreviewRight),
             (&self.scroll_preview_up, Action::ScrollPreviewUp),
             (&self.scroll_preview_down, Action::ScrollPreviewDown),
-        ];
-
-        bindings
-            .iter()
-            .find_map(|(keys, action)| keys.matches_event(key).then_some(*action))
+        ]
     }
 
     /// Returns the action bound to `c`, if any.
+    #[cfg(test)]
     pub(crate) fn action_for(&self, c: char) -> Option<Action> {
         self.action_for_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
     }
@@ -516,181 +586,223 @@ impl KeyBindings {
         let raw = vec![
             RawBinding {
                 name: "quit",
+                action: Action::Quit,
                 override_value: overrides.quit,
                 default: defaults.quit.clone(),
             },
             RawBinding {
                 name: "quit_without_cd",
+                action: Action::QuitWithoutCd,
                 override_value: overrides.quit_without_cd,
                 default: defaults.quit_without_cd.clone(),
             },
             RawBinding {
                 name: "yank",
+                action: Action::Yank,
                 override_value: overrides.yank,
                 default: defaults.yank.clone(),
             },
             RawBinding {
                 name: "cut",
+                action: Action::Cut,
                 override_value: overrides.cut,
                 default: defaults.cut.clone(),
             },
             RawBinding {
                 name: "paste",
+                action: Action::Paste,
                 override_value: overrides.paste,
                 default: defaults.paste.clone(),
             },
             RawBinding {
                 name: "trash",
+                action: Action::Trash,
                 override_value: overrides.trash,
                 default: defaults.trash.clone(),
             },
             RawBinding {
                 name: "delete_permanently",
+                action: Action::DeletePermanently,
                 override_value: overrides.delete_permanently,
                 default: defaults.delete_permanently.clone(),
             },
             RawBinding {
                 name: "create",
+                action: Action::Create,
                 override_value: overrides.create,
                 default: defaults.create.clone(),
             },
             RawBinding {
                 name: "rename",
+                action: Action::Rename,
                 override_value: overrides.rename,
                 default: defaults.rename.clone(),
             },
             RawBinding {
+                name: "restore_from_trash",
+                action: Action::RestoreFromTrash,
+                override_value: overrides.restore_from_trash,
+                default: defaults.restore_from_trash.clone(),
+            },
+            RawBinding {
                 name: "copy_path",
+                action: Action::CopyPath,
                 override_value: overrides.copy_path,
                 default: defaults.copy_path.clone(),
             },
             RawBinding {
                 name: "search_folders",
+                action: Action::SearchFolders,
                 override_value: overrides.search_folders,
                 default: defaults.search_folders.clone(),
             },
             RawBinding {
                 name: "zoxide",
+                action: Action::Zoxide,
                 override_value: overrides.zoxide,
                 default: defaults.zoxide.clone(),
             },
             RawBinding {
                 name: "shell",
+                action: Action::Shell,
                 override_value: overrides.shell,
                 default: defaults.shell.clone(),
             },
             RawBinding {
                 name: "open",
+                action: Action::Open,
                 override_value: overrides.open,
                 default: defaults.open.clone(),
             },
             RawBinding {
                 name: "open_with",
+                action: Action::OpenWith,
                 override_value: overrides.open_with,
                 default: defaults.open_with.clone(),
             },
             RawBinding {
                 name: "open_or_enter",
+                action: Action::OpenOrEnter,
                 override_value: overrides.open_or_enter,
                 default: defaults.open_or_enter.clone(),
             },
             RawBinding {
                 name: "go_to",
+                action: Action::GoTo,
                 override_value: overrides.go_to,
                 default: defaults.go_to.clone(),
             },
             RawBinding {
                 name: "toggle_selection",
+                action: Action::ToggleSelection,
                 override_value: overrides.toggle_selection,
                 default: defaults.toggle_selection.clone(),
             },
             RawBinding {
                 name: "cycle_places_next",
+                action: Action::CyclePlacesNext,
                 override_value: overrides.cycle_places_next,
                 default: defaults.cycle_places_next.clone(),
             },
             RawBinding {
                 name: "cycle_places_previous",
+                action: Action::CyclePlacesPrevious,
                 override_value: overrides.cycle_places_previous,
                 default: defaults.cycle_places_previous.clone(),
             },
             RawBinding {
                 name: "go_parent",
+                action: Action::GoParent,
                 override_value: overrides.go_parent,
                 default: defaults.go_parent.clone(),
             },
             RawBinding {
                 name: "page_up",
+                action: Action::PageUp,
                 override_value: overrides.page_up,
                 default: defaults.page_up.clone(),
             },
             RawBinding {
                 name: "page_down",
+                action: Action::PageDown,
                 override_value: overrides.page_down,
                 default: defaults.page_down.clone(),
             },
             RawBinding {
                 name: "select_first",
+                action: Action::SelectFirst,
                 override_value: overrides.select_first,
                 default: defaults.select_first.clone(),
             },
             RawBinding {
                 name: "select_last",
+                action: Action::SelectLast,
                 override_value: overrides.select_last,
                 default: defaults.select_last.clone(),
             },
             RawBinding {
                 name: "sort",
+                action: Action::Sort,
                 override_value: overrides.sort,
                 default: defaults.sort.clone(),
             },
             RawBinding {
                 name: "toggle_view",
+                action: Action::ToggleView,
                 override_value: overrides.toggle_view,
                 default: defaults.toggle_view.clone(),
             },
             RawBinding {
                 name: "toggle_hidden",
+                action: Action::ToggleHidden,
                 override_value: overrides.toggle_hidden,
                 default: defaults.toggle_hidden.clone(),
             },
             RawBinding {
                 name: "nav_left",
+                action: Action::NavLeft,
                 override_value: overrides.nav_left,
                 default: defaults.nav_left.clone(),
             },
             RawBinding {
                 name: "nav_down",
+                action: Action::NavDown,
                 override_value: overrides.nav_down,
                 default: defaults.nav_down.clone(),
             },
             RawBinding {
                 name: "nav_up",
+                action: Action::NavUp,
                 override_value: overrides.nav_up,
                 default: defaults.nav_up.clone(),
             },
             RawBinding {
                 name: "nav_right",
+                action: Action::NavRight,
                 override_value: overrides.nav_right,
                 default: defaults.nav_right.clone(),
             },
             RawBinding {
                 name: "scroll_preview_left",
+                action: Action::ScrollPreviewLeft,
                 override_value: overrides.scroll_preview_left,
                 default: defaults.scroll_preview_left.clone(),
             },
             RawBinding {
                 name: "scroll_preview_right",
+                action: Action::ScrollPreviewRight,
                 override_value: overrides.scroll_preview_right,
                 default: defaults.scroll_preview_right.clone(),
             },
             RawBinding {
                 name: "scroll_preview_up",
+                action: Action::ScrollPreviewUp,
                 override_value: overrides.scroll_preview_up,
                 default: defaults.scroll_preview_up.clone(),
             },
             RawBinding {
                 name: "scroll_preview_down",
+                action: Action::ScrollPreviewDown,
                 override_value: overrides.scroll_preview_down,
                 default: defaults.scroll_preview_down.clone(),
             },
@@ -722,7 +834,13 @@ impl KeyBindings {
                 let collision = candidates[index].0.keys().find_map(|candidate| {
                     (0..raw.len())
                         .filter(|&other_index| other_index != index)
-                        .find(|&other_index| candidates[other_index].0.contains(candidate))
+                        .find(|&other_index| {
+                            raw[index]
+                                .action
+                                .key_contexts()
+                                .intersects(raw[other_index].action.key_contexts())
+                                && candidates[other_index].0.contains(candidate)
+                        })
                         .map(|other_index| (candidate, other_index))
                 });
 
@@ -752,33 +870,34 @@ impl KeyBindings {
             delete_permanently: resolved(6),
             create: resolved(7),
             rename: resolved(8),
-            copy_path: resolved(9),
-            search_folders: resolved(10),
-            zoxide: resolved(11),
-            shell: resolved(12),
-            open: resolved(13),
-            open_with: resolved(14),
-            open_or_enter: resolved(15),
-            go_to: resolved(16),
-            toggle_selection: resolved(17),
-            cycle_places_next: resolved(18),
-            cycle_places_previous: resolved(19),
-            go_parent: resolved(20),
-            page_up: resolved(21),
-            page_down: resolved(22),
-            select_first: resolved(23),
-            select_last: resolved(24),
-            sort: resolved(25),
-            toggle_view: resolved(26),
-            toggle_hidden: resolved(27),
-            nav_left: resolved(28),
-            nav_down: resolved(29),
-            nav_up: resolved(30),
-            nav_right: resolved(31),
-            scroll_preview_left: resolved(32),
-            scroll_preview_right: resolved(33),
-            scroll_preview_up: resolved(34),
-            scroll_preview_down: resolved(35),
+            restore_from_trash: resolved(9),
+            copy_path: resolved(10),
+            search_folders: resolved(11),
+            zoxide: resolved(12),
+            shell: resolved(13),
+            open: resolved(14),
+            open_with: resolved(15),
+            open_or_enter: resolved(16),
+            go_to: resolved(17),
+            toggle_selection: resolved(18),
+            cycle_places_next: resolved(19),
+            cycle_places_previous: resolved(20),
+            go_parent: resolved(21),
+            page_up: resolved(22),
+            page_down: resolved(23),
+            select_first: resolved(24),
+            select_last: resolved(25),
+            sort: resolved(26),
+            toggle_view: resolved(27),
+            toggle_hidden: resolved(28),
+            nav_left: resolved(29),
+            nav_down: resolved(30),
+            nav_up: resolved(31),
+            nav_right: resolved(32),
+            scroll_preview_left: resolved(33),
+            scroll_preview_right: resolved(34),
+            scroll_preview_up: resolved(35),
+            scroll_preview_down: resolved(36),
         }
     }
 }
@@ -807,7 +926,7 @@ fn parse_key_override(name: &str, value: &KeyConfigOverride, default: &KeyList) 
 fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec> {
     let (mut modifiers, key_name) = parse_key_modifiers(name, value, default)?;
 
-    if modifiers.shift && key_name == "tab" {
+    if modifiers.shift && key_name.eq_ignore_ascii_case("tab") {
         modifiers.shift = false;
         return validate_key_spec(
             name,
@@ -819,7 +938,14 @@ fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec>
         );
     }
 
-    if modifiers.shift && key_name == "space" {
+    if modifiers.shift && key_name.eq_ignore_ascii_case("backtab") {
+        eprintln!(
+            "elio: keys.{name}: {value:?} uses shift with backtab; use \"shift+tab\" or \"backtab\" instead; using default '{default}'"
+        );
+        return None;
+    }
+
+    if modifiers.shift && key_name.eq_ignore_ascii_case("space") {
         eprintln!(
             "elio: keys.{name}: {value:?} uses shift with space, which terminals do not report reliably; using default '{default}'"
         );
@@ -839,7 +965,10 @@ fn parse_key_spec(name: &str, value: &str, default: &KeyList) -> Option<KeySpec>
         return None;
     }
 
-    if key_name == "shift" || key_name == "ctrl" || key_name == "alt" {
+    if key_name.eq_ignore_ascii_case("shift")
+        || key_name.eq_ignore_ascii_case("ctrl")
+        || key_name.eq_ignore_ascii_case("alt")
+    {
         eprintln!(
             "elio: keys.{name}: {value:?} is missing a key after modifiers; using default '{default}'"
         );
@@ -954,7 +1083,7 @@ fn parse_key_modifiers<'a>(
             break;
         }
 
-        match part {
+        match part.to_ascii_lowercase().as_str() {
             "ctrl" => {
                 if modifiers.ctrl {
                     eprintln!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ mod ui;
 use serde::Deserialize;
 
 pub(crate) use self::{
-    keys::{Action, KeyBindings, KeyList},
+    keys::{Action, KeyBindings, KeyContext, KeyList},
     layout::{LayoutConfig, PaneWeights},
     loading::config_dir,
     places::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -319,9 +319,8 @@ open_with = "alt+ctrl+e"
     )
     .expect("config should parse");
 
-    // Modifiers are intentionally lower-case only; uppercase aliases fall back
-    // instead of being accepted ambiguously.
-    assert_eq!(config.keys.open.to_string(), "o");
+    // Modifier names are case-insensitive, while the final character key keeps its case.
+    assert_eq!(config.keys.open.to_string(), "Ctrl+O");
     assert_eq!(config.keys.open_with.to_string(), "Ctrl+Alt+E");
     assert_eq!(
         config.keys.action_for_key(KeyEvent::new(
@@ -521,6 +520,280 @@ cut = "y"
     .expect("config should parse");
     assert_eq!(config.keys.yank, 'x');
     assert_eq!(config.keys.cut, 'y');
+}
+
+#[test]
+fn function_keys_can_be_bound_and_displayed() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "F5"
+open_with = ["O", "f12"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.open.to_string(), "F5");
+    assert_eq!(config.keys.open_with.to_string(), "O/F12");
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE)),
+        Some(Action::OpenWith)
+    );
+}
+
+#[test]
+fn named_keys_and_modifiers_are_case_insensitive() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+page_up = "PageUp"
+cycle_places_previous = "Shift+Tab"
+open = "Alt+Up"
+open_with = "O"
+open_or_enter = "SHIft+Enter"
+rename = ["r", "F2"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.page_up.to_string(), "PageUp");
+    assert_eq!(config.keys.cycle_places_previous.to_string(), "Shift+Tab");
+    assert_eq!(config.keys.open.to_string(), "Alt+↑");
+    assert_eq!(config.keys.open_with.to_string(), "O");
+    assert_eq!(config.keys.open_or_enter.to_string(), "Shift+Enter");
+    assert_eq!(config.keys.rename.to_string(), "r/F2");
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+        Some(Action::PageUp)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE)),
+        Some(Action::CyclePlacesPrevious)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Up, KeyModifiers::ALT)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('O'), KeyModifiers::SHIFT)),
+        Some(Action::OpenWith)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE)),
+        Some(Action::Rename)
+    );
+}
+
+#[test]
+fn shift_character_bindings_keep_using_uppercase_character_form() {
+    let cases = ["Shift+O", "Shift+o", "SHIft+O", "SHIft+o"];
+
+    for value in cases {
+        let config =
+            Config::from_str(&format!("[keys]\nopen = \"{value}\"")).expect("config should parse");
+
+        assert_eq!(
+            config.keys.open.to_string(),
+            "o",
+            "{value:?} should fall back; shifted characters are written as uppercase chars"
+        );
+    }
+
+    let config = Config::from_str("[keys]\nopen_with = \"O\"").expect("config should parse");
+    assert_eq!(config.keys.open_with.to_string(), "O");
+}
+
+#[test]
+fn shift_backtab_bindings_fall_back_because_backtab_already_means_shift_tab() {
+    let cases = ["Shift+BackTab", "shift+backtab", "SHIft+BackTab"];
+
+    for value in cases {
+        let config = Config::from_str(&format!("[keys]\ncycle_places_previous = \"{value}\""))
+            .expect("config should parse");
+
+        assert_eq!(
+            config.keys.cycle_places_previous.to_string(),
+            "Shift+Tab",
+            "{value:?} should fall back; use shift+tab or backtab instead"
+        );
+    }
+}
+
+#[test]
+fn default_rename_and_restore_share_r_in_disjoint_contexts() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let key_bindings = KeyBindings::default();
+    let r = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE);
+
+    assert_eq!(key_bindings.rename.to_string(), "r/F2");
+    assert_eq!(key_bindings.restore_from_trash.to_string(), "r");
+    assert_eq!(
+        key_bindings.action_for_key_in_context(r, KeyContext::Normal),
+        Some(Action::Rename)
+    );
+    assert_eq!(
+        key_bindings.action_for_key_in_context(r, KeyContext::Trash),
+        Some(Action::RestoreFromTrash)
+    );
+    assert_eq!(
+        key_bindings.action_for_key_in_context(
+            KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(Action::Rename)
+    );
+    assert_eq!(
+        key_bindings.action_for_key_in_context(
+            KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE),
+            KeyContext::Trash,
+        ),
+        None
+    );
+}
+
+#[test]
+fn normal_actions_cannot_reuse_contextual_r_default() {
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "r"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.open.to_string(), "o");
+    assert_eq!(config.keys.rename.to_string(), "r/F2");
+    assert_eq!(config.keys.restore_from_trash.to_string(), "r");
+}
+
+#[test]
+fn contextual_rename_and_restore_bindings_can_overlap() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+rename = "e"
+restore_from_trash = "e"
+"#,
+    )
+    .expect("config should parse");
+    let e = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE);
+
+    assert_eq!(
+        config.keys.action_for_key_in_context(e, KeyContext::Normal),
+        Some(Action::Rename)
+    );
+    assert_eq!(
+        config.keys.action_for_key_in_context(e, KeyContext::Trash),
+        Some(Action::RestoreFromTrash)
+    );
+}
+
+#[test]
+fn disabled_rename_removes_f2_without_disabling_restore() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+rename = []
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config.keys.action_for_key_in_context(
+            KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        None
+    );
+    assert_eq!(
+        config.keys.action_for_key_in_context(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            KeyContext::Trash,
+        ),
+        Some(Action::RestoreFromTrash)
+    );
+}
+
+#[test]
+fn disabled_restore_from_trash_keeps_normal_rename_bindings() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+restore_from_trash = []
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config.keys.action_for_key_in_context(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            KeyContext::Trash,
+        ),
+        None
+    );
+    assert_eq!(
+        config.keys.action_for_key_in_context(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(Action::Rename)
+    );
+    assert_eq!(
+        config.keys.action_for_key_in_context(
+            KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(Action::Rename)
+    );
+}
+
+#[test]
+fn restore_from_trash_cannot_reuse_global_open_binding() {
+    let config = Config::from_str(
+        r#"
+[keys]
+restore_from_trash = "o"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.open.to_string(), "o");
+    assert_eq!(config.keys.restore_from_trash.to_string(), "r");
 }
 
 #[test]

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -29,15 +29,15 @@ pub(super) fn render_help(
         e("Ctrl+W / Alt+D", "fallback word delete"),
     ];
     let clipboard_entries = clipboard_entries(kb);
-    let rename_key = format!("{} / F2", kb.rename);
-    let rename_trash_key = format!("{} (in trash)", kb.rename);
+    let rename_key = kb.rename.to_string();
+    let restore_key = format!("{} (in trash)", kb.restore_from_trash);
     let files_entries = vec![
         e(&kb.create.to_string(), "create file or folder"),
         e("Alt/Shift+Enter", "add line in create prompt"),
         e(&kb.trash.to_string(), "trash (delete if in trash)"),
         e(&kb.delete_permanently.to_string(), "delete permanently"),
         e(&rename_key, "rename (bulk if selection)"),
-        e(&rename_trash_key, "restore from trash"),
+        e(&restore_key, "restore from trash"),
         e(&kb.shell.to_string(), "open shell here"),
         e(&kb.open.to_string(), "open with default app"),
         e(&kb.open_with.to_string(), "open with"),


### PR DESCRIPTION
## Summary

Splits rename and restore into separate configurable `[keys]` actions while keeping the existing default behavior.

Normal files keep `r` / `F2` for rename, and trash keeps `r` for restore.

## What Changed

* Added a new configurable `[keys]` action:

  * `restore_from_trash`
* Added function-key support for configurable bindings:

  * `F1` through `F12`
* Made named keys and modifiers case-insensitive, so values like `F2`, `f2`, `PageUp`, and `Ctrl+O` are accepted.
* Made key resolution context-aware so `rename = "r"` and `restore_from_trash = "r"` can coexist without colliding.
* Kept `rename` active only outside trash.
* Kept `restore_from_trash` active only in trash/trash subfolders.
* Preserved default behavior:

  * `r` / `F2` rename outside trash
  * `r` restores from trash
  * `F2` does not restore from trash
* Kept normal/global actions from reusing context-specific keys when they would still collide.
* Rejected redundant `shift+backtab` bindings because `backtab` already means `shift+tab`.
* Updated the help overlay to show resolved rename and restore bindings separately.
* Updated README, example config, and changelog.

## User Impact

Users can now configure rename and restore independently.

For example:

```toml
[keys]
rename = ["r", "F2"]
restore_from_trash = "F3"
```

Or both actions can intentionally share the same key because they only apply in different contexts:

```toml
[keys]
rename = "e"
restore_from_trash = "e"
```

Existing configs keep the previous behavior by default.

## Notes

* Function-key names are accepted case-insensitively, so `F2` and `f2` resolve to the same key.
* Shifted character bindings still use uppercase character form, such as `O`, not `shift+o`.
* `shift+backtab` is rejected because `backtab` is already the terminal event for `shift+tab`.

## Testing

Verified with:

* [x] `cargo fmt --check`
* [x] `cargo test --locked --test architecture_guardrails`
* [x] `cargo clippy --locked --all-targets -- -D warnings`
* [x] `cargo test --locked`
* [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

* [x] Default `r` renames outside trash.
* [x] Default `F2` renames outside trash.
* [x] Default `r` restores from trash.
* [x] `F2` does not restore from trash.
* [x] `F3` can be assigned to rename.
* [x] `F3` can be assigned to restore.
* [x] Lowercase `f3` works the same as `F3`.
* [x] Rename and restore can share the same configured key in their separate contexts.
* [x] Rename and restore can be configured to different keys.
* [x] `shift+backtab` is rejected while `shift+tab` / `backtab` remain valid.
* [x] Shift/backspace behavior was checked.
* [x] Help overlay reflects the resolved rename and restore bindings.

Result:

All checks passed locally.

## Documentation and Changelog

* [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
* [x] Added a `CHANGELOG.md` entry for user-visible changes
* [ ] Docs and changelog are not needed
