### PR TITLE
chore: update Rust toolchain and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
             fi
           fi
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
 
@@ -92,8 +92,8 @@ jobs:
             ln -sf "$(command -v mkisofs)" /usr/local/bin/genisoimage
           fi
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -114,8 +114,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
             fi
           fi
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -92,8 +92,8 @@ jobs:
             ln -sf "$(command -v mkisofs)" /usr/local/bin/genisoimage
           fi
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -114,8 +114,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,8 @@ jobs:
             fi
           fi
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -149,8 +149,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -203,8 +203,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -240,8 +240,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -374,8 +374,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.93.0
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,8 @@ jobs:
             fi
           fi
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -149,8 +149,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -203,8 +203,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -240,8 +240,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -374,8 +374,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust 1.96.0
-        uses: dtolnay/rust-toolchain@1.96.0
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ cd elio
 git checkout -b your-branch-name
 ```
 
-The repository includes [`rust-toolchain.toml`](rust-toolchain.toml), which pins Rust `1.96.0` and installs the required `clippy` and `rustfmt` components automatically.
+The repository includes [`rust-toolchain.toml`](rust-toolchain.toml), which pins Rust `1.95.0` and installs the required `clippy` and `rustfmt` components automatically.
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ cd elio
 git checkout -b your-branch-name
 ```
 
-The repository includes [`rust-toolchain.toml`](rust-toolchain.toml), which pins Rust `1.93.0` and installs the required `clippy` and `rustfmt` components automatically.
+The repository includes [`rust-toolchain.toml`](rust-toolchain.toml), which pins Rust `1.96.0` and installs the required `clippy` and `rustfmt` components automatically.
 
 ## Project Structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,9 +1116,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,9 +67,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block2"
@@ -76,6 +85,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -192,7 +207,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -302,7 +317,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -311,7 +326,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -376,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -390,6 +405,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fdeflate"
@@ -520,6 +541,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -621,7 +644,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -723,12 +746,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -757,7 +786,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -821,11 +850,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -872,7 +901,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -890,7 +919,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -932,7 +961,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -949,7 +978,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -977,7 +1006,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -998,6 +1027,30 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1058,7 +1111,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1092,7 +1145,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1137,29 +1190,32 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror",
  "unicode-segmentation",
@@ -1169,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -1181,17 +1237,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.0",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -1204,7 +1261,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1213,7 +1270,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1249,7 +1306,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1273,11 +1330,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1446,18 +1503,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1785,7 +1842,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,14 +519,17 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -733,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1242,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ notify = "8.2"
 json5 = "1.3"
 lofty = "0.24"
 pulldown-cmark = "0.13"
-quick-xml = "0.39"
+quick-xml = "0.40"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "crossterm_0_29"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "elio"
 version = "1.8.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.95"
 description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support."
 license = "MIT"
 repository = "https://github.com/elio-fm/elio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ toml_edit = "0.25"
 unicode-width = "0.2"
 zip = { version = "8.6", default-features = false, features = ["deflate"] }
 trash = "5.2.5"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 
 [build-dependencies]
 syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "yaml-load", "regex-onig"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "elio"
 version = "1.8.0"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.96"
 description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support."
 license = "MIT"
 repository = "https://github.com/elio-fm/elio"

--- a/packaging/fedora/elio.spec
+++ b/packaging/fedora/elio.spec
@@ -13,8 +13,8 @@ Source0:        %{name}-%{version}.tar.gz
 Source1:        vendor-%{version}.tar.zst
 
 BuildRequires:  cargo-rpm-macros
-BuildRequires:  cargo >= 1.93
-BuildRequires:  rust >= 1.93
+BuildRequires:  cargo >= 1.96
+BuildRequires:  rust >= 1.96
 BuildRequires:  gcc
 BuildRequires:  pkgconf-pkg-config
 BuildRequires:  zstd

--- a/packaging/fedora/elio.spec
+++ b/packaging/fedora/elio.spec
@@ -13,8 +13,8 @@ Source0:        %{name}-%{version}.tar.gz
 Source1:        vendor-%{version}.tar.zst
 
 BuildRequires:  cargo-rpm-macros
