### PR TITLE
fix(selection): avoid freezes when selecting many files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed several terminal/UI freeze cases around large image-preview output, focus changes, keyboard enhancement probing, and slow autofs/network mounts.
 - Fixed image and PDF preview redraws during resize bursts, with resize settling tuned separately for tmux and non-tmux terminals.
 - Fixed the active sidebar item highlight in the terminal ANSI and transparent example themes.
+- Fixed UI freezes when selecting all items in very large folders.
 
 ## [1.8.0] - 2026-06-06
 

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -126,8 +126,52 @@ impl App {
     }
 
     fn has_selection_nesting_conflict(&self, path: &Path) -> bool {
-        self.navigation.selected_paths.iter().any(|selected| {
-            selected != path && (selected.starts_with(path) || path.starts_with(selected))
-        })
+        self.navigation.selected_paths.has_nesting_conflict(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::state::SelectedPaths;
+    use std::path::PathBuf;
+
+    #[test]
+    fn selected_paths_tracks_nested_conflicts_without_scanning_selected_siblings() {
+        let mut selected = SelectedPaths::default();
+        let siblings: Vec<PathBuf> = (0..1_000)
+            .map(|index| PathBuf::from(format!("/tmp/elio-selection/file-{index}")))
+            .collect();
+
+        for path in siblings.iter().cloned() {
+            assert!(selected.insert(path));
+        }
+        assert_eq!(selected.len(), siblings.len());
+        assert!(selected.has_nesting_conflict(PathBuf::from("/tmp/elio-selection").as_path()));
+        assert!(!selected.has_nesting_conflict(PathBuf::from("/tmp/other").as_path()));
+
+        assert!(selected.remove(&siblings[0]));
+        assert!(!selected.contains(&siblings[0]));
+        assert_eq!(selected.len(), siblings.len() - 1);
+        assert!(selected.has_nesting_conflict(PathBuf::from("/tmp/elio-selection").as_path()));
+
+        selected.clear();
+        assert!(selected.is_empty());
+        assert!(!selected.has_nesting_conflict(PathBuf::from("/tmp/elio-selection").as_path()));
+    }
+
+    #[test]
+    fn selected_paths_rejects_parent_child_mixes() {
+        let mut selected = SelectedPaths::default();
+        let parent = PathBuf::from("/tmp/elio-selection");
+        let child = parent.join("child");
+        let sibling = PathBuf::from("/tmp/other");
+
+        assert!(selected.insert(child.clone()));
+        assert!(!selected.insert(parent.clone()));
+        assert!(selected.insert(sibling));
+
+        assert!(selected.remove(&child));
+        assert!(selected.insert(parent.clone()));
+        assert!(!selected.insert(parent.join("nested")));
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -369,6 +369,83 @@ pub(super) struct DirectoryViewMemory {
 }
 
 #[derive(Clone, Debug, Default)]
+pub(in crate::app) struct SelectedPaths {
+    inner: HashSet<PathBuf>,
+    ancestor_counts: HashMap<PathBuf, usize>,
+}
+
+impl SelectedPaths {
+    pub(in crate::app) fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub(in crate::app) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub(in crate::app) fn contains(&self, path: &std::path::Path) -> bool {
+        self.inner.contains(path)
+    }
+
+    pub(in crate::app) fn iter(&self) -> impl Iterator<Item = &PathBuf> {
+        self.inner.iter()
+    }
+
+    pub(in crate::app) fn clear(&mut self) {
+        self.inner.clear();
+        self.ancestor_counts.clear();
+    }
+
+    pub(in crate::app) fn insert(&mut self, path: PathBuf) -> bool {
+        if self.has_nesting_conflict(&path) {
+            return false;
+        }
+        if !self.inner.insert(path.clone()) {
+            return false;
+        }
+        self.add_ancestors(&path);
+        true
+    }
+
+    pub(in crate::app) fn remove(&mut self, path: &std::path::Path) -> bool {
+        if !self.inner.remove(path) {
+            return false;
+        }
+        self.remove_ancestors(path);
+        true
+    }
+
+    pub(in crate::app) fn has_nesting_conflict(&self, path: &std::path::Path) -> bool {
+        self.ancestor_counts.contains_key(path)
+            || path
+                .ancestors()
+                .skip(1)
+                .any(|ancestor| self.inner.contains(ancestor))
+    }
+
+    fn add_ancestors(&mut self, path: &std::path::Path) {
+        for ancestor in path.ancestors().skip(1) {
+            *self
+                .ancestor_counts
+                .entry(ancestor.to_path_buf())
+                .or_default() += 1;
+        }
+    }
+
+    fn remove_ancestors(&mut self, path: &std::path::Path) {
+        for ancestor in path.ancestors().skip(1) {
+            let Some(count) = self.ancestor_counts.get_mut(ancestor) else {
+                continue;
+            };
+            *count -= 1;
+            if *count == 0 {
+                self.ancestor_counts.remove(ancestor);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
 pub(super) struct MediaPreviewState {
     pub(super) ffprobe_available: Option<bool>,
     pub(super) ffmpeg_available: Option<bool>,
@@ -502,7 +579,7 @@ pub(crate) struct NavigationState {
     /// Set in apply_directory_snapshot so it's only true once the load completes.
     pub(in crate::app) in_trash: bool,
     pub(in crate::app) navigation_history: NavigationHistory,
-    pub(in crate::app) selected_paths: HashSet<PathBuf>,
+    pub(in crate::app) selected_paths: SelectedPaths,
     pub(in crate::app) directory_item_count_cache: HashMap<DirectoryItemCountKey, Option<usize>>,
     pub(in crate::app) directory_item_count_order: VecDeque<DirectoryItemCountKey>,
     pub(in crate::app) directory_count_viewport: Option<DirectoryCountViewport>,
@@ -644,7 +721,7 @@ impl App {
                 show_hidden: crate::config::ui().show_hidden || reveal_hidden_start_focus,
                 in_trash: false,
                 navigation_history: NavigationHistory::default(),
-                selected_paths: HashSet::new(),
+                selected_paths: SelectedPaths::default(),
                 directory_item_count_cache: HashMap::new(),
                 directory_item_count_order: VecDeque::new(),
                 directory_count_viewport: None,


### PR DESCRIPTION
## Summary

Fixes UI freezes when selecting all items in very large folders.

Large multi-selections previously checked every already-selected path for nesting conflicts on each new selected path, which made bulk selection scale poorly. Selection now tracks ancestor counts, so nesting conflict checks avoid scanning all selected siblings.

## What Changed

- Added a `SelectedPaths` wrapper around the selected-path set.
- Tracks selected ancestors with reference counts to make nesting checks fast.
- Preserved the existing parent/child selection rejection behavior.
- Added tests for large sibling selections, parent/child conflicts, removal, and clearing selection.
- Added a changelog entry.

## User Impact

Bulk-selecting many files in one folder no longer freezes the UI.

Before this change, selecting all in a large folder could freeze for several seconds while elio checked nesting conflicts against the growing selection. After this change, the same bulk selection is effectively instant.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested bulk-selecting many files in a large folder.
- Reproduced the previous multi-second freeze before the fix.
- Verified the same bulk selection is instant after the fix.
- Verified nested selections are still rejected.

Result:

All checks passed locally.

## Documentation and Changelog

- [x] Added a `CHANGELOG.md` entry for the user-visible fix
- [x] Docs are not needed beyond the changelog because behavior/configuration did not change
