### PR TITLE
feat(keys): add search and history bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `[]` support for unbinding configurable `[keys]` actions.
 - Added support for modifier `[keys]` bindings such as `ctrl+o`, `alt+o`, and `shift+right`.
 - Added named `[keys]` values for `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`.
-- Added configurable browser control bindings for `go_to`, `toggle_selection`, `cycle_places_next`, `cycle_places_previous`, `go_parent`, `page_up`, `page_down`, `select_first`, and `select_last`.
+- Added configurable browser control bindings for `go_to`, `toggle_selection`, `cycle_places_next`, `cycle_places_previous`, `go_parent`, `page_up`, `page_down`, `jump_first`, and `jump_last`.
+- Added configurable `[keys]` bindings for `search_files`, `select_all`, `history_back`, and `history_forward`, and added `[` / `]` as default bindings for the existing `scroll_preview_up` / `scroll_preview_down` actions.
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -274,14 +274,14 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `G` / `End` `*` | Jump to last item |
 | `PageUp` / `PageDown` `*` | Page up / down |
 | `Tab` / `Shift+Tab` `*` | Cycle places |
-| `Alt+←` / `Alt+→` | Back / forward in history |
+| `Alt+←` / `Alt+→` `*` | Back / forward in history |
 
 ### Search
 
 | Key | Action |
 |---|---|
 | `f` `*` | Fuzzy-find folders in the current tree |
-| `Ctrl+F` | Fuzzy-find files in the current tree |
+| `Ctrl+F` `*` | Fuzzy-find files in the current tree |
 | `z` `*` | Jump with zoxide directory history |
 
 ### File Actions
@@ -310,16 +310,16 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 
 | Key | Action |
 |---|---|
-| `Shift+K` / `Shift+J` `*` | Step page (PDF, comic, EPUB) or scroll preview up / down |
+| `Shift+K` / `[` `*` | Step page (PDF, comic, EPUB) or scroll preview up |
+| `Shift+J` / `]` `*` | Step page (PDF, comic, EPUB) or scroll preview down |
 | `Shift+H` / `Shift+L` `*` | Scroll preview left / right |
-| `[` / `]` | Step page (PDF, comic, EPUB) or scroll text/code |
 
 ### Selection and Clipboard
 
 | Key | Action |
 |---|---|
 | `Space` `*` | Toggle selection |
-| `Ctrl+A` | Select all |
+| `Ctrl+A` `*` | Select all |
 | `y` `*` | Yank (copy) |
 | `x` `*` | Cut |
 | `p` `*` | Paste |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -75,15 +75,15 @@
 # Example: nav_right = [] frees "l" and "right".
 # Then open_or_enter = ["enter", "l", "right"] can use them.
 #
-# Reserved bare keys: ? [ ] + = - _
-# Reserved shortcuts: Ctrl+C, Ctrl+F, Ctrl+A, Ctrl+Plus/Minus, Alt+Left/Right
+# Reserved bare keys: ? + = - _
+# Reserved shortcuts: Ctrl+C, Ctrl+Plus/Minus
 # Omit any key to keep the built-in default shown in the comment.
 #
 # [keys]
-# nav_left            = ["h", "left"]
-# nav_down            = ["j", "down"]
-# nav_up              = ["k", "up"]
-# nav_right           = ["l", "right"]
+# nav_left             = ["h", "left"]
+# nav_down             = ["j", "down"]
+# nav_up               = ["k", "up"]
+# nav_right            = ["l", "right"]
 # quit                 = "q"
 # yank                 = "y"
 # cut                  = "x"
@@ -95,6 +95,7 @@
 # restore_from_trash   = "r"
 # copy_path            = "c"
 # search_folders       = "f"
+# search_files         = "ctrl+f"
 # zoxide               = "z"
 # shell                = "!"
 # open                 = "o"
@@ -107,16 +108,15 @@
 # go_parent            = "backspace"
 # page_up              = "pageup"
 # page_down            = "pagedown"
-# select_first         = "home"
-# select_last          = ["G", "end"]
+# jump_first           = "home"
+# jump_last            = ["G", "end"]
+# select_all           = "ctrl+a"
+# history_back         = "alt+left"
+# history_forward      = "alt+right"
 # sort                 = "s"
 # toggle_view          = "v"
 # toggle_hidden        = "."
