### PR TITLE
feat(selection): persist selection across directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `--chooser-file FILE [PATH]` to run elio as a file chooser, writing the confirmed selection as absolute paths, one per line, to `FILE` or stdout with `-`; cancel exits silently with a nonzero status. ([#153])
+- Added persistent multi-path selection across directories, allowing chooser confirmation and bulk actions to use selected paths from multiple folders.
 - `elio <path>` now accepts file paths as well as directories, opening the parent directory and focusing the file entry, including hidden files, file symlinks, and broken symlinks.
 
 ### Changed
 
 - Updated shell integration scripts to pass `--chooser-file` invocations directly to `elio`, so chooser mode does not change the parent shell directory. Re-run `elio shell install` after upgrading to refresh existing shell integration.
+
+### Fixed
+
+- Blocked nested selections and prevented pasting a folder into itself.
 
 ## [1.8.0] - 2026-06-06
 

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -112,6 +112,31 @@ impl App {
         })
     }
 
+    pub(in crate::app) fn queue_directory_escape_for_paths(
+        &mut self,
+        paths: &[PathBuf],
+    ) -> Result<PathBuf> {
+        let target_cwd = self
+            .current_directory_escape_for_paths(paths)
+            .unwrap_or_else(|| self.navigation.cwd.clone());
+
+        if target_cwd != self.navigation.cwd {
+            self.queue_directory_load(PendingDirectoryLoad {
+                token: 0,
+                target_cwd: target_cwd.clone(),
+                previous_cwd: self.navigation.cwd.clone(),
+                previous_selected_path: self.selected_entry().map(|entry| entry.path.clone()),
+                previous_selection_name: None,
+                reselect_path: None,
+                history_mode: DirectoryHistoryMode::None,
+                refresh_search: false,
+                completion: DirectoryLoadCompletion::Keep,
+            })?;
+        }
+
+        Ok(target_cwd)
+    }
+
     pub(in crate::app) fn apply_directory_snapshot(
         &mut self,
         load: PendingDirectoryLoad,
@@ -166,7 +191,6 @@ impl App {
         self.clear_wheel_scroll();
 
         if cwd_changed {
-            self.navigation.selected_paths.clear();
             self.reset_directory_watch();
         }
 

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -408,7 +408,6 @@ impl App {
         #[cfg(all(unix, not(target_os = "macos")))]
         if self
             .single_file_open_target_entry()
-            .cloned()
             .is_some_and(|entry| self.queue_terminal_default_open_if_needed(&entry))
         {
             return Ok(());
@@ -471,36 +470,43 @@ impl App {
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
-    fn single_file_open_target_entry(&self) -> Option<&Entry> {
-        if self.navigation.selected_paths.len() > 1 {
-            return None;
-        }
-
-        if let Some(path) = self.navigation.selected_paths.iter().next() {
+    fn single_file_open_target_entry(&self) -> Option<Entry> {
+        if self.navigation.selected_paths.len() == 1 {
+            let path = self.navigation.selected_paths.iter().next()?;
             return self
                 .navigation
                 .entries
                 .iter()
                 .find(|entry| &entry.path == path)
-                .filter(|entry| !entry.is_dir());
+                .filter(|entry| !entry.is_dir())
+                .cloned()
+                .or_else(|| entry_from_existing_file(path));
         }
 
-        self.selected_entry().filter(|entry| !entry.is_dir())
+        if !self.navigation.selected_paths.is_empty() {
+            return None;
+        }
+
+        self.selected_entry()
+            .filter(|entry| !entry.is_dir())
+            .cloned()
     }
 
     fn open_in_system_targets(&self) -> Vec<PathBuf> {
         if !self.navigation.selected_paths.is_empty() {
-            return self
-                .navigation
-                .entries
-                .iter()
-                .filter(|entry| self.navigation.selected_paths.contains(&entry.path))
-                .map(|entry| entry.path.clone())
-                .collect();
+            return self.selected_paths_sorted();
         }
 
         self.selected_entry()
             .map(|entry| vec![entry.path.clone()])
             .unwrap_or_default()
     }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn entry_from_existing_file(path: &Path) -> Option<Entry> {
+    let name = path.file_name()?.to_string_lossy().into_owned();
+    crate::fs::entry_from_path(path.to_path_buf(), name)
+        .ok()
+        .filter(|entry| !entry.is_dir())
 }

--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -88,6 +88,15 @@ impl App {
             return Ok(());
         };
 
+        if paste_would_copy_directory_into_itself(&request) {
+            self.jobs.clipboard = Some(Clipboard {
+                paths: request.paths,
+                op: request.op,
+            });
+            self.status = "Cannot paste a folder into itself".to_string();
+            return Ok(());
+        }
+
         if self.jobs.paste_progress.is_some() {
             self.jobs.queued_pastes.push_back(request);
             let pending = self.jobs.queued_pastes.len();
@@ -162,6 +171,13 @@ impl App {
             }
         }
     }
+}
+
+fn paste_would_copy_directory_into_itself(request: &QueuedPaste) -> bool {
+    request
+        .paths
+        .iter()
+        .any(|path| path.is_dir() && request.dest_dir.starts_with(path))
 }
 
 #[cfg(test)]

--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -242,6 +242,67 @@ fn cut_and_paste_moves_file_to_destination() {
     fs::remove_dir_all(&dst_dir).unwrap();
 }
 
+#[test]
+fn yank_allows_selected_parent_of_current_directory() {
+    let root = temp_path("yank-parent-selection");
+    let parent = root.join("parent");
+    fs::create_dir_all(&parent).unwrap();
+
+    let mut app = App::new_at(root.clone()).unwrap();
+    app.navigation.selected_paths.insert(parent.clone());
+    app.navigation.cwd = parent.clone();
+
+    app.yank();
+
+    assert_eq!(app.status_message(), "Yanked 1 item");
+    assert_eq!(app.clipboard_info(), Some((1, ClipOp::Yank)));
+    assert!(app.navigation.selected_paths.is_empty());
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn cut_allows_selected_parent_of_current_directory() {
+    let root = temp_path("cut-parent-selection");
+    let parent = root.join("parent");
+    fs::create_dir_all(&parent).unwrap();
+
+    let mut app = App::new_at(root.clone()).unwrap();
+    app.navigation.selected_paths.insert(parent.clone());
+    app.navigation.cwd = parent.clone();
+
+    app.cut();
+
+    assert_eq!(app.status_message(), "Cut 1 item");
+    assert_eq!(app.clipboard_info(), Some((1, ClipOp::Cut)));
+    assert!(app.navigation.selected_paths.is_empty());
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn paste_refuses_folder_into_itself() {
+    let root = temp_path("paste-folder-into-self");
+    let source = root.join("source");
+    let child = source.join("child");
+    fs::create_dir_all(&child).unwrap();
+
+    let mut app = App::new_at(child.clone()).unwrap();
+    app.jobs.clipboard = Some(super::super::state::Clipboard {
+        paths: vec![source.clone()],
+        op: ClipOp::Yank,
+    });
+
+    app.paste().unwrap();
+
+    assert_eq!(app.status_message(), "Cannot paste a folder into itself");
+    assert!(app.paste_progress().is_none());
+    assert_eq!(app.clipboard_info(), Some((1, ClipOp::Yank)));
+    assert!(!child.join("source").exists());
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
 // ── progress state machine ────────────────────────────────────────────────────
 
 #[test]

--- a/src/app/create/bulk_rename.rs
+++ b/src/app/create/bulk_rename.rs
@@ -12,23 +12,27 @@ use super::super::{
 use crate::fs::rect_contains;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 impl App {
     pub(in crate::app) fn open_bulk_rename_prompt(&mut self) {
         if self.navigation.in_trash {
             return;
         }
-        let items: Vec<BulkRenameItem> = self
-            .navigation
-            .entries
+        let selected_paths = self.selected_paths_sorted();
+        if selected_paths
             .iter()
-            .filter(|entry| self.navigation.selected_paths.contains(&entry.path))
-            .map(|entry| BulkRenameItem {
-                path: entry.path.clone(),
-                original_name: entry.name.clone(),
-                is_dir: entry.is_dir(),
-            })
+            .any(|path| self.trash_target_is_inside_trash(path))
+        {
+            self.status = "Cannot rename items from Trash".to_string();
+            return;
+        }
+        let items: Vec<BulkRenameItem> = selected_paths
+            .into_iter()
+            .map(bulk_rename_item_from_path)
             .collect();
         if items.is_empty() {
             return;
@@ -347,7 +351,7 @@ impl App {
         let mut first_error: Option<usize> = None;
         let renaming_paths: std::collections::HashSet<&PathBuf> =
             r.items.iter().map(|item| &item.path).collect();
-        let mut seen_new_names: std::collections::HashSet<String> =
+        let mut seen_new_paths: std::collections::HashSet<PathBuf> =
             std::collections::HashSet::new();
 
         for (index, (item, new_name_raw)) in r.items.iter().zip(r.new_names.iter()).enumerate() {
@@ -356,14 +360,13 @@ impl App {
                 Some("Name cannot be empty".to_string())
             } else if new_name.contains('/') {
                 Some("Name cannot contain /".to_string())
-            } else if !seen_new_names.insert(new_name.clone()) {
-                Some(format!("\"{}\" appears more than once", new_name))
             } else {
-                let new_path = self.navigation.cwd.join(&new_name);
-                if new_path.exists() && !renaming_paths.contains(&new_path) {
+                let new_path = renamed_path(&item.path, &new_name);
+                if !seen_new_paths.insert(new_path.clone()) {
+                    Some(format!("\"{}\" appears more than once", new_name))
+                } else if new_path.exists() && !renaming_paths.contains(&new_path) {
                     Some(format!("\"{}\" already exists", new_name))
                 } else {
-                    let _ = item;
                     None
                 }
             };
@@ -385,18 +388,28 @@ impl App {
             return Ok(());
         }
 
-        let ops: Vec<(PathBuf, String, String)> = r
+        let ops: Vec<(PathBuf, String, String, PathBuf)> = r
             .items
             .iter()
             .zip(r.new_names.iter())
             .map(|(item, new_name)| {
+                let new_name = new_name.trim().to_string();
                 (
                     item.path.clone(),
                     item.original_name.clone(),
-                    new_name.trim().to_string(),
+                    new_name.clone(),
+                    renamed_path(&item.path, &new_name),
                 )
             })
             .collect();
+        let changed_old_paths: Vec<PathBuf> = ops
+            .iter()
+            .filter(|(_, original_name, new_name, _)| original_name != new_name)
+            .map(|(old_path, _, _, _)| old_path.clone())
+            .collect();
+        let reload_cwd = self
+            .current_directory_escape_for_paths(&changed_old_paths)
+            .unwrap_or_else(|| self.navigation.cwd.clone());
 
         self.overlays.bulk_rename = None;
         self.navigation.selected_paths.clear();
@@ -404,12 +417,11 @@ impl App {
         let mut renamed = 0usize;
         let mut last_new_path: Option<PathBuf> = None;
 
-        for (old_path, original_name, new_name) in &ops {
+        for (old_path, original_name, new_name, new_path) in &ops {
             if *new_name == *original_name {
                 continue;
             }
-            let new_path = self.navigation.cwd.join(new_name);
-            if let Err(error) = fs::rename(old_path, &new_path) {
+            if let Err(error) = fs::rename(old_path, new_path) {
                 let msg = match error.kind() {
                     std::io::ErrorKind::PermissionDenied => {
                         format!("Permission denied renaming \"{}\"", original_name)
@@ -418,7 +430,7 @@ impl App {
                 };
                 self.queue_directory_load(PendingDirectoryLoad {
                     token: 0,
-                    target_cwd: self.navigation.cwd.clone(),
+                    target_cwd: reload_cwd.clone(),
                     previous_cwd: self.navigation.cwd.clone(),
                     previous_selected_path: None,
                     previous_selection_name: None,
@@ -429,16 +441,16 @@ impl App {
                 })?;
                 return Ok(());
             }
-            last_new_path = Some(self.navigation.cwd.join(new_name));
+            last_new_path = Some(new_path.clone());
             renamed += 1;
         }
 
         let status = match renamed {
             0 => "No files renamed".to_string(),
             1 => {
-                let (_, original, new_name) = ops
+                let (_, original, new_name, _) = ops
                     .iter()
-                    .find(|(_, original, new_name)| original != new_name)
+                    .find(|(_, original, new_name, _)| original != new_name)
                     .expect("changed rename op should exist");
                 format!("Renamed \"{}\" → \"{}\"", original, new_name)
             }
@@ -446,7 +458,7 @@ impl App {
         };
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
-            target_cwd: self.navigation.cwd.clone(),
+            target_cwd: reload_cwd,
             previous_cwd: self.navigation.cwd.clone(),
             previous_selected_path: None,
             previous_selection_name: None,
@@ -457,4 +469,27 @@ impl App {
         })?;
         Ok(())
     }
+}
+
+fn bulk_rename_item_from_path(path: PathBuf) -> BulkRenameItem {
+    let original_name = path_name(&path);
+    let is_dir = path.is_dir();
+    BulkRenameItem {
+        path,
+        original_name,
+        is_dir,
+    }
+}
+
+fn path_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_owned)
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn renamed_path(path: &Path, new_name: &str) -> PathBuf {
+    path.parent()
+        .map(|parent| parent.join(new_name))
+        .unwrap_or_else(|| PathBuf::from(new_name))
 }

--- a/src/app/create/restore.rs
+++ b/src/app/create/restore.rs
@@ -6,6 +6,7 @@ use super::super::{
 use crate::fs::rect_contains;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use std::path::PathBuf;
 
 impl App {
     pub(in crate::app) fn open_restore_prompt(&mut self) {
@@ -16,6 +17,26 @@ impl App {
 
         if targets.is_empty() {
             return;
+        }
+
+        if !self.navigation.selected_paths.is_empty() {
+            let has_trash = targets
+                .iter()
+                .any(|target| self.trash_target_is_inside_trash(&target.path));
+            let has_normal = targets
+                .iter()
+                .any(|target| !self.trash_target_is_inside_trash(&target.path));
+            match (has_trash, has_normal) {
+                (true, true) => {
+                    self.status = "Selection mixes trash and normal files".to_string();
+                    return;
+                }
+                (false, true) => {
+                    self.status = "Cannot restore normal files".to_string();
+                    return;
+                }
+                _ => {}
+            }
         }
 
         self.overlays.help = false;
@@ -221,6 +242,9 @@ impl App {
             return Ok(());
         }
         self.navigation.selected_paths.clear();
+        let target_paths: Vec<PathBuf> =
+            r.targets.iter().map(|target| target.path.clone()).collect();
+        let source_cwd = self.queue_directory_escape_for_paths(&target_paths)?;
 
         let restored_paths: std::collections::HashSet<_> =
             r.targets.iter().map(|t| &t.path).collect();
@@ -247,7 +271,7 @@ impl App {
             total: r.targets.len(),
             next_selection,
         });
-        self.jobs.restore_source_cwd = Some(self.navigation.cwd.clone());
+        self.jobs.restore_source_cwd = Some(source_cwd.clone());
 
         self.jobs.scheduler.submit_restore(RestoreRequest {
             token,

--- a/src/app/create/tests.rs
+++ b/src/app/create/tests.rs
@@ -1,10 +1,53 @@
 use super::super::{App, state::DirectoryLoadCompletion};
 use super::rename;
+#[cfg(all(unix, not(target_os = "macos")))]
+use std::{
+    env,
+    ffi::OsString,
+    sync::{Mutex, OnceLock},
+};
 use std::{
     fs,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl EnvVarGuard {
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let original = env::var_os(key);
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self { key, original }
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.original.as_ref() {
+            Some(value) => unsafe {
+                env::set_var(self.key, value);
+            },
+            None => unsafe {
+                env::remove_var(self.key);
+            },
+        }
+    }
+}
 
 /// Drive background jobs until both the trash worker and the subsequent
 /// directory reload have both completed.  Checking only `trash_progress`
@@ -283,6 +326,159 @@ fn confirm_bulk_rename_reports_duplicate_destination_names() {
 }
 
 #[test]
+fn bulk_rename_uses_selection_from_multiple_directories() {
+    let root = temp_path("bulk-rename-cross-directory-selection");
+    let child = root.join("child");
+    let alpha = root.join("alpha.txt");
+    let beta = child.join("beta.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+    app.open_bulk_rename_prompt();
+
+    let overlay = app
+        .overlays
+        .bulk_rename
+        .as_mut()
+        .expect("bulk rename overlay should be open");
+    assert_eq!(overlay.new_names, vec!["alpha.txt", "beta.txt"]);
+    overlay.new_names = vec![
+        "alpha-renamed.txt".to_string(),
+        "beta-renamed.txt".to_string(),
+    ];
+
+    app.confirm_bulk_rename()
+        .expect("bulk rename should succeed");
+
+    assert!(!alpha.exists());
+    assert!(!beta.exists());
+    assert!(root.join("alpha-renamed.txt").is_file());
+    assert!(child.join("beta-renamed.txt").is_file());
+    assert!(app.navigation.selected_paths.is_empty());
+
+    let (status, reselect_path) = take_pending_status(&mut app);
+    assert_eq!(status, "Renamed 2 items");
+    assert_eq!(reselect_path, Some(child.join("beta-renamed.txt")));
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn bulk_rename_allows_same_new_name_in_different_directories() {
+    let root = temp_path("bulk-rename-same-name-different-dirs");
+    let left = root.join("left");
+    let right = root.join("right");
+    let left_file = left.join("old.txt");
+    let right_file = right.join("old.txt");
+    fs::create_dir_all(&left).expect("failed to create left dir");
+    fs::create_dir_all(&right).expect("failed to create right dir");
+    fs::write(&left_file, "left").expect("failed to write left file");
+    fs::write(&right_file, "right").expect("failed to write right file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(left_file);
+    app.navigation.selected_paths.insert(right_file);
+    app.open_bulk_rename_prompt();
+
+    let overlay = app
+        .overlays
+        .bulk_rename
+        .as_mut()
+        .expect("bulk rename overlay should be open");
+    overlay.new_names = vec!["new.txt".to_string(), "new.txt".to_string()];
+
+    app.confirm_bulk_rename()
+        .expect("bulk rename should succeed");
+
+    assert!(app.overlays.bulk_rename.is_none());
+    assert!(left.join("new.txt").is_file());
+    assert!(right.join("new.txt").is_file());
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn bulk_rename_refuses_selection_containing_trash_item() {
+    let _env_guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let root = temp_path("bulk-rename-refuses-trash-selection");
+    let data_home = root.join("data");
+    let trash_files = data_home.join("Trash/files");
+    let normal_dir = root.join("normal");
+    let normal = normal_dir.join("normal.txt");
+    let trashed = trash_files.join("trashed.txt");
+    fs::create_dir_all(&trash_files).expect("failed to create trash files dir");
+    fs::create_dir_all(&normal_dir).expect("failed to create normal dir");
+    fs::write(&normal, "normal").expect("failed to write normal file");
+    fs::write(&trashed, "trashed").expect("failed to write trashed file");
+
+    let _xdg_data_home = EnvVarGuard::set_path("XDG_DATA_HOME", &data_home);
+
+    let mut app = App::new_at(normal_dir.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(normal);
+    app.navigation.selected_paths.insert(trashed);
+    app.open_bulk_rename_prompt();
+
+    assert!(!app.bulk_rename_is_open());
+    assert_eq!(app.status_message(), "Cannot rename items from Trash");
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn bulk_rename_selected_parent_of_current_directory_reloads_parent() {
+    let root = temp_path("bulk-rename-parent-selection");
+    let parent = root.join("parent");
+    let child_file = parent.join("child.txt");
+    fs::create_dir_all(&parent).expect("failed to create parent dir");
+    fs::write(&child_file, "child").expect("failed to write child file");
+
+    let mut app = App::new_at(parent.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(parent.clone());
+    app.open_bulk_rename_prompt();
+
+    assert!(app.bulk_rename_is_open());
+    assert_eq!(app.bulk_rename_item_count(), 1);
+
+    let overlay = app
+        .overlays
+        .bulk_rename
+        .as_mut()
+        .expect("bulk rename overlay should be open");
+    overlay.new_names[0] = "renamed".to_string();
+
+    app.confirm_bulk_rename()
+        .expect("bulk rename should succeed");
+
+    let load = app
+        .navigation
+        .directory_runtime
+        .pending_load
+        .as_ref()
+        .expect("rename should queue a directory reload");
+    assert_eq!(load.target_cwd, root);
+    assert_eq!(load.reselect_path, Some(root.join("renamed")));
+    assert!(!parent.exists());
+    assert!(root.join("renamed/child.txt").is_file());
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn confirm_trash_permanently_deletes_selected_items_inside_trash() {
     let root = temp_path("trash-permanent");
     fs::create_dir_all(&root).expect("failed to create temp root");
@@ -332,6 +528,35 @@ fn confirm_delete_permanently_removes_selected_items_outside_trash() {
 
     assert!(!root.join("gone.txt").exists());
     assert_eq!(app.status_message(), "Permanently deleted \"gone.txt\"");
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn confirm_delete_selected_parent_of_current_directory_moves_to_parent() {
+    let root = temp_path("delete-parent-of-current");
+    let parent = root.join("parent");
+    let child = parent.join("child");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(child.join("file.txt"), "child").expect("failed to write child file");
+
+    let mut app = App::new_at(child.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(parent.clone());
+    app.open_delete_permanently_prompt();
+
+    assert_eq!(app.trash_title(), "Delete permanently 1 selected folder?");
+    app.confirm_trash().expect("delete should succeed");
+
+    assert!(app.overlays.trash.is_none());
+    assert!(app.navigation.selected_paths.is_empty());
+
+    wait_for_trash_and_reload(&mut app);
+
+    assert_eq!(app.navigation.cwd, root);
+    assert!(!parent.exists());
+    assert_eq!(app.status_message(), "Permanently deleted \"parent\"");
 
     app.navigation.directory_runtime.watch = None;
     drop(app);
@@ -721,6 +946,80 @@ fn confirm_restore_bulk_restores_multiple_files_and_reports_count() {
     assert!(!trash_files.join("alpha.txt").exists());
     assert!(!trash_files.join("beta.txt").exists());
     assert_eq!(app.status_message(), "Restored 2 items");
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn restore_refuses_normal_selection_from_trash() {
+    let root = temp_path("restore-normal-selection");
+    let trash_files = root.join("Trash/files");
+    let normal = root.join("normal.txt");
+    fs::create_dir_all(&trash_files).expect("failed to create trash files dir");
+    fs::write(&normal, "normal").expect("failed to write normal file");
+
+    let mut app = App::new_at(trash_files.clone()).expect("failed to create app");
+    app.navigation.in_trash = true;
+    app.navigation.selected_paths.insert(normal);
+    app.open_restore_prompt();
+
+    assert!(!app.restore_is_open());
+    assert_eq!(app.status_message(), "Cannot restore normal files");
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn restore_refuses_mixed_trash_and_normal_selection() {
+    let root = temp_path("restore-mixed-selection");
+    let trash_files = root.join("Trash/files");
+    let trashed = trash_files.join("trashed.txt");
+    let normal = root.join("normal.txt");
+    fs::create_dir_all(&trash_files).expect("failed to create trash files dir");
+    fs::write(&trashed, "trashed").expect("failed to write trashed file");
+    fs::write(&normal, "normal").expect("failed to write normal file");
+
+    let mut app = App::new_at(trash_files.clone()).expect("failed to create app");
+    app.navigation.in_trash = true;
+    app.navigation.selected_paths.insert(trashed);
+    app.navigation.selected_paths.insert(normal);
+    app.open_restore_prompt();
+
+    assert!(!app.restore_is_open());
+    assert_eq!(
+        app.status_message(),
+        "Selection mixes trash and normal files"
+    );
+
+    app.navigation.directory_runtime.watch = None;
+    drop(app);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn restore_allows_selected_parent_of_current_directory() {
+    let root = temp_path("restore-parent-selection");
+    let trash_files = root.join("Trash/files");
+    let parent = trash_files.join("parent");
+    let child_file = parent.join("child.txt");
+    fs::create_dir_all(&parent).expect("failed to create parent dir");
+    fs::write(&child_file, "child").expect("failed to write child file");
+
+    let mut app = App::new_at(parent.clone()).expect("failed to create app");
+    app.navigation.in_trash = true;
+    app.navigation.selected_paths.insert(parent);
+    app.open_restore_prompt();
+
+    assert!(app.restore_is_open());
+    assert_eq!(app.restore_title(), "Restore 1 selected folder?");
+    assert_eq!(
+        app.restore_target_path_at(0),
+        Some(trash_files.join("parent").as_path())
+    );
 
     app.navigation.directory_runtime.watch = None;
     drop(app);

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -6,7 +6,7 @@ use super::super::{
 use crate::fs::rect_contains;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 impl App {
     pub(in crate::app) fn cwd_is_trash(&self) -> bool {
@@ -29,6 +29,12 @@ impl App {
             .is_some_and(|trash| path == trash)
     }
 
+    pub(in crate::app) fn path_is_inside_trash(path: &Path) -> bool {
+        crate::fs::home_dir()
+            .and_then(|home| crate::fs::trash_dir(&home))
+            .is_some_and(|trash| path.starts_with(&trash))
+    }
+
     pub(in crate::app) fn effective_show_hidden(&self) -> bool {
         self.navigation.show_hidden || self.navigation.in_trash
     }
@@ -41,15 +47,9 @@ impl App {
 impl App {
     pub(in crate::app::create) fn selected_trash_targets(&self) -> Vec<TrashTarget> {
         if !self.navigation.selected_paths.is_empty() {
-            self.navigation
-                .entries
-                .iter()
-                .filter(|entry| self.navigation.selected_paths.contains(&entry.path))
-                .map(|entry| TrashTarget {
-                    path: entry.path.clone(),
-                    name: entry.name.clone(),
-                    is_dir: entry.is_dir(),
-                })
+            self.selected_paths_sorted()
+                .into_iter()
+                .map(trash_target_from_path)
                 .collect()
         } else {
             self.selected_entry()
@@ -71,7 +71,13 @@ impl App {
             return;
         }
 
-        self.open_trash_prompt_for_targets(targets, self.cwd_is_trash());
+        match self.trash_target_scope(&targets) {
+            TrashTargetScope::Normal => self.open_trash_prompt_for_targets(targets, false),
+            TrashTargetScope::Trash => self.open_trash_prompt_for_targets(targets, true),
+            TrashTargetScope::Mixed => {
+                self.status = "Selection mixes trash and normal files".to_string();
+            }
+        }
     }
 
     pub(in crate::app) fn open_delete_permanently_prompt(&mut self) {
@@ -94,6 +100,26 @@ impl App {
             confirmed: true,
             permanent,
         });
+    }
+
+    fn trash_target_scope(&self, targets: &[TrashTarget]) -> TrashTargetScope {
+        let has_trash = targets
+            .iter()
+            .any(|target| self.trash_target_is_inside_trash(&target.path));
+        let has_normal = targets
+            .iter()
+            .any(|target| !self.trash_target_is_inside_trash(&target.path));
+
+        match (has_trash, has_normal) {
+            (true, true) => TrashTargetScope::Mixed,
+            (true, false) => TrashTargetScope::Trash,
+            _ => TrashTargetScope::Normal,
+        }
+    }
+
+    pub(in crate::app) fn trash_target_is_inside_trash(&self, path: &Path) -> bool {
+        Self::path_is_inside_trash(path)
+            || (self.navigation.in_trash && path.starts_with(&self.navigation.cwd))
     }
 
     pub fn trash_is_open(&self) -> bool {
@@ -157,12 +183,26 @@ impl App {
         self.trash_target_count().min(8)
     }
 
-    pub fn trash_target_name_at(&self, index: usize) -> Option<&str> {
-        self.overlays
+    pub fn trash_target_label_at(&self, index: usize) -> Option<String> {
+        let target = self
+            .overlays
             .trash
             .as_ref()
-            .and_then(|t| t.targets.get(index))
-            .map(|target| target.name.as_str())
+            .and_then(|t| t.targets.get(index))?;
+
+        if self.trash_targets_need_path_labels() {
+            Some(target.path.display().to_string())
+        } else {
+            Some(target.name.clone())
+        }
+    }
+
+    fn trash_targets_need_path_labels(&self) -> bool {
+        self.overlays.trash.as_ref().is_some_and(|t| {
+            t.targets
+                .iter()
+                .any(|target| target.path.parent() != Some(self.navigation.cwd.as_path()))
+        })
     }
 
     pub fn trash_target_path_at(&self, index: usize) -> Option<&std::path::Path> {
@@ -297,6 +337,9 @@ impl App {
             return Ok(());
         }
         self.navigation.selected_paths.clear();
+        let target_paths: Vec<PathBuf> =
+            t.targets.iter().map(|target| target.path.clone()).collect();
+        let source_cwd = self.queue_directory_escape_for_paths(&target_paths)?;
 
         // Compute which entry to land on after deletion: first surviving entry
         // at or after the current cursor, falling back to the last surviving
@@ -327,7 +370,7 @@ impl App {
             permanent: t.permanent,
             next_selection,
         });
-        self.jobs.trash_source_cwd = Some(self.navigation.cwd.clone());
+        self.jobs.trash_source_cwd = Some(source_cwd.clone());
 
         // Best-effort cross-device detection: if the source appears to be on a
         // different device than the home data dir (where the trash usually lives),
@@ -347,6 +390,22 @@ impl App {
 
         Ok(())
     }
+}
+
+fn trash_target_from_path(path: PathBuf) -> TrashTarget {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_owned)
+        .unwrap_or_else(|| path.display().to_string());
+    let is_dir = path.is_dir();
+    TrashTarget { path, name, is_dir }
+}
+
+enum TrashTargetScope {
+    Normal,
+    Trash,
+    Mixed,
 }
 
 /// Returns `true` when the first trash target appears to be on a different

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -341,18 +341,17 @@ impl App {
     }
 
     pub(in crate::app) fn open_selected(&mut self) -> Result<()> {
-        if !self.navigation.selected_paths.is_empty() {
-            return self.dispatch_action(crate::config::Action::Open);
-        }
-
         let Some(entry) = self.selected_entry() else {
+            if !self.navigation.selected_paths.is_empty() {
+                return self.dispatch_action(crate::config::Action::Open);
+            }
             return Ok(());
         };
         if entry.is_dir() {
-            self.set_dir(entry.path.clone())
-        } else {
-            self.dispatch_action(crate::config::Action::Open)
+            return self.set_dir(entry.path.clone());
         }
+
+        self.dispatch_action(crate::config::Action::Open)
     }
 }
 

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -7,7 +7,9 @@ use super::helpers::{
 };
 use crate::config::Action;
 use std::{
-    fs, thread,
+    fs,
+    path::PathBuf,
+    thread,
     time::{Duration, Instant},
 };
 
@@ -44,6 +46,59 @@ fn fake_default_open_with_app(
         is_default: true,
         requires_terminal,
     }
+}
+
+fn app_with_offscreen_selected_dir(label: &str) -> (PathBuf, PathBuf, App) {
+    let root = temp_path(label);
+    let offscreen = root.join("offscreen");
+    let child = root.join("child");
+    fs::create_dir_all(&offscreen).expect("failed to create offscreen dir");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(child.join("visible.txt"), "visible").expect("failed to write visible file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(offscreen.clone());
+    app.set_dir(child).expect("entering child should succeed");
+    wait_for_directory_load(&mut app);
+
+    (root, offscreen, app)
+}
+
+fn app_with_trash_and_normal_selection(label: &str) -> (PathBuf, App) {
+    let root = temp_path(label);
+    let trash_root = root.join("trash");
+    let trashed = trash_root.join("trashed.txt");
+    let normal = root.join("normal.txt");
+    fs::create_dir_all(&trash_root).expect("failed to create trash root");
+    fs::write(&trashed, "trashed").expect("failed to write trashed file");
+    fs::write(&normal, "normal").expect("failed to write normal file");
+
+    let mut app = App::new_at(trash_root).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.in_trash = true;
+    app.navigation.selected_paths.insert(trashed);
+    app.navigation.selected_paths.insert(normal);
+
+    (root, app)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn app_in_empty_dir_with_offscreen_file(label: &str) -> (PathBuf, PathBuf, App) {
+    let root = temp_path(label);
+    let empty = root.join("empty");
+    let file_path = root.join("note.txt");
+    fs::create_dir_all(&empty).expect("failed to create empty dir");
+    fs::write(&file_path, "hello").expect("failed to write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(file_path.clone());
+    app.set_dir(empty)
+        .expect("entering empty dir should succeed");
+    wait_for_directory_load(&mut app);
+
+    (root, file_path, app)
 }
 
 #[test]
@@ -194,6 +249,36 @@ fn chooser_enter_confirms_sorted_selection() {
     assert_eq!(
         app.chooser_exit.as_ref(),
         Some(&ChooserExit::Confirmed(vec![alpha, gamma]))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn chooser_enter_confirms_selection_from_multiple_directories() {
+    let root = temp_path("chooser-enter-multi-directory-selection");
+    let child = root.join("child");
+    let alpha = root.join("alpha.txt");
+    let beta = child.join("beta.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+    app.enable_chooser_mode();
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should confirm selected chooser paths");
+
+    assert_eq!(
+        app.chooser_exit.as_ref(),
+        Some(&ChooserExit::Confirmed(vec![alpha, beta]))
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -369,6 +454,99 @@ fn capital_d_permanent_delete_prompt_uses_selection() {
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
+#[test]
+fn trash_prompt_uses_selection_when_selection_is_offscreen() {
+    let (root, offscreen, mut app) =
+        app_with_offscreen_selected_dir("trash-offscreen-selection-shortcut");
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('d'))))
+        .expect("d should open trash prompt");
+
+    assert!(app.trash_is_open());
+    assert_eq!(app.trash_title(), "Trash 1 selected folder?");
+    assert_eq!(app.trash_target_path_at(0), Some(offscreen.as_path()));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn trash_prompt_keeps_normal_selection_non_permanent_from_trash() {
+    let root = temp_path("trash-normal-selection-from-trash");
+    let trash_root = root.join("trash");
+    let normal = root.join("normal.txt");
+    fs::create_dir_all(&trash_root).expect("failed to create trash root");
+    fs::write(&normal, "normal").expect("failed to write normal file");
+
+    let mut app = App::new_at(trash_root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.in_trash = true;
+    app.navigation.selected_paths.insert(normal.clone());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('d'))))
+        .expect("d should open trash prompt");
+
+    assert!(app.trash_is_open());
+    assert_eq!(app.trash_title(), "Trash 1 selected file?");
+    assert_eq!(app.trash_target_path_at(0), Some(normal.as_path()));
+    assert_eq!(
+        app.trash_target_label_at(0),
+        Some(normal.display().to_string())
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn trash_prompt_permanently_deletes_trash_only_selection() {
+    let root = temp_path("trash-only-selection-from-trash");
+    let trashed = root.join("trashed.txt");
+    fs::create_dir_all(&root).expect("failed to create trash root");
+    fs::write(&trashed, "trashed").expect("failed to write trashed file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.in_trash = true;
+    app.navigation.selected_paths.insert(trashed.clone());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('d'))))
+        .expect("d should open permanent delete prompt");
+
+    assert!(app.trash_is_open());
+    assert_eq!(app.trash_title(), "Delete permanently 1 selected file?");
+    assert_eq!(app.trash_target_path_at(0), Some(trashed.as_path()));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn trash_prompt_refuses_mixed_trash_and_normal_selection() {
+    let (root, mut app) = app_with_trash_and_normal_selection("trash-mixed-selection");
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('d'))))
+        .expect("d should reject mixed selection");
+
+    assert!(!app.trash_is_open());
+    assert_eq!(
+        app.status_message(),
+        "Selection mixes trash and normal files"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn permanent_delete_prompt_accepts_mixed_trash_and_normal_selection() {
+    let (root, mut app) = app_with_trash_and_normal_selection("delete-mixed-selection");
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('D'))))
+        .expect("D should open permanent delete prompt");
+
+    assert!(app.trash_is_open());
+    assert_eq!(app.trash_title(), "Delete permanently 2 files?");
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn enter_opens_selected_file_with_system_opener() {
@@ -438,6 +616,64 @@ fn enter_queues_terminal_default_app_for_selected_file() {
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     wait_for_directory_load(&mut app);
 
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should queue terminal default app");
+
+    assert_eq!(
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Command {
+            program: "hx".to_string(),
+            args: vec![file_path.display().to_string()],
+        })
+    );
+    assert!(app.status.is_empty());
+    assert!(
+        !capture.exists(),
+        "system opener should not run for terminal default app"
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn enter_opens_selection_when_current_directory_is_empty() {
+    let (root, file_path, mut app) =
+        app_in_empty_dir_with_offscreen_file("enter-empty-dir-opens-selection");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+
+    assert!(app.selected_entry().is_none());
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("enter should open offscreen selection");
+
+    let opened = read_open_capture(&capture);
+    assert_eq!(opened, file_path.display().to_string());
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn enter_queues_terminal_default_app_for_single_offscreen_selection() {
+    let (root, file_path, mut app) =
+        app_in_empty_dir_with_offscreen_file("enter-offscreen-terminal-default");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+    let _default_guard = DefaultOpenWithAppGuard::install(fake_default_open_with_app(
+        "Helix",
+        "hx",
+        vec![file_path.display().to_string()],
+        true,
+    ));
+
+    assert!(app.selected_entry().is_none());
     app.handle_event(Event::Key(KeyEvent::new(
         KeyCode::Enter,
         KeyModifiers::NONE,
@@ -549,6 +785,41 @@ fn open_action_opens_selected_entries_with_system_opener() {
     wait_for_directory_load(&mut app);
     app.navigation.selected_paths.insert(alpha.clone());
     app.navigation.selected_paths.insert(beta.clone());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('o'))))
+        .expect("o should open selected entries");
+
+    let opened = read_open_capture(&capture);
+    let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
+    assert_eq!(
+        opened,
+        vec![alpha.display().to_string(), beta.display().to_string()]
+    );
+    assert_eq!(app.status, "Opened 2 items");
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn open_action_opens_selected_entries_from_multiple_directories() {
+    let root = temp_path("open-action-opens-cross-directory-selection");
+    let child = root.join("child");
+    let alpha = root.join("alpha.txt");
+    let beta = child.join("beta.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+    app.set_dir(child.clone())
+        .expect("entering child should succeed");
+    wait_for_directory_load(&mut app);
 
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('o'))))
         .expect("o should open selected entries");

--- a/src/app/input/tests/navigation.rs
+++ b/src/app/input/tests/navigation.rs
@@ -1,6 +1,46 @@
 use super::super::*;
 use super::helpers::{temp_path, wait_for_directory_load};
-use std::fs;
+use std::{fs, path::PathBuf};
+
+fn app_in_child_with_parent_selection(label: &str) -> (PathBuf, PathBuf, PathBuf, App) {
+    let root = temp_path(label);
+    let child = root.join("child");
+    let selected = root.join("selected.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&selected, "selected").expect("failed to write selected file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(selected.clone());
+    app.set_dir(child.clone())
+        .expect("entering child should succeed");
+    wait_for_directory_load(&mut app);
+
+    (root, child, selected, app)
+}
+
+fn assert_clear_selection_after_directory_change(label: &str, key: KeyEvent) {
+    let (root, child, _, mut app) = app_in_child_with_parent_selection(label);
+
+    assert_eq!(app.navigation.cwd, child);
+    assert_eq!(app.selection_count(), 1);
+
+    app.handle_event(Event::Key(key))
+        .expect("key should clear selection");
+
+    assert_eq!(app.selection_count(), 0);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+fn folder_with_child_file(label: &str) -> (PathBuf, PathBuf, PathBuf) {
+    let root = temp_path(label);
+    let folder = root.join("folder");
+    let child = folder.join("child.txt");
+    fs::create_dir_all(&folder).expect("failed to create folder");
+    fs::write(&child, "child").expect("failed to write child");
+    (root, folder, child)
+}
 
 #[test]
 fn right_arrow_does_not_open_selected_file_in_list_view() {
@@ -61,7 +101,7 @@ fn right_arrow_enters_focused_directory_even_when_selection_exists() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     app.navigation.view_mode = ViewMode::List;
-    app.navigation.selected_paths.insert(file);
+    app.navigation.selected_paths.insert(file.clone());
     app.select_index(0);
 
     app.handle_event(Event::Key(KeyEvent::new(
@@ -72,6 +112,236 @@ fn right_arrow_enters_focused_directory_even_when_selection_exists() {
     wait_for_directory_load(&mut app);
 
     assert_eq!(app.navigation.cwd, child);
+    assert!(app.navigation.selected_paths.contains(&file));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn selection_persists_after_entering_and_leaving_directory() {
+    let (root, child, selected, mut app) =
+        app_in_child_with_parent_selection("persistent-selection-nav");
+
+    assert_eq!(app.navigation.cwd, child);
+    assert!(app.navigation.selected_paths.contains(&selected));
+
+    app.go_parent().expect("going parent should succeed");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, root);
+    assert!(app.navigation.selected_paths.contains(&selected));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn esc_clears_selection_after_directory_change() {
+    assert_clear_selection_after_directory_change(
+        "persistent-selection-esc",
+        KeyEvent::from(KeyCode::Esc),
+    );
+}
+
+#[test]
+fn ctrl_c_clears_selection_after_directory_change() {
+    assert_clear_selection_after_directory_change(
+        "persistent-selection-ctrl-c",
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+    );
+}
+
+#[test]
+fn select_all_extends_cross_directory_selection() {
+    let root = temp_path("persistent-selection-select-all");
+    let child = root.join("child");
+    let selected = root.join("selected.txt");
+    let beta = child.join("beta.txt");
+    let gamma = child.join("gamma.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&selected, "selected").expect("failed to write selected file");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    fs::write(&gamma, "gamma").expect("failed to write gamma");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(selected.clone());
+    app.set_dir(child.clone())
+        .expect("entering child should succeed");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL,
+    )))
+    .expect("Ctrl+A should select all visible entries");
+
+    assert!(app.navigation.selected_paths.contains(&selected));
+    assert!(app.navigation.selected_paths.contains(&beta));
+    assert!(app.navigation.selected_paths.contains(&gamma));
+    assert_eq!(app.selection_count(), 3);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn selecting_child_inside_selected_folder_is_blocked() {
+    let (root, folder, child) = folder_with_child_file("selection-blocks-selected-parent");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    let folder_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == folder)
+        .expect("folder should be visible");
+    app.select_index(folder_index);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(' '))))
+        .expect("space should select folder");
+
+    app.set_dir(folder.clone())
+        .expect("entering folder should succeed");
+    wait_for_directory_load(&mut app);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(' '))))
+        .expect("space should reject nested child selection");
+
+    assert_eq!(app.status_message(), "Cannot select nested paths");
+    assert!(app.navigation.selected_paths.contains(&folder));
+    assert!(!app.navigation.selected_paths.contains(&child));
+    assert_eq!(app.selection_count(), 1);
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.path.as_path()),
+        Some(child.as_path())
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn selecting_folder_containing_selected_child_is_blocked() {
+    let (root, folder, child) = folder_with_child_file("selection-blocks-selected-child");
+
+    let mut app = App::new_at(folder.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(' '))))
+        .expect("space should select child");
+
+    app.go_parent().expect("going parent should succeed");
+    wait_for_directory_load(&mut app);
+    let folder_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == folder)
+        .expect("folder should be visible");
+    app.select_index(folder_index);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(' '))))
+        .expect("space should reject nested folder selection");
+
+    assert_eq!(app.status_message(), "Cannot select nested paths");
+    assert!(app.navigation.selected_paths.contains(&child));
+    assert!(!app.navigation.selected_paths.contains(&folder));
+    assert_eq!(app.selection_count(), 1);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn select_all_skips_entries_inside_selected_folder() {
+    let root = temp_path("selection-select-all-skips-nested");
+    let folder = root.join("folder");
+    let alpha = folder.join("alpha.txt");
+    let beta = folder.join("beta.txt");
+    fs::create_dir_all(&folder).expect("failed to create folder");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(folder.clone());
+    app.set_dir(folder.clone())
+        .expect("entering folder should succeed");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL,
+    )))
+    .expect("Ctrl+A should skip nested entries");
+
+    assert_eq!(app.status_message(), "Cannot select nested paths");
+    assert!(app.navigation.selected_paths.contains(&folder));
+    assert!(!app.navigation.selected_paths.contains(&alpha));
+    assert!(!app.navigation.selected_paths.contains(&beta));
+    assert_eq!(app.selection_count(), 1);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn enter_uses_focused_entry_when_selection_is_offscreen() {
+    let root = temp_path("persistent-selection-enter-offscreen");
+    let child = root.join("child");
+    let grandchild = child.join("grandchild");
+    let selected = root.join("selected.txt");
+    fs::create_dir_all(&grandchild).expect("failed to create grandchild dir");
+    fs::write(&selected, "selected").expect("failed to write selected file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(selected.clone());
+    app.set_dir(child.clone())
+        .expect("entering child should succeed");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, child);
+    assert!(app.navigation.selected_paths.contains(&selected));
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.path.as_path()),
+        Some(grandchild.as_path())
+    );
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("Enter should open focused directory");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, grandchild);
+    assert!(app.navigation.selected_paths.contains(&selected));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn enter_uses_focused_directory_when_selection_is_visible() {
+    let root = temp_path("persistent-selection-enter-visible-directory");
+    let child = root.join("child");
+    let selected = root.join("selected.txt");
+    fs::create_dir_all(&child).expect("failed to create child dir");
+    fs::write(&selected, "selected").expect("failed to write selected file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(selected.clone());
+    let child_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == child)
+        .expect("child should be visible");
+    app.select_index(child_index);
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .expect("Enter should enter focused directory");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, child);
+    assert!(app.navigation.selected_paths.contains(&selected));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -323,8 +323,8 @@ impl App {
                             .as_ref()
                             .map(|l| l.target_cwd.as_path());
                         let nav_to_source = nav_target == Some(source_cwd.as_path());
-                        if source_cwd == self.navigation.cwd
-                            && (nav_target.is_none() || nav_to_source)
+                        if nav_to_source
+                            || (source_cwd == self.navigation.cwd && nav_target.is_none())
                         {
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,
@@ -370,8 +370,8 @@ impl App {
                             .as_ref()
                             .map(|l| l.target_cwd.as_path());
                         let nav_to_source = nav_target == Some(source_cwd.as_path());
-                        if source_cwd == self.navigation.cwd
-                            && (nav_target.is_none() || nav_to_source)
+                        if nav_to_source
+                            || (source_cwd == self.navigation.cwd && nav_target.is_none())
                         {
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,

--- a/src/app/jobs/tasks/paste.rs
+++ b/src/app/jobs/tasks/paste.rs
@@ -225,6 +225,14 @@ fn run_paste(
 
         let dest = unique_dest(&request.dest_dir, file_name);
 
+        if source_contains_destination(src, &dest) {
+            errors.push(format!("\"{}\" cannot be pasted into itself", file_name));
+            if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at) {
+                break;
+            }
+            continue;
+        }
+
         let ok = match request.op {
             ClipOp::Yank => match copy_recursive(src, &dest) {
                 Ok(()) => true,
@@ -341,6 +349,9 @@ fn format_copy_name(stem: &str, ext: Option<&str>, suffix: Option<u32>) -> Strin
 
 /// Recursively copy `src` to `dest`.
 fn copy_recursive(src: &Path, dest: &Path) -> anyhow::Result<()> {
+    if source_contains_destination(src, dest) {
+        anyhow::bail!("Cannot paste a folder into itself");
+    }
     if src.is_dir() {
         fs::create_dir_all(dest)
             .map_err(|e| anyhow::anyhow!("Cannot create directory \"{}\": {e}", dest.display()))?;
@@ -361,6 +372,10 @@ fn copy_recursive(src: &Path, dest: &Path) -> anyhow::Result<()> {
         })?;
     }
     Ok(())
+}
+
+fn source_contains_destination(src: &Path, dest: &Path) -> bool {
+    src.is_dir() && dest.starts_with(src)
 }
 
 #[cfg(test)]
@@ -422,5 +437,50 @@ mod tests {
         assert_eq!(unique_dest(&dir, "aur_1.txt"), dir.join("aur_1_1.txt"));
 
         fs::remove_dir_all(&dir).expect("failed to remove temp dir");
+    }
+
+    #[test]
+    fn copy_recursive_refuses_directory_into_itself() {
+        let root = temp_path("copy-into-self");
+        let source = root.join("source");
+        let dest = source.join("source");
+        fs::create_dir_all(&source).expect("failed to create source dir");
+        fs::write(source.join("file.txt"), "data").expect("failed to write source file");
+
+        let error = copy_recursive(&source, &dest).expect_err("copy should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Cannot paste a folder into itself"),
+            "unexpected error: {error}"
+        );
+        assert!(!dest.exists());
+
+        fs::remove_dir_all(&root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn source_contains_destination_only_blocks_directory_descendants() {
+        let root = temp_path("source-dest-check");
+        let source_dir = root.join("source");
+        let source_file = root.join("file.txt");
+        fs::create_dir_all(&source_dir).expect("failed to create source dir");
+        fs::write(&source_file, "data").expect("failed to write source file");
+
+        assert!(source_contains_destination(
+            &source_dir,
+            &source_dir.join("child")
+        ));
+        assert!(!source_contains_destination(
+            &source_dir,
+            &root.join("source_copy")
+        ));
+        assert!(!source_contains_destination(
+            &source_file,
+            &source_file.join("child")
+        ));
+
+        fs::remove_dir_all(&root).expect("failed to remove temp root");
     }
 }

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -10,26 +10,63 @@ impl App {
         self.navigation.selected_paths.len()
     }
 
+    pub(in crate::app) fn selected_paths_sorted(&self) -> Vec<PathBuf> {
+        let mut paths: Vec<PathBuf> = self.navigation.selected_paths.iter().cloned().collect();
+        paths.sort();
+        paths
+    }
+
+    pub(in crate::app) fn current_directory_escape_for_paths(
+        &self,
+        paths: &[PathBuf],
+    ) -> Option<PathBuf> {
+        paths
+            .iter()
+            .filter(|path| self.navigation.cwd == **path || self.navigation.cwd.starts_with(path))
+            .filter_map(|path| path.parent().map(Path::to_path_buf))
+            .min_by_key(|path| path.components().count())
+    }
+
     pub(in crate::app) fn toggle_selection(&mut self) {
         let Some(entry) = self.selected_entry() else {
             return;
         };
         let path = entry.path.clone();
-        if !self.navigation.selected_paths.remove(&path) {
-            self.navigation.selected_paths.insert(path);
+        if self.navigation.selected_paths.remove(&path) {
+            if self.navigation.view_mode == ViewMode::List {
+                self.move_vertical(1);
+            }
+            return;
         }
+
+        if self.has_selection_nesting_conflict(&path) {
+            self.status = "Cannot select nested paths".to_string();
+            return;
+        }
+
+        self.navigation.selected_paths.insert(path);
         if self.navigation.view_mode == ViewMode::List {
             self.move_vertical(1);
         }
     }
 
     pub(in crate::app) fn select_all(&mut self) {
-        self.navigation.selected_paths = self
+        let mut blocked = false;
+        for path in self
             .navigation
             .entries
             .iter()
-            .map(|e| e.path.clone())
-            .collect();
+            .map(|entry| entry.path.clone())
+        {
+            if self.has_selection_nesting_conflict(&path) {
+                blocked = true;
+                continue;
+            }
+            self.navigation.selected_paths.insert(path);
+        }
+        if blocked {
+            self.status = "Cannot select nested paths".to_string();
+        }
     }
 
     pub(in crate::app) fn clear_selection(&mut self) {
@@ -71,8 +108,7 @@ impl App {
         }
 
         let mut paths: Vec<PathBuf> = self
-            .navigation
-            .selected_paths
+            .selected_paths_sorted()
             .iter()
             .map(|path| self.absolute_chooser_path(path))
             .collect();
@@ -87,5 +123,11 @@ impl App {
         } else {
             self.navigation.cwd.join(path)
         }
+    }
+
+    fn has_selection_nesting_conflict(&self, path: &Path) -> bool {
+        self.navigation.selected_paths.iter().any(|selected| {
+            selected != path && (selected.starts_with(path) || path.starts_with(selected))
+        })
     }
 }

--- a/src/ui/overlay_manager/trash.rs
+++ b/src/ui/overlay_manager/trash.rs
@@ -64,7 +64,7 @@ pub(super) fn render_trash_overlay(
 
     for row_offset in 0..visible {
         let item_index = scroll + row_offset;
-        let Some(name) = app.trash_target_name_at(item_index) else {
+        let Some(label) = app.trash_target_label_at(item_index) else {
             break;
         };
         let is_dir = app.trash_target_is_dir_at(item_index);
@@ -102,7 +102,7 @@ pub(super) fn render_trash_overlay(
                 ),
                 Span::raw(" "),
                 Span::styled(
-                    helpers::clamp_label(name, name_width),
+                    helpers::clamp_label(&label, name_width),
                     Style::default().fg(palette.muted),
                 ),
             ]))


### PR DESCRIPTION
## Summary

Adds persistent multi-path selection across directories so selected paths can be used by chooser mode and bulk actions after navigating away from their original folder.

## What Changed

- Kept selected paths when changing directories.
- Updated chooser confirmation, open, trash/delete, restore, bulk rename, yank/cut, and copy-to-clipboard to use selected paths across folders.
- Blocked nested selections to avoid parent/child target conflicts.
- Added safe parent reloads when deleting, restoring, or renaming a selected parent of the current directory.
- Prevented pasting a folder into itself or one of its descendants.
- Added regression coverage for cross-directory selection, offscreen selections, Trash/normal selection handling, bulk rename, chooser confirmation, and paste safety.

## User Impact

Users can now select files or folders from multiple directories and then run bulk actions or chooser confirmation on the whole selection.

## Notes

`Open With` remains focused-file only for now.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested chooser confirmation with no selection, single selection, and multi-selection across directories.
- Tested open/open-or-enter behavior with focused selected items, focused unselected items, offscreen selections, files, folders, and empty directories.
- Tested rename/bulk rename, trash, delete permanently, restore, yank, cut, paste, and copy-to-clipboard with no selection, single selection, multi-selection, and cross-directory selections.
- Tested selected-parent-of-current-directory cases for delete/restore/rename safe reload behavior.
- Tested nested selection conflicts and paste-folder-into-itself prevention.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
