### PR TITLE
feat(theme): select bundled themes from config.toml and inherit the terminal background by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- elio now inherits the terminal background by default (the bundled `transparent` theme), so it matches the terminal's own theme, including translucent backgrounds. Set `theme = "default"` in `config.toml` to restore the previous opaque dark look.
 - Updated shell integration scripts to pass `--chooser-file` invocations directly to `elio`, so chooser mode does not change the parent shell directory. Re-run `elio shell install` after upgrading to refresh existing shell integration.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a top-level `theme` key to `config.toml` that selects a bundled theme by name (`default`, `amber-dusk`, `blush-light`, `catppuccin-mocha`, `default-light`, `navi`, `neon-cherry`, `terminal-ansi`, `tokyo-night`, `transparent`); all bundled themes now ship inside the binary, and a user `theme.toml` still layers on top of the selection.
 - Added `--chooser-file FILE [PATH]` to run elio as a file chooser, writing the confirmed selection as absolute paths, one per line, to `FILE` or stdout with `-`; cancel exits silently with a nonzero status. ([#153])
 - Added persistent multi-path selection across directories, allowing chooser confirmation and bulk actions to use selected paths from multiple folders.
 - `elio <path>` now accepts file paths as well as directories, opening the parent directory and focusing the file entry, including hidden files, file symlinks, and broken symlinks.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,15 @@ https://elio-fm.github.io/docs/configuration/
 
 ## Theming
 
-elio themes are TOML files layered on top of the built-in defaults, so you only need to set the keys you want to change.
+All bundled themes ship inside the binary and can be selected with the top-level `theme` key in `config.toml` — no files to copy:
+
+```toml
+theme = "tokyo-night"
+```
+
+Available names: `default`, `amber-dusk`, `blush-light`, `catppuccin-mocha`, `default-light`, `navi`, `neon-cherry`, `terminal-ansi`, `tokyo-night`, and `transparent`.
+
+For finer control, elio themes are TOML files layered on top of the selected built-in theme, so you only need to set the keys you want to change.
 
 | Platform | Theme file |
 |---|---|
@@ -246,9 +254,9 @@ elio themes are TOML files layered on top of the built-in defaults, so you only 
 | macOS | `~/Library/Application Support/elio/theme.toml` |
 | Windows | `%APPDATA%\elio\theme.toml` |
 
-See [`assets/themes/default/theme.toml`](assets/themes/default/theme.toml) for the full default theme and [`examples/themes/`](examples/themes/) for ready-made themes.
+See [`assets/themes/default/theme.toml`](assets/themes/default/theme.toml) for the full default theme and [`examples/themes/`](examples/themes/) for the bundled themes' sources.
 
-For transparent or terminal-palette setups, see [`examples/themes/transparent/theme.toml`](examples/themes/transparent/theme.toml) and [`examples/themes/terminal-ansi/theme.toml`](examples/themes/terminal-ansi/theme.toml).
+For transparent or terminal-palette setups, use `theme = "transparent"` or `theme = "terminal-ansi"` ([`transparent/theme.toml`](examples/themes/transparent/theme.toml), [`terminal-ansi/theme.toml`](examples/themes/terminal-ansi/theme.toml)).
 
 Theme docs:
 https://elio-fm.github.io/docs/themes/

--- a/README.md
+++ b/README.md
@@ -238,13 +238,13 @@ https://elio-fm.github.io/docs/configuration/
 
 ## Theming
 
-All bundled themes ship inside the binary and can be selected with the top-level `theme` key in `config.toml` — no files to copy:
+Out of the box elio inherits your terminal's background (the `transparent` theme), so it matches whatever your terminal is themed to — including translucent backgrounds. All bundled themes ship inside the binary and can be selected with the top-level `theme` key in `config.toml` — no files to copy:
 
 ```toml
 theme = "tokyo-night"
 ```
 
-Available names: `default`, `amber-dusk`, `blush-light`, `catppuccin-mocha`, `default-light`, `navi`, `neon-cherry`, `terminal-ansi`, `tokyo-night`, and `transparent`.
+Available names: `default`, `amber-dusk`, `blush-light`, `catppuccin-mocha`, `default-light`, `navi`, `neon-cherry`, `terminal-ansi`, `tokyo-night`, and `transparent`. To restore the previous opaque dark look, set `theme = "default"`; on light terminals, `default-light` or `blush-light` pair well.
 
 For finer control, elio themes are TOML files layered on top of the selected built-in theme, so you only need to set the keys you want to change.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -3,6 +3,8 @@
 # Select a bundled theme by name. Available: default, amber-dusk, blush-light,
 # catppuccin-mocha, default-light, navi, neon-cherry, terminal-ansi,
 # transparent, tokyo-night. A theme.toml next to this file still layers on top.
+# Unset, elio uses "transparent", which inherits the terminal's background;
+# set "default" for the opaque dark look.
 #
 # theme = "tokyo-night"
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,5 +1,11 @@
 # Copy to ~/.config/elio/config.toml to customize Elio's behavior.
 
+# Select a bundled theme by name. Available: default, amber-dusk, blush-light,
+# catppuccin-mocha, default-light, navi, neon-cherry, terminal-ansi,
+# transparent, tokyo-night. A theme.toml next to this file still layers on top.
+#
+# theme = "tokyo-night"
+
 # [ui]
 # show_top_bar = false
 # grid_zoom = 1    # starting zoom level for grid view: 0, 1, or 2 (clamped)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use self::{
 };
 
 struct Config {
+    theme: Option<String>,
     ui: UiConfig,
     places: PlacesConfig,
     layout: LayoutConfig,
@@ -25,6 +26,7 @@ struct Config {
 
 #[derive(Deserialize, Default)]
 struct ConfigFile {
+    theme: Option<String>,
     ui: Option<ui::UiConfigOverride>,
     places: Option<places::PlacesConfigOverride>,
     layout: Option<layout::LayoutConfigOverride>,
@@ -51,9 +53,16 @@ pub(crate) fn keys() -> &'static KeyBindings {
     &loading::active_config().keys
 }
 
+/// The built-in theme selected by the top-level `theme` key in config.toml,
+/// if any.
+pub(crate) fn theme_name() -> Option<&'static str> {
+    loading::active_config().theme.as_deref()
+}
+
 impl Config {
     fn default_config() -> Self {
         Self {
+            theme: None,
             ui: UiConfig::default(),
             places: PlacesConfig::default(),
             layout: LayoutConfig::default(),
@@ -64,6 +73,7 @@ impl Config {
     fn from_str(config: &str) -> anyhow::Result<Self> {
         let parsed: ConfigFile = toml::from_str(config)?;
         let mut resolved = Self::default_config();
+        resolved.theme = parsed.theme;
         if let Some(ui) = parsed.ui {
             resolved.ui.apply_override(ui);
         }

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -1,6 +1,7 @@
 mod keys;
 mod layout;
 mod places;
+mod theme;
 mod ui;
 
 fn toml_string(value: &str) -> String {

--- a/src/config/tests/theme.rs
+++ b/src/config/tests/theme.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+
+#[test]
+fn config_defaults_to_no_theme_selection() {
+    let config = Config::default_config();
+    assert!(config.theme.is_none());
+
+    let config = Config::from_str("").expect("empty config should parse");
+    assert!(config.theme.is_none());
+}
+
+#[test]
+fn theme_key_parses_top_level_string() {
+    let config = Config::from_str(r#"theme = "transparent""#).expect("config should parse");
+    assert_eq!(config.theme.as_deref(), Some("transparent"));
+}
+
+#[test]
+fn theme_key_coexists_with_other_sections() {
+    let config = Config::from_str("theme = \"tokyo-night\"\n\n[ui]\nshow_top_bar = true\n")
+        .expect("config should parse");
+    assert_eq!(config.theme.as_deref(), Some("tokyo-night"));
+    assert!(config.ui.show_top_bar);
+}

--- a/src/ui/theme/appearance/loading.rs
+++ b/src/ui/theme/appearance/loading.rs
@@ -3,29 +3,30 @@ use crate::config;
 use std::{fs, io, path::PathBuf};
 
 pub(super) fn load_theme_from_disk() -> Theme {
+    let base = Theme::selected_builtin_theme(config::theme_name());
     let Some(path) = theme_path() else {
-        return Theme::default_theme();
+        return base;
     };
     let contents = match fs::read_to_string(&path) {
         Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Theme::default_theme(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return base,
         Err(error) => {
             eprintln!(
                 "elio: failed to read theme from {}: {error}",
                 path.display()
             );
-            return Theme::default_theme();
+            return base;
         }
     };
 
-    match Theme::from_config_str(&contents) {
+    match Theme::apply_config_on(base.clone(), &contents) {
         Ok(theme) => theme,
         Err(error) => {
             eprintln!(
                 "elio: failed to load theme from {}: {error}",
                 path.display()
             );
-            Theme::default_theme()
+            base
         }
     }
 }

--- a/src/ui/theme/appearance/mod.rs
+++ b/src/ui/theme/appearance/mod.rs
@@ -12,7 +12,9 @@ use self::{
     resolve::builtin_classify_browser_entry,
     types::{EntryClassCacheKey, ResolvedAppearance, Theme},
 };
-use super::builtin_themes::DEFAULT_THEME_TOML;
+use super::builtin_themes::{
+    DEFAULT_THEME_NAME, DEFAULT_THEME_TOML, available_theme_names, builtin_theme_overrides,
+};
 use crate::core::{Entry, EntryKind, FileClass};
 use std::{
     collections::{HashMap, VecDeque},
@@ -101,6 +103,27 @@ impl Theme {
         Self::apply_config_on(Self::base_theme(), DEFAULT_THEME_TOML).unwrap_or_else(|error| {
             eprintln!("elio: failed to load built-in default theme: {error}");
             Self::base_theme()
+        })
+    }
+
+    /// The built-in theme selected by the top-level `theme` key in config.toml
+    /// (the default theme when the key is absent). A user `theme.toml` layers
+    /// on top of whatever this returns.
+    pub(super) fn selected_builtin_theme(name: Option<&str>) -> Self {
+        let name = name.unwrap_or(DEFAULT_THEME_NAME);
+        if name == "default" {
+            return Self::default_theme();
+        }
+        let Some(overrides) = builtin_theme_overrides(name) else {
+            eprintln!(
+                "elio: unknown theme \"{name}\" in config.toml; available built-in themes: {}",
+                available_theme_names()
+            );
+            return Self::default_theme();
+        };
+        Self::apply_config_on(Self::default_theme(), overrides).unwrap_or_else(|error| {
+            eprintln!("elio: failed to load built-in theme \"{name}\": {error}");
+            Self::default_theme()
         })
     }
 }

--- a/src/ui/theme/appearance/parsing.rs
+++ b/src/ui/theme/appearance/parsing.rs
@@ -94,6 +94,10 @@ enum RuleOverrideDef {
 }
 
 impl Theme {
+    /// Parses a user theme layered over the default theme. Production code
+    /// layers over [`Theme::selected_builtin_theme`] instead (loading.rs);
+    /// tests keep this shorthand for the no-`theme`-key behavior.
+    #[cfg(test)]
     pub(super) fn from_config_str(config: &str) -> anyhow::Result<Self> {
         Self::apply_config_on(Self::default_theme(), config)
     }

--- a/src/ui/theme/appearance/tests/examples.rs
+++ b/src/ui/theme/appearance/tests/examples.rs
@@ -40,20 +40,8 @@ const GENERIC_DEV_DIRECTORIES: &[&str] = &[
 ];
 
 fn alternate_example_theme_config(name: &str) -> &'static str {
-    match name {
-        "default-light" => include_str!("../../../../../examples/themes/default-light/theme.toml"),
-        "blush-light" => include_str!("../../../../../examples/themes/blush-light/theme.toml"),
-        "amber-dusk" => include_str!("../../../../../examples/themes/amber-dusk/theme.toml"),
-        "catppuccin-mocha" => {
-            include_str!("../../../../../examples/themes/catppuccin-mocha/theme.toml")
-        }
-        "tokyo-night" => include_str!("../../../../../examples/themes/tokyo-night/theme.toml"),
-        "navi" => include_str!("../../../../../examples/themes/navi/theme.toml"),
-        "neon-cherry" => include_str!("../../../../../examples/themes/neon-cherry/theme.toml"),
-        "terminal-ansi" => include_str!("../../../../../examples/themes/terminal-ansi/theme.toml"),
-        "transparent" => include_str!("../../../../../examples/themes/transparent/theme.toml"),
-        _ => panic!("unknown alternate example theme fixture: {name}"),
-    }
+    super::super::super::builtin_themes::builtin_theme_overrides(name)
+        .unwrap_or_else(|| panic!("unknown alternate example theme fixture: {name}"))
 }
 
 fn load_alternate_example_theme(name: &str) -> Theme {
@@ -331,4 +319,35 @@ fn alternate_example_themes_use_normal_folder_color_for_generic_dev_directories(
         let theme = load_alternate_example_theme(label);
         assert_uses_normal_folder_color_for_generic_dev_directories(&theme, label);
     }
+}
+
+#[test]
+fn selected_builtin_theme_defaults_to_the_default_theme() {
+    let theme = Theme::selected_builtin_theme(None);
+    assert_eq!(theme.palette.bg, rgb(0x05, 0x05, 0x05));
+}
+
+#[test]
+fn selected_builtin_theme_resolves_bundled_names() {
+    use ratatui::style::Color;
+
+    let transparent = Theme::selected_builtin_theme(Some("transparent"));
+    assert_eq!(transparent.palette.bg, Color::Reset);
+    assert_eq!(transparent.palette.panel, Color::Reset);
+    assert_eq!(transparent.preview.code.bg, Color::Reset);
+
+    let tokyo_night = Theme::selected_builtin_theme(Some("tokyo-night"));
+    assert_eq!(tokyo_night.palette.bg, rgb(0x1a, 0x1b, 0x26));
+}
+
+#[test]
+fn selected_builtin_theme_accepts_default_by_name() {
+    let theme = Theme::selected_builtin_theme(Some("default"));
+    assert_eq!(theme.palette.bg, rgb(0x05, 0x05, 0x05));
+}
+
+#[test]
+fn selected_builtin_theme_falls_back_to_default_for_unknown_names() {
+    let theme = Theme::selected_builtin_theme(Some("does-not-exist"));
+    assert_eq!(theme.palette.bg, rgb(0x05, 0x05, 0x05));
 }

--- a/src/ui/theme/appearance/tests/examples.rs
+++ b/src/ui/theme/appearance/tests/examples.rs
@@ -322,9 +322,18 @@ fn alternate_example_themes_use_normal_folder_color_for_generic_dev_directories(
 }
 
 #[test]
-fn selected_builtin_theme_defaults_to_the_default_theme() {
+fn selected_builtin_theme_defaults_to_the_transparent_theme() {
+    use ratatui::style::Color;
+
     let theme = Theme::selected_builtin_theme(None);
-    assert_eq!(theme.palette.bg, rgb(0x05, 0x05, 0x05));
+    assert_eq!(theme.palette.bg, Color::Reset);
+    assert_eq!(theme.palette.panel, Color::Reset);
+    assert_eq!(theme.palette.chrome, Color::Reset);
+    // Everything except the surfaces still matches the default palette.
+    assert_eq!(
+        theme.palette.text,
+        Theme::selected_builtin_theme(Some("default")).palette.text
+    );
 }
 
 #[test]

--- a/src/ui/theme/appearance/tests/overrides.rs
+++ b/src/ui/theme/appearance/tests/overrides.rs
@@ -92,7 +92,7 @@ keyword = "#abcdef"
 }
 
 #[test]
-fn load_theme_from_disk_falls_back_to_default_theme_for_invalid_theme_file() {
+fn load_theme_from_disk_falls_back_to_selected_base_for_invalid_theme_file() {
     let (config_home, path, _guard) = write_theme_file(
         "load-theme-invalid",
         r##"
@@ -103,16 +103,13 @@ keyword = "#12"
     let _xdg = EnvVarGuard::set_path("XDG_CONFIG_HOME", &config_home);
 
     let theme = load_theme_from_disk();
-    let default_theme = Theme::default_theme();
+    let base_theme = Theme::selected_builtin_theme(None);
 
-    assert_eq!(theme.palette.bg, default_theme.palette.bg);
-    assert_eq!(
-        theme.preview.code.keyword,
-        default_theme.preview.code.keyword
-    );
+    assert_eq!(theme.palette.bg, base_theme.palette.bg);
+    assert_eq!(theme.preview.code.keyword, base_theme.preview.code.keyword);
     assert_eq!(
         theme.resolve(Path::new("Cargo.lock"), EntryKind::File).icon,
-        default_theme
+        base_theme
             .resolve(Path::new("Cargo.lock"), EntryKind::File)
             .icon,
     );

--- a/src/ui/theme/builtin_themes.rs
+++ b/src/ui/theme/builtin_themes.rs
@@ -3,8 +3,12 @@ pub(super) const DEFAULT_THEME_TOML: &str = include_str!(concat!(
     "/assets/themes/default/theme.toml"
 ));
 
-/// The built-in theme used when config.toml does not select one.
-pub(super) const DEFAULT_THEME_NAME: &str = "default";
+/// The built-in theme used when config.toml does not select one. The
+/// transparent theme keeps the default palette but inherits the terminal's
+/// own background, so elio matches whatever the terminal is themed to
+/// (including translucent backgrounds); `theme = "default"` restores the
+/// opaque look.
+pub(super) const DEFAULT_THEME_NAME: &str = "transparent";
 
 macro_rules! bundled_theme {
     ($name:literal) => {

--- a/src/ui/theme/builtin_themes.rs
+++ b/src/ui/theme/builtin_themes.rs
@@ -2,3 +2,53 @@ pub(super) const DEFAULT_THEME_TOML: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/assets/themes/default/theme.toml"
 ));
+
+/// The built-in theme used when config.toml does not select one.
+pub(super) const DEFAULT_THEME_NAME: &str = "default";
+
+macro_rules! bundled_theme {
+    ($name:literal) => {
+        (
+            $name,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/examples/themes/",
+                $name,
+                "/theme.toml"
+            )),
+        )
+    };
+}
+
+/// Built-in themes selectable by name through the top-level `theme` key in
+/// config.toml. Each TOML layers on top of the default theme, exactly like a
+/// user `theme.toml` would; `"default"` selects the default theme itself.
+/// These are the bundled themes from `examples/themes/`.
+const BUILTIN_THEME_OVERRIDES: &[(&str, &str)] = &[
+    bundled_theme!("amber-dusk"),
+    bundled_theme!("blush-light"),
+    bundled_theme!("catppuccin-mocha"),
+    bundled_theme!("default-light"),
+    bundled_theme!("navi"),
+    bundled_theme!("neon-cherry"),
+    bundled_theme!("terminal-ansi"),
+    bundled_theme!("tokyo-night"),
+    bundled_theme!("transparent"),
+];
+
+/// The override TOML for a named built-in theme, or `None` for unknown names.
+/// `"default"` is handled by the caller (there is nothing to layer).
+pub(super) fn builtin_theme_overrides(name: &str) -> Option<&'static str> {
+    BUILTIN_THEME_OVERRIDES
+        .iter()
+        .find(|(theme_name, _)| *theme_name == name)
+        .map(|(_, overrides)| *overrides)
+}
+
+/// Comma-separated list of every selectable theme name, for error messages.
+pub(super) fn available_theme_names() -> String {
+    std::iter::once(DEFAULT_THEME_NAME)
+        .chain(BUILTIN_THEME_OVERRIDES.iter().map(|(name, _)| *name))
+        .collect::<Vec<_>>()
+        .join(", ")
+}


### PR DESCRIPTION
## Summary

Two related theming improvements, split into independent commits so they can be taken separately:

1. **Select bundled themes by name** — all bundled themes now ship inside the binary and can be picked with a top-level `theme` key in `config.toml`, instead of hand-copying `theme.toml` files.
2. **Inherit the terminal background by default** — the bundled `transparent` theme becomes the default, so elio matches whatever the terminal itself is themed to (including translucent backgrounds). The previous look stays one line away: `theme = "default"`.

The motivation: on setups that theme the terminal itself (omarchy/Hyprland and other tiling environments, but really any terminal with a configured background or translucency), elio currently paints an opaque dark slab over it and stands out from every other TUI. With the transparent default the palette is unchanged — only the surface backgrounds resolve to the terminal default.

If the default change is too opinionated, the first commit stands on its own and `theme = "transparent"` becomes the documented opt-in.

## What Changed

- `feat(theme): select bundled themes by name from config.toml`
  - The nine themes under `examples/themes/` are embedded in the binary (`builtin_themes.rs`) and selectable with `theme = "<name>"`: `default`, `amber-dusk`, `blush-light`, `catppuccin-mocha`, `default-light`, `navi`, `neon-cherry`, `terminal-ansi`, `tokyo-night`, `transparent`.
  - The selected theme layers over the default exactly like a user `theme.toml` would, and a user `theme.toml` still layers on top of the selection (verified: `theme = "transparent"` + a `theme.toml` setting `chrome` shows the override over the transparent base).
  - Unknown names warn on stderr with the list of available themes and fall back to the default.
  - The existing example-theme test fixtures now read from the embedded table instead of duplicating the `include_str!` list.
- `feat(theme): inherit the terminal background by default`
  - `DEFAULT_THEME_NAME` flips from `default` to `transparent`; everything else is docs and test updates.

## User Impact

- Out of the box, elio now matches the terminal's own background — themed, light, dark, or translucent — instead of forcing its own. Selection highlight, accents, text colors, and file-class colors are unchanged.
- Switching themes no longer requires copying files: one line in `config.toml`.
- Users who prefer the previous opaque dark look set `theme = "default"`; on light terminals `default-light` / `blush-light` pair well (the README says so).

## Notes

- Verified the surface coverage empirically: with the opaque default a rendered frame contains 99 truecolor-background cells (chrome, panels, scrollbar, selection); with the transparent default only the 3 `selected_bg` cursor-row cells remain.
- The Kitty/iTerm/Sixel image-preview paths already handle `Color::Reset` panels (they skip the background SGR), so inline image previews work unchanged on the transparent default — verified with an SVG preview through Ghostty.
- The README hero screenshot still shows the opaque default; happy to regenerate screenshots if you want them to reflect the new default.
- Before/after screenshots (Ghostty + Hyprland, themed translucent terminal) can be attached in a comment if useful.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` — 1169 passed; the 5 failures (preview-wheel/scroll timing tests) fail identically on `main` on this machine and are unrelated
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Arch Linux, Hyprland, Ghostty (translucent omarchy theme), and a scripted tmux harness capturing frames with escape sequences.
- No config → terminal background shows through all panes; `theme = "default"` → previous opaque look; `theme = "tokyo-night"` → Tokyo Night palette; bogus name → stderr warning listing available themes, default look retained.
- `theme = "transparent"` plus a user `theme.toml` overriding `chrome` → override applied on top of the transparent base.
- SVG image preview (Kitty graphics protocol) renders correctly on the transparent default.
- Both commits compile warning-free in isolation (`cargo check --all-targets` per commit).

Result:

All checks passed locally apart from the 5 machine-specific test failures noted above, which reproduce identically on `main`.

## Documentation and Changelog

- [x] Updated `README.md` (Theming section) and `examples/config.toml` for the new `theme` key and the new default
- [x] Added `CHANGELOG.md` entries (Added: theme selection; Changed: transparent default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
