### PR TITLE
fix(keys): normalize Caps Lock character bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Blocked nested selections and prevented pasting a folder into itself.
+- Fixed Caps Lock letter input when terminals report Caps Lock separately from the character.
 - Fixed image previews inside tmux when stale Alacritty/Kitty markers from the tmux server environment hid the active supported terminal.
 - Fixed several terminal/UI freeze cases around large image-preview output, focus changes, keyboard enhancement probing, and slow autofs/network mounts.
 - Fixed image and PDF preview redraws during resize bursts, with resize settling tuned separately for tmux and non-tmux terminals.

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventState, KeyModifiers};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
@@ -295,12 +295,20 @@ impl KeySpec {
 
 fn normalize_key_event(key: KeyEvent) -> (KeyCode, KeyModifierSpec) {
     let mut modifiers = KeyModifierSpec::from_event(key.modifiers);
+    let caps_lock = key.state.contains(KeyEventState::CAPS_LOCK);
     let code = match key.code {
         KeyCode::Char(c) if modifiers.ctrl || modifiers.alt => {
             modifiers.shift = false;
             KeyCode::Char(c.to_ascii_lowercase())
         }
-        KeyCode::Char(c) => {
+        KeyCode::Char(mut c) => {
+            if caps_lock {
+                c = if modifiers.shift {
+                    single_case_mapping(c.to_lowercase()).unwrap_or(c)
+                } else {
+                    single_case_mapping(c.to_uppercase()).unwrap_or(c)
+                };
+            }
             modifiers.shift = false;
             KeyCode::Char(c)
         }
@@ -311,6 +319,11 @@ fn normalize_key_event(key: KeyEvent) -> (KeyCode, KeyModifierSpec) {
         code => code,
     };
     (code, modifiers)
+}
+
+fn single_case_mapping(mut mapping: impl Iterator<Item = char>) -> Option<char> {
+    let mapped = mapping.next()?;
+    mapping.next().is_none().then_some(mapped)
 }
 
 impl std::fmt::Display for KeySpec {

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -230,6 +230,108 @@ nav_left = "ctrl+alt+up"
 }
 
 #[test]
+fn caps_lock_character_events_match_uppercase_bindings() {
+    use crossterm::event::KeyModifiers;
+
+    let key_bindings = KeyBindings::default();
+
+    assert_eq!(
+        key_bindings.action_for_key(caps_lock_char('o', KeyModifiers::NONE)),
+        Some(Action::OpenWith)
+    );
+}
+
+#[test]
+fn caps_lock_with_shift_character_events_match_lowercase_bindings() {
+    use crossterm::event::KeyModifiers;
+
+    let key_bindings = KeyBindings::default();
+
+    assert_eq!(
+        key_bindings.action_for_key(caps_lock_char('o', KeyModifiers::SHIFT)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        key_bindings.action_for_key(caps_lock_char('O', KeyModifiers::SHIFT)),
+        Some(Action::Open)
+    );
+}
+
+#[test]
+fn caps_lock_character_events_use_unicode_case_mapping() {
+    use crossterm::event::KeyModifiers;
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "ñ"
+open_with = "Ñ"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(caps_lock_char('ñ', KeyModifiers::NONE)),
+        Some(Action::OpenWith)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(caps_lock_char('ñ', KeyModifiers::SHIFT)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(caps_lock_char('Ñ', KeyModifiers::SHIFT)),
+        Some(Action::Open)
+    );
+}
+
+#[test]
+fn caps_lock_does_not_change_ctrl_alt_character_matching() {
+    use crossterm::event::KeyModifiers;
+
+    let config = Config::from_str(
+        r#"
+[keys]
+open = "ctrl+o"
+open_with = "alt+o"
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(caps_lock_char('o', KeyModifiers::CONTROL)),
+        Some(Action::Open)
+    );
+    assert_eq!(
+        config
+            .keys
+            .action_for_key(caps_lock_char('o', KeyModifiers::ALT)),
+        Some(Action::OpenWith)
+    );
+}
+
+fn caps_lock_char(
+    c: char,
+    modifiers: crossterm::event::KeyModifiers,
+) -> crossterm::event::KeyEvent {
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState};
+
+    KeyEvent::new_with_kind_and_state(
+        KeyCode::Char(c),
+        modifiers,
+        KeyEventKind::Press,
+        KeyEventState::CAPS_LOCK,
+    )
+}
+
+#[test]
 fn delete_named_key_supports_plain_and_shift_bindings() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 


### PR DESCRIPTION
## Summary

Fixes character key matching when terminals report Caps Lock separately from the typed character.

Caps Lock now behaves like normal text input for character bindings:

- Caps Lock + \`o\` matches \`O\`
- Caps Lock + Shift + \`o\` matches \`o\`
- non-ASCII single-character case pairs such as \`ñ\` / \`Ñ\` and \`ç\` / \`Ç\` work too

Ctrl/Alt character bindings and named keys are unchanged.

## Testing

- [x] \`cargo fmt --check\`
- [x] \`cargo test --locked --test architecture_guardrails\`
- [x] \`cargo clippy --locked --all-targets -- -D warnings\`
- [x] \`cargo test --locked\`
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --locked --no-deps\`

Manual checks:

- Verified \`o\` / \`O\`, \`a\` / \`A\`, \`d\` / \`D\`, \`ñ\` / \`Ñ\`, and \`ç\` / \`Ç\` bindings with Caps Lock on and off.
- Verified Shift inversion with Caps Lock enabled: Caps Lock + \`o\` triggers the uppercase binding, while Caps Lock + Shift + \`o\` triggers the lowercase binding.
- Verified named and modified keys still behave normally, including \`Del\`, \`Shift+Del\`, \`Tab\`, and \`Shift+Tab\`.
- Verified existing modifier bindings were not affected.