### PR TITLE
fix(keys): warn on unknown actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for modifier `[keys]` bindings such as `ctrl+o`, `alt+o`, and `shift+right`.
 - Added named `[keys]` values for `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, and `end`.
 - Added configurable browser control bindings for `go_to`, `toggle_selection`, `cycle_places_next`, `cycle_places_previous`, `go_parent`, `page_up`, `page_down`, `jump_first`, and `jump_last`.
-- Added configurable `[keys]` bindings for `search_files`, `select_all`, `history_back`, and `history_forward`, and added `[` / `]` as default bindings for the existing `scroll_preview_up` / `scroll_preview_down` actions.
+- Added configurable `[keys]` bindings for `quit_without_cd`, `search_files`, `select_all`, `history_back`, and `history_forward`, plus `[` / `]` defaults for the existing `scroll_preview_up` / `scroll_preview_down` actions.
 - Added a configurable `D` (`delete_permanently`) shortcut for permanently deleting selected entries without first opening Trash. ([#140])
 
 ### Changed
 
-- Updated the help overlay to reflect the new configurable bindings.
+- Updated the help overlay to reflect the new configurable bindings and clearer quit-without-cd wording.
+- Warn when `[keys]` contains unknown action names, while still applying valid key bindings.
 
 ## [1.7.0] - 2026-05-30
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -85,6 +85,7 @@
 # nav_up               = ["k", "up"]
 # nav_right            = ["l", "right"]
 # quit                 = "q"
+# quit_without_cd      = "Q"
 # yank                 = "y"
 # cut                  = "x"
 # paste                = "p"

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -1,5 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
 /// A browser action that can be triggered by a configurable key binding.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -525,6 +526,8 @@ pub(super) struct KeysConfigOverride {
     scroll_preview_right: Option<KeyConfigOverride>,
     scroll_preview_up: Option<KeyConfigOverride>,
     scroll_preview_down: Option<KeyConfigOverride>,
+    #[serde(flatten)]
+    unknown: BTreeMap<String, toml::Value>,
 }
 
 struct RawBinding {
@@ -532,6 +535,16 @@ struct RawBinding {
     action: Action,
     override_value: Option<KeyConfigOverride>,
     default: KeyList,
+}
+
+fn warn_unknown_key_actions(unknown: &BTreeMap<String, toml::Value>) {
+    for key in unknown.keys() {
+        eprintln!("{}", unknown_key_action_warning(key));
+    }
+}
+
+pub(super) fn unknown_key_action_warning(key: &str) -> String {
+    format!("elio: keys.{key}: unknown key action; ignoring")
 }
 
 impl KeyBindings {
@@ -620,6 +633,8 @@ impl KeyBindings {
     }
 
     pub(super) fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
+        warn_unknown_key_actions(&overrides.unknown);
+
         let raw = vec![
             RawBinding {
                 name: "quit",

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -29,6 +29,29 @@ cut = "X"
 }
 
 #[test]
+fn unknown_keys_are_ignored_without_dropping_valid_overrides() {
+    let config = Config::from_str(
+        r#"
+[keys]
+open_withh = "w"
+open_with = "P"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.open_with, 'P');
+    assert_eq!(config.keys.action_for('w'), None);
+}
+
+#[test]
+fn unknown_key_warning_names_config_path() {
+    assert_eq!(
+        super::super::keys::unknown_key_action_warning("open_withh"),
+        "elio: keys.open_withh: unknown key action; ignoring"
+    );
+}
+
+#[test]
 fn keys_accept_array_overrides() {
     let config = Config::from_str(
         r#"

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -48,7 +48,7 @@ pub(super) fn render_help(
         e(&kb.toggle_hidden.to_string(), "toggle dotfiles"),
         e(&kb.sort.to_string(), "cycle sort"),
         e(&kb.quit.to_string(), "quit"),
-        e(&kb.quit_without_cd.to_string(), "quit, keep shell cwd"),
+        e(&kb.quit_without_cd.to_string(), "quit without cd"),
     ];
     let preview_vertical_key =
         format_preview_scroll_key(&kb.scroll_preview_up, &kb.scroll_preview_down);


### PR DESCRIPTION
## Summary

Warn when `[keys]` contains unknown action names instead of silently ignoring typos, while preserving valid bindings in the same table.

## What Changed

- Capture unknown `[keys]` fields during deserialization and emit warnings like `elio: keys.open_withh: unknown key action; ignoring`.
- Keep valid key overrides applying even when the same `[keys]` table contains unknown action names.
- List `quit_without_cd` in `examples/config.toml` and clarify the help overlay label to `quit without cd`.

## User Impact

Users now get a clear warning for mistyped or unsupported key actions such as `open_withh`, instead of having the setting silently do nothing. Valid key bindings in the same config still work.

## Notes

Unknown actions are ignored with a warning rather than treated as fatal config errors, so one typo does not discard otherwise valid key configuration.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested a `[keys]` config containing unknown actions such as `open_withh` and `ssss`.
- Confirmed elio prints warnings like `elio: keys.open_withh: unknown key action; ignoring`.
- Confirmed valid bindings in the same `[keys]` table still apply.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
