### PR TITLE
feat(keys): add Del and Shift+Del delete shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added persistent multi-path selection across directories, allowing chooser confirmation and bulk actions to use selected paths from multiple folders.
 - `elio <path>` now accepts file paths as well as directories, opening the parent directory and focusing the file entry, including hidden files, file symlinks, and broken symlinks.
 - Added configurable `symlink_absolute` (`-`) and `symlink_relative` (`_`) shortcuts for creating absolute or relative symlinks from yanked items in the current directory. ([#159])
+- Added `Del` as a default trash shortcut and `Shift+Del` as a default permanent-delete shortcut; `[keys]` now accepts `delete` / `del` as named key values. ([#162])
 
 ### Changed
 
@@ -239,3 +240,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#141]: https://github.com/elio-fm/elio/issues/141
 [#153]: https://github.com/elio-fm/elio/issues/153
 [#159]: https://github.com/elio-fm/elio/issues/159
+[#162]: https://github.com/elio-fm/elio/issues/162

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ https://elio-fm.github.io/docs/themes/
 <details>
 <summary><strong>Controls</strong></summary>
 
-Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for arrows, `enter`, `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, `end`, and `F1`–`F12`; named keys and modifiers are case-insensitive, so `F2`, `PageUp`, and `Ctrl+O` work. Modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
+Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults are shown here. Configurable actions accept one key, a list, or an empty list to unbind the action, such as `open_with = ["O", "w"]` or `delete_permanently = []`. Named keys are supported for arrows, `enter`, `space`, `tab`, `backtab` / `shift+tab`, `backspace`, `delete` / `del`, `pageup`, `pagedown`, `home`, `end`, and `F1`–`F12`; named keys and modifiers are case-insensitive, so `F2`, `PageUp`, and `Ctrl+O` work. Modifier bindings such as `ctrl+o`, `alt+o`, and `ctrl+enter` are also supported. Setting an action replaces its full default key list.
 
 ### Navigation
 
@@ -292,8 +292,8 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `O` `*` | Open With chooser |
 | `!` `*` | Open shell in current folder |
 | `a` `*` | Create file or folder |
-| `d` `*` | Trash; permanently delete if already in trash |
-| `D` `*` | Delete permanently |
+| `d` / `Del` `*` | Trash; permanently delete if already in trash |
+| `D` / `Shift+Del` `*` | Delete permanently |
 | `r` / `F2` `*` | Rename / bulk rename |
 | `r` `*` (in Trash) | Restore from trash |
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -61,8 +61,8 @@
 #
 # Keys may be one-character strings, named keys, or modifier bindings.
 # Supported named keys: "left", "right", "up", "down", "enter", "space",
-# "tab", "backtab", "shift+tab", "backspace", "pageup", "pagedown", "home",
-# "end", "f1".."f12".
+# "tab", "backtab", "shift+tab", "backspace", "delete", "del", "pageup",
+# "pagedown", "home", "end", "f1".."f12".
 # Named keys and modifiers are case-insensitive: "F2", "PageUp", "Ctrl+O".
 #
 # Examples: open_with = ["O", "w"], open = "ctrl+o", nav_right = "shift+right".
@@ -94,8 +94,8 @@
 # paste                = "p"
 # symlink_absolute     = "-"
 # symlink_relative     = "_"
-# trash                = "d"
-# delete_permanently   = "D"   # Shift+D
+# trash                = ["d", "del"]
+# delete_permanently   = ["D", "shift+del"]
 # create               = "a"
 # rename               = ["r", "F2"]
 # restore_from_trash   = "r"

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -68,6 +68,7 @@ pub(crate) enum NamedKey {
     Tab,
     BackTab,
     Backspace,
+    Delete,
     PageUp,
     PageDown,
     Home,
@@ -89,6 +90,7 @@ impl NamedKey {
             "tab" => Some(Self::Tab),
             "backtab" => Some(Self::BackTab),
             "backspace" => Some(Self::Backspace),
+            "delete" | "del" => Some(Self::Delete),
             "pageup" => Some(Self::PageUp),
             "pagedown" => Some(Self::PageDown),
             "home" => Some(Self::Home),
@@ -113,6 +115,7 @@ impl NamedKey {
             | (Self::Tab, KeyCode::Tab)
             | (Self::BackTab, KeyCode::BackTab)
             | (Self::Backspace, KeyCode::Backspace)
+            | (Self::Delete, KeyCode::Delete)
             | (Self::PageUp, KeyCode::PageUp)
             | (Self::PageDown, KeyCode::PageDown)
             | (Self::Home, KeyCode::Home)
@@ -135,6 +138,7 @@ impl std::fmt::Display for NamedKey {
             Self::Tab => "Tab",
             Self::BackTab => "Shift+Tab",
             Self::Backspace => "Backspace",
+            Self::Delete => "Del",
             Self::PageUp => "PageUp",
             Self::PageDown => "PageDown",
             Self::Home => "Home",
@@ -254,6 +258,16 @@ impl KeySpec {
             code: KeyCodeSpec::Named(named),
             modifiers: KeyModifierSpec {
                 alt: true,
+                ..KeyModifierSpec::NONE
+            },
+        }
+    }
+
+    fn shift_named(named: NamedKey) -> Self {
+        Self {
+            code: KeyCodeSpec::Named(named),
+            modifiers: KeyModifierSpec {
+                shift: true,
                 ..KeyModifierSpec::NONE
             },
         }
@@ -385,7 +399,8 @@ impl PartialEq<char> for KeyList {
 /// Empty lists unbind the action (`open = []`).
 /// Character bindings must be one character; named bindings currently support
 /// `left`, `right`, `up`, `down`, `enter`, `space`, `tab`, `backtab`,
-/// `shift+tab`, `backspace`, `pageup`, `pagedown`, `home`, `end`, and `f1`..`f12`.
+/// `shift+tab`, `backspace`, `delete`, `del`, `pageup`, `pagedown`, `home`,
+/// `end`, and `f1`..`f12`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct KeyBindings {
     pub choose: KeyList,
@@ -458,8 +473,11 @@ impl Default for KeyBindings {
             paste: KeyList::one('p'),
             symlink_absolute: KeyList::one('-'),
             symlink_relative: KeyList::one('_'),
-            trash: KeyList::one('d'),
-            delete_permanently: KeyList::one('D'),
+            trash: KeyList(vec![KeySpec::char('d'), KeySpec::named(NamedKey::Delete)]),
+            delete_permanently: KeyList(vec![
+                KeySpec::char('D'),
+                KeySpec::shift_named(NamedKey::Delete),
+            ]),
             create: KeyList::one('a'),
             rename: KeyList(vec![
                 KeySpec::char('r'),

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -2,13 +2,23 @@ use super::super::*;
 
 #[test]
 fn keys_default_bindings_are_sane() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
     let config = Config::default_config();
     assert_eq!(config.keys.yank, 'y');
     assert_eq!(config.keys.cut, 'x');
     assert_eq!(config.keys.paste, 'p');
     assert_eq!(config.keys.symlink_absolute, '-');
     assert_eq!(config.keys.symlink_relative, '_');
-    assert_eq!(config.keys.delete_permanently, 'D');
+    assert_eq!(config.keys.trash.to_string(), "d/Del");
+    assert_eq!(config.keys.action_for('d'), Some(Action::Trash));
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE)),
+        Some(Action::Trash)
+    );
+    assert_eq!(config.keys.delete_permanently.to_string(), "D/Shift+Del");
     assert_eq!(config.keys.choose.to_string(), "Enter");
     assert_eq!(config.keys.quit, 'q');
     assert_eq!(config.keys.quit_without_cd, 'Q');
@@ -216,6 +226,35 @@ nav_left = "ctrl+alt+up"
             KeyModifiers::CONTROL | KeyModifiers::ALT
         )),
         Some(Action::NavLeft)
+    );
+}
+
+#[test]
+fn delete_named_key_supports_plain_and_shift_bindings() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let config = Config::from_str(
+        r#"
+[keys]
+trash = ["d", "del"]
+delete_permanently = ["D", "shift+delete"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.keys.trash.to_string(), "d/Del");
+    assert_eq!(config.keys.delete_permanently.to_string(), "D/Shift+Del");
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE)),
+        Some(Action::Trash)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(KeyEvent::new(KeyCode::Delete, KeyModifiers::SHIFT)),
+        Some(Action::DeletePermanently)
     );
 }
 
@@ -548,7 +587,7 @@ yank = "d"
     )
     .expect("config should parse");
     assert_eq!(config.keys.yank, 'y');
-    assert_eq!(config.keys.trash, 'd');
+    assert_eq!(config.keys.trash.to_string(), "d/Del");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds GUI-style delete shortcuts while keeping the existing `d` / `D` bindings.

Closes #162

## What Changed

- Added `Del` as a default trash shortcut alongside `d`.
- Added `Shift+Del` as a default permanent-delete shortcut alongside `D`.
- Added `delete` / `del` as named `[keys]` values.
- Updated the README controls, example config, and changelog.

## User Impact

Users can now use delete shortcuts:

```toml
trash = ["d", "del"]
delete_permanently = ["D", "shift+del"]
```

Existing configs keep working. Users can still override or unbind these actions normally in `[keys]`.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested default `Del` trash behavior and confirmed `d` still works.
- Tested default `Shift+Del` permanent-delete behavior and confirmed `D` still works.
- Tested `delete_permanently = ["D", "shift+delete"]`.
- Tested `delete_permanently = "shift+delete"` disables `D`.
- Tested `trash = ["d"]` disables `Del`.
- Checked the help overlay reflects the configured bindings.
- Tested `Shift+Del` in Kitty, Ghostty, GNOME Terminal, WezTerm, Foot, Konsole, and Alacritty.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed