### PR TITLE
fix(open-with): add Linux/BSD editor fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed image and PDF preview redraws during resize bursts, with resize settling tuned separately for tmux and non-tmux terminals.
 - Fixed the active sidebar item highlight in the terminal ANSI and transparent example themes.
 - Fixed UI freezes when selecting all items in very large folders.
+- Fixed Linux/BSD Open With behavior for text-like files by reporting missing handlers accurately, showing which app is used for direct single-app launches, and offering a terminal editor from `$VISUAL` or `$EDITOR` when it is available but not discovered through the desktop app list.
 
 ## [1.8.0] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed image and PDF preview redraws during resize bursts, with resize settling tuned separately for tmux and non-tmux terminals.
 - Fixed the active sidebar item highlight in the terminal ANSI and transparent example themes.
 - Fixed UI freezes when selecting all items in very large folders.
-- Fixed Linux/BSD Open With behavior for text-like files by reporting missing handlers accurately, showing which app is used for direct single-app launches, and offering a terminal editor from `$VISUAL` or `$EDITOR` when it is available but not discovered through the desktop app list.
+- Fixed Linux/BSD Open With (`O`) behavior by reporting missing handlers accurately, showing the app used for direct single-app launches, and offering `$VISUAL` or `$EDITOR` in the current terminal for text/code files when the editor is not registered as a desktop app; `o` / `Enter` uses the same editor fallback only when no desktop handler is available. ([#168])
 
 ## [1.8.0] - 2026-06-06
 
@@ -248,3 +248,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#153]: https://github.com/elio-fm/elio/issues/153
 [#159]: https://github.com/elio-fm/elio/issues/159
 [#162]: https://github.com/elio-fm/elio/issues/162
+[#168]: https://github.com/elio-fm/elio/issues/168

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -406,11 +406,14 @@ impl App {
 
     pub(in crate::app) fn open_in_system(&mut self) -> Result<()> {
         #[cfg(all(unix, not(target_os = "macos")))]
-        if self
-            .single_file_open_target_entry()
-            .is_some_and(|entry| self.queue_terminal_default_open_if_needed(&entry))
-        {
-            return Ok(());
+        if let Some(entry) = self.single_file_open_target_entry() {
+            if self.queue_terminal_default_open_if_needed(&entry) {
+                return Ok(());
+            }
+            if !crate::app::open_with::open_with_apps_found_for_entry(&entry) {
+                self.status = "No app found".to_string();
+                return Ok(());
+            }
         }
 
         let targets = self.open_in_system_targets();
@@ -419,8 +422,14 @@ impl App {
 
     fn open_entry_in_system(&mut self, entry: &Entry) -> Result<()> {
         #[cfg(all(unix, not(target_os = "macos")))]
-        if self.queue_terminal_default_open_if_needed(entry) {
-            return Ok(());
+        {
+            if self.queue_terminal_default_open_if_needed(entry) {
+                return Ok(());
+            }
+            if !crate::app::open_with::open_with_apps_found_for_entry(entry) {
+                self.status = "No app found".to_string();
+                return Ok(());
+            }
         }
 
         self.open_paths_in_system(vec![entry.path.clone()])

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -411,6 +411,9 @@ impl App {
                 return Ok(());
             }
             if !crate::app::open_with::open_with_apps_found_for_entry(&entry) {
+                if self.queue_editor_fallback_open_if_needed(&entry) {
+                    return Ok(());
+                }
                 self.status = "No app found".to_string();
                 return Ok(());
             }
@@ -427,6 +430,9 @@ impl App {
                 return Ok(());
             }
             if !crate::app::open_with::open_with_apps_found_for_entry(entry) {
+                if self.queue_editor_fallback_open_if_needed(entry) {
+                    return Ok(());
+                }
                 self.status = "No app found".to_string();
                 return Ok(());
             }
@@ -443,6 +449,20 @@ impl App {
             return false;
         };
 
+        self.queue_terminal_open(app)
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn queue_editor_fallback_open_if_needed(&mut self, entry: &Entry) -> bool {
+        let Some(app) = crate::app::open_with::editor_fallback_app_for_entry(entry) else {
+            return false;
+        };
+
+        self.queue_terminal_open(app)
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn queue_terminal_open(&mut self, app: crate::app::state::OpenWithApp) -> bool {
         self.pending_terminal_task = Some(crate::app::PendingTerminalTask::Command {
             program: app.program,
             args: app.args,

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -32,6 +32,42 @@ impl Drop for DefaultOpenWithAppGuard {
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
+struct OpenWithAppsFoundGuard;
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl OpenWithAppsFoundGuard {
+    fn install(found: bool) -> Self {
+        crate::app::open_with::set_open_with_apps_found_for_test(Some(found));
+        Self
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl Drop for OpenWithAppsFoundGuard {
+    fn drop(&mut self) {
+        crate::app::open_with::set_open_with_apps_found_for_test(None);
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+struct EditorFallbackAppGuard;
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl EditorFallbackAppGuard {
+    fn install(app: crate::app::state::OpenWithApp) -> Self {
+        crate::app::open_with::set_editor_fallback_app_for_test(Some(app));
+        Self
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+impl Drop for EditorFallbackAppGuard {
+    fn drop(&mut self) {
+        crate::app::open_with::set_editor_fallback_app_for_test(None);
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn fake_default_open_with_app(
     display_name: &str,
     program: &str,
@@ -768,6 +804,45 @@ fn open_action_keeps_system_opener_for_gui_default_app() {
     assert_eq!(opened, file_path.display().to_string());
     assert_eq!(app.pending_terminal_task, None);
     assert_eq!(app.status, format!("Opened {}", file_path.display()));
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn open_action_uses_editor_fallback_when_no_desktop_app_exists() {
+    let root = temp_path("open-editor-fallback-no-desktop");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let file_path = root.join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").expect("failed to write temp file");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture.clone());
+    let _found_guard = OpenWithAppsFoundGuard::install(false);
+    let _editor_guard = EditorFallbackAppGuard::install(fake_default_open_with_app(
+        "Helix ($VISUAL)",
+        "hx",
+        vec![file_path.display().to_string()],
+        true,
+    ));
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('o'))))
+        .expect("o should use editor fallback when no desktop app exists");
+
+    assert_eq!(
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Command {
+            program: "hx".to_string(),
+            args: vec![file_path.display().to_string()],
+        })
+    );
+    assert!(app.status.is_empty());
+    assert!(
+        !capture.exists(),
+        "system opener should not run when editor fallback is available"
+    );
 
     fs::remove_dir_all(root).ok();
 }

--- a/src/app/open_with/discovery/editor.rs
+++ b/src/app/open_with/discovery/editor.rs
@@ -1,0 +1,254 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use super::super::super::state::OpenWithApp;
+use super::exec::tokenize_exec;
+
+pub(super) fn append_editor_fallback(apps: &mut Vec<OpenWithApp>, path: &Path) {
+    if !super::super::path_is_text_like(path) {
+        return;
+    }
+
+    let Some(path_str) = path.to_str() else {
+        return;
+    };
+
+    for var in ["VISUAL", "EDITOR"] {
+        let Some(value) = env::var_os(var).and_then(|value| value.into_string().ok()) else {
+            continue;
+        };
+        let Some(app) = editor_app_from_command(var, &value, path_str) else {
+            continue;
+        };
+        if !duplicates_discovered_app(&app, apps) {
+            apps.push(app);
+        }
+        break;
+    }
+}
+
+fn editor_app_from_command(var: &str, command: &str, path_str: &str) -> Option<OpenWithApp> {
+    let mut tokens = tokenize_exec(command);
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let program = tokens.remove(0);
+    let resolved = resolve_executable(&program)?;
+    let program_name = resolved
+        .file_name()
+        .and_then(|name| name.to_str())
+        .or_else(|| {
+            Path::new(&program)
+                .file_name()
+                .and_then(|name| name.to_str())
+        })?;
+    let display_name = editor_display_name(program_name);
+
+    tokens.push(path_str.to_string());
+    Some(OpenWithApp {
+        display_name: format!("{display_name} (${var})"),
+        desktop_id: None,
+        program,
+        args: tokens,
+        is_default: false,
+        requires_terminal: true,
+    })
+}
+
+fn duplicates_discovered_app(editor: &OpenWithApp, apps: &[OpenWithApp]) -> bool {
+    let editor_program = program_key(&editor.program);
+    apps.iter()
+        .any(|app| program_key(&app.program) == editor_program)
+}
+
+fn program_key(program: &str) -> Option<String> {
+    let path = resolve_executable(program).unwrap_or_else(|| PathBuf::from(program));
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_ascii_lowercase())
+}
+
+fn resolve_executable(program: &str) -> Option<PathBuf> {
+    if program.is_empty() {
+        return None;
+    }
+
+    let program_path = Path::new(program);
+    if program_path.components().count() > 1 {
+        return executable_file_exists(program_path).then(|| canonical_path(program_path));
+    }
+
+    env::var_os("PATH").and_then(|paths| {
+        env::split_paths(&paths)
+            .map(|dir| dir.join(program))
+            .find(|path| executable_file_exists(path))
+            .map(|path| canonical_path(&path))
+    })
+}
+
+fn canonical_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn executable_file_exists(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+fn editor_display_name(program_name: &str) -> &str {
+    match program_name.to_ascii_lowercase().as_str() {
+        "nvim" => "Neovim",
+        "vim" => "Vim",
+        "vi" => "Vi",
+        "helix" => "Helix",
+        "micro" => "Micro",
+        "nano" => "Nano",
+        "emacs" => "Emacs",
+        "kak" | "kakoune" => "Kakoune",
+        _ => program_name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        ffi::OsString,
+        io::Write,
+        sync::{Mutex, OnceLock},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = env::var_os(key);
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = env::var_os(key);
+            unsafe {
+                env::remove_var(key);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.original.as_ref() {
+                Some(value) => unsafe {
+                    env::set_var(self.key, value);
+                },
+                None => unsafe {
+                    env::remove_var(self.key);
+                },
+            }
+        }
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        env::temp_dir().join(format!("elio-editor-fallback-{label}-{unique}"))
+    }
+
+    fn write_executable(path: &Path) {
+        let mut file = fs::File::create(path).expect("create executable");
+        writeln!(file, "#!/bin/sh").expect("write shebang");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = file.metadata().expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).expect("chmod executable");
+        }
+    }
+
+    #[test]
+    fn editor_fallback_adds_path_editor_for_text_files() {
+        let _lock = env_lock().lock().expect("lock env");
+        let root = temp_dir("adds-editor");
+        fs::create_dir_all(&root).expect("create root");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("create bin");
+        write_executable(&bin.join("hx"));
+        let file = root.join("note.txt");
+        fs::write(&file, "hello\n").expect("write text file");
+
+        let _path = EnvGuard::set("PATH", &bin);
+        let _visual = EnvGuard::remove("VISUAL");
+        let _editor = EnvGuard::set("EDITOR", "hx");
+
+        let mut apps = vec![OpenWithApp {
+            display_name: "Text Editor".to_string(),
+            desktop_id: Some("org.gnome.gedit.desktop".to_string()),
+            program: "gedit".to_string(),
+            args: vec![file.display().to_string()],
+            is_default: true,
+            requires_terminal: false,
+        }];
+        append_editor_fallback(&mut apps, &file);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(apps.len(), 2);
+        assert_eq!(apps[1].display_name, "hx ($EDITOR)");
+        assert_eq!(apps[1].program, "hx");
+        assert_eq!(apps[1].args, vec![file.display().to_string()]);
+        assert!(apps[1].requires_terminal);
+    }
+
+    #[test]
+    fn editor_fallback_dedupes_matching_program() {
+        let _lock = env_lock().lock().expect("lock env");
+        let root = temp_dir("dedupe");
+        fs::create_dir_all(&root).expect("create root");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("create bin");
+        write_executable(&bin.join("hx"));
+        let file = root.join("note.txt");
+        fs::write(&file, "hello\n").expect("write text file");
+
+        let _path = EnvGuard::set("PATH", &bin);
+        let _visual = EnvGuard::remove("VISUAL");
+        let _editor = EnvGuard::set("EDITOR", "hx");
+
+        let mut apps = vec![OpenWithApp {
+            display_name: "Helix".to_string(),
+            desktop_id: Some("Helix.desktop".to_string()),
+            program: bin.join("hx").display().to_string(),
+            args: vec![file.display().to_string()],
+            is_default: true,
+            requires_terminal: true,
+        }];
+        append_editor_fallback(&mut apps, &file);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(apps.len(), 1);
+    }
+}

--- a/src/app/open_with/discovery/editor.rs
+++ b/src/app/open_with/discovery/editor.rs
@@ -7,26 +7,31 @@ use super::super::super::state::OpenWithApp;
 use super::exec::tokenize_exec;
 
 pub(super) fn append_editor_fallback(apps: &mut Vec<OpenWithApp>, path: &Path) {
-    if !super::super::path_is_text_like(path) {
-        return;
-    }
-
-    let Some(path_str) = path.to_str() else {
+    let Some(app) = editor_fallback_for_path(path) else {
         return;
     };
+    if !duplicates_discovered_app(&app, apps) {
+        apps.push(app);
+    }
+}
+
+pub(super) fn editor_fallback_for_path(path: &Path) -> Option<OpenWithApp> {
+    if !super::super::path_is_text_like(path) {
+        return None;
+    }
+
+    let path_str = path.to_str()?;
 
     for var in ["VISUAL", "EDITOR"] {
         let Some(value) = env::var_os(var).and_then(|value| value.into_string().ok()) else {
             continue;
         };
-        let Some(app) = editor_app_from_command(var, &value, path_str) else {
-            continue;
-        };
-        if !duplicates_discovered_app(&app, apps) {
-            apps.push(app);
+        if let Some(app) = editor_app_from_command(var, &value, path_str) {
+            return Some(app);
         }
-        break;
     }
+
+    None
 }
 
 fn editor_app_from_command(var: &str, command: &str, path_str: &str) -> Option<OpenWithApp> {

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -21,23 +21,41 @@ use crate::core::Entry;
 // ── public entry point ────────────────────────────────────────────────────────
 
 pub(super) fn discover_open_with_apps_for_entry(entry: &Entry) -> Vec<OpenWithApp> {
-    discover_open_with_apps_inner(&entry.path, Some(entry.name.as_str()))
+    discover_open_with_apps_inner(&entry.path, Some(entry.name.as_str()), true)
 }
 
-fn discover_open_with_apps_inner(path: &Path, display_name: Option<&str>) -> Vec<OpenWithApp> {
+#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg_attr(test, allow(dead_code))]
+pub(super) fn discover_desktop_apps_for_entry(entry: &Entry) -> Vec<OpenWithApp> {
+    discover_open_with_apps_inner(&entry.path, Some(entry.name.as_str()), false)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg_attr(test, allow(dead_code))]
+pub(super) fn editor_fallback_app_for_entry(entry: &Entry) -> Option<OpenWithApp> {
+    editor::editor_fallback_for_path(&entry.path)
+}
+
+fn discover_open_with_apps_inner(
+    path: &Path,
+    display_name: Option<&str>,
+    include_editor_fallback: bool,
+) -> Vec<OpenWithApp> {
     #[cfg(target_os = "macos")]
     {
         let _ = display_name;
+        let _ = include_editor_fallback;
         macos::discover_via_nsworkspace(path)
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        discover_xdg(path, display_name)
+        discover_xdg(path, display_name, include_editor_fallback)
     }
     #[cfg(not(any(target_os = "macos", all(unix, not(target_os = "macos")))))]
     {
         let _ = path;
         let _ = display_name;
+        let _ = include_editor_fallback;
         vec![]
     }
 }
@@ -89,7 +107,11 @@ pub(super) fn current_desktops() -> Vec<String> {
 // ── XDG discovery (Linux / BSD) ───────────────────────────────────────────────
 
 #[cfg(all(unix, not(target_os = "macos")))]
-fn discover_xdg(path: &Path, display_name: Option<&str>) -> Vec<OpenWithApp> {
+fn discover_xdg(
+    path: &Path,
+    display_name: Option<&str>,
+    include_editor_fallback: bool,
+) -> Vec<OpenWithApp> {
     use std::time::{Duration, Instant};
 
     // 3-second budget for subprocess fallbacks; pure-Rust MIME lookup is
@@ -103,15 +125,16 @@ fn discover_xdg(path: &Path, display_name: Option<&str>) -> Vec<OpenWithApp> {
 
     // Primary: gio handles MIME inheritance (e.g. text/markdown → text/plain),
     // aliases, and added/removed associations from mimeapps.list.
-    let mut apps = if let Some(apps) = gio::discover_via_gio(&mime_type, path, &canceled)
-        && !apps.is_empty()
-    {
-        apps
-    } else {
-        // Fallback: manual desktop-file scan with exact MIME match.
-        scan::discover_via_desktop_scan(&mime_type, path)
+    let mut apps = match gio::discover_via_gio(&mime_type, path, &canceled) {
+        Some(apps) if !apps.is_empty() => apps,
+        _ => {
+            // Fallback: manual desktop-file scan with exact MIME match.
+            scan::discover_via_desktop_scan(&mime_type, path)
+        }
     };
 
-    editor::append_editor_fallback(&mut apps, path);
+    if include_editor_fallback {
+        editor::append_editor_fallback(&mut apps, path);
+    }
     apps
 }

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(all(unix, not(target_os = "macos")))]
 mod desktop_file;
+#[cfg(all(unix, not(target_os = "macos")))]
+mod editor;
 mod exec;
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -101,12 +103,15 @@ fn discover_xdg(path: &Path, display_name: Option<&str>) -> Vec<OpenWithApp> {
 
     // Primary: gio handles MIME inheritance (e.g. text/markdown → text/plain),
     // aliases, and added/removed associations from mimeapps.list.
-    if let Some(apps) = gio::discover_via_gio(&mime_type, path, &canceled)
+    let mut apps = if let Some(apps) = gio::discover_via_gio(&mime_type, path, &canceled)
         && !apps.is_empty()
     {
-        return apps;
-    }
+        apps
+    } else {
+        // Fallback: manual desktop-file scan with exact MIME match.
+        scan::discover_via_desktop_scan(&mime_type, path)
+    };
 
-    // Fallback: manual desktop-file scan with exact MIME match.
-    scan::discover_via_desktop_scan(&mime_type, path)
+    editor::append_editor_fallback(&mut apps, path);
+    apps
 }

--- a/src/app/open_with/mod.rs
+++ b/src/app/open_with/mod.rs
@@ -20,6 +20,8 @@ use crate::{
 #[cfg(all(test, unix, not(target_os = "macos")))]
 thread_local! {
     static TEST_DEFAULT_OPEN_WITH_APP: RefCell<Option<OpenWithApp>> = const { RefCell::new(None) };
+    static TEST_OPEN_WITH_APPS_FOUND: RefCell<Option<bool>> = const { RefCell::new(None) };
+    static TEST_EDITOR_FALLBACK_APP: RefCell<Option<OpenWithApp>> = const { RefCell::new(None) };
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -31,7 +33,7 @@ pub(in crate::app) fn default_open_with_app_for_entry(entry: &Entry) -> Option<O
     }
 
     #[cfg(not(test))]
-    discovery::discover_open_with_apps_for_entry(entry)
+    discovery::discover_desktop_apps_for_entry(entry)
         .into_iter()
         .find(|app| app.is_default)
 }
@@ -41,17 +43,41 @@ pub(in crate::app) fn set_default_open_with_app_for_test(app: Option<OpenWithApp
     TEST_DEFAULT_OPEN_WITH_APP.with(|slot| *slot.borrow_mut() = app);
 }
 
+#[cfg(all(test, unix, not(target_os = "macos")))]
+pub(in crate::app) fn set_open_with_apps_found_for_test(found: Option<bool>) {
+    TEST_OPEN_WITH_APPS_FOUND.with(|slot| *slot.borrow_mut() = found);
+}
+
+#[cfg(all(test, unix, not(target_os = "macos")))]
+pub(in crate::app) fn set_editor_fallback_app_for_test(app: Option<OpenWithApp>) {
+    TEST_EDITOR_FALLBACK_APP.with(|slot| *slot.borrow_mut() = app);
+}
+
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(in crate::app) fn open_with_apps_found_for_entry(entry: &Entry) -> bool {
     #[cfg(test)]
     {
         let _ = entry;
-        true
+        TEST_OPEN_WITH_APPS_FOUND.with(|slot| slot.borrow().unwrap_or(true))
     }
 
     #[cfg(not(test))]
     {
-        !discovery::discover_open_with_apps_for_entry(entry).is_empty()
+        !discovery::discover_desktop_apps_for_entry(entry).is_empty()
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(in crate::app) fn editor_fallback_app_for_entry(entry: &Entry) -> Option<OpenWithApp> {
+    #[cfg(test)]
+    {
+        let _ = entry;
+        TEST_EDITOR_FALLBACK_APP.with(|slot| slot.borrow().clone())
+    }
+
+    #[cfg(not(test))]
+    {
+        discovery::editor_fallback_app_for_entry(entry)
     }
 }
 

--- a/src/app/open_with/mod.rs
+++ b/src/app/open_with/mod.rs
@@ -41,6 +41,20 @@ pub(in crate::app) fn set_default_open_with_app_for_test(app: Option<OpenWithApp
     TEST_DEFAULT_OPEN_WITH_APP.with(|slot| *slot.borrow_mut() = app);
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(in crate::app) fn open_with_apps_found_for_entry(entry: &Entry) -> bool {
+    #[cfg(test)]
+    {
+        let _ = entry;
+        true
+    }
+
+    #[cfg(not(test))]
+    {
+        !discovery::discover_open_with_apps_for_entry(entry).is_empty()
+    }
+}
+
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(super) fn path_is_text_like(path: &Path) -> bool {
     let facts = inspect_path(path, EntryKind::File);

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -147,7 +147,7 @@ impl App {
                     self.status.clear();
                 } else {
                     match launch_app(&app) {
-                        Ok(()) => self.status.clear(),
+                        Ok(()) => self.status = format!("Opened with {}", app.display_name),
                         Err(_) => self.status = format!("Failed to open with {}", app.display_name),
                     }
                 }

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -4,11 +4,14 @@ use super::super::{
     App,
     state::{OpenWithApp, OpenWithOverlay, OpenWithRow, PendingTerminalTask},
 };
-use crate::fs::{detached_open_command, open_in_system};
+use crate::fs::detached_open_command;
+#[cfg(any(test, target_os = "macos", not(unix)))]
+use crate::fs::open_in_system;
 use anyhow::Result;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(in crate::app) enum FallbackOpenOutcome {
+    #[cfg_attr(all(unix, not(target_os = "macos"), not(test)), allow(dead_code))]
     DefaultApp,
     #[cfg(target_os = "macos")]
     TextEditor,
@@ -131,6 +134,7 @@ impl App {
                 Ok(FallbackOpenOutcome::TextEditor) => {
                     self.status = "No apps found, opened in text editor".to_string();
                 }
+                Err(e) if e == "No apps found" => self.status = e,
                 Err(e) => self.status = format!("Failed to open: {e}"),
             },
             1 => {
@@ -202,8 +206,16 @@ fn open_with_fallback(path: &Path) -> std::result::Result<FallbackOpenOutcome, S
         if super::path_is_text_like(path) {
             return open_in_text_editor(path).map(|()| FallbackOpenOutcome::TextEditor);
         }
+        return open_in_system(path).map(|()| FallbackOpenOutcome::DefaultApp);
     }
 
+    #[cfg(all(unix, not(target_os = "macos"), not(test)))]
+    {
+        let _ = path;
+        Err("No apps found".to_string())
+    }
+
+    #[cfg(any(not(unix), test))]
     open_in_system(path).map(|()| FallbackOpenOutcome::DefaultApp)
 }
 

--- a/src/app/open_with/tests.rs
+++ b/src/app/open_with/tests.rs
@@ -95,9 +95,9 @@ fn single_discovered_app_launches_without_opening_overlay() {
         app.overlays.open_with.is_none(),
         "overlay must remain closed"
     );
-    assert!(
-        app.status.is_empty(),
-        "successful launch should clear status"
+    assert_eq!(
+        app.status, "Opened with Fake App",
+        "successful direct launch should name the app"
     );
 
     fs::remove_dir_all(root).ok();


### PR DESCRIPTION
## Summary

Fixes Linux/BSD Open With behavior when a text/code editor is configured through `$VISUAL` or `$EDITOR` but is not registered as a desktop/MIME app.

Fixes #168

## What Changed

- Added `$VISUAL` / `$EDITOR` as a terminal Open With option for text/code files when the editor is valid and not already discovered.
- Split Linux/BSD desktop-app discovery from editor fallback discovery so normal open checks still use real desktop handlers.
- Kept `o` / `Enter` using desktop/system handlers first.
- Added a narrow `o` / `Enter` editor fallback only when no desktop handler exists for a single text/code file.
- Made Linux/BSD Open With report missing handlers accurately.
- Made direct single-app Open With launches report the app that was used.
- Added a changelog entry.

## User Impact

Users on Linux/BSD systems, including SSH or shared-host setups, can now use Open With (`O`) with editors configured only through `$VISUAL` or `$EDITOR`.

Normal `o` / `Enter` behavior still respects desktop defaults first. If no desktop handler exists for a text/code file, `o` / `Enter` falls back to the configured editor instead of reporting `No app found`.

## Notes

The editor fallback is only used as a fallback for normal open. Existing desktop handlers and defaults still take precedence.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks on Fedora:

- Tested with no `text/plain` default and standalone Helix available only through `$VISUAL` / `$EDITOR`, with no Helix desktop/MIME registration:
  - text/code files with no desktop handler open with Helix through both `o` / `Enter` and `O`
  - Markdown keeps opening with the configured Markdown app, while Open With shows both the Markdown app and Helix
- Tested with `nvim.desktop` as the `text/plain` default:
  - matching text/code files keep opening with Neovim through `o` / `Enter`
  - Open With shows Neovim plus Helix
  - files without a desktop handler still fall back to Helix
- Tested with `org.gnome.gedit.desktop` as the `text/plain` default:
  - matching text/code files keep opening with Gedit through `o` / `Enter`
  - Open With shows Gedit plus Helix
  - files without a desktop handler still fall back to Helix
- Tested with multiple discovered apps:
  - Open With shows all discovered desktop apps plus Helix
  - `o` / `Enter` keeps using the system/default desktop handler when one exists
- Tested with no valid editor fallback:
  - missing-handler cases report `No app found` instead of reporting a misleading successful open

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