-BuildRequires:  cargo >= 1.96
-BuildRequires:  rust >= 1.96
+BuildRequires:  cargo >= 1.95
+BuildRequires:  rust >= 1.95
 BuildRequires:  gcc
 BuildRequires:  pkgconf-pkg-config
 BuildRequires:  zstd

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/app/jobs/metrics.rs
+++ b/src/app/jobs/metrics.rs
@@ -51,11 +51,9 @@ impl SchedulerMetrics {
 
     #[cfg(test)]
     pub(super) fn snapshot(&self) -> SchedulerMetricsSnapshot {
-        let preview_avg_build_ms = if self.preview_jobs_completed == 0 {
-            0
-        } else {
-            (self.preview_total_build_time.as_millis() as u64) / self.preview_jobs_completed
-        };
+        let preview_avg_build_ms = (self.preview_total_build_time.as_millis() as u64)
+            .checked_div(self.preview_jobs_completed)
+            .unwrap_or(0);
         SchedulerMetricsSnapshot {
             directory_jobs_submitted: self.directory_jobs_submitted,
             directory_jobs_completed: self.directory_jobs_completed,

--- a/src/app/open_with/discovery/desktop_file.rs
+++ b/src/app/open_with/discovery/desktop_file.rs
@@ -112,10 +112,8 @@ pub(super) fn parse_desktop_entry(contents: &str) -> Option<DesktopEntryCandidat
         match key {
             // Only accept the unlocalized Name= (localized keys have the form
             // Name[de]=…, whose key contains '[').
-            "Name" => {
-                if name.is_none() {
-                    name = Some(value.to_string());
-                }
+            "Name" if name.is_none() => {
+                name = Some(value.to_string());
             }
             "Exec" => exec = Some(value.to_string()),
             "MimeType" => {

--- a/src/app/open_with/discovery/scan.rs
+++ b/src/app/open_with/discovery/scan.rs
@@ -110,7 +110,7 @@ fn discover_via_desktop_scan_inner(
     }
 
     let mut remaining: Vec<_> = candidates.into_iter().collect();
-    remaining.sort_by(|a, b| a.1.name.to_lowercase().cmp(&b.1.name.to_lowercase()));
+    remaining.sort_by_key(|a| a.1.name.to_lowercase());
 
     for (desktop_id, candidate) in remaining {
         let Some((program, args)) = expand_exec_template(&candidate.exec, path) else {

--- a/src/app/overlays/images/format.rs
+++ b/src/app/overlays/images/format.rs
@@ -227,7 +227,12 @@ pub(super) fn read_svg_dimensions(path: &Path) -> Option<RenderedImageDimensions
                 let mut view_box = None;
                 for attribute in tag.attributes().flatten() {
                     let key = attribute.key.as_ref();
-                    let value = attribute.decode_and_unescape_value(reader.decoder()).ok()?;
+                    let value = attribute
+                        .decoded_and_normalized_value(
+                            quick_xml::XmlVersion::Implicit1_0,
+                            reader.decoder(),
+                        )
+                        .ok()?;
                     match key {
                         b"width" => width = parse_svg_length_px(&value),
                         b"height" => height = parse_svg_length_px(&value),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use crossterm::{
 use ratatui::{
     Terminal,
     backend::CrosstermBackend,
-    buffer::{Buffer, Cell},
+    buffer::{Buffer, Cell, CellDiffOption},
     layout::Rect,
 };
 use std::{
@@ -675,7 +675,7 @@ fn collect_buffer_cells(rects: &[Rect], buffer: &Buffer) -> Vec<(u16, u16, Cell)
                 let Some(cell) = buffer.cell((x, y)) else {
                     continue;
                 };
-                if cell.skip {
+                if matches!(cell.diff_option, CellDiffOption::Skip) {
                     continue;
                 }
                 cells.push((x, y, cell.clone()));

--- a/src/preview/container/archive/comic.rs
+++ b/src/preview/container/archive/comic.rs
@@ -1123,7 +1123,11 @@ fn xml_attribute_value(
 ) -> Option<String> {
     event.attributes().flatten().find_map(|attribute| {
         (xml_local_name(attribute.key.as_ref()).eq_ignore_ascii_case(name))
-            .then(|| attribute.decode_and_unescape_value(decoder).ok())
+            .then(|| {
+                attribute
+                    .decoded_and_normalized_value(quick_xml::XmlVersion::Implicit1_0, decoder)
+                    .ok()
+            })
             .flatten()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())

--- a/src/preview/document/common.rs
+++ b/src/preview/document/common.rs
@@ -84,7 +84,11 @@ pub(super) fn xml_attribute_value(
 ) -> Option<String> {
     event.attributes().flatten().find_map(|attribute| {
         (local_name(attribute.key.as_ref()) == name)
-            .then(|| attribute.decode_and_unescape_value(decoder).ok())
+            .then(|| {
+                attribute
+                    .decoded_and_normalized_value(quick_xml::XmlVersion::Implicit1_0, decoder)
+                    .ok()
+            })
             .flatten()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
@@ -129,7 +133,10 @@ pub(super) fn parse_xml_text_fields(xml: &str) -> BTreeMap<String, String> {
                 if tag == "document-statistic" {
                     for attribute in event.attributes().flatten() {
                         let key = local_name(attribute.key.as_ref());
-                        if let Ok(value) = attribute.decode_and_unescape_value(reader.decoder()) {
+                        if let Ok(value) = attribute.decoded_and_normalized_value(
+                            quick_xml::XmlVersion::Implicit1_0,
+                            reader.decoder(),
+                        ) {
                             let value = value.trim();
                             if !value.is_empty() {
                                 fields.insert(key, value.to_string());
@@ -143,7 +150,10 @@ pub(super) fn parse_xml_text_fields(xml: &str) -> BTreeMap<String, String> {
                 if local_name(event.name().as_ref()) == "document-statistic" {
                     for attribute in event.attributes().flatten() {
                         let key = local_name(attribute.key.as_ref());
-                        if let Ok(value) = attribute.decode_and_unescape_value(reader.decoder()) {
+                        if let Ok(value) = attribute.decoded_and_normalized_value(
+                            quick_xml::XmlVersion::Implicit1_0,
+                            reader.decoder(),
+                        ) {
                             let value = value.trim();
                             if !value.is_empty() {
                                 fields.insert(key, value.to_string());

--- a/src/preview/document/epub/parse.rs
+++ b/src/preview/document/epub/parse.rs
@@ -84,10 +84,8 @@ pub(super) fn parse_epub_package_document(xml: &str) -> EpubPackageDocument {
                 let tag = local_name(event.name().as_ref());
                 match tag.as_str() {
                     "metadata" | "manifest" => {}
-                    "spine" => {
-                        if package.toc_id.is_none() {
-                            package.toc_id = xml_attribute_value(&event, reader.decoder(), "toc");
-                        }
+                    "spine" if package.toc_id.is_none() => {
+                        package.toc_id = xml_attribute_value(&event, reader.decoder(), "toc");
                     }
                     "item" if stack.last().is_some_and(|section| section == "manifest") => {
                         register_epub_manifest_item(&mut package, &event, reader.decoder());

--- a/src/preview/document/epub/parse.rs
+++ b/src/preview/document/epub/parse.rs
@@ -94,10 +94,10 @@ pub(super) fn parse_epub_package_document(xml: &str) -> EpubPackageDocument {
                         register_epub_meta(&mut package, &event, reader.decoder());
                     }
                     "title" | "subject" | "creator" | "language" | "publisher" | "identifier"
-                    | "date" => {
-                        if stack.last().is_some_and(|section| section == "metadata") {
-                            current_metadata_tag = Some(tag.clone());
-                        }
+                    | "date"
+                        if stack.last().is_some_and(|section| section == "metadata") =>
+                    {
+                        current_metadata_tag = Some(tag.clone());
                     }
                     _ => {}
                 }

--- a/src/preview/document/epub/parse.rs
+++ b/src/preview/document/epub/parse.rs
@@ -53,7 +53,12 @@ pub(super) fn parse_epub_rootfile_path(xml: &str) -> Option<String> {
                     if local_name(attribute.key.as_ref()) != "full-path" {
                         continue;
                     }
-                    let value = attribute.decode_and_unescape_value(reader.decoder()).ok()?;
+                    let value = attribute
+                        .decoded_and_normalized_value(
+                            quick_xml::XmlVersion::Implicit1_0,
+                            reader.decoder(),
+                        )
+                        .ok()?;
                     let value = value.trim();
                     if !value.is_empty() {
                         return Some(value.to_string());

--- a/src/preview/document/epub/render.rs
+++ b/src/preview/document/epub/render.rs
@@ -405,10 +405,8 @@ fn extract_xhtml_image_href(xml: &str) -> Option<String> {
                     return Some(data);
                 }
             }
-            Ok(Event::End(event)) => {
-                if local_name(event.name().as_ref()) == "body" {
-                    body_depth = body_depth.saturating_sub(1);
-                }
+            Ok(Event::End(event)) if local_name(event.name().as_ref()) == "body" => {
+                body_depth = body_depth.saturating_sub(1);
             }
             Ok(Event::Eof) | Err(_) => break,
             _ => {}

--- a/src/preview/document/epub/toc.rs
+++ b/src/preview/document/epub/toc.rs
@@ -205,10 +205,10 @@ fn parse_ncx_toc(xml: &str) -> Vec<EpubNavPoint> {
                     _ => {}
                 }
             }
-            Ok(Event::Empty(event)) => {
-                if nav_depth > 0 && local_name(event.name().as_ref()) == "content" {
-                    current_href = xml_attribute_value(&event, reader.decoder(), "src");
-                }
+            Ok(Event::Empty(event))
+                if nav_depth > 0 && local_name(event.name().as_ref()) == "content" =>
+            {
+                current_href = xml_attribute_value(&event, reader.decoder(), "src");
             }
             Ok(Event::Text(text)) => {
                 if in_label

--- a/src/preview/document/epub/toc.rs
+++ b/src/preview/document/epub/toc.rs
@@ -246,7 +246,9 @@ fn epub_nav_is_toc(
 ) -> bool {
     event.attributes().flatten().any(|attribute| {
         let key = local_name(attribute.key.as_ref());
-        let Ok(value) = attribute.decode_and_unescape_value(decoder) else {
+        let Ok(value) =
+            attribute.decoded_and_normalized_value(quick_xml::XmlVersion::Implicit1_0, decoder)
+        else {
             return false;
         };
         let value = value.trim();

--- a/src/preview/markdown.rs
+++ b/src/preview/markdown.rs
@@ -179,10 +179,8 @@ impl MarkdownRenderer {
 
     fn start_tag(&mut self, tag: Tag<'_>) {
         match tag {
-            Tag::Paragraph => {
-                if self.current_item.is_none() {
-                    self.ensure_block_gap();
-                }
+            Tag::Paragraph if self.current_item.is_none() => {
+                self.ensure_block_gap();
             }
             Tag::Heading { level, .. } => {
                 self.ensure_block_gap();

--- a/src/ui/browser/layout.rs
+++ b/src/ui/browser/layout.rs
@@ -403,11 +403,7 @@ fn allocate_weighted_lengths(total: u16, weights: Vec<u16>) -> Vec<u16> {
 
     for (index, weight) in weights.iter().copied().enumerate() {
         let product = total as u32 * weight as u32;
-        let portion = if total_weight == 0 {
-            0
-        } else {
-            (product / total_weight) as u16
-        };
+        let portion = product.checked_div(total_weight).unwrap_or(0) as u16;
         lengths[index] = portion;
         assigned = assigned.saturating_add(portion);
         remainders.push((

--- a/src/ui/browser/scrollbar.rs
+++ b/src/ui/browser/scrollbar.rs
@@ -39,11 +39,11 @@ pub(super) fn render_preview_scrollbar(
         .min(area.height as usize);
     let max_scroll = total.saturating_sub(visible_rows.max(1));
     let thumb_max_top = area.height as usize - thumb_height;
-    let thumb_top = if max_scroll == 0 {
-        0
-    } else {
-        (app.preview_scroll_offset() * thumb_max_top) / max_scroll
-    };
+    let thumb_top = app
+        .preview_scroll_offset()
+        .checked_mul(thumb_max_top)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
 
     let thumb = Rect {
         x: area.x,
@@ -108,11 +108,10 @@ pub(super) fn render_browser_scrollbar(
         .min(area.height as usize);
     let max_scroll = total_rows.saturating_sub(visible_rows.max(1));
     let thumb_max_top = area.height as usize - thumb_height;
-    let thumb_top = if max_scroll == 0 {
-        0
-    } else {
-        (scroll_row * thumb_max_top) / max_scroll
-    };
+    let thumb_top = scroll_row
+        .checked_mul(thumb_max_top)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
 
     let thumb = Rect {
         x: area.x,

--- a/src/ui/overlay_manager/bulk_rename.rs
+++ b/src/ui/overlay_manager/bulk_rename.rs
@@ -65,11 +65,10 @@ pub(super) fn render_bulk_rename_overlay(
         0
     };
     let max_scroll = item_count.saturating_sub(visible_lines as usize);
-    let thumb_pos = if max_scroll == 0 {
-        0
-    } else {
-        scroll_top * (visible_lines as usize - thumb_size) / max_scroll
-    };
+    let thumb_pos = scroll_top
+        .checked_mul(visible_lines as usize - thumb_size)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
     let bar_x = list_area.x + list_area.width.saturating_sub(1);
 
     let mut cursor_screen_pos: Option<(u16, u16)> = None;

--- a/src/ui/overlay_manager/create.rs
+++ b/src/ui/overlay_manager/create.rs
@@ -91,11 +91,10 @@ pub(super) fn render_create_overlay(
         0
     };
     let max_scroll = line_count.saturating_sub(visible_lines as usize);
-    let thumb_pos = if max_scroll == 0 {
-        0
-    } else {
-        scroll_top * (visible_lines as usize - thumb_size) / max_scroll
-    };
+    let thumb_pos = scroll_top
+        .checked_mul(visible_lines as usize - thumb_size)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
     let bar_x = list_area.x + list_area.width.saturating_sub(1);
 
     let mut cursor_screen_pos: Option<(u16, u16)> = None;

--- a/src/ui/overlay_manager/restore.rs
+++ b/src/ui/overlay_manager/restore.rs
@@ -56,11 +56,10 @@ pub(super) fn render_restore_overlay(
         0
     };
     let max_scroll = count.saturating_sub(visible);
-    let thumb_pos = if max_scroll == 0 {
-        0
-    } else {
-        scroll * (visible - thumb_size) / max_scroll
-    };
+    let thumb_pos = scroll
+        .checked_mul(visible - thumb_size)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
     let bar_x = list_area.x + list_area.width.saturating_sub(1);
 
     for row_offset in 0..visible {

--- a/src/ui/overlay_manager/trash.rs
+++ b/src/ui/overlay_manager/trash.rs
@@ -56,11 +56,10 @@ pub(super) fn render_trash_overlay(
         0
     };
     let max_scroll = count.saturating_sub(visible);
-    let thumb_pos = if max_scroll == 0 {
-        0
-    } else {
-        scroll * (visible - thumb_size) / max_scroll
-    };
+    let thumb_pos = scroll
+        .checked_mul(visible - thumb_size)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
     let bar_x = list_area.x + list_area.width.saturating_sub(1);
 
     for row_offset in 0..visible {


### PR DESCRIPTION
## Summary

Updates the pinned Rust toolchain to 1.95 and refreshes a small set of dependencies.

## What Changed

- Bumped the Rust toolchain/MSRV from 1.93 to 1.95.
- Updated release CI and Fedora packaging metadata to match Rust 1.95.
- Updated `quick-xml`, `rusqlite`, and `ratatui`.
- Migrated affected `quick-xml` and `ratatui` API usage.

## User Impact

No intended user-visible behavior change.

## Notes

Left `color_quant` on the 1.x line because it is still required by `image`/`gif`; `2.0.0` is a major version and not compatible with the current dependency graph.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Compared EPUB, MOBI, DOCX, XLSX, SVG, CBZ, CBR, and SQLite previews against the latest released `elio`.

Result:

All automated checks passed locally. Manual preview results matched the latest release.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed
