### PR TITLE
feat(cli): accept file paths as startup arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `elio <path>` now accepts file paths as well as directories, opening the parent directory and focusing the file entry, including hidden files, file symlinks, and broken symlinks.
+
 ## [1.8.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Install from crates.io:
 cargo install elio
 ```
 
-`elio` starts in your current working directory by default. Pass a directory path to start there instead, for example `elio path/to/directory`.
+`elio` starts in your current working directory by default. Pass a directory path to start there, or a file path to open its parent directory and focus the file, for example `elio ~/Downloads` or `elio ~/Downloads/report.pdf`.
 
 > [!TIP]
 > Recommended: use a Nerd Font in your terminal so icons display correctly.

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -613,6 +613,14 @@ impl App {
     }
 
     pub fn new_at(cwd: PathBuf) -> Result<Self> {
+        Self::new_at_startup(cwd, None, false)
+    }
+
+    pub(crate) fn new_at_startup(
+        cwd: PathBuf,
+        start_focus: Option<PathBuf>,
+        reveal_hidden_start_focus: bool,
+    ) -> Result<Self> {
         let scheduler = JobScheduler::new();
         let (directory_watch_tx, directory_watch_rx) = std::sync::mpsc::channel();
         let mut app = Self {
@@ -625,7 +633,7 @@ impl App {
                 view_mode: startup_view_mode(crate::config::ui().start_in_grid),
                 zoom_level: crate::config::ui().grid_zoom,
                 sort_mode: SortMode::Name,
-                show_hidden: crate::config::ui().show_hidden,
+                show_hidden: crate::config::ui().show_hidden || reveal_hidden_start_focus,
                 in_trash: false,
                 navigation_history: NavigationHistory::default(),
                 selected_paths: HashSet::new(),
@@ -728,7 +736,17 @@ impl App {
         app.navigation.last_sidebar_refresh_at = Instant::now();
         app.navigation.entries = snapshot.entries;
         app.navigation.directory_runtime.fingerprint = snapshot.fingerprint;
+        if let Some(start_focus) = start_focus
+            && let Some(index) = app
+                .navigation
+                .entries
+                .iter()
+                .position(|entry| entry.path == start_focus)
+        {
+            app.navigation.selected = index;
+        }
         app.clamp_selection();
+        app.sync_scroll();
         app.remember_current_directory_view();
         app.refresh_preview();
         app.reset_directory_watch();
@@ -792,6 +810,19 @@ pub(super) fn detect_wheel_profile() -> WheelProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-state-{label}-{unique}"))
+    }
 
     #[test]
     fn startup_view_mode_defaults_to_list() {
@@ -801,5 +832,58 @@ mod tests {
     #[test]
     fn startup_view_mode_can_start_in_grid() {
         assert_eq!(startup_view_mode(true), ViewMode::Grid);
+    }
+
+    #[test]
+    fn startup_focus_selects_and_scrolls_entry_without_status_history_or_multi_selection() {
+        let root = temp_path("startup-focus");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        for index in 0..8 {
+            fs::write(root.join(format!("file-{index}.txt")), format!("{index}"))
+                .expect("file should be created");
+        }
+        let target = root.join("file-6.txt");
+
+        let app = App::new_at_startup(root.clone(), Some(target.clone()), false)
+            .expect("app should initialize");
+
+        assert_eq!(
+            app.selected_entry().map(|entry| entry.path.as_path()),
+            Some(target.as_path())
+        );
+        assert_eq!(app.navigation.scroll_row, app.navigation.selected);
+        assert!(app.navigation.selected_paths.is_empty());
+        assert!(app.navigation.navigation_history.back.is_empty());
+        assert!(app.navigation.navigation_history.forward.is_empty());
+        assert_eq!(app.status_message(), "");
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn startup_focus_can_reveal_hidden_targets_without_persisted_config() {
+        let root = temp_path("startup-hidden-focus");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let visible = root.join("visible.txt");
+        let hidden = root.join(".env");
+        fs::write(&visible, "visible").expect("visible file should be created");
+        fs::write(&hidden, "secret").expect("hidden file should be created");
+
+        let app = App::new_at_startup(root.clone(), Some(hidden.clone()), true)
+            .expect("app should initialize");
+
+        assert!(app.navigation.show_hidden);
+        assert_eq!(
+            app.selected_entry().map(|entry| entry.path.as_path()),
+            Some(hidden.as_path())
+        );
+        assert!(
+            app.navigation
+                .entries
+                .iter()
+                .any(|entry| entry.path == hidden)
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,13 +1,21 @@
 use crate::shell_integration::{self, Shell, ShellIntegrationAction};
 use anyhow::Result;
 use std::{
-    env, fs, io,
+    env,
+    ffi::OsStr,
+    fs, io,
     path::{Path, PathBuf},
 };
 
+const RUN_USAGE: &str = "Usage: elio [OPTIONS] [PATH]";
+
 pub(crate) fn run() -> Result<()> {
     match parse_args(env::args().skip(1))? {
-        Command::Run(options) => elio::run_with_options(options),
+        Command::Run {
+            options,
+            start_focus,
+            reveal_hidden_start_focus,
+        } => elio::run_with_startup_options(options, start_focus, reveal_hidden_start_focus),
         Command::PrintVersion => {
             print_version();
             Ok(())
@@ -79,7 +87,11 @@ pub(crate) fn run() -> Result<()> {
 
 #[derive(Debug)]
 enum Command {
-    Run(elio::RunOptions),
+    Run {
+        options: elio::RunOptions,
+        start_focus: Option<PathBuf>,
+        reveal_hidden_start_focus: bool,
+    },
     PrintVersion,
     PrintHelp,
     PrintShellInit(Shell),
@@ -91,7 +103,11 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
     let args = args.into_iter().collect::<Vec<_>>();
 
     if args.is_empty() {
-        return Ok(Command::Run(elio::RunOptions::default()));
+        return Ok(Command::Run {
+            options: elio::RunOptions::default(),
+            start_focus: None,
+            reveal_hidden_start_focus: false,
+        });
     }
 
     match args.as_slice() {
@@ -128,30 +144,24 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
             if command == "shell" && subcommand == "install" =>
         {
             return Err(anyhow::anyhow!(
-                unknown_argument_message(unexpected).replace(
-                    "Usage: elio [OPTIONS] [DIRECTORY]",
-                    "Usage: elio shell install [SHELL]",
-                )
+                unknown_argument_message(unexpected)
+                    .replace(RUN_USAGE, "Usage: elio shell install [SHELL]")
             ));
         }
         [command, subcommand, _shell, unexpected, ..]
             if command == "shell" && subcommand == "uninstall" =>
         {
             return Err(anyhow::anyhow!(
-                unknown_argument_message(unexpected).replace(
-                    "Usage: elio [OPTIONS] [DIRECTORY]",
-                    "Usage: elio shell uninstall [SHELL]",
-                )
+                unknown_argument_message(unexpected)
+                    .replace(RUN_USAGE, "Usage: elio shell uninstall [SHELL]")
             ));
         }
         [command, subcommand, _shell, unexpected, ..]
             if command == "shell" && subcommand == "init" =>
         {
             return Err(anyhow::anyhow!(
-                unknown_argument_message(unexpected).replace(
-                    "Usage: elio [OPTIONS] [DIRECTORY]",
-                    "Usage: elio shell init <SHELL>",
-                )
+                unknown_argument_message(unexpected)
+                    .replace(RUN_USAGE, "Usage: elio shell init <SHELL>")
             ));
         }
         [command, subcommand] if command == "shell" && subcommand == "init" => {
@@ -172,6 +182,8 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
 
 fn parse_run_args(args: Vec<String>) -> Result<Command> {
     let mut start_dir = None;
+    let mut start_focus = None;
+    let mut reveal_hidden_start_focus = false;
     let mut cwd_file = None;
     let mut index = 0;
 
@@ -180,12 +192,12 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
         if let Some(file) = arg.strip_prefix("--cwd-file=") {
             if cwd_file.is_some() {
                 return Err(anyhow::anyhow!(
-                    "error: '--cwd-file' cannot be used more than once\n\nUsage: elio [OPTIONS] [DIRECTORY]"
+                    "error: '--cwd-file' cannot be used more than once\n\n{RUN_USAGE}"
                 ));
             }
             if file.is_empty() {
                 return Err(anyhow::anyhow!(
-                    "error: expected a file path after '--cwd-file'\n\nUsage: elio [OPTIONS] [DIRECTORY]"
+                    "error: expected a file path after '--cwd-file'\n\n{RUN_USAGE}"
                 ));
             }
             cwd_file = Some(PathBuf::from(file));
@@ -196,12 +208,12 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
         if arg == "--cwd-file" {
             if cwd_file.is_some() {
                 return Err(anyhow::anyhow!(
-                    "error: '--cwd-file' cannot be used more than once\n\nUsage: elio [OPTIONS] [DIRECTORY]"
+                    "error: '--cwd-file' cannot be used more than once\n\n{RUN_USAGE}"
                 ));
             }
             let Some(file) = args.get(index + 1) else {
                 return Err(anyhow::anyhow!(
-                    "error: expected a file path after '--cwd-file'\n\nUsage: elio [OPTIONS] [DIRECTORY]"
+                    "error: expected a file path after '--cwd-file'\n\n{RUN_USAGE}"
                 ));
             };
             cwd_file = Some(PathBuf::from(file));
@@ -216,14 +228,21 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
         if start_dir.is_some() {
             return Err(anyhow::anyhow!(unknown_argument_message(arg)));
         }
-        start_dir = Some(resolve_startup_directory(arg)?);
+        let startup_path = resolve_startup_path(arg)?;
+        start_dir = Some(startup_path.start_dir);
+        start_focus = startup_path.start_focus;
+        reveal_hidden_start_focus = startup_path.reveal_hidden_start_focus;
         index += 1;
     }
 
-    Ok(Command::Run(elio::RunOptions {
-        start_dir,
-        cwd_file,
-    }))
+    Ok(Command::Run {
+        options: elio::RunOptions {
+            start_dir,
+            cwd_file,
+        },
+        start_focus,
+        reveal_hidden_start_focus,
+    })
 }
 
 fn print_version() {
@@ -233,13 +252,15 @@ fn print_version() {
 fn print_help() {
     println!("elio {}", env!("CARGO_PKG_VERSION"));
     println!();
-    println!("Usage: elio [OPTIONS] [DIRECTORY]");
+    println!("{RUN_USAGE}");
     println!("       elio shell init <SHELL>");
     println!("       elio shell install [SHELL]");
     println!("       elio shell uninstall [SHELL]");
     println!();
     println!("Arguments:");
-    println!("  [DIRECTORY]          Start elio in this directory");
+    println!(
+        "  [PATH]               Start in a directory, or focus a file in its parent directory"
+    );
     println!();
     println!("Options:");
     println!("      --cwd-file FILE  Write the final current directory to FILE on exit");
@@ -252,16 +273,64 @@ fn print_help() {
     println!("  shell uninstall [SHELL]  Remove shell integration for bash, zsh, fish, or nu");
 }
 
-fn resolve_startup_directory(arg: &str) -> Result<PathBuf> {
+#[derive(Debug, Eq, PartialEq)]
+struct StartupPath {
+    start_dir: PathBuf,
+    start_focus: Option<PathBuf>,
+    reveal_hidden_start_focus: bool,
+}
+
+fn resolve_startup_path(arg: &str) -> Result<StartupPath> {
     let path = PathBuf::from(arg);
-    let metadata = fs::metadata(&path).map_err(|error| startup_path_error(&path, &error))?;
-    if !metadata.is_dir() {
-        return Err(anyhow::anyhow!(
-            "Cannot open \"{}\": not a directory",
-            path.display()
-        ));
+    match fs::metadata(&path) {
+        Ok(metadata) if metadata.is_dir() => Ok(StartupPath {
+            start_dir: path.canonicalize().unwrap_or(path),
+            start_focus: None,
+            reveal_hidden_start_focus: false,
+        }),
+        Ok(_) => resolve_startup_file(&path),
+        Err(error) => {
+            if fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+                return resolve_startup_file(&path);
+            }
+            Err(startup_path_error(&path, &error))
+        }
     }
-    Ok(path.canonicalize().unwrap_or(path))
+}
+
+fn resolve_startup_file(path: &Path) -> Result<StartupPath> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Cannot open \"{}\": no file name", path.display()))?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let start_dir = parent
+        .canonicalize()
+        .map_err(|error| startup_path_error(parent, &error))?;
+    Ok(StartupPath {
+        start_focus: Some(start_dir.join(file_name)),
+        start_dir,
+        reveal_hidden_start_focus: should_reveal_hidden_start_focus(path, file_name),
+    })
+}
+
+fn should_reveal_hidden_start_focus(path: &Path, file_name: &OsStr) -> bool {
+    file_name.to_string_lossy().starts_with('.') || has_hidden_attribute(path)
+}
+
+#[cfg(windows)]
+fn has_hidden_attribute(path: &Path) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_HIDDEN: u32 = 0x2;
+    fs::symlink_metadata(path)
+        .is_ok_and(|metadata| metadata.file_attributes() & FILE_ATTRIBUTE_HIDDEN != 0)
+}
+
+#[cfg(not(windows))]
+fn has_hidden_attribute(_path: &Path) -> bool {
+    false
 }
 
 fn startup_path_error(path: &Path, error: &io::Error) -> anyhow::Error {
@@ -286,14 +355,15 @@ fn unknown_argument_message(arg: &str) -> String {
         message.push_str("\n\n  tip: a similar argument exists: '--cwd-file'");
     }
 
-    message.push_str("\n\nUsage: elio [OPTIONS] [DIRECTORY]");
+    message.push_str("\n\n");
+    message.push_str(RUN_USAGE);
     message.push_str("\n\nFor more information, try '--help'.");
     message
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_startup_directory;
+    use super::{StartupPath, resolve_startup_path};
     use std::{
         fs,
         path::PathBuf,
@@ -309,53 +379,135 @@ mod tests {
     }
 
     #[test]
-    fn resolve_startup_directory_accepts_existing_directory() {
+    fn resolve_startup_path_accepts_existing_directory() {
         let root = temp_path("directory");
         fs::create_dir_all(&root).expect("temp directory should be created");
 
-        let resolved = resolve_startup_directory(root.to_str().expect("temp path should be utf-8"))
+        let resolved = resolve_startup_path(root.to_str().expect("temp path should be utf-8"))
             .expect("existing directory should resolve");
 
         assert_eq!(
             resolved,
-            root.canonicalize()
-                .expect("temp directory should canonicalize successfully")
+            StartupPath {
+                start_dir: root
+                    .canonicalize()
+                    .expect("temp directory should canonicalize successfully"),
+                start_focus: None,
+                reveal_hidden_start_focus: false,
+            }
         );
 
         fs::remove_dir_all(root).expect("temp directory should be removed");
     }
 
     #[test]
-    fn resolve_startup_directory_rejects_missing_path() {
-        let missing = temp_path("missing");
-
-        let error =
-            resolve_startup_directory(missing.to_str().expect("temp path should be valid utf-8"))
-                .expect_err("missing path should return an error");
-
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "Cannot open \"{}\": no such file or directory",
-                missing.display()
-            )
-        );
-    }
-
-    #[test]
-    fn resolve_startup_directory_rejects_files() {
+    fn resolve_startup_path_accepts_existing_file() {
         let root = temp_path("file");
         fs::create_dir_all(&root).expect("temp directory should be created");
         let file = root.join("notes.txt");
         fs::write(&file, "hello").expect("temp file should be created");
 
-        let error =
-            resolve_startup_directory(file.to_str().expect("temp path should be valid utf-8"))
-                .expect_err("file path should return an error");
+        let resolved =
+            resolve_startup_path(file.to_str().expect("temp path should be valid utf-8"))
+                .expect("file path should resolve");
+        let canonical_root = root
+            .canonicalize()
+            .expect("temp directory should canonicalize successfully");
 
         assert_eq!(
-            error.to_string(),
-            format!("Cannot open \"{}\": not a directory", file.display())
+            resolved,
+            StartupPath {
+                start_dir: canonical_root.clone(),
+                start_focus: Some(canonical_root.join("notes.txt")),
+                reveal_hidden_start_focus: false,
+            }
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn resolve_startup_path_reveals_hidden_file_targets() {
+        let root = temp_path("hidden-file");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let file = root.join(".env");
+        fs::write(&file, "secret").expect("temp file should be created");
+
+        let resolved =
+            resolve_startup_path(file.to_str().expect("temp path should be valid utf-8"))
+                .expect("hidden file path should resolve");
+        let canonical_root = root
+            .canonicalize()
+            .expect("temp directory should canonicalize successfully");
+
+        assert_eq!(
+            resolved,
+            StartupPath {
+                start_dir: canonical_root.clone(),
+                start_focus: Some(canonical_root.join(".env")),
+                reveal_hidden_start_focus: true,
+            }
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_startup_path_focuses_file_symlink_itself() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("file-symlink");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let target = root.join("target.txt");
+        let link = root.join("link.txt");
+        fs::write(&target, "target").expect("target file should be created");
+        symlink(&target, &link).expect("file symlink should be created");
+
+        let resolved =
+            resolve_startup_path(link.to_str().expect("temp path should be valid utf-8"))
+                .expect("file symlink should resolve");
+        let canonical_root = root
+            .canonicalize()
+            .expect("temp directory should canonicalize successfully");
+
+        assert_eq!(
+            resolved,
+            StartupPath {
+                start_dir: canonical_root.clone(),
+                start_focus: Some(canonical_root.join("link.txt")),
+                reveal_hidden_start_focus: false,
+            }
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_startup_path_focuses_broken_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("broken-symlink");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let missing_target = root.join("missing.txt");
+        let link = root.join("broken.txt");
+        symlink(&missing_target, &link).expect("broken symlink should be created");
+
+        let resolved =
+            resolve_startup_path(link.to_str().expect("temp path should be valid utf-8"))
+                .expect("broken symlink should resolve");
+        let canonical_root = root
+            .canonicalize()
+            .expect("temp directory should canonicalize successfully");
+
+        assert_eq!(
+            resolved,
+            StartupPath {
+                start_dir: canonical_root.clone(),
+                start_focus: Some(canonical_root.join("broken.txt")),
+                reveal_hidden_start_focus: false,
+            }
         );
 
         fs::remove_dir_all(root).expect("temp directory should be removed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,32 @@ pub fn run_at(cwd: PathBuf) -> Result<()> {
 }
 
 pub fn run_with_options(options: RunOptions) -> Result<()> {
+    run_with_startup_state(options, None, false)
+}
+
+#[doc(hidden)]
+pub fn run_with_startup_options(
+    options: RunOptions,
+    start_focus: Option<PathBuf>,
+    reveal_hidden_start_focus: bool,
+) -> Result<()> {
+    run_with_startup_state(options, start_focus, reveal_hidden_start_focus)
+}
+
+fn run_with_startup_state(
+    options: RunOptions,
+    start_focus: Option<PathBuf>,
+    reveal_hidden_start_focus: bool,
+) -> Result<()> {
     config::initialize();
     ui::theme::initialize();
     let mut terminal = init_terminal()?;
-    let result = run_app(&mut terminal, options.start_dir);
+    let result = run_app(
+        &mut terminal,
+        options.start_dir,
+        start_focus,
+        reveal_hidden_start_focus,
+    );
     restore_terminal(&mut terminal)?;
     if let Some(final_cwd) = result? {
         write_cwd_file_if_requested(options.cwd_file.as_deref(), &final_cwd)?;
@@ -296,9 +318,11 @@ fn write_cwd_file(cwd_file: &Path, final_cwd: &Path) -> Result<()> {
 fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     cwd: Option<PathBuf>,
+    start_focus: Option<PathBuf>,
+    reveal_hidden_start_focus: bool,
 ) -> Result<Option<PathBuf>> {
     let mut app = match cwd {
-        Some(cwd) => App::new_at(cwd)?,
+        Some(cwd) => App::new_at_startup(cwd, start_focus, reveal_hidden_start_focus)?,
         None => App::new()?,
     };
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -27,11 +27,13 @@ fn help_prints_usage() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Usage: elio [OPTIONS] [DIRECTORY]"));
+    assert!(stdout.contains("Usage: elio [OPTIONS] [PATH]"));
     assert!(stdout.contains("       elio shell init <SHELL>"));
     assert!(stdout.contains("       elio shell uninstall [SHELL]"));
     assert!(stdout.contains("Arguments:"));
-    assert!(stdout.contains("[DIRECTORY]          Start elio in this directory"));
+    assert!(stdout.contains(
+        "[PATH]               Start in a directory, or focus a file in its parent directory"
+    ));
     assert!(stdout.contains("--cwd-file FILE  Write the final current directory to FILE on exit"));
     assert!(stdout.contains("-h, --help           Print help"));
     assert!(stdout.contains("-V, --version        Print version"));
@@ -80,7 +82,7 @@ fn extra_argument_after_version_reports_the_extra_argument() {
 }
 
 #[test]
-fn missing_directory_argument_exits_with_clear_error() {
+fn missing_path_argument_exits_with_clear_error() {
     let missing = temp_path("missing");
 
     let output = elio()
@@ -100,29 +102,7 @@ fn missing_directory_argument_exits_with_clear_error() {
 }
 
 #[test]
-fn file_argument_exits_with_not_a_directory_error() {
-    let root = temp_path("file");
-    fs::create_dir_all(&root).expect("temp directory should be created");
-    let file = root.join("notes.txt");
-    fs::write(&file, "hello").expect("temp file should be created");
-
-    let output = elio()
-        .arg(file.to_str().expect("temp path should be valid utf-8"))
-        .output()
-        .expect("failed to run elio with file path");
-
-    assert!(!output.status.success());
-    assert!(output.stdout.is_empty());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stderr),
-        format!("Cannot open \"{}\": not a directory\n", file.display())
-    );
-
-    fs::remove_dir_all(root).expect("temp directory should be removed");
-}
-
-#[test]
-fn more_than_one_directory_is_rejected() {
+fn more_than_one_path_is_rejected() {
     let first = temp_path("dir-one");
     let second = temp_path("dir-two");
     fs::create_dir_all(&first).expect("first temp directory should be created");


### PR DESCRIPTION
## Summary

Allow `elio <path>` to accept file paths as well as directories. When the startup path is a file, elio opens the parent directory and focuses that file entry.

## What Changed

- Resolve the startup positional argument as a general path instead of directory-only input.
- Keep directory arguments working as before.
- For file arguments, start in the parent directory and focus the provided file.
- Preserve focused startup behavior for hidden files, file symlinks, and broken symlinks.
- Keep startup focus out of navigation history, status messages, and multi-selection state.
- Update CLI help, README, changelog, and CLI tests for `[PATH]`.

## User Impact

Users can now launch elio directly against a file:

```bash
elio ~/Downloads/report.pdf
```

Directory startup still works unchanged.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified `elio --help` shows `[PATH]` and describes file focus behavior.
- Smoke-tested startup with directory, file, hidden file, file symlink, and broken symlink paths.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
