### PR TITLE
fix(themes): show active sidebar item in transparent themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed image previews inside tmux when stale Alacritty/Kitty markers from the tmux server environment hid the active supported terminal.
 - Fixed several terminal/UI freeze cases around large image-preview output, focus changes, keyboard enhancement probing, and slow autofs/network mounts.
 - Fixed image and PDF preview redraws during resize bursts, with resize settling tuned separately for tmux and non-tmux terminals.
+- Fixed the active sidebar item highlight in the terminal ANSI and transparent example themes.
 
 ## [1.8.0] - 2026-06-06
 

--- a/examples/themes/terminal-ansi/theme.toml
+++ b/examples/themes/terminal-ansi/theme.toml
@@ -9,7 +9,7 @@ surface = "none"
 elevated = "none"
 button_bg = "none"
 button_disabled_bg = "none"
-sidebar_active = "none"
+sidebar_active = "#1a2a43"
 accent_soft = "none"
 path_bg = "none"
 

--- a/examples/themes/transparent/theme.toml
+++ b/examples/themes/transparent/theme.toml
@@ -9,7 +9,7 @@ surface = "none"
 elevated = "none"
 button_bg = "none"
 button_disabled_bg = "none"
-sidebar_active = "none"
+sidebar_active = "#1a2a43"
 accent_soft = "none"
 path_bg = "none"
 


### PR DESCRIPTION
## Summary

Fixes the active sidebar item highlight in the transparent example themes.

`terminal-ansi` and `transparent` both used `sidebar_active = "none"`, which made the active Places entry lose its background indicator. They now use the same subtle active color as the default dark theme.

## Testing

Manual checks:

- [x] Verified both updated themes show the active sidebar item correctly.