### PR TITLE
feat(cli): add chooser file mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--chooser-file FILE [PATH]` to run elio as a file chooser, writing the confirmed selection as absolute paths, one per line, to `FILE` or stdout with `-`; cancel exits silently with a nonzero status. ([#153])
 - `elio <path>` now accepts file paths as well as directories, opening the parent directory and focusing the file entry, including hidden files, file symlinks, and broken symlinks.
+
+### Changed
+
+- Updated shell integration scripts to pass `--chooser-file` invocations directly to `elio`, so chooser mode does not change the parent shell directory. Re-run `elio shell install` after upgrading to refresh existing shell integration.
 
 ## [1.8.0] - 2026-06-06
 
@@ -226,3 +231,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#138]: https://github.com/elio-fm/elio/pull/138
 [#140]: https://github.com/elio-fm/elio/issues/140
 [#141]: https://github.com/elio-fm/elio/issues/141
+[#153]: https://github.com/elio-fm/elio/issues/153

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -75,6 +75,9 @@
 # Example: nav_right = [] frees "l" and "right".
 # Then open_or_enter = ["enter", "l", "right"] can use them.
 #
+# In chooser mode (--chooser-file), choose takes priority over normal actions
+# that use the same key.
+#
 # Reserved bare keys: ? + = - _
 # Reserved shortcuts: Ctrl+C, Ctrl+Plus/Minus
 # Omit any key to keep the built-in default shown in the comment.
@@ -102,6 +105,7 @@
 # open                 = "o"
 # open_with            = "O"
 # open_or_enter        = "enter"
+# choose               = "enter"  # confirm chooser selection
 # go_to                = "g"
 # toggle_selection     = "space"
 # cycle_places_next    = "tab"

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -115,8 +115,22 @@ impl App {
             }
         }
 
-        let configured_action =
-            crate::config::keys().action_for_key_in_context(key, self.key_context());
+        let configured_action = if self.chooser_mode {
+            match crate::config::keys().chooser_action_for_key(key, self.key_context()) {
+                Some(crate::config::ChooserKeyAction::Choose) => {
+                    self.confirm_chooser();
+                    return Ok(());
+                }
+                Some(crate::config::ChooserKeyAction::Cancel) => {
+                    self.cancel_chooser();
+                    return Ok(());
+                }
+                Some(crate::config::ChooserKeyAction::Normal(action)) => Some(action),
+                None => None,
+            }
+        } else {
+            crate::config::keys().action_for_key_in_context(key, self.key_context())
+        };
 
         if self.input.wheel_profile == WheelProfile::HighFrequency
             && should_handle_high_frequency_horizontal_key(key, configured_action)

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -135,6 +135,158 @@ fn q_sets_should_quit() {
 }
 
 #[test]
+fn chooser_enter_confirms_hovered_entry() {
+    let root = temp_path("chooser-enter-hovered");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let file_path = root.join("note.txt");
+    fs::write(&file_path, "hello").expect("failed to write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.enable_chooser_mode();
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should confirm chooser selection");
+
+    assert!(app.should_quit);
+    assert!(app.should_change_directory_on_quit);
+    assert_eq!(
+        app.chooser_exit.as_ref(),
+        Some(&ChooserExit::Confirmed(vec![file_path]))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn chooser_enter_confirms_sorted_selection() {
+    let root = temp_path("chooser-enter-selection");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    let gamma = root.join("gamma.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    fs::write(&gamma, "gamma").expect("failed to write gamma");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(gamma.clone());
+    app.navigation.selected_paths.insert(alpha.clone());
+    let beta_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == beta)
+        .expect("beta should be visible");
+    app.select_index(beta_index);
+    app.enable_chooser_mode();
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should confirm selected chooser paths");
+
+    assert_eq!(
+        app.chooser_exit.as_ref(),
+        Some(&ChooserExit::Confirmed(vec![alpha, gamma]))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn chooser_quit_cancels_without_cd() {
+    let root = temp_path("chooser-cancel");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.enable_chooser_mode();
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('q'))))
+        .expect("q should cancel chooser mode");
+
+    assert!(app.should_quit);
+    assert!(!app.should_change_directory_on_quit);
+    assert_eq!(app.chooser_exit.as_ref(), Some(&ChooserExit::Cancelled));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn chooser_esc_keeps_normal_selection_clear_behavior() {
+    let root = temp_path("chooser-esc-selection");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let file_path = root.join("note.txt");
+    fs::write(&file_path, "hello").expect("failed to write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(file_path);
+    app.enable_chooser_mode();
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Esc)))
+        .expect("esc should keep normal selection behavior");
+
+    assert!(!app.should_quit);
+    assert!(app.should_change_directory_on_quit);
+    assert_eq!(app.chooser_exit, None);
+    assert!(app.navigation.selected_paths.is_empty());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn chooser_right_enters_directory_instead_of_confirming() {
+    let root = temp_path("chooser-right-directory");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let nested = root.join("nested");
+    fs::create_dir_all(&nested).expect("failed to create nested directory");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.view_mode = ViewMode::List;
+    app.select_index(0);
+    app.enable_chooser_mode();
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Right)))
+        .expect("right should enter the selected directory");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, nested);
+    assert!(!app.should_quit);
+    assert_eq!(app.chooser_exit, None);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn chooser_open_or_enter_action_keeps_normal_behavior() {
+    let root = temp_path("chooser-open-or-enter-directory");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let nested = root.join("nested");
+    fs::create_dir_all(&nested).expect("failed to create nested directory");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.view_mode = ViewMode::List;
+    app.select_index(0);
+    app.enable_chooser_mode();
+
+    app.dispatch_action(Action::OpenOrEnter)
+        .expect("open_or_enter should keep normal behavior in chooser mode");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, nested);
+    assert!(!app.should_quit);
+    assert_eq!(app.chooser_exit, None);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn modified_plain_shortcut_does_not_trigger_plain_action() {
     let root = temp_path("modified-plain-shortcut");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,9 +28,9 @@ use std::{
 };
 
 pub use self::state::App;
-pub(crate) use self::state::PendingTerminalTask;
 #[cfg(test)]
 pub use self::state::PreviewMetricsSnapshot;
+pub(crate) use self::state::{ChooserExit, PendingTerminalTask};
 pub(crate) use crate::core::FileClass;
 pub(crate) use crate::fs::{
     format_item_count, format_size, format_size_parts, format_time_ago, rect_contains,

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::{Path, PathBuf};
 
 impl App {
     pub fn is_selected(&self, path: &std::path::Path) -> bool {
@@ -33,5 +34,58 @@ impl App {
 
     pub(in crate::app) fn clear_selection(&mut self) {
         self.navigation.selected_paths.clear();
+    }
+
+    pub(crate) fn enable_chooser_mode(&mut self) {
+        self.chooser_mode = true;
+        self.status = "Chooser mode".to_string();
+    }
+
+    pub(crate) fn take_chooser_exit(&mut self) -> Option<ChooserExit> {
+        self.chooser_exit.take()
+    }
+
+    pub(in crate::app) fn confirm_chooser(&mut self) {
+        if !self.chooser_mode {
+            return;
+        }
+        self.chooser_exit = Some(ChooserExit::Confirmed(self.chooser_selection_paths()));
+        self.should_quit = true;
+    }
+
+    pub(in crate::app) fn cancel_chooser(&mut self) {
+        if !self.chooser_mode {
+            return;
+        }
+        self.chooser_exit = Some(ChooserExit::Cancelled);
+        self.should_change_directory_on_quit = false;
+        self.should_quit = true;
+    }
+
+    fn chooser_selection_paths(&self) -> Vec<PathBuf> {
+        if self.navigation.selected_paths.is_empty() {
+            return self
+                .selected_entry()
+                .map(|entry| vec![self.absolute_chooser_path(&entry.path)])
+                .unwrap_or_default();
+        }
+
+        let mut paths: Vec<PathBuf> = self
+            .navigation
+            .selected_paths
+            .iter()
+            .map(|path| self.absolute_chooser_path(path))
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    fn absolute_chooser_path(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.navigation.cwd.join(path)
+        }
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -592,6 +592,12 @@ pub(crate) enum PendingTerminalTask {
     Zoxide,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ChooserExit {
+    Confirmed(Vec<PathBuf>),
+    Cancelled,
+}
+
 pub struct App {
     pub(crate) navigation: NavigationState,
     pub(in crate::app) preview: PreviewRuntime,
@@ -601,6 +607,8 @@ pub struct App {
     pub(in crate::app) status: String,
     pub(crate) should_quit: bool,
     pub(crate) should_change_directory_on_quit: bool,
+    pub(crate) chooser_mode: bool,
+    pub(crate) chooser_exit: Option<ChooserExit>,
     /// Set by features that need direct terminal control.  The event loop in
     /// `lib.rs` drains this, suspends the TUI, runs the task, then restores the TUI.
     pub(crate) pending_terminal_task: Option<PendingTerminalTask>,
@@ -724,6 +732,8 @@ impl App {
             status: String::new(),
             should_quit: false,
             should_change_directory_on_quit: true,
+            chooser_mode: false,
+            chooser_exit: None,
             pending_terminal_task: None,
         };
         app.navigation.in_trash = App::path_is_trash(&app.navigation.cwd);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,24 +5,32 @@ use std::{
     ffi::OsStr,
     fs, io,
     path::{Path, PathBuf},
+    process::ExitCode,
 };
 
 const RUN_USAGE: &str = "Usage: elio [OPTIONS] [PATH]";
 
-pub(crate) fn run() -> Result<()> {
+pub(crate) fn run() -> Result<ExitCode> {
     match parse_args(env::args().skip(1))? {
         Command::Run {
             options,
+            chooser_file,
             start_focus,
             reveal_hidden_start_focus,
-        } => elio::run_with_startup_options(options, start_focus, reveal_hidden_start_focus),
+        } => elio::run_with_startup_options(
+            options,
+            start_focus,
+            reveal_hidden_start_focus,
+            chooser_file,
+        )
+        .map(run_outcome_exit_code),
         Command::PrintVersion => {
             print_version();
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
         Command::PrintHelp => {
             print_help();
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
         Command::PrintShellInit(shell) => {
             let executable = env::current_exe()?;
@@ -30,7 +38,7 @@ pub(crate) fn run() -> Result<()> {
             let binary =
                 shell_integration::binary_command(shell, invocation.as_deref(), &executable);
             print!("{}", shell_integration::init_script(shell, &binary));
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
         Command::InstallShellIntegration(shell) => {
             let executable = env::current_exe()?;
@@ -53,7 +61,7 @@ pub(crate) fn run() -> Result<()> {
             println!("  {}", report.reload_command);
             println!();
             println!("From now on, `elio` will change your shell directory on quit.");
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
         Command::UninstallShellIntegration(shell) => {
             let shell = match shell {
@@ -80,8 +88,15 @@ pub(crate) fn run() -> Result<()> {
             println!("  {}", report.reload_command);
             println!();
             println!("From now on, `elio` will leave your shell directory unchanged.");
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
+    }
+}
+
+fn run_outcome_exit_code(outcome: elio::RunOutcome) -> ExitCode {
+    match outcome {
+        elio::RunOutcome::Success => ExitCode::SUCCESS,
+        elio::RunOutcome::Cancelled => ExitCode::FAILURE,
     }
 }
 
@@ -89,6 +104,7 @@ pub(crate) fn run() -> Result<()> {
 enum Command {
     Run {
         options: elio::RunOptions,
+        chooser_file: Option<PathBuf>,
         start_focus: Option<PathBuf>,
         reveal_hidden_start_focus: bool,
     },
@@ -105,6 +121,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
     if args.is_empty() {
         return Ok(Command::Run {
             options: elio::RunOptions::default(),
+            chooser_file: None,
             start_focus: None,
             reveal_hidden_start_focus: false,
         });
@@ -185,39 +202,32 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
     let mut start_focus = None;
     let mut reveal_hidden_start_focus = false;
     let mut cwd_file = None;
+    let mut chooser_file = None;
     let mut index = 0;
 
     while index < args.len() {
         let arg = &args[index];
-        if let Some(file) = arg.strip_prefix("--cwd-file=") {
+        if path_option_matches(arg, "--cwd-file") {
             if cwd_file.is_some() {
                 return Err(anyhow::anyhow!(
                     "error: '--cwd-file' cannot be used more than once\n\n{RUN_USAGE}"
                 ));
             }
-            if file.is_empty() {
-                return Err(anyhow::anyhow!(
-                    "error: expected a file path after '--cwd-file'\n\n{RUN_USAGE}"
-                ));
-            }
-            cwd_file = Some(PathBuf::from(file));
-            index += 1;
+            let (file, next_index) = take_path_option_value(&args, index, "--cwd-file")?;
+            cwd_file = Some(file);
+            index = next_index;
             continue;
         }
 
-        if arg == "--cwd-file" {
-            if cwd_file.is_some() {
+        if path_option_matches(arg, "--chooser-file") {
+            if chooser_file.is_some() {
                 return Err(anyhow::anyhow!(
-                    "error: '--cwd-file' cannot be used more than once\n\n{RUN_USAGE}"
+                    "error: '--chooser-file' cannot be used more than once\n\n{RUN_USAGE}"
                 ));
             }
-            let Some(file) = args.get(index + 1) else {
-                return Err(anyhow::anyhow!(
-                    "error: expected a file path after '--cwd-file'\n\n{RUN_USAGE}"
-                ));
-            };
-            cwd_file = Some(PathBuf::from(file));
-            index += 2;
+            let (file, next_index) = take_path_option_value(&args, index, "--chooser-file")?;
+            chooser_file = Some(file);
+            index = next_index;
             continue;
         }
 
@@ -240,9 +250,41 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
             start_dir,
             cwd_file,
         },
+        chooser_file,
         start_focus,
         reveal_hidden_start_focus,
     })
+}
+
+fn path_option_matches(arg: &str, flag: &str) -> bool {
+    arg == flag
+        || arg
+            .strip_prefix(flag)
+            .is_some_and(|suffix| suffix.starts_with('='))
+}
+
+fn take_path_option_value(
+    args: &[String],
+    index: usize,
+    flag: &'static str,
+) -> Result<(PathBuf, usize)> {
+    let arg = &args[index];
+    let inline_prefix = format!("{flag}=");
+    if let Some(file) = arg.strip_prefix(&inline_prefix) {
+        if file.is_empty() {
+            return Err(anyhow::anyhow!(
+                "error: expected a file path after '{flag}'\n\n{RUN_USAGE}"
+            ));
+        }
+        return Ok((PathBuf::from(file), index + 1));
+    }
+
+    let Some(file) = args.get(index + 1) else {
+        return Err(anyhow::anyhow!(
+            "error: expected a file path after '{flag}'\n\n{RUN_USAGE}"
+        ));
+    };
+    Ok((PathBuf::from(file), index + 2))
 }
 
 fn print_version() {
@@ -263,6 +305,7 @@ fn print_help() {
     );
     println!();
     println!("Options:");
+    println!("      --chooser-file FILE  Write chosen paths to FILE, or stdout with '-'");
     println!("      --cwd-file FILE  Write the final current directory to FILE on exit");
     println!("  -h, --help           Print help");
     println!("  -V, --version        Print version");
@@ -353,6 +396,8 @@ fn unknown_argument_message(arg: &str) -> String {
         message.push_str("\n\n  tip: a similar argument exists: '--help'");
     } else if arg != "--cwd-file" && "--cwd-file".starts_with(arg) {
         message.push_str("\n\n  tip: a similar argument exists: '--cwd-file'");
+    } else if arg != "--chooser-file" && "--chooser-file".starts_with(arg) {
+        message.push_str("\n\n  tip: a similar argument exists: '--chooser-file'");
     }
 
     message.push_str("\n\n");

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -48,6 +48,13 @@ pub(crate) enum Action {
     ScrollPreviewDown,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ChooserKeyAction {
+    Choose,
+    Cancel,
+    Normal(Action),
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum NamedKey {
     Left,
@@ -333,6 +340,16 @@ impl KeyList {
         self.0.iter().copied()
     }
 
+    pub(crate) fn without(&self, shadowed: &Self) -> Self {
+        Self(
+            self.0
+                .iter()
+                .copied()
+                .filter(|key| !shadowed.contains(*key))
+                .collect(),
+        )
+    }
+
     pub(crate) fn single_char(&self) -> Option<char> {
         match self.0.as_slice() {
             [spec] => spec.single_char(),
@@ -369,6 +386,7 @@ impl PartialEq<char> for KeyList {
 /// `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, `end`, and `f1`..`f12`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct KeyBindings {
+    pub choose: KeyList,
     pub quit: KeyList,
     pub quit_without_cd: KeyList,
     pub yank: KeyList,
@@ -428,6 +446,7 @@ const RESERVED_MODIFIED_CHARS: &[char] = &[
 impl Default for KeyBindings {
     fn default() -> Self {
         Self {
+            choose: KeyList(vec![KeySpec::named(NamedKey::Enter)]),
             quit: KeyList::one('q'),
             quit_without_cd: KeyList::one('Q'),
             yank: KeyList::one('y'),
@@ -485,6 +504,7 @@ pub(super) enum KeyConfigOverride {
 
 #[derive(Deserialize, Default)]
 pub(super) struct KeysConfigOverride {
+    choose: Option<KeyConfigOverride>,
     quit: Option<KeyConfigOverride>,
     quit_without_cd: Option<KeyConfigOverride>,
     yank: Option<KeyConfigOverride>,
@@ -569,6 +589,21 @@ impl KeyBindings {
         })
     }
 
+    pub(crate) fn chooser_action_for_key(
+        &self,
+        key: KeyEvent,
+        context: KeyContext,
+    ) -> Option<ChooserKeyAction> {
+        if self.choose.matches_event(key) {
+            return Some(ChooserKeyAction::Choose);
+        }
+        if self.quit.matches_event(key) || self.quit_without_cd.matches_event(key) {
+            return Some(ChooserKeyAction::Cancel);
+        }
+        self.action_for_key_in_context(key, context)
+            .map(ChooserKeyAction::Normal)
+    }
+
     fn bindings(&self) -> [(&KeyList, Action); 41] {
         [
             (&self.quit, Action::Quit),
@@ -634,6 +669,12 @@ impl KeyBindings {
 
     pub(super) fn from_override(overrides: KeysConfigOverride, defaults: &Self) -> Self {
         warn_unknown_key_actions(&overrides.unknown);
+
+        let choose = overrides
+            .choose
+            .as_ref()
+            .and_then(|value| parse_key_override("choose", value, &defaults.choose))
+            .unwrap_or_else(|| defaults.choose.clone());
 
         let raw = vec![
             RawBinding {
@@ -937,6 +978,7 @@ impl KeyBindings {
         // Step 3: build from the resolved candidates (order matches `raw`).
         let resolved = |index: usize| candidates[index].0.clone();
         Self {
+            choose,
             quit: resolved(0),
             quit_without_cd: resolved(1),
             yank: resolved(2),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ mod ui;
 use serde::Deserialize;
 
 pub(crate) use self::{
-    keys::{Action, KeyBindings, KeyContext, KeyList},
+    keys::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList},
     layout::{LayoutConfig, PaneWeights},
     loading::config_dir,
     places::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -7,6 +7,7 @@ fn keys_default_bindings_are_sane() {
     assert_eq!(config.keys.cut, 'x');
     assert_eq!(config.keys.paste, 'p');
     assert_eq!(config.keys.delete_permanently, 'D');
+    assert_eq!(config.keys.choose.to_string(), "Enter");
     assert_eq!(config.keys.quit, 'q');
     assert_eq!(config.keys.quit_without_cd, 'Q');
     assert_eq!(config.keys.zoxide, 'z');
@@ -1049,6 +1050,109 @@ fn open_or_enter_defaults_to_enter() {
     assert_eq!(
         key_bindings.action_for_key(KeyEvent::new(KeyCode::Char('\n'), KeyModifiers::NONE)),
         Some(Action::OpenOrEnter)
+    );
+}
+
+#[test]
+fn choose_defaults_to_enter_but_normal_enter_stays_open_or_enter() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let key_bindings = KeyBindings::default();
+    assert_eq!(key_bindings.choose.to_string(), "Enter");
+    assert_eq!(
+        key_bindings.action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        key_bindings.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Choose)
+    );
+}
+
+#[test]
+fn chooser_lookup_prioritizes_choose_over_smart_open_or_enter() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_right = []
+open_or_enter = ["enter", "l", "right"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::OpenOrEnter)
+    );
+    assert_eq!(
+        config.keys.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Choose)
+    );
+    assert_eq!(
+        config.keys.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Normal(Action::OpenOrEnter))
+    );
+    assert_eq!(
+        config.keys.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Normal(Action::OpenOrEnter))
+    );
+}
+
+#[test]
+fn choose_can_be_unbound_or_rebound_without_changing_normal_enter() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let unbound = Config::from_str(
+        r#"
+[keys]
+choose = []
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(
+        unbound.keys.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Normal(Action::OpenOrEnter))
+    );
+
+    let rebound = Config::from_str(
+        r#"
+[keys]
+choose = "ctrl+enter"
+"#,
+    )
+    .expect("config should parse");
+    assert_eq!(
+        rebound.keys.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Normal(Action::OpenOrEnter))
+    );
+    assert_eq!(
+        rebound.keys.chooser_action_for_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
+            KeyContext::Normal,
+        ),
+        Some(ChooserKeyAction::Choose)
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod shell;
 mod ui;
 mod zoxide;
 
-use crate::app::{App, PendingTerminalTask};
+use crate::app::{App, ChooserExit, PendingTerminalTask};
 use anyhow::Result;
 use crossterm::{
     cursor::{RestorePosition, SavePosition, SetCursorStyle},
@@ -48,6 +48,19 @@ pub struct RunOptions {
     pub cwd_file: Option<PathBuf>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[doc(hidden)]
+pub enum RunOutcome {
+    Success,
+    Cancelled,
+}
+
+#[derive(Debug)]
+struct AppExit {
+    final_cwd: Option<PathBuf>,
+    chooser: Option<ChooserExit>,
+}
+
 pub fn run() -> Result<()> {
     run_with_options(RunOptions::default())
 }
@@ -60,7 +73,7 @@ pub fn run_at(cwd: PathBuf) -> Result<()> {
 }
 
 pub fn run_with_options(options: RunOptions) -> Result<()> {
-    run_with_startup_state(options, None, false)
+    run_with_startup_state(options, None, false, None).map(|_| ())
 }
 
 #[doc(hidden)]
@@ -68,29 +81,49 @@ pub fn run_with_startup_options(
     options: RunOptions,
     start_focus: Option<PathBuf>,
     reveal_hidden_start_focus: bool,
-) -> Result<()> {
-    run_with_startup_state(options, start_focus, reveal_hidden_start_focus)
+    chooser_file: Option<PathBuf>,
+) -> Result<RunOutcome> {
+    run_with_startup_state(
+        options,
+        start_focus,
+        reveal_hidden_start_focus,
+        chooser_file,
+    )
 }
 
 fn run_with_startup_state(
     options: RunOptions,
     start_focus: Option<PathBuf>,
     reveal_hidden_start_focus: bool,
-) -> Result<()> {
+    chooser_file: Option<PathBuf>,
+) -> Result<RunOutcome> {
+    let RunOptions {
+        start_dir,
+        cwd_file,
+    } = options;
     config::initialize();
     ui::theme::initialize();
     let mut terminal = init_terminal()?;
     let result = run_app(
         &mut terminal,
-        options.start_dir,
+        start_dir,
         start_focus,
         reveal_hidden_start_focus,
+        chooser_file.is_some(),
     );
     restore_terminal(&mut terminal)?;
-    if let Some(final_cwd) = result? {
-        write_cwd_file_if_requested(options.cwd_file.as_deref(), &final_cwd)?;
+    let app_exit = result?;
+    if let Some(final_cwd) = app_exit.final_cwd {
+        write_cwd_file_if_requested(cwd_file.as_deref(), &final_cwd)?;
     }
-    Ok(())
+    match app_exit.chooser {
+        Some(ChooserExit::Confirmed(paths)) => {
+            write_chooser_file_if_requested(chooser_file.as_deref(), &paths)?;
+            Ok(RunOutcome::Success)
+        }
+        Some(ChooserExit::Cancelled) => Ok(RunOutcome::Cancelled),
+        None => Ok(RunOutcome::Success),
+    }
 }
 
 fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
@@ -315,16 +348,66 @@ fn write_cwd_file(cwd_file: &Path, final_cwd: &Path) -> Result<()> {
     Ok(())
 }
 
+fn write_chooser_file_if_requested(chooser_file: Option<&Path>, paths: &[PathBuf]) -> Result<()> {
+    let Some(chooser_file) = chooser_file else {
+        return Ok(());
+    };
+
+    write_chooser_file(chooser_file, paths)
+}
+
+fn write_chooser_file(chooser_file: &Path, paths: &[PathBuf]) -> Result<()> {
+    let bytes = chooser_output_bytes(paths);
+    if chooser_file_is_stdout(chooser_file) {
+        let mut stdout = io::stdout().lock();
+        stdout.write_all(&bytes)?;
+        stdout.flush()?;
+    } else {
+        std_fs::write(chooser_file, bytes)?;
+    }
+    Ok(())
+}
+
+fn chooser_file_is_stdout(chooser_file: &Path) -> bool {
+    chooser_file == Path::new("-")
+}
+
+#[cfg(unix)]
+fn chooser_output_bytes(paths: &[PathBuf]) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut bytes = Vec::new();
+    for path in paths {
+        bytes.extend_from_slice(path.as_os_str().as_bytes());
+        bytes.push(b'\n');
+    }
+    bytes
+}
+
+#[cfg(not(unix))]
+fn chooser_output_bytes(paths: &[PathBuf]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for path in paths {
+        bytes.extend_from_slice(path.to_string_lossy().as_bytes());
+        bytes.push(b'\n');
+    }
+    bytes
+}
+
 fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     cwd: Option<PathBuf>,
     start_focus: Option<PathBuf>,
     reveal_hidden_start_focus: bool,
-) -> Result<Option<PathBuf>> {
+    chooser_enabled: bool,
+) -> Result<AppExit> {
     let mut app = match cwd {
         Some(cwd) => App::new_at_startup(cwd, start_focus, reveal_hidden_start_focus)?,
         None => App::new()?,
     };
+    if chooser_enabled {
+        app.enable_chooser_mode();
+    }
 
     // Enable terminal image previews. Detection handles the current policy:
     // Kitty, Ghostty, Warp, WezTerm, iTerm2, and Konsole auto-enable supported
@@ -553,6 +636,7 @@ fn run_app(
     let final_cwd = app
         .should_change_directory_on_quit
         .then(|| app.navigation.cwd.clone());
+    let chooser = app.take_chooser_exit();
     app.queue_forced_iterm_preview_erase();
     let mut overlay_bytes = app.clear_preview_overlay()?;
     overlay_bytes.extend(app.iterm_pre_draw_erase());
@@ -560,7 +644,7 @@ fn run_app(
         terminal.backend_mut().write_all(&overlay_bytes)?;
         terminal.backend_mut().flush()?;
     }
-    Ok(final_cwd)
+    Ok(AppExit { final_cwd, chooser })
 }
 
 fn draw_terminal_frame(
@@ -788,6 +872,53 @@ mod tests {
         let bytes = fs::read(&cwd_file).expect("cwd file should be readable");
         assert!(!bytes.ends_with(b"\n"));
         assert_eq!(String::from_utf8_lossy(&bytes), final_cwd.to_string_lossy());
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn chooser_file_is_not_written_when_absent() {
+        crate::write_chooser_file_if_requested(None, &[PathBuf::from("/tmp/example")])
+            .expect("absent chooser file should be a no-op");
+    }
+
+    #[test]
+    fn chooser_file_hyphen_targets_stdout() {
+        assert!(crate::chooser_file_is_stdout(Path::new("-")));
+        assert!(!crate::chooser_file_is_stdout(Path::new("./-")));
+        assert!(!crate::chooser_file_is_stdout(Path::new("/dev/stdout")));
+    }
+
+    #[test]
+    fn chooser_file_writes_paths_with_trailing_newline() {
+        let root = temp_path("chooser-file");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let chooser_file = root.join("selection");
+        let alpha = root.join("alpha.txt");
+        let beta = root.join("beta.txt");
+
+        crate::write_chooser_file_if_requested(Some(&chooser_file), &[alpha.clone(), beta.clone()])
+            .expect("chooser file should be written");
+
+        let bytes = fs::read(&chooser_file).expect("chooser file should be readable");
+        let expected = format!("{}\n{}\n", alpha.to_string_lossy(), beta.to_string_lossy());
+        assert_eq!(String::from_utf8_lossy(&bytes), expected);
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn chooser_file_truncates_on_empty_confirmation() {
+        let root = temp_path("chooser-empty");
+        fs::create_dir_all(&root).expect("temp directory should be created");
+        let chooser_file = root.join("selection");
+        fs::write(&chooser_file, "stale\n").expect("chooser file should be primed");
+
+        crate::write_chooser_file_if_requested(Some(&chooser_file), &[])
+            .expect("empty chooser confirmation should be written");
+
+        let bytes = fs::read(&chooser_file).expect("chooser file should be readable");
+        assert!(bytes.is_empty());
 
         fs::remove_dir_all(root).expect("temp directory should be removed");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::process::ExitCode;
 
 fn main() -> ExitCode {
     match cli::run() {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(exit_code) => exit_code,
         Err(error) => {
             eprintln!("{error}");
             ExitCode::FAILURE

--- a/src/shell_integration/scripts.rs
+++ b/src/shell_integration/scripts.rs
@@ -50,7 +50,16 @@ fn posix_init_script(executable: &str) -> String {
             ;;
     esac
 
-    local tmp cwd status_code
+    local arg tmp cwd status_code
+    for arg in "$@"; do
+        case "$arg" in
+            --chooser-file|--chooser-file=*)
+                {executable} "$@"
+                return $?
+                ;;
+        esac
+    done
+
     tmp="$(mktemp -t "elio-cwd.XXXXXX")" || return
     {executable} --cwd-file "$tmp" "$@"
     status_code=$?
@@ -80,6 +89,14 @@ fn fish_init_script(executable: &str) -> String {
             return $status
     end
 
+    for arg in $argv
+        switch "$arg"
+            case --chooser-file '--chooser-file=*'
+                {executable} $argv
+                return $status
+        end
+    end
+
     set -l tmp (mktemp -t "elio-cwd.XXXXXX")
     or return
 
@@ -105,6 +122,23 @@ end
 fn nu_init_script(executable: &str) -> String {
     format!(
         r#"def --env --wrapped elio [...args] {{
+  let has_chooser_file = ($args | any {{|arg|
+    let value = ($arg | into string)
+    ($value == '--chooser-file') or ($value | str starts-with '--chooser-file=')
+  }})
+
+  if $has_chooser_file {{
+    let status_code = (
+      try {{
+        run-external {executable} ...$args
+        $env.LAST_EXIT_CODE
+      }} catch {{|e| ($e.exit_code? | default 127) }}
+    )
+
+    $env.LAST_EXIT_CODE = $status_code
+    return
+  }}
+
   if (($args | length) > 0) and (
     (($args.0 | into string) == 'shell') or
     (($args.0 | into string) | str starts-with '-')

--- a/src/shell_integration/tests.rs
+++ b/src/shell_integration/tests.rs
@@ -93,8 +93,9 @@ fn posix_init_script_passes_cli_commands_through() {
 
     assert!(script.contains("case \"${1-}\" in"));
     assert!(script.contains("shell|-*)"));
+    assert!(script.contains("--chooser-file|--chooser-file=*)"));
     assert!(script.contains("command elio \"$@\""));
-    assert!(script.contains("local tmp cwd status_code"));
+    assert!(script.contains("local arg tmp cwd status_code"));
     assert!(script.contains("command elio --cwd-file \"$tmp\" \"$@\""));
     assert!(script.contains("status_code=$?"));
     assert!(script.contains("return \"$status_code\""));
@@ -107,6 +108,7 @@ fn fish_init_script_passes_cli_commands_through() {
 
     assert!(script.contains("switch \"$argv[1]\""));
     assert!(script.contains("case shell '-*'"));
+    assert!(script.contains("case --chooser-file '--chooser-file=*'"));
     assert!(script.contains("command elio $argv"));
     assert!(script.contains("command elio --cwd-file \"$tmp\" $argv"));
     assert!(script.contains("cd \"$cwd\"; or return $status"));
@@ -117,6 +119,10 @@ fn nu_init_script_passes_cli_commands_through_without_posix_syntax() {
     let script = init_script(Shell::Nu, r#""elio""#);
 
     assert!(script.contains("def --env --wrapped elio [...args]"));
+    assert!(script.contains("let has_chooser_file = ($args | any"));
+    assert!(script.contains("$has_chooser_file"));
+    assert!(script.contains("if $has_chooser_file {"));
+    assert!(script.contains("run-external \"elio\" ...$args\n        $env.LAST_EXIT_CODE"));
     assert!(script.contains("run-external \"elio\" ...$args"));
     assert!(script.contains("mktemp -t \"elio-cwd.XXXXXX\""));
     assert!(script.contains("let command_args = ([\"--cwd-file\", $tmp] ++ $args)"));
@@ -128,6 +134,15 @@ fn nu_init_script_passes_cli_commands_through_without_posix_syntax() {
     assert!(!script.contains("case \"${1-}\""));
     assert!(!script.contains("command elio"));
     assert!(!script.contains("return $status_code"));
+    assert!(
+        script
+            .find("if $has_chooser_file {")
+            .expect("chooser branch should exist")
+            < script
+                .find("| complete")
+                .expect("complete branch should exist"),
+        "chooser mode must run before the captured pass-through branch"
+    );
 }
 
 #[test]

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1286,6 +1286,59 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
 }
 
 #[test]
+fn chooser_help_overlay_uses_chooser_actions_without_changing_esc() {
+    let root = temp_path("chooser-help-overlay");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    app.enable_chooser_mode();
+    app.overlays.help = true;
+    let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal should init");
+
+    draw_ui(&mut terminal, &mut app);
+    let rendered = buffer_text(terminal.backend().buffer());
+
+    assert!(
+        rendered.contains("Chooser controls"),
+        "expected chooser help title, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("confirm selection"),
+        "expected chooser help to list choose action, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("cancel chooser"),
+        "expected chooser help to relabel quit as cancellation, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Esc"),
+        "expected chooser help to keep normal Esc behavior visible, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("clear selection"),
+        "expected chooser help to keep Esc as clear selection, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("copy path details"),
+        "expected chooser help to keep copy path visible, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("cut"),
+        "expected chooser help to keep cut visible, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("paste"),
+        "expected chooser help to keep paste visible, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("quit without cd"),
+        "chooser help should not describe quit_without_cd as normal quit, got: {rendered:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn entries_and_preview_panels_keep_top_border_segments() {
     let root = temp_path("panel-top-borders");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -103,6 +103,6 @@ pub fn render(frame: &mut Frame<'_>, app: &App, state: &mut FrameState) {
     } else if app.search_is_open() {
         overlay_manager::render_search_overlay(frame, area, app, state, palette);
     } else if app.overlays.help {
-        overlay_manager::render_help(frame, area, state, palette);
+        overlay_manager::render_help(frame, area, app, state, palette);
     }
 }

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -1,5 +1,6 @@
+use super::HelpMode;
 use crate::app::FrameState;
-use crate::config::KeyBindings;
+use crate::config::{KeyBindings, KeyList};
 use crate::ui::{helpers, theme::Palette};
 use ratatui::{
     Frame,
@@ -13,51 +14,65 @@ use unicode_width::UnicodeWidthStr;
 pub(super) fn render_help(
     frame: &mut Frame<'_>,
     area: Rect,
+    mode: HelpMode,
     state: &mut FrameState,
     palette: Palette,
 ) {
     let kb = crate::config::keys();
+    let keys = HelpKeys::new(kb, mode);
 
-    let navigation_entries = navigation_entries(kb);
-    let search_entries = vec![
-        e(&kb.zoxide.to_string(), "zoxide history"),
-        e(&kb.search_folders.to_string(), "search folders"),
-        e(&kb.search_files.to_string(), "search files"),
+    let navigation_entries = navigation_entries(&keys);
+    let search_entries = entries([
+        keys.action(&kb.zoxide, "zoxide history"),
+        keys.action(&kb.search_folders, "search folders"),
+        keys.action(&kb.search_files, "search files"),
         e("Ctrl+←→", "move by word"),
         e("Ctrl+Backspace", "delete previous word"),
         e("Ctrl+Del", "delete next word"),
         e("Ctrl+W / Alt+D", "fallback word delete"),
-    ];
-    let clipboard_entries = clipboard_entries(kb);
-    let rename_key = kb.rename.to_string();
-    let restore_key = format!("{} (in trash)", kb.restore_from_trash);
-    let files_entries = vec![
-        e(&kb.create.to_string(), "create file or folder"),
+    ]);
+    let clipboard_entries = clipboard_entries(&keys);
+    let files_entries = entries([
+        keys.action(&kb.create, "create file or folder"),
         e("Alt/Shift+Enter", "add line in create prompt"),
-        e(&kb.trash.to_string(), "trash (delete if in trash)"),
-        e(&kb.delete_permanently.to_string(), "delete permanently"),
-        e(&rename_key, "rename (bulk if selection)"),
-        e(&restore_key, "restore from trash"),
-        e(&kb.shell.to_string(), "open shell here"),
-        e(&kb.open.to_string(), "open with default app"),
-        e(&kb.open_with.to_string(), "open with"),
-    ];
-    let view_entries = vec![
-        e(&kb.toggle_view.to_string(), "toggle grid / list"),
+        keys.action(&kb.trash, "trash (delete if in trash)"),
+        keys.action(&kb.delete_permanently, "delete permanently"),
+        keys.action(&kb.rename, "rename (bulk if selection)"),
+        keys.action_with_suffix(&kb.restore_from_trash, " (in trash)", "restore from trash"),
+        keys.action(&kb.shell, "open shell here"),
+        keys.action(&kb.open, "open with default app"),
+        keys.action(&kb.open_with, "open with"),
+    ]);
+    let quit_action = if mode.is_chooser() {
+        "cancel chooser"
+    } else {
+        "quit"
+    };
+    let quit_without_cd_action = if mode.is_chooser() {
+        "cancel chooser"
+    } else {
+        "quit without cd"
+    };
+    let view_entries = entries([
+        keys.action(&kb.toggle_view, "toggle grid / list"),
         e("+ / -", "grid zoom in / out"),
-        e(&kb.toggle_hidden.to_string(), "toggle dotfiles"),
-        e(&kb.sort.to_string(), "cycle sort"),
-        e(&kb.quit.to_string(), "quit"),
-        e(&kb.quit_without_cd.to_string(), "quit without cd"),
-    ];
-    let preview_vertical_key =
-        format_preview_scroll_key(&kb.scroll_preview_up, &kb.scroll_preview_down);
-    let preview_horizontal_key =
-        format_preview_scroll_key(&kb.scroll_preview_left, &kb.scroll_preview_right);
-    let preview_entries = vec![
-        e(&preview_vertical_key, "step page or scroll"),
-        e(&preview_horizontal_key, "scroll left / right"),
-    ];
+        keys.action(&kb.toggle_hidden, "toggle dotfiles"),
+        keys.action(&kb.sort, "cycle sort"),
+        keys.action(&kb.quit, quit_action),
+        keys.action(&kb.quit_without_cd, quit_without_cd_action),
+    ]);
+    let preview_entries = entries([
+        keys.preview_action(
+            &kb.scroll_preview_up,
+            &kb.scroll_preview_down,
+            "step page or scroll",
+        ),
+        keys.preview_action(
+            &kb.scroll_preview_left,
+            &kb.scroll_preview_right,
+            "scroll left / right",
+        ),
+    ]);
     let mouse_entries = vec![
         e("Click", "select item"),
         e("Double-click", "open item"),
@@ -97,7 +112,7 @@ pub(super) fn render_help(
         },
     ];
 
-    let popup = helpers::centered_rect(area, 90, 33);
+    let popup = helpers::centered_rect(area, 90, 35);
     state.help_panel = Some(popup);
     frame.render_widget(Clear, popup);
     frame.render_widget(
@@ -111,7 +126,7 @@ pub(super) fn render_help(
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    " Keyboard and mouse controls ",
+                    mode.title(),
                     Style::default()
                         .fg(palette.accent_text)
                         .add_modifier(Modifier::BOLD),
@@ -203,37 +218,128 @@ pub(super) fn render_help(
     );
 }
 
-fn navigation_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
-    let parent_key = format_key_pair(&kb.nav_left, &kb.go_parent);
-    let page_key = format_key_pair(&kb.page_up, &kb.page_down);
-    let place_key = format_key_pair(&kb.cycle_places_next, &kb.cycle_places_previous);
-    let history_key = format_key_pair(&kb.history_back, &kb.history_forward);
+impl HelpMode {
+    fn is_chooser(self) -> bool {
+        matches!(self, Self::Chooser)
+    }
 
-    vec![
-        e(&kb.nav_up.to_string(), "move up"),
-        e(&kb.nav_down.to_string(), "move down"),
-        e(&parent_key, "parent folder"),
-        e(&kb.nav_right.to_string(), "enter folder"),
-        e(&kb.open_or_enter.to_string(), "enter folder / open"),
-        e(&kb.go_to.to_string(), "go-to menu"),
-        e(&kb.jump_first.to_string(), "first item"),
-        e(&kb.jump_last.to_string(), "last item"),
-        e(&page_key, "page up / down"),
-        e(&place_key, "cycle places"),
-        e(&history_key, "back / forward"),
-    ]
+    fn title(self) -> &'static str {
+        match self {
+            Self::Normal => " Keyboard and mouse controls ",
+            Self::Chooser => " Chooser controls ",
+        }
+    }
 }
 
-fn clipboard_entries(kb: &KeyBindings) -> Vec<HelpEntry> {
-    vec![
-        e(&kb.toggle_selection.to_string(), "toggle selection"),
-        e(&kb.select_all.to_string(), "select all"),
+struct HelpKeys<'a> {
+    kb: &'a KeyBindings,
+    mode: HelpMode,
+}
+
+impl<'a> HelpKeys<'a> {
+    fn new(kb: &'a KeyBindings, mode: HelpMode) -> Self {
+        Self { kb, mode }
+    }
+
+    fn action(&self, keys: &KeyList, action: &'static str) -> HelpEntry {
+        self.entry(self.key(keys), action)
+    }
+
+    fn action_with_suffix(
+        &self,
+        keys: &KeyList,
+        suffix: &'static str,
+        action: &'static str,
+    ) -> HelpEntry {
+        let mut key = self.key(keys);
+        if !key.is_empty() {
+            key.push_str(suffix);
+        }
+        self.entry(key, action)
+    }
+
+    fn pair_action(&self, first: &KeyList, second: &KeyList, action: &'static str) -> HelpEntry {
+        self.entry(self.pair(first, second), action)
+    }
+
+    fn preview_action(&self, low: &KeyList, high: &KeyList, action: &'static str) -> HelpEntry {
+        self.entry(self.preview_pair(low, high), action)
+    }
+
+    fn key(&self, keys: &KeyList) -> String {
+        self.effective_keys(keys).to_string()
+    }
+
+    fn pair(&self, first: &KeyList, second: &KeyList) -> String {
+        format_key_pair(&self.effective_keys(first), &self.effective_keys(second))
+    }
+
+    fn preview_pair(&self, low: &KeyList, high: &KeyList) -> String {
+        let low = self.effective_keys(low);
+        let high = self.effective_keys(high);
+        if self.mode.is_chooser() {
+            let low_label = low.to_string();
+            let high_label = high.to_string();
+            match (low_label.is_empty(), high_label.is_empty()) {
+                (true, true) => return String::new(),
+                (true, false) => return high_label,
+                (false, true) => return low_label,
+                (false, false) => {}
+            }
+        }
+        format_preview_scroll_key(&low, &high)
+    }
+
+    fn effective_keys(&self, keys: &KeyList) -> KeyList {
+        if self.mode.is_chooser() {
+            keys.without(&self.kb.choose)
+        } else {
+            keys.clone()
+        }
+    }
+
+    fn entry(&self, key: String, action: &'static str) -> HelpEntry {
+        entry(key, action)
+    }
+}
+
+fn navigation_entries(keys: &HelpKeys<'_>) -> Vec<HelpEntry> {
+    let kb = keys.kb;
+    entries([
+        keys.action(&kb.nav_up, "move up"),
+        keys.action(&kb.nav_down, "move down"),
+        keys.pair_action(&kb.nav_left, &kb.go_parent, "parent folder"),
+        keys.action(&kb.nav_right, "enter folder"),
+        keys.action(&kb.open_or_enter, "enter folder / open"),
+        keys.action(&kb.go_to, "go-to menu"),
+        keys.action(&kb.jump_first, "first item"),
+        keys.action(&kb.jump_last, "last item"),
+        keys.pair_action(&kb.page_up, &kb.page_down, "page up / down"),
+        keys.pair_action(
+            &kb.cycle_places_next,
+            &kb.cycle_places_previous,
+            "cycle places",
+        ),
+        keys.pair_action(&kb.history_back, &kb.history_forward, "back / forward"),
+    ])
+}
+
+fn clipboard_entries(keys: &HelpKeys<'_>) -> Vec<HelpEntry> {
+    let kb = keys.kb;
+    let mut entries = Vec::new();
+    if keys.mode.is_chooser() {
+        entries.push(e(&kb.choose.to_string(), "confirm selection"));
+    }
+    entries.extend([
+        keys.action(&kb.toggle_selection, "toggle selection"),
+        keys.action(&kb.select_all, "select all"),
         e("Esc", "clear selection"),
-        e(&kb.yank.to_string(), "yank (copy)"),
-        e(&kb.copy_path.to_string(), "copy path details"),
-        e(&kb.cut.to_string(), "cut"),
-        e(&kb.paste.to_string(), "paste"),
-    ]
+        keys.action(&kb.yank, "yank (copy)"),
+        keys.action(&kb.copy_path, "copy path details"),
+        keys.action(&kb.cut, "cut"),
+        keys.action(&kb.paste, "paste"),
+    ]);
+    entries
 }
 
 fn format_key_pair(first: &crate::config::KeyList, second: &crate::config::KeyList) -> String {
@@ -266,10 +372,15 @@ struct HelpEntry {
 /// Convenience constructor — accepts anything that converts to a `String` for
 /// the key so call sites can pass `&str`, `String`, or `&String` uniformly.
 fn e(key: &str, action: &'static str) -> HelpEntry {
-    HelpEntry {
-        key: key.to_string(),
-        action,
-    }
+    entry(key.to_string(), action)
+}
+
+fn entry(key: String, action: &'static str) -> HelpEntry {
+    HelpEntry { key, action }
+}
+
+fn entries(items: impl IntoIterator<Item = HelpEntry>) -> Vec<HelpEntry> {
+    items.into_iter().collect()
 }
 
 struct HelpSection {
@@ -403,11 +514,24 @@ mod tests {
             .clone()
     }
 
+    fn entry_keys(entries: &[HelpEntry], action: &str) -> Vec<String> {
+        entries
+            .iter()
+            .filter(|entry| entry.action == action)
+            .map(|entry| entry.key.clone())
+            .collect()
+    }
+
+    fn has_action(entries: &[HelpEntry], action: &str) -> bool {
+        entries.iter().any(|entry| entry.action == action)
+    }
+
     #[test]
     fn help_uses_configurable_browser_control_defaults() {
         let kb = KeyBindings::default();
-        let navigation = navigation_entries(&kb);
-        let clipboard = clipboard_entries(&kb);
+        let keys = HelpKeys::new(&kb, HelpMode::Normal);
+        let navigation = navigation_entries(&keys);
+        let clipboard = clipboard_entries(&keys);
 
         assert_eq!(entry_key(&navigation, "go-to menu"), "g");
         assert_eq!(entry_key(&navigation, "first item"), "Home");
@@ -420,6 +544,10 @@ mod tests {
         assert_eq!(entry_key(&navigation, "back / forward"), "Alt+← / Alt+→");
         assert_eq!(entry_key(&clipboard, "toggle selection"), "Space");
         assert_eq!(entry_key(&clipboard, "select all"), "Ctrl+A");
+        assert!(
+            !has_action(&clipboard, "confirm selection"),
+            "normal help should not show chooser-only actions"
+        );
     }
 
     #[test]
@@ -439,8 +567,9 @@ history_back = "alt+h"
 history_forward = "alt+l"
 "#,
         );
-        let navigation = navigation_entries(&kb);
-        let clipboard = clipboard_entries(&kb);
+        let keys = HelpKeys::new(&kb, HelpMode::Normal);
+        let navigation = navigation_entries(&keys);
+        let clipboard = clipboard_entries(&keys);
 
         assert_eq!(entry_key(&navigation, "go-to menu"), "u");
         assert_eq!(entry_key(&navigation, "first item"), "1");
@@ -450,5 +579,100 @@ history_forward = "alt+l"
         assert_eq!(entry_key(&navigation, "back / forward"), "Alt+H / Alt+L");
         assert_eq!(entry_key(&clipboard, "toggle selection"), "t");
         assert_eq!(entry_key(&clipboard, "select all"), "A");
+    }
+
+    #[test]
+    fn chooser_help_adds_choose_and_relabels_quit() {
+        let kb = KeyBindings::default();
+        let keys = HelpKeys::new(&kb, HelpMode::Chooser);
+        let clipboard = clipboard_entries(&keys);
+        let view_entries = entries([
+            keys.action(&kb.quit, "cancel chooser"),
+            keys.action(&kb.quit_without_cd, "cancel chooser"),
+        ]);
+
+        assert_eq!(entry_key(&clipboard, "confirm selection"), "Enter");
+        assert_eq!(entry_key(&view_entries, "cancel chooser"), "q");
+        assert!(
+            !has_action(&view_entries, "quit"),
+            "chooser help should describe quit keys as chooser cancellation"
+        );
+    }
+
+    #[test]
+    fn chooser_help_removes_choose_key_from_normal_action_labels() {
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+nav_right = []
+open_or_enter = ["enter", "l", "right"]
+"#,
+        );
+
+        let keys = HelpKeys::new(&kb, HelpMode::Chooser);
+        let navigation = navigation_entries(&keys);
+        let clipboard = clipboard_entries(&keys);
+
+        assert_eq!(entry_key(&clipboard, "confirm selection"), "Enter");
+        assert_eq!(entry_key(&navigation, "enter folder / open"), "l/→");
+    }
+
+    #[test]
+    fn chooser_help_gives_choose_precedence_over_quit() {
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+choose = "q"
+"#,
+        );
+        let keys = HelpKeys::new(&kb, HelpMode::Chooser);
+        let clipboard = clipboard_entries(&keys);
+        let view_entries = entries([
+            keys.action(&kb.quit, "cancel chooser"),
+            keys.action(&kb.quit_without_cd, "cancel chooser"),
+        ]);
+
+        assert_eq!(entry_key(&clipboard, "confirm selection"), "q");
+        assert_eq!(
+            entry_keys(&view_entries, "cancel chooser"),
+            vec![String::new(), "Q".to_string()]
+        );
+    }
+
+    #[test]
+    fn preview_scroll_help_drops_empty_sides() {
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+choose = "K"
+"#,
+        );
+        let keys = HelpKeys::new(&kb, HelpMode::Chooser);
+
+        assert_eq!(
+            keys.preview_pair(&kb.scroll_preview_up, &kb.scroll_preview_down),
+            "[ / J/]"
+        );
+
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+choose = ["K", "["]
+"#,
+        );
+        let keys = HelpKeys::new(&kb, HelpMode::Chooser);
+
+        assert_eq!(
+            keys.preview_pair(&kb.scroll_preview_up, &kb.scroll_preview_down),
+            "J/]"
+        );
+
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+choose = ["K", "[", "J", "]"]
+"#,
+        );
+        let keys = HelpKeys::new(&kb, HelpMode::Chooser);
+
+        assert_eq!(
+            keys.preview_pair(&kb.scroll_preview_up, &kb.scroll_preview_down),
+            ""
+        );
     }
 }

--- a/src/ui/overlay_manager/mod.rs
+++ b/src/ui/overlay_manager/mod.rs
@@ -13,6 +13,12 @@ mod restore;
 mod search;
 mod trash;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum HelpMode {
+    Normal,
+    Chooser,
+}
+
 pub(super) fn render_trash_overlay(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -106,10 +112,16 @@ pub(super) fn render_search_overlay(
 pub(super) fn render_help(
     frame: &mut Frame<'_>,
     area: Rect,
+    app: &App,
     state: &mut FrameState,
     palette: Palette,
 ) {
-    help::render_help(frame, area, state, palette);
+    let mode = if app.chooser_mode {
+        HelpMode::Chooser
+    } else {
+        HelpMode::Normal
+    };
+    help::render_help(frame, area, mode, state, palette);
 }
 
 fn compute_scroll_top(cursor_line: usize, visible: usize) -> usize {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,6 +34,7 @@ fn help_prints_usage() {
     assert!(stdout.contains(
         "[PATH]               Start in a directory, or focus a file in its parent directory"
     ));
+    assert!(stdout.contains("--chooser-file FILE  Write chosen paths to FILE, or stdout with '-'"));
     assert!(stdout.contains("--cwd-file FILE  Write the final current directory to FILE on exit"));
     assert!(stdout.contains("-h, --help           Print help"));
     assert!(stdout.contains("-V, --version        Print version"));
@@ -65,6 +66,20 @@ fn mistyped_version_flag_exits_with_suggestion() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("error: unexpected argument '--v' found"));
     assert!(stderr.contains("tip: a similar argument exists: '--version'"));
+}
+
+#[test]
+fn mistyped_chooser_file_flag_exits_with_suggestion() {
+    let output = elio()
+        .arg("--chooser")
+        .output()
+        .expect("failed to run elio --chooser");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("error: unexpected argument '--chooser' found"));
+    assert!(stderr.contains("tip: a similar argument exists: '--chooser-file'"));
 }
 
 #[test]

--- a/tests/shell_integration_cli.rs
+++ b/tests/shell_integration_cli.rs
@@ -74,6 +74,7 @@ fn shell_init_fish_prints_sourceable_function() {
     assert!(stdout.contains("function elio"));
     assert!(stdout.contains("switch \"$argv[1]\""));
     assert!(stdout.contains("case shell '-*'"));
+    assert!(stdout.contains("case --chooser-file '--chooser-file=*'"));
     assert!(stdout.contains(env!("CARGO_BIN_EXE_elio")));
     assert!(stdout.contains("$argv"));
     assert!(stdout.contains("--cwd-file \"$tmp\" $argv"));
@@ -95,9 +96,10 @@ fn shell_init_bash_prints_function() {
     assert!(stdout.contains("elio() {"));
     assert!(stdout.contains("case \"${1-}\" in"));
     assert!(stdout.contains("shell|-*)"));
+    assert!(stdout.contains("--chooser-file|--chooser-file=*)"));
     assert!(stdout.contains(env!("CARGO_BIN_EXE_elio")));
     assert!(stdout.contains("\"$@\""));
-    assert!(stdout.contains("local tmp cwd status_code"));
+    assert!(stdout.contains("local arg tmp cwd status_code"));
     assert!(stdout.contains("--cwd-file \"$tmp\" \"$@\""));
     assert!(stdout.contains("status_code=$?"));
     assert!(!stdout.contains("command elio --cwd-file"));
@@ -118,7 +120,8 @@ fn shell_init_zsh_prints_function() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("elio() {"));
     assert!(stdout.contains(env!("CARGO_BIN_EXE_elio")));
-    assert!(stdout.contains("local tmp cwd status_code"));
+    assert!(stdout.contains("--chooser-file|--chooser-file=*)"));
+    assert!(stdout.contains("local arg tmp cwd status_code"));
     assert!(stdout.contains("--cwd-file \"$tmp\" \"$@\""));
     assert!(stdout.contains("status_code=$?"));
     assert!(!stdout.contains("command elio --cwd-file"));
@@ -139,6 +142,18 @@ fn shell_init_nu_prints_sourceable_command() {
     assert!(stdout.contains("def --env --wrapped elio [...args]"));
     assert!(stdout.contains(&nu_literal(env!("CARGO_BIN_EXE_elio"))));
     assert!(stdout.contains("run-external"));
+    assert!(stdout.contains("let has_chooser_file = ($args | any"));
+    assert!(stdout.contains("$has_chooser_file"));
+    assert!(stdout.contains("if $has_chooser_file {"));
+    assert!(
+        stdout
+            .find("if $has_chooser_file {")
+            .expect("chooser branch should exist")
+            < stdout
+                .find("| complete")
+                .expect("complete branch should exist"),
+        "chooser mode must run before the captured Nu pass-through branch"
+    );
     assert!(stdout.contains("--cwd-file"));
     assert!(stdout.contains("$env.LAST_EXIT_CODE = $status_code"));
     assert!(!stdout.contains("command elio"));

--- a/tests/shell_integration_cli.rs
+++ b/tests/shell_integration_cli.rs
@@ -1156,6 +1156,38 @@ fn cwd_file_equals_requires_value() {
 }
 
 #[test]
+fn chooser_file_requires_value() {
+    let output = elio()
+        .arg("--chooser-file")
+        .output()
+        .expect("failed to run elio --chooser-file");
+
+    assert_failure("elio --chooser-file", &output);
+    assert_no_stdout("elio --chooser-file", &output);
+    assert_stderr_contains(
+        "elio --chooser-file",
+        &output,
+        "error: expected a file path after '--chooser-file'",
+    );
+}
+
+#[test]
+fn chooser_file_equals_requires_value() {
+    let output = elio()
+        .arg("--chooser-file=")
+        .output()
+        .expect("failed to run elio --chooser-file=");
+
+    assert_failure("elio --chooser-file=", &output);
+    assert_no_stdout("elio --chooser-file=", &output);
+    assert_stderr_contains(
+        "elio --chooser-file=",
+        &output,
+        "error: expected a file path after '--chooser-file'",
+    );
+}
+
+#[test]
 fn duplicate_cwd_file_is_rejected() {
     let first = temp_path("cwd-first");
     let second = temp_path("cwd-second");
@@ -1173,6 +1205,46 @@ fn duplicate_cwd_file_is_rejected() {
         "elio with duplicate --cwd-file",
         &output,
         "error: '--cwd-file' cannot be used more than once",
+    );
+}
+
+#[test]
+fn duplicate_chooser_file_is_rejected() {
+    let first = temp_path("chooser-first");
+    let second = temp_path("chooser-second");
+    let output = elio()
+        .arg("--chooser-file")
+        .arg(&first)
+        .arg("--chooser-file")
+        .arg(&second)
+        .output()
+        .expect("failed to run elio with duplicate --chooser-file");
+
+    assert_failure("elio with duplicate --chooser-file", &output);
+    assert_no_stdout("elio with duplicate --chooser-file", &output);
+    assert_stderr_contains(
+        "elio with duplicate --chooser-file",
+        &output,
+        "error: '--chooser-file' cannot be used more than once",
+    );
+}
+
+#[test]
+fn duplicate_chooser_file_equals_is_rejected() {
+    let first = temp_path("chooser-first");
+    let second = temp_path("chooser-second");
+    let output = elio()
+        .arg(format!("--chooser-file={}", first.display()))
+        .arg(format!("--chooser-file={}", second.display()))
+        .output()
+        .expect("failed to run elio with duplicate --chooser-file");
+
+    assert_failure("elio with duplicate --chooser-file=", &output);
+    assert_no_stdout("elio with duplicate --chooser-file=", &output);
+    assert_stderr_contains(
+        "elio with duplicate --chooser-file=",
+        &output,
+        "error: '--chooser-file' cannot be used more than once",
     );
 }
 

--- a/tests/shell_runtime_cli.rs
+++ b/tests/shell_runtime_cli.rs
@@ -230,6 +230,18 @@ cd {}
 elio empty
 printf 'empty_cwd=%s empty_code=%s\n' "$PWD" "$?"
 
+cd {}
+elio --chooser-file /tmp/elio-choice child
+printf 'chooser_flag_first_cwd=%s chooser_flag_first_code=%s\n' "$PWD" "$?"
+
+cd {}
+elio child --chooser-file /tmp/elio-choice
+printf 'chooser_cwd=%s chooser_code=%s\n' "$PWD" "$?"
+
+cd {}
+elio child --chooser-file=/tmp/elio-choice
+printf 'chooser_equals_cwd=%s chooser_equals_code=%s\n' "$PWD" "$?"
+
 elio --help
 printf 'help_code=%s\n' "$?"
 
@@ -237,6 +249,9 @@ elio shell status
 printf 'shell_code=%s\n' "$?"
 "#,
         shell_quote(init_script),
+        shell_quote(start_dir),
+        shell_quote(start_dir),
+        shell_quote(start_dir),
         shell_quote(start_dir),
         shell_quote(start_dir),
         shell_quote(start_dir),
@@ -256,6 +271,18 @@ cd {}
 elio empty
 printf 'empty_cwd=%s empty_code=%s\n' "$PWD" "$status"
 
+cd {}
+elio --chooser-file /tmp/elio-choice child
+printf 'chooser_flag_first_cwd=%s chooser_flag_first_code=%s\n' "$PWD" "$status"
+
+cd {}
+elio child --chooser-file /tmp/elio-choice
+printf 'chooser_cwd=%s chooser_code=%s\n' "$PWD" "$status"
+
+cd {}
+elio child --chooser-file=/tmp/elio-choice
+printf 'chooser_equals_cwd=%s chooser_equals_code=%s\n' "$PWD" "$status"
+
 elio --help
 printf 'help_code=%s\n' "$status"
 
@@ -263,6 +290,9 @@ elio shell status
 printf 'shell_code=%s\n' "$status"
 "#,
         shell_quote(init_script),
+        shell_quote(start_dir),
+        shell_quote(start_dir),
+        shell_quote(start_dir),
         shell_quote(start_dir),
         shell_quote(start_dir),
         shell_quote(start_dir),
@@ -283,6 +313,18 @@ cd {}
 elio empty
 print $"empty_cwd=($env.PWD) empty_code=($env.LAST_EXIT_CODE)"
 
+cd {}
+elio --chooser-file /tmp/elio-choice child
+print $"chooser_flag_first_cwd=($env.PWD) chooser_flag_first_code=($env.LAST_EXIT_CODE)"
+
+cd {}
+elio child --chooser-file /tmp/elio-choice
+print $"chooser_cwd=($env.PWD) chooser_code=($env.LAST_EXIT_CODE)"
+
+cd {}
+elio child --chooser-file=/tmp/elio-choice
+print $"chooser_equals_cwd=($env.PWD) chooser_equals_code=($env.LAST_EXIT_CODE)"
+
 elio --help
 print $"help_code=($env.LAST_EXIT_CODE)"
 
@@ -294,6 +336,9 @@ print $"shell_pipeline_code=($env.LAST_EXIT_CODE)"
 print $"shell_pipeline=(open --raw {})"
 "#,
         nu_quote(init_script),
+        nu_quote(start_dir),
+        nu_quote(start_dir),
+        nu_quote(start_dir),
         nu_quote(start_dir),
         nu_quote(start_dir),
         nu_quote(start_dir),
@@ -321,6 +366,27 @@ fn assert_runtime_output(output: std::process::Output, start_dir: &Path) {
     assert!(
         stdout.contains(&format!("empty_cwd={} empty_code=9", start_dir.display())),
         "empty cwd file should leave the shell in the original directory\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "chooser_flag_first_cwd={} chooser_flag_first_code=5",
+            start_dir.display()
+        )),
+        "flag-first chooser calls should pass through without cwd integration\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "chooser_cwd={} chooser_code=5",
+            start_dir.display()
+        )),
+        "path-first chooser calls should pass through without cwd integration\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "chooser_equals_cwd={} chooser_equals_code=5",
+            start_dir.display()
+        )),
+        "path-first chooser= calls should pass through without cwd integration\nstdout:\n{stdout}"
     );
     let has_nu_pipeline_checks = stdout.contains("shell_pipeline_code=");
     if !has_nu_pipeline_checks {


### PR DESCRIPTION
## Summary

Adds `--chooser-file FILE [PATH]` so elio can be used as a file chooser for scripts, editors, and other integrations.

Closes #153.

## What Changed

- Added chooser mode with confirm/cancel outcomes and absolute path output.
- Added a chooser-only `choose` key action, defaulting to `enter`.
- Updated shell integration wrappers to pass chooser invocations directly to `elio`.
- Documented chooser key precedence and release-note behavior.

## User Impact

Users can run:

```bash
elio --chooser-file FILE [PATH]
elio --chooser-file - [PATH]
```

Confirmed selections are written one absolute path per line. Cancel exits silently with a nonzero status.

Users with existing shell integration should re-run `elio shell install` after upgrading.

## Notes

Chooser mode keeps normal elio navigation available; `choose` takes priority only in chooser mode when it shares a key with normal actions.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Installed the branch locally with `cargo install --path .` and refreshed the shell integration.
- Verified normal no-arg and path-arg `elio` calls still update the parent shell directory on exit.
- Verified `--help`, `-V`, `shell init`, and `shell install` still behave correctly.
- Verified chooser calls (`--chooser-file FILE`, `--chooser-file=FILE`, path-first forms, and `--chooser-file -`) preserve the parent shell directory.
- Verified real `--chooser-file - PATH` output through the installed shell integration.
- Verified chooser-mode key behavior and help overlay with custom bindings, including `open_or_enter = ["enter", "l", "right"]` and rebinding `choose`.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