-# scroll_preview_up    = "K"   # Shift+K
-# scroll_preview_down  = "J"   # Shift+J
-# scroll_preview_left  = "H"   # Shift+H
-# scroll_preview_right = "L"   # Shift+L
-#
-# Example: make l/Enter/Right all open or enter.
-# nav_right     = []
-# open_or_enter = ["enter", "l", "right"]
+# scroll_preview_up    = ["K", "["]   # Shift+K, [
+# scroll_preview_down  = ["J", "]"]   # Shift+J, ]
+# scroll_preview_left  = "H"           # Shift+H
+# scroll_preview_right = "L"           # Shift+L

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -285,7 +285,7 @@ impl App {
         self.set_selected(index);
     }
 
-    pub(in crate::app) fn select_last(&mut self) {
+    pub(in crate::app) fn jump_last(&mut self) {
         self.set_selected_last();
     }
 

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -103,14 +103,6 @@ impl App {
         }
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
-                KeyCode::Char('f') => {
-                    self.open_search_with_status(SearchScope::Files);
-                    return Ok(());
-                }
-                KeyCode::Char('a') => {
-                    self.select_all();
-                    return Ok(());
-                }
                 KeyCode::Char('+') | KeyCode::Char('=') => {
                     self.adjust_zoom(1);
                     return Ok(());
@@ -123,9 +115,11 @@ impl App {
             }
         }
 
+        let configured_action =
+            crate::config::keys().action_for_key_in_context(key, self.key_context());
+
         if self.input.wheel_profile == WheelProfile::HighFrequency
-            && key.modifiers.contains(KeyModifiers::ALT)
-            && !key.modifiers.contains(KeyModifiers::CONTROL)
+            && should_handle_high_frequency_horizontal_key(key, configured_action)
         {
             match key.code {
                 KeyCode::Left if self.handle_horizontal_navigation_key(-1) => return Ok(()),
@@ -133,44 +127,6 @@ impl App {
                 _ => {}
             }
         }
-
-        if key.modifiers.contains(KeyModifiers::ALT) {
-            match key.code {
-                KeyCode::Left => return self.go_back(),
-                KeyCode::Right => return self.go_forward(),
-                _ => {}
-            }
-        }
-
-        if !key
-            .modifiers
-            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-        {
-            match key.code {
-                KeyCode::Char('[') => {
-                    if self.step_epub_section(-1)
-                        || self.step_comic_page(-1)
-                        || self.step_pdf_page(-1)
-                    {
-                        return Ok(());
-                    }
-                    self.scroll_preview_lines(-1);
-                    return Ok(());
-                }
-                KeyCode::Char(']') => {
-                    if self.step_epub_section(1) || self.step_comic_page(1) || self.step_pdf_page(1)
-                    {
-                        return Ok(());
-                    }
-                    self.scroll_preview_lines(1);
-                    return Ok(());
-                }
-                _ => {}
-            }
-        }
-
-        let configured_action =
-            crate::config::keys().action_for_key_in_context(key, self.key_context());
 
         match key.code {
             KeyCode::Esc => {
@@ -248,6 +204,7 @@ impl App {
             }
             Action::CopyPath => self.open_copy_overlay(),
             Action::SearchFolders => self.open_search_with_status(SearchScope::Folders),
+            Action::SearchFiles => self.open_search_with_status(SearchScope::Files),
             Action::Zoxide => {
                 self.pending_terminal_task = Some(PendingTerminalTask::Zoxide);
                 self.status.clear();
@@ -268,8 +225,11 @@ impl App {
             Action::GoParent => self.go_parent()?,
             Action::PageUp => self.page(-1),
             Action::PageDown => self.page(1),
-            Action::SelectFirst => self.select_index(0),
-            Action::SelectLast => self.select_last(),
+            Action::JumpFirst => self.select_index(0),
+            Action::JumpLast => self.jump_last(),
+            Action::SelectAll => self.select_all(),
+            Action::HistoryBack => return self.go_back(),
+            Action::HistoryForward => return self.go_forward(),
             Action::Sort => self.cycle_sort_mode()?,
             Action::ToggleView => self.toggle_view_mode(),
             Action::ToggleHidden => self.toggle_hidden_files()?,
@@ -360,8 +320,8 @@ impl App {
             Some(crate::config::Action::NavRight) => Some(NavigationRepeatKey::Right),
             Some(crate::config::Action::PageUp) => Some(NavigationRepeatKey::PageUp),
             Some(crate::config::Action::PageDown) => Some(NavigationRepeatKey::PageDown),
-            Some(crate::config::Action::SelectFirst) => Some(NavigationRepeatKey::Home),
-            Some(crate::config::Action::SelectLast) => Some(NavigationRepeatKey::End),
+            Some(crate::config::Action::JumpFirst) => Some(NavigationRepeatKey::Home),
+            Some(crate::config::Action::JumpLast) => Some(NavigationRepeatKey::End),
             _ => None,
         }
     }
@@ -382,6 +342,18 @@ impl App {
     }
 }
 
+fn should_handle_high_frequency_horizontal_key(
+    key: KeyEvent,
+    configured_action: Option<crate::config::Action>,
+) -> bool {
+    key.modifiers == KeyModifiers::ALT
+        && matches!(
+            (key.code, configured_action),
+            (KeyCode::Left, Some(crate::config::Action::HistoryBack))
+                | (KeyCode::Right, Some(crate::config::Action::HistoryForward))
+        )
+}
+
 fn is_help_shortcut(key: KeyEvent) -> bool {
     if key
         .modifiers
@@ -392,4 +364,34 @@ fn is_help_shortcut(key: KeyEvent) -> bool {
 
     matches!(key.code, KeyCode::Char('?'))
         || matches!(key.code, KeyCode::Char('/')) && key.modifiers.contains(KeyModifiers::SHIFT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Action;
+
+    #[test]
+    fn high_frequency_horizontal_emulation_only_uses_default_history_actions() {
+        assert!(should_handle_high_frequency_horizontal_key(
+            KeyEvent::new(KeyCode::Left, KeyModifiers::ALT),
+            Some(Action::HistoryBack),
+        ));
+        assert!(should_handle_high_frequency_horizontal_key(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::ALT),
+            Some(Action::HistoryForward),
+        ));
+        assert!(!should_handle_high_frequency_horizontal_key(
+            KeyEvent::new(KeyCode::Left, KeyModifiers::ALT),
+            Some(Action::Open),
+        ));
+        assert!(!should_handle_high_frequency_horizontal_key(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::ALT),
+            Some(Action::Open),
+        ));
+        assert!(!should_handle_high_frequency_horizontal_key(
+            KeyEvent::new(KeyCode::Char('h'), KeyModifiers::ALT),
+            Some(Action::HistoryBack),
+        ));
+    }
 }

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -478,7 +478,7 @@ fn g_opens_goto_overlay_and_goto_shortcuts_keep_g_for_top() {
     }
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.select_last();
+    app.jump_last();
     assert_eq!(
         app.navigation.selected, 2,
         "G behavior should still reach the last item"

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -16,6 +16,7 @@ pub(crate) enum Action {
     RestoreFromTrash,
     CopyPath,
     SearchFolders,
+    SearchFiles,
     Zoxide,
     Shell,
     Open,
@@ -28,8 +29,11 @@ pub(crate) enum Action {
     GoParent,
     PageUp,
     PageDown,
-    SelectFirst,
-    SelectLast,
+    JumpFirst,
+    JumpLast,
+    SelectAll,
+    HistoryBack,
+    HistoryForward,
     Sort,
     ToggleView,
     ToggleHidden,
@@ -225,6 +229,26 @@ impl KeySpec {
         }
     }
 
+    fn ctrl_char(c: char) -> Self {
+        Self {
+            code: KeyCodeSpec::Char(c),
+            modifiers: KeyModifierSpec {
+                ctrl: true,
+                ..KeyModifierSpec::NONE
+            },
+        }
+    }
+
+    fn alt_named(named: NamedKey) -> Self {
+        Self {
+            code: KeyCodeSpec::Named(named),
+            modifiers: KeyModifierSpec {
+                alt: true,
+                ..KeyModifierSpec::NONE
+            },
+        }
+    }
+
     fn single_char(self) -> Option<char> {
         match (self.code, self.modifiers.is_empty()) {
             (KeyCodeSpec::Char(c), true) => Some(c),
@@ -356,6 +380,7 @@ pub(crate) struct KeyBindings {
     pub restore_from_trash: KeyList,
     pub copy_path: KeyList,
     pub search_folders: KeyList,
+    pub search_files: KeyList,
     pub zoxide: KeyList,
     pub shell: KeyList,
     pub open: KeyList,
@@ -368,8 +393,11 @@ pub(crate) struct KeyBindings {
     pub go_parent: KeyList,
     pub page_up: KeyList,
     pub page_down: KeyList,
-    pub select_first: KeyList,
-    pub select_last: KeyList,
+    pub jump_first: KeyList,
+    pub jump_last: KeyList,
+    pub select_all: KeyList,
+    pub history_back: KeyList,
+    pub history_forward: KeyList,
     pub sort: KeyList,
     pub toggle_view: KeyList,
     pub toggle_hidden: KeyList,
@@ -387,15 +415,12 @@ pub(crate) struct KeyBindings {
 /// used as key binding values.
 const RESERVED_CHARS: &[char] = &[
     '?', // help
-    '[', ']', // page stepping (epub / comic / pdf)
     '+', '=', '-', '_', // grid zoom
 ];
 
 /// Modified keys that are still hard-wired before configurable browser actions.
 const RESERVED_MODIFIED_CHARS: &[char] = &[
     'c', // cancel/clear
-    'f', // file search
-    'a', // select all
     '+', '=', '-', '_', // grid zoom
 ];
 
@@ -417,6 +442,7 @@ impl Default for KeyBindings {
             restore_from_trash: KeyList::one('r'),
             copy_path: KeyList::one('c'),
             search_folders: KeyList::one('f'),
+            search_files: KeyList(vec![KeySpec::ctrl_char('f')]),
             zoxide: KeyList::one('z'),
             shell: KeyList::one('!'),
             open: KeyList::one('o'),
@@ -429,8 +455,11 @@ impl Default for KeyBindings {
             go_parent: KeyList(vec![KeySpec::named(NamedKey::Backspace)]),
             page_up: KeyList(vec![KeySpec::named(NamedKey::PageUp)]),
             page_down: KeyList(vec![KeySpec::named(NamedKey::PageDown)]),
-            select_first: KeyList(vec![KeySpec::named(NamedKey::Home)]),
-            select_last: KeyList(vec![KeySpec::char('G'), KeySpec::named(NamedKey::End)]),
+            jump_first: KeyList(vec![KeySpec::named(NamedKey::Home)]),
+            jump_last: KeyList(vec![KeySpec::char('G'), KeySpec::named(NamedKey::End)]),
+            select_all: KeyList(vec![KeySpec::ctrl_char('a')]),
+            history_back: KeyList(vec![KeySpec::alt_named(NamedKey::Left)]),
+            history_forward: KeyList(vec![KeySpec::alt_named(NamedKey::Right)]),
             sort: KeyList::one('s'),
             toggle_view: KeyList::one('v'),
             toggle_hidden: KeyList::one('.'),
@@ -440,8 +469,8 @@ impl Default for KeyBindings {
             nav_right: KeyList(vec![KeySpec::char('l'), KeySpec::named(NamedKey::Right)]),
             scroll_preview_left: KeyList::one('H'),
             scroll_preview_right: KeyList::one('L'),
-            scroll_preview_up: KeyList::one('K'),
-            scroll_preview_down: KeyList::one('J'),
+            scroll_preview_up: KeyList(vec![KeySpec::char('K'), KeySpec::char('[')]),
+            scroll_preview_down: KeyList(vec![KeySpec::char('J'), KeySpec::char(']')]),
         }
     }
 }
@@ -467,6 +496,7 @@ pub(super) struct KeysConfigOverride {
     restore_from_trash: Option<KeyConfigOverride>,
     copy_path: Option<KeyConfigOverride>,
     search_folders: Option<KeyConfigOverride>,
+    search_files: Option<KeyConfigOverride>,
     zoxide: Option<KeyConfigOverride>,
     shell: Option<KeyConfigOverride>,
     open: Option<KeyConfigOverride>,
@@ -479,8 +509,11 @@ pub(super) struct KeysConfigOverride {
     go_parent: Option<KeyConfigOverride>,
     page_up: Option<KeyConfigOverride>,
     page_down: Option<KeyConfigOverride>,
-    select_first: Option<KeyConfigOverride>,
-    select_last: Option<KeyConfigOverride>,
+    jump_first: Option<KeyConfigOverride>,
+    jump_last: Option<KeyConfigOverride>,
+    select_all: Option<KeyConfigOverride>,
+    history_back: Option<KeyConfigOverride>,
+    history_forward: Option<KeyConfigOverride>,
     sort: Option<KeyConfigOverride>,
     toggle_view: Option<KeyConfigOverride>,
     toggle_hidden: Option<KeyConfigOverride>,
@@ -523,7 +556,7 @@ impl KeyBindings {
         })
     }
 
-    fn bindings(&self) -> [(&KeyList, Action); 37] {
+    fn bindings(&self) -> [(&KeyList, Action); 41] {
         [
             (&self.quit, Action::Quit),
             (&self.quit_without_cd, Action::QuitWithoutCd),
@@ -537,6 +570,7 @@ impl KeyBindings {
             (&self.restore_from_trash, Action::RestoreFromTrash),
             (&self.copy_path, Action::CopyPath),
             (&self.search_folders, Action::SearchFolders),
+            (&self.search_files, Action::SearchFiles),
             (&self.zoxide, Action::Zoxide),
             (&self.shell, Action::Shell),
             (&self.open, Action::Open),
@@ -549,8 +583,11 @@ impl KeyBindings {
             (&self.go_parent, Action::GoParent),
             (&self.page_up, Action::PageUp),
             (&self.page_down, Action::PageDown),
-            (&self.select_first, Action::SelectFirst),
-            (&self.select_last, Action::SelectLast),
+            (&self.jump_first, Action::JumpFirst),
+            (&self.jump_last, Action::JumpLast),
+            (&self.select_all, Action::SelectAll),
+            (&self.history_back, Action::HistoryBack),
+            (&self.history_forward, Action::HistoryForward),
             (&self.sort, Action::Sort),
             (&self.toggle_view, Action::ToggleView),
             (&self.toggle_hidden, Action::ToggleHidden),
@@ -657,6 +694,12 @@ impl KeyBindings {
                 default: defaults.search_folders.clone(),
             },
             RawBinding {
+                name: "search_files",
+                action: Action::SearchFiles,
+                override_value: overrides.search_files,
+                default: defaults.search_files.clone(),
+            },
+            RawBinding {
                 name: "zoxide",
                 action: Action::Zoxide,
                 override_value: overrides.zoxide,
@@ -729,16 +772,34 @@ impl KeyBindings {
                 default: defaults.page_down.clone(),
             },
             RawBinding {
-                name: "select_first",
-                action: Action::SelectFirst,
-                override_value: overrides.select_first,
-                default: defaults.select_first.clone(),
+                name: "jump_first",
+                action: Action::JumpFirst,
+                override_value: overrides.jump_first,
+                default: defaults.jump_first.clone(),
             },
             RawBinding {
-                name: "select_last",
-                action: Action::SelectLast,
-                override_value: overrides.select_last,
-                default: defaults.select_last.clone(),
+                name: "jump_last",
+                action: Action::JumpLast,
+                override_value: overrides.jump_last,
+                default: defaults.jump_last.clone(),
+            },
+            RawBinding {
+                name: "select_all",
+                action: Action::SelectAll,
+                override_value: overrides.select_all,
+                default: defaults.select_all.clone(),
+            },
+            RawBinding {
+                name: "history_back",
+                action: Action::HistoryBack,
+                override_value: overrides.history_back,
+                default: defaults.history_back.clone(),
+            },
+            RawBinding {
+                name: "history_forward",
+                action: Action::HistoryForward,
+                override_value: overrides.history_forward,
+                default: defaults.history_forward.clone(),
             },
             RawBinding {
                 name: "sort",
@@ -873,31 +934,35 @@ impl KeyBindings {
             restore_from_trash: resolved(9),
             copy_path: resolved(10),
             search_folders: resolved(11),
-            zoxide: resolved(12),
-            shell: resolved(13),
-            open: resolved(14),
-            open_with: resolved(15),
-            open_or_enter: resolved(16),
-            go_to: resolved(17),
-            toggle_selection: resolved(18),
-            cycle_places_next: resolved(19),
-            cycle_places_previous: resolved(20),
-            go_parent: resolved(21),
-            page_up: resolved(22),
-            page_down: resolved(23),
-            select_first: resolved(24),
-            select_last: resolved(25),
-            sort: resolved(26),
-            toggle_view: resolved(27),
-            toggle_hidden: resolved(28),
-            nav_left: resolved(29),
-            nav_down: resolved(30),
-            nav_up: resolved(31),
-            nav_right: resolved(32),
-            scroll_preview_left: resolved(33),
-            scroll_preview_right: resolved(34),
-            scroll_preview_up: resolved(35),
-            scroll_preview_down: resolved(36),
+            search_files: resolved(12),
+            zoxide: resolved(13),
+            shell: resolved(14),
+            open: resolved(15),
+            open_with: resolved(16),
+            open_or_enter: resolved(17),
+            go_to: resolved(18),
+            toggle_selection: resolved(19),
+            cycle_places_next: resolved(20),
+            cycle_places_previous: resolved(21),
+            go_parent: resolved(22),
+            page_up: resolved(23),
+            page_down: resolved(24),
+            jump_first: resolved(25),
+            jump_last: resolved(26),
+            select_all: resolved(27),
+            history_back: resolved(28),
+            history_forward: resolved(29),
+            sort: resolved(30),
+            toggle_view: resolved(31),
+            toggle_hidden: resolved(32),
+            nav_left: resolved(33),
+            nav_down: resolved(34),
+            nav_up: resolved(35),
+            nav_right: resolved(36),
+            scroll_preview_left: resolved(37),
+            scroll_preview_right: resolved(38),
+            scroll_preview_up: resolved(39),
+            scroll_preview_down: resolved(40),
         }
     }
 }
@@ -1050,7 +1115,6 @@ fn is_reserved_key_spec(spec: KeySpec) -> bool {
         KeyCodeSpec::Char(c) if spec.modifiers.ctrl => {
             RESERVED_MODIFIED_CHARS.contains(&c.to_ascii_lowercase())
         }
-        KeyCodeSpec::Named(NamedKey::Left | NamedKey::Right) if spec.modifiers.alt => true,
         _ => false,
     }
 }

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -823,6 +823,34 @@ fn action_for_returns_correct_action_for_default_bindings() {
     assert_eq!(key_bindings.action_for('j'), Some(Action::NavDown));
     assert_eq!(key_bindings.action_for('k'), Some(Action::NavUp));
     assert_eq!(key_bindings.action_for('l'), Some(Action::NavRight));
+    assert_eq!(
+        key_bindings.action_for_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('f'),
+            crossterm::event::KeyModifiers::CONTROL,
+        )),
+        Some(Action::SearchFiles)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('a'),
+            crossterm::event::KeyModifiers::CONTROL,
+        )),
+        Some(Action::SelectAll)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Left,
+            crossterm::event::KeyModifiers::ALT,
+        )),
+        Some(Action::HistoryBack)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::ALT,
+        )),
+        Some(Action::HistoryForward)
+    );
 }
 
 #[test]
@@ -1104,15 +1132,20 @@ shell = "S"
 }
 
 #[test]
-fn preview_scroll_defaults_map_to_shift_h_j_k_l() {
+fn preview_scroll_defaults_map_to_shift_h_j_k_l_and_brackets() {
     let key_bindings = KeyBindings::default();
-    assert_eq!(key_bindings.scroll_preview_up, 'K');
-    assert_eq!(key_bindings.scroll_preview_down, 'J');
+    assert_eq!(key_bindings.scroll_preview_up.to_string(), "K/[");
+    assert_eq!(key_bindings.scroll_preview_down.to_string(), "J/]");
     assert_eq!(key_bindings.scroll_preview_left, 'H');
     assert_eq!(key_bindings.scroll_preview_right, 'L');
     assert_eq!(key_bindings.action_for('K'), Some(Action::ScrollPreviewUp));
+    assert_eq!(key_bindings.action_for('['), Some(Action::ScrollPreviewUp));
     assert_eq!(
         key_bindings.action_for('J'),
+        Some(Action::ScrollPreviewDown)
+    );
+    assert_eq!(
+        key_bindings.action_for(']'),
         Some(Action::ScrollPreviewDown)
     );
     assert_eq!(
@@ -1154,7 +1187,8 @@ scroll_preview_up = "y"
     )
     .expect("config should parse");
     assert_eq!(
-        config.keys.scroll_preview_up, 'K',
+        config.keys.scroll_preview_up.to_string(),
+        "K/[",
         "user override colliding with default 'y' (yank) must fall back to default 'K'"
     );
     assert_eq!(config.keys.yank, 'y');
@@ -1180,7 +1214,7 @@ scroll_preview_down = "U"
 "#,
     )
     .expect("config should parse");
-    assert_eq!(config.keys.scroll_preview_up, 'K');
+    assert_eq!(config.keys.scroll_preview_up.to_string(), "K/[");
     assert_eq!(config.keys.scroll_preview_down, 'U');
     assert_eq!(config.keys.action_for('U'), Some(Action::ScrollPreviewDown));
     assert_eq!(config.keys.action_for('K'), Some(Action::ScrollPreviewUp));
@@ -1192,12 +1226,73 @@ scroll_preview_down = "U"
 }
 
 #[test]
+fn remaining_browser_shortcuts_can_be_overridden_and_freed() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+search_files = "ctrl+s"
+select_all = "A"
+history_back = "alt+h"
+history_forward = "alt+l"
+open = ["o", "ctrl+f", "ctrl+a", "alt+left", "alt+right"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL)),
+        Some(Action::SearchFiles)
+    );
+    assert_eq!(config.keys.action_for('A'), Some(Action::SelectAll));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::ALT)),
+        Some(Action::HistoryBack)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::ALT)),
+        Some(Action::HistoryForward)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Left, KeyModifiers::ALT)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Right, KeyModifiers::ALT)),
+        Some(Action::Open)
+    );
+}
+
+#[test]
 fn browser_control_defaults_are_configurable_actions() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let key_bindings = KeyBindings::default();
     assert_eq!(key_bindings.action_for('g'), Some(Action::GoTo));
-    assert_eq!(key_bindings.action_for('G'), Some(Action::SelectLast));
+    assert_eq!(key_bindings.action_for('G'), Some(Action::JumpLast));
     assert_eq!(key_bindings.action_for(' '), Some(Action::ToggleSelection));
     assert_eq!(
         key_bindings.action_for_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
@@ -1240,11 +1335,11 @@ fn browser_control_defaults_are_configurable_actions() {
     );
     assert_eq!(
         key_bindings.action_for_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE)),
-        Some(Action::SelectFirst)
+        Some(Action::JumpFirst)
     );
     assert_eq!(
         key_bindings.action_for_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE)),
-        Some(Action::SelectLast)
+        Some(Action::JumpLast)
     );
 }
 
@@ -1262,8 +1357,8 @@ cycle_places_previous = []
 go_parent = []
 page_up = []
 page_down = []
-select_first = []
-select_last = []
+jump_first = []
+jump_last = []
 open = ["o", "g", "G", "space", "tab", "backtab", "backspace", "pageup", "pagedown", "home", "end"]
 "#,
     )

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1263,7 +1263,7 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
         "expected help overlay to include the Preview section header, got: {rendered:?}"
     );
     assert!(
-        rendered.contains("Shift+K / Shift+J"),
+        rendered.contains("K/[ / J/]"),
         "expected help overlay to list the vertical preview scroll keys, got: {rendered:?}"
     );
     assert!(

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -22,7 +22,7 @@ pub(super) fn render_help(
     let search_entries = vec![
         e(&kb.zoxide.to_string(), "zoxide history"),
         e(&kb.search_folders.to_string(), "search folders"),
-        e("Ctrl+F", "search files"),
+        e(&kb.search_files.to_string(), "search files"),
         e("Ctrl+←→", "move by word"),
         e("Ctrl+Backspace", "delete previous word"),
         e("Ctrl+Del", "delete next word"),
@@ -56,7 +56,6 @@ pub(super) fn render_help(
         format_preview_scroll_key(&kb.scroll_preview_left, &kb.scroll_preview_right);
     let preview_entries = vec![
         e(&preview_vertical_key, "step page or scroll"),
-        e("[ / ]", "step page or scroll"),
         e(&preview_horizontal_key, "scroll left / right"),
     ];
     let mouse_entries = vec![
@@ -208,6 +207,7 @@ fn navigation_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
     let parent_key = format_key_pair(&kb.nav_left, &kb.go_parent);
     let page_key = format_key_pair(&kb.page_up, &kb.page_down);
     let place_key = format_key_pair(&kb.cycle_places_next, &kb.cycle_places_previous);
+    let history_key = format_key_pair(&kb.history_back, &kb.history_forward);
 
     vec![
         e(&kb.nav_up.to_string(), "move up"),
@@ -216,18 +216,18 @@ fn navigation_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
         e(&kb.nav_right.to_string(), "enter folder"),
         e(&kb.open_or_enter.to_string(), "enter folder / open"),
         e(&kb.go_to.to_string(), "go-to menu"),
-        e(&kb.select_first.to_string(), "first item"),
-        e(&kb.select_last.to_string(), "last item"),
+        e(&kb.jump_first.to_string(), "first item"),
+        e(&kb.jump_last.to_string(), "last item"),
         e(&page_key, "page up / down"),
         e(&place_key, "cycle places"),
-        e("Alt+← / Alt+→", "back / forward"),
+        e(&history_key, "back / forward"),
     ]
 }
 
 fn clipboard_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
     vec![
         e(&kb.toggle_selection.to_string(), "toggle selection"),
-        e("Ctrl+A", "select all"),
+        e(&kb.select_all.to_string(), "select all"),
         e("Esc", "clear selection"),
         e(&kb.yank.to_string(), "yank (copy)"),
         e(&kb.copy_path.to_string(), "copy path details"),
@@ -417,7 +417,9 @@ mod tests {
             "PageUp / PageDown"
         );
         assert_eq!(entry_key(&navigation, "cycle places"), "Tab / Shift+Tab");
+        assert_eq!(entry_key(&navigation, "back / forward"), "Alt+← / Alt+→");
         assert_eq!(entry_key(&clipboard, "toggle selection"), "Space");
+        assert_eq!(entry_key(&clipboard, "select all"), "Ctrl+A");
     }
 
     #[test]
@@ -430,8 +432,11 @@ cycle_places_next = "n"
 cycle_places_previous = "P"
 page_up = "<"
 page_down = ">"
-select_first = "1"
-select_last = "2"
+jump_first = "1"
+jump_last = "2"
+select_all = "A"
+history_back = "alt+h"
+history_forward = "alt+l"
 "#,
         );
         let navigation = navigation_entries(&kb);
@@ -442,6 +447,8 @@ select_last = "2"
         assert_eq!(entry_key(&navigation, "last item"), "2");
         assert_eq!(entry_key(&navigation, "page up / down"), "< / >");
         assert_eq!(entry_key(&navigation, "cycle places"), "n / P");
+        assert_eq!(entry_key(&navigation, "back / forward"), "Alt+H / Alt+L");
         assert_eq!(entry_key(&clipboard, "toggle selection"), "t");
+        assert_eq!(entry_key(&clipboard, "select all"), "A");
     }
 }


### PR DESCRIPTION
## Summary

Adds configurable key bindings for file search, select-all, and history navigation, plus `[` / `]` defaults for preview page stepping.

## What Changed

- Added `[keys]` support for `search_files`, `select_all`, `history_back`, and `history_forward`.
- Added `[` / `]` as default bindings for the existing `scroll_preview_up` / `scroll_preview_down` actions.
- Updated key resolution, help overlay output, README/config examples, and changelog entries for the new bindings.

## User Impact

Users can now remap or unbind file search, select-all, and history back/forward shortcuts through `[keys]`.

Preview page stepping also keeps the existing `K` / `J` behavior while adding `[` / `]` defaults.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified single-key overrides with `search_files = "t"`, `select_all = "T"`, `history_back = "0"`, `history_forward = "9"`, and `open_with = "w"`.
- Verified overridden defaults stop working for `ctrl+f`, `ctrl+a`, and `alt+left`.
- Verified preview page stepping with `scroll_preview_up = "["` and `scroll_preview_down = "]"`.
- Verified multiple bindings and unbinding with `search_files = ["t", "ctrl+f"]`, `select_all = []`, `history_back = "alt+h"`, and `history_forward = "alt+l"`.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
