### PR TITLE
feat(open-with): add menu navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated shell integration scripts to pass `--chooser-file` invocations directly to `elio`, so chooser mode does not change the parent shell directory. Re-run `elio shell install` after upgrading to refresh existing shell integration.
+- Improved the Open With menu with keyboard navigation, scrolling, and an overflow scrollbar for long app lists.
 
 ### Fixed
 

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -294,7 +294,7 @@ impl App {
         Ok(())
     }
 
-    fn key_context(&self) -> crate::config::KeyContext {
+    pub(in crate::app) fn key_context(&self) -> crate::config::KeyContext {
         if self.navigation.in_trash || self.cwd_is_inside_trash_subfolder() {
             crate::config::KeyContext::Trash
         } else {

--- a/src/app/open_with/input.rs
+++ b/src/app/open_with/input.rs
@@ -1,5 +1,5 @@
 use super::super::App;
-use crate::fs::rect_contains;
+use crate::{config::Action, fs::rect_contains};
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
@@ -14,43 +14,55 @@ impl App {
             KeyCode::Esc => {
                 self.overlays.open_with = None;
             }
-            KeyCode::Char(ch)
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                if let Some(index) = self.open_with_row_index_for_shortcut(ch) {
-                    self.confirm_open_with_index(index)?;
-                }
-            }
-            _ => {}
+            _ => match crate::config::keys().action_for_key_in_context(key, self.key_context()) {
+                Some(Action::NavDown) => self.move_open_with_selection(1),
+                Some(Action::NavUp) => self.move_open_with_selection(-1),
+                Some(Action::OpenOrEnter) => self.confirm_selected_open_with_row()?,
+                _ => match key.code {
+                    KeyCode::Char(ch)
+                        if !key
+                            .modifiers
+                            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        if let Some(index) = self.open_with_row_index_for_shortcut(ch) {
+                            self.confirm_open_with_index(index)?;
+                        }
+                    }
+                    _ => {}
+                },
+            },
         }
 
         Ok(())
     }
 
     pub(in crate::app) fn handle_open_with_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
-        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
-            let inside = self
-                .input
-                .frame_state
-                .open_with_panel
-                .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
-            if !inside {
-                self.overlays.open_with = None;
-                return Ok(());
-            }
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                let inside = self
+                    .input
+                    .frame_state
+                    .open_with_panel
+                    .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
+                if !inside {
+                    self.overlays.open_with = None;
+                    return Ok(());
+                }
 
-            if let Some(hit) = self
-                .input
-                .frame_state
-                .open_with_hits
-                .iter()
-                .find(|hit| rect_contains(hit.rect, mouse.column, mouse.row))
-                .cloned()
-            {
-                self.confirm_open_with_index(hit.index)?;
+                if let Some(hit) = self
+                    .input
+                    .frame_state
+                    .open_with_hits
+                    .iter()
+                    .find(|hit| rect_contains(hit.rect, mouse.column, mouse.row))
+                    .cloned()
+                {
+                    self.confirm_open_with_index(hit.index)?;
+                }
             }
+            MouseEventKind::ScrollDown => self.move_open_with_selection(1),
+            MouseEventKind::ScrollUp => self.move_open_with_selection(-1),
+            _ => {}
         }
 
         Ok(())
@@ -59,10 +71,10 @@ impl App {
     fn open_with_row_index_for_shortcut(&self, ch: char) -> Option<usize> {
         let needle = ch.to_ascii_lowercase();
         self.overlays.open_with.as_ref().and_then(|overlay| {
-            overlay
-                .rows
-                .iter()
-                .position(|row| row.shortcut.to_ascii_lowercase() == needle)
+            overlay.rows.iter().position(|row| {
+                row.shortcut
+                    .is_some_and(|shortcut| shortcut.to_ascii_lowercase() == needle)
+            })
         })
     }
 }

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -54,7 +54,15 @@ impl App {
             .open_with
             .as_ref()
             .and_then(|overlay| overlay.rows.get(index))
-            .map(|row| row.shortcut)
+            .and_then(|row| row.shortcut)
+    }
+
+    pub fn open_with_selected_index(&self) -> usize {
+        self.overlays
+            .open_with
+            .as_ref()
+            .map(|overlay| overlay.selected)
+            .unwrap_or(0)
     }
 }
 
@@ -154,19 +162,48 @@ impl App {
             }
             _ => {
                 self.overlays.help = false;
-                self.overlays.open_with = Some(build_open_with_overlay(apps));
+                self.overlays.open_with = Some(build_open_with_overlay(
+                    apps,
+                    &crate::config::keys().open_with_reserved_shortcuts(),
+                ));
                 self.status.clear();
             }
         }
     }
+
+    pub(in crate::app) fn move_open_with_selection(&mut self, delta: isize) {
+        let Some(overlay) = self.overlays.open_with.as_mut() else {
+            return;
+        };
+        if overlay.rows.is_empty() {
+            overlay.selected = 0;
+            return;
+        }
+
+        let max = overlay.rows.len().saturating_sub(1) as isize;
+        overlay.selected = (overlay.selected as isize + delta).clamp(0, max) as usize;
+    }
+
+    pub(in crate::app) fn confirm_selected_open_with_row(&mut self) -> Result<()> {
+        let Some(index) = self
+            .overlays
+            .open_with
+            .as_ref()
+            .map(|overlay| overlay.selected)
+        else {
+            return Ok(());
+        };
+
+        self.confirm_open_with_index(index)
+    }
 }
 
-fn build_open_with_overlay(apps: Vec<OpenWithApp>) -> OpenWithOverlay {
+fn build_open_with_overlay(apps: Vec<OpenWithApp>, reserved_shortcuts: &[char]) -> OpenWithOverlay {
+    let mut shortcuts = open_with_shortcuts(reserved_shortcuts);
     let rows = apps
         .into_iter()
-        .enumerate()
-        .filter_map(|(index, app)| {
-            let shortcut = assign_shortcut(index)?;
+        .map(|app| {
+            let shortcut = shortcuts.next();
             let mut label = app.display_name.clone();
             if app.requires_terminal {
                 label.push_str(" (terminal)");
@@ -174,30 +211,27 @@ fn build_open_with_overlay(apps: Vec<OpenWithApp>) -> OpenWithOverlay {
             if app.is_default {
                 label.push_str(" (default)");
             }
-            Some(OpenWithRow {
+            OpenWithRow {
                 shortcut,
                 label,
                 app,
-            })
+            }
         })
         .collect();
 
     OpenWithOverlay {
         title: "Open With".to_string(),
         rows,
+        selected: 0,
     }
 }
 
-/// Assigns a keyboard shortcut for the row at `index`.
-/// Slots 0–8 → `'1'`–`'9'`, slots 9–34 → `'a'`–`'z'`.
-fn assign_shortcut(index: usize) -> Option<char> {
-    if index < 9 {
-        char::from_digit((index + 1) as u32, 10)
-    } else if index < 9 + 26 {
-        Some((b'a' + (index - 9) as u8) as char)
-    } else {
-        None
-    }
+const OPEN_WITH_SHORTCUTS: &str = "123456789abcdefghijklmnopqrstuvwxyz";
+
+fn open_with_shortcuts(reserved: &[char]) -> impl Iterator<Item = char> + '_ {
+    OPEN_WITH_SHORTCUTS
+        .chars()
+        .filter(move |shortcut| !reserved.contains(shortcut))
 }
 
 fn open_with_fallback(path: &Path) -> std::result::Result<FallbackOpenOutcome, String> {
@@ -251,21 +285,40 @@ impl App {
         args: Vec<String>,
         requires_terminal: bool,
     ) {
+        self.inject_open_with_rows_for_test(vec![(
+            display_name.to_string(),
+            program.to_string(),
+            args,
+            requires_terminal,
+        )]);
+    }
+
+    pub(crate) fn inject_open_with_rows_for_test(
+        &mut self,
+        rows: Vec<(String, String, Vec<String>, bool)>,
+    ) {
         use super::super::state::{OpenWithApp, OpenWithOverlay, OpenWithRow};
         self.overlays.open_with = Some(OpenWithOverlay {
             title: "Open With".to_string(),
-            rows: vec![OpenWithRow {
-                shortcut: '1',
-                label: display_name.to_string(),
-                app: OpenWithApp {
-                    display_name: display_name.to_string(),
-                    desktop_id: None,
-                    program: program.to_string(),
-                    args,
-                    is_default: false,
-                    requires_terminal,
-                },
-            }],
+            rows: rows
+                .into_iter()
+                .enumerate()
+                .map(
+                    |(index, (display_name, program, args, requires_terminal))| OpenWithRow {
+                        shortcut: char::from_digit((index + 1) as u32, 10),
+                        label: display_name.clone(),
+                        app: OpenWithApp {
+                            display_name,
+                            desktop_id: None,
+                            program,
+                            args,
+                            is_default: false,
+                            requires_terminal,
+                        },
+                    },
+                )
+                .collect(),
+            selected: 0,
         });
     }
 }

--- a/src/app/open_with/tests.rs
+++ b/src/app/open_with/tests.rs
@@ -6,6 +6,7 @@ use super::{
     overlay::FallbackOpenOutcome,
     path_is_text_like,
 };
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use std::{
     cell::{Cell, RefCell},
     fs,
@@ -177,6 +178,140 @@ fn confirm_terminal_app_from_overlay_queues_pending_command() {
     // The first row is the terminal app. Confirm it.
     app.confirm_open_with_index(0)
         .expect("confirm should not error");
+
+    assert!(app.overlays.open_with.is_none(), "overlay must close");
+    assert_eq!(
+        app.pending_terminal_task,
+        Some(PendingTerminalTask::Command {
+            program: "nvim".to_string(),
+            args: vec!["/tmp/file.txt".to_string()],
+        })
+    );
+    assert!(app.status.is_empty());
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn open_with_nav_keys_move_selection() {
+    let root = temp_dir_path("nav-keys-root");
+    fs::create_dir_all(&root).expect("create temp root");
+    let path = root.join("file.txt");
+    fs::write(&path, "hello").expect("write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("create app");
+    app.handle_discovered_open_with_apps(
+        &path,
+        vec![fake_open_with_app("Gedit"), fake_terminal_app("Neovim")],
+        |_| unreachable!(),
+        |_| unreachable!(),
+    );
+
+    assert_eq!(app.open_with_selected_index(), 0);
+
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Char('j')))
+        .expect("nav_down should be handled");
+    assert_eq!(app.open_with_selected_index(), 1);
+
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Char('j')))
+        .expect("nav_down should clamp");
+    assert_eq!(app.open_with_selected_index(), 1);
+
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Char('k')))
+        .expect("nav_up should be handled");
+    assert_eq!(app.open_with_selected_index(), 0);
+
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Char('k')))
+        .expect("nav_up should clamp");
+    assert_eq!(app.open_with_selected_index(), 0);
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn open_with_shortcuts_skip_nav_keys_without_dropping_rows() {
+    let root = temp_dir_path("shortcut-precedence-root");
+    fs::create_dir_all(&root).expect("create temp root");
+    let path = root.join("file.txt");
+    fs::write(&path, "hello").expect("write temp file");
+
+    let apps: Vec<_> = (0..40)
+        .map(|index| fake_open_with_app(&format!("App {index}")))
+        .collect();
+
+    let mut app = App::new_at(root.clone()).expect("create app");
+    app.handle_discovered_open_with_apps(&path, apps, |_| unreachable!(), |_| unreachable!());
+
+    assert_eq!(app.open_with_row_count(), 40);
+    assert!(
+        (0..app.open_with_row_count())
+            .all(|index| { !matches!(app.open_with_row_shortcut(index), Some('j' | 'k')) })
+    );
+
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Char('j')))
+        .expect("nav_down should be handled");
+
+    assert!(app.overlays.open_with.is_some(), "overlay must stay open");
+    assert_eq!(app.open_with_selected_index(), 1);
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn open_with_mouse_wheel_moves_selection() {
+    let root = temp_dir_path("mouse-wheel-root");
+    fs::create_dir_all(&root).expect("create temp root");
+    let path = root.join("file.txt");
+    fs::write(&path, "hello").expect("write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("create app");
+    app.handle_discovered_open_with_apps(
+        &path,
+        vec![fake_open_with_app("Gedit"), fake_terminal_app("Neovim")],
+        |_| unreachable!(),
+        |_| unreachable!(),
+    );
+
+    app.handle_open_with_mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    })
+    .expect("wheel down should be handled");
+    assert_eq!(app.open_with_selected_index(), 1);
+
+    app.handle_open_with_mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    })
+    .expect("wheel up should be handled");
+    assert_eq!(app.open_with_selected_index(), 0);
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn open_with_open_or_enter_confirms_selected_row() {
+    let root = temp_dir_path("nav-confirm-root");
+    fs::create_dir_all(&root).expect("create temp root");
+    let path = root.join("file.txt");
+    fs::write(&path, "hello").expect("write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("create app");
+    app.handle_discovered_open_with_apps(
+        &path,
+        vec![fake_open_with_app("Gedit"), fake_terminal_app("Neovim")],
+        |_| unreachable!(),
+        |_| unreachable!(),
+    );
+
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Char('j')))
+        .expect("nav_down should be handled");
+    app.handle_open_with_key(KeyEvent::from(KeyCode::Enter))
+        .expect("open_or_enter should confirm selection");
 
     assert!(app.overlays.open_with.is_none(), "overlay must close");
     assert_eq!(

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -253,7 +253,7 @@ pub(super) struct OpenWithApp {
 
 #[derive(Clone, Debug)]
 pub(super) struct OpenWithRow {
-    pub(super) shortcut: char,
+    pub(super) shortcut: Option<char>,
     pub(super) label: String,
     pub(super) app: OpenWithApp,
 }
@@ -262,6 +262,7 @@ pub(super) struct OpenWithRow {
 pub(super) struct OpenWithOverlay {
     pub(super) title: String,
     pub(super) rows: Vec<OpenWithRow>,
+    pub(super) selected: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -385,6 +385,12 @@ impl KeyList {
             _ => None,
         }
     }
+
+    pub(crate) fn single_chars(&self) -> impl Iterator<Item = char> + '_ {
+        self.0
+            .iter()
+            .filter_map(|spec| spec.single_char().map(|ch| ch.to_ascii_lowercase()))
+    }
 }
 
 impl std::fmt::Display for KeyList {
@@ -641,6 +647,14 @@ impl KeyBindings {
         }
         self.action_for_key_in_context(key, context)
             .map(ChooserKeyAction::Normal)
+    }
+
+    pub(crate) fn open_with_reserved_shortcuts(&self) -> Vec<char> {
+        self.nav_down
+            .single_chars()
+            .chain(self.nav_up.single_chars())
+            .chain(self.open_or_enter.single_chars())
+            .collect()
     }
 
     fn bindings(&self) -> [(&KeyList, Action); 43] {

--- a/src/config/tests/keys.rs
+++ b/src/config/tests/keys.rs
@@ -1198,6 +1198,25 @@ open_with = "w"
 }
 
 #[test]
+fn open_with_reserved_shortcuts_follow_custom_menu_controls() {
+    let config = Config::from_str(
+        r#"
+[keys]
+nav_down = "n"
+nav_up = "m"
+nav_right = []
+open_or_enter = ["enter", "l", "right"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config.keys.open_with_reserved_shortcuts(),
+        vec!['n', 'm', 'l']
+    );
+}
+
+#[test]
 fn open_or_enter_defaults_to_enter() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -987,6 +987,62 @@ fn open_with_overlay_renders_expected_hits() {
 }
 
 #[test]
+fn open_with_overlay_draws_scrollbar_only_when_rows_overflow() {
+    let root = temp_path("open-with-overlay-scrollbar");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("document.txt"), "hello\n").expect("failed to write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    let mut terminal = Terminal::new(TestBackend::new(90, 12)).expect("terminal should init");
+
+    app.inject_open_with_for_test("Text Editor", "/usr/bin/true", vec![], false);
+    let state = draw_ui(&mut terminal, &mut app);
+    let panel = state
+        .open_with_panel
+        .expect("open-with panel should render");
+    let inner = helpers::inner_with_padding(panel);
+    let right_column = (inner.y..inner.y + inner.height)
+        .map(|y| terminal.backend().buffer()[(inner.x + inner.width - 1, y)].symbol())
+        .collect::<String>();
+    assert!(
+        !right_column.contains('┃'),
+        "single-row open-with overlay should not draw a scrollbar"
+    );
+
+    app.inject_open_with_rows_for_test(
+        (0..20)
+            .map(|index| {
+                (
+                    format!("App {index}"),
+                    "/usr/bin/true".to_string(),
+                    Vec::new(),
+                    false,
+                )
+            })
+            .collect(),
+    );
+    let state = draw_ui(&mut terminal, &mut app);
+    let panel = state
+        .open_with_panel
+        .expect("open-with panel should render");
+    let inner = helpers::inner_with_padding(panel);
+    let right_column = (inner.y..inner.y + inner.height)
+        .map(|y| terminal.backend().buffer()[(inner.x + inner.width - 1, y)].symbol())
+        .collect::<String>();
+
+    assert!(
+        right_column.contains('┃'),
+        "overflowing open-with overlay should draw a scrollbar thumb"
+    );
+    assert!(
+        right_column.contains('│'),
+        "overflowing open-with overlay should draw a scrollbar track"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn trash_overlay_tabs_focus_between_confirm_and_cancel_buttons() {
     let root = temp_path("trash-overlay-focus");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/ui/overlay_manager/open_with.rs
+++ b/src/ui/overlay_manager/open_with.rs
@@ -3,7 +3,7 @@ use crate::ui::{helpers, theme::Palette};
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
-    style::Style,
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
@@ -16,10 +16,10 @@ pub(super) fn render_open_with_overlay(
     palette: Palette,
 ) {
     let row_count = app.open_with_row_count().max(1);
-    // border (2) + padding top/bottom (2) + one line per row
-    let popup_height = (row_count as u16 + 4)
+    // border (2) + one line per row
+    let popup_height = (row_count as u16 + 2)
         .min(area.height.saturating_sub(2))
-        .max(4);
+        .max(3);
     let popup_width = area.width.saturating_sub(8).clamp(48, 72);
     let popup = Rect {
         x: area.x + area.width.saturating_sub(popup_width) / 2,
@@ -45,37 +45,148 @@ pub(super) fn render_open_with_overlay(
     );
 
     let inner = helpers::inner_with_padding(popup);
+    let row_count = app.open_with_row_count();
+    let needs_scrollbar = row_count > inner.height as usize;
+    let (rows_area, scrollbar_area) = if needs_scrollbar && inner.width >= 6 {
+        (
+            Rect {
+                width: inner.width.saturating_sub(1),
+                ..inner
+            },
+            Some(Rect {
+                x: inner.x + inner.width.saturating_sub(1),
+                width: 1,
+                ..inner
+            }),
+        )
+    } else {
+        (inner, None)
+    };
+    let visible_rows = rows_area.height as usize;
+    let scroll_top = open_with_scroll_top(app.open_with_selected_index(), row_count, visible_rows);
 
-    for index in 0..app.open_with_row_count() {
+    for (visible_index, index) in (scroll_top..row_count).enumerate() {
         let rect = Rect {
-            x: inner.x,
-            y: inner.y + index as u16,
-            width: inner.width,
+            x: rows_area.x,
+            y: rows_area.y + visible_index as u16,
+            width: rows_area.width,
             height: 1,
         };
-        if rect.y >= inner.y + inner.height {
+        if rect.y >= rows_area.y + rows_area.height {
             break;
         }
 
         let shortcut = app
             .open_with_row_shortcut(index)
-            .unwrap_or('?')
-            .to_ascii_lowercase();
+            .map(|shortcut| shortcut.to_ascii_lowercase().to_string())
+            .unwrap_or_else(|| " ".to_string());
         let label = helpers::clamp_label(
             app.open_with_row_label(index),
-            inner.width.saturating_sub(6) as usize,
+            rows_area.width.saturating_sub(6) as usize,
         );
+        let selected = index == app.open_with_selected_index();
+        let row_style = if selected {
+            Style::default().bg(palette.selected_bg).fg(palette.text)
+        } else {
+            Style::default().bg(palette.chrome_alt).fg(palette.text)
+        };
+        let shortcut_style = if selected {
+            Style::default().fg(palette.accent_text)
+        } else {
+            Style::default().fg(palette.accent)
+        };
+        let arrow_style = if selected {
+            Style::default().fg(palette.text)
+        } else {
+            Style::default().fg(palette.muted)
+        };
 
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled(shortcut.to_string(), Style::default().fg(palette.accent)),
-                Span::styled(" -> ", Style::default().fg(palette.muted)),
+                Span::styled(shortcut, shortcut_style),
+                Span::styled(" -> ", arrow_style),
                 Span::styled(label, Style::default().fg(palette.text)),
             ]))
-            .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
+            .style(row_style),
             rect,
         );
 
         state.open_with_hits.push(OpenWithHit { rect, index });
     }
+
+    if let Some(scrollbar) = scrollbar_area {
+        render_open_with_scrollbar(
+            frame,
+            scrollbar,
+            row_count,
+            visible_rows,
+            scroll_top,
+            palette,
+        );
+    }
+}
+
+fn render_open_with_scrollbar(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    total_rows: usize,
+    visible_rows: usize,
+    scroll_top: usize,
+    palette: Palette,
+) {
+    if area.height == 0 || total_rows <= visible_rows.max(1) {
+        return;
+    }
+
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "│",
+                Style::default().fg(palette.border)
+            ));
+            area.height as usize
+        ])
+        .style(Style::default().bg(palette.chrome_alt)),
+        area,
+    );
+
+    let thumb_height = ((visible_rows.max(1) * area.height as usize) / total_rows)
+        .max(1)
+        .min(area.height as usize);
+    let max_scroll = total_rows.saturating_sub(visible_rows.max(1));
+    let thumb_max_top = area.height as usize - thumb_height;
+    let thumb_top = scroll_top
+        .checked_mul(thumb_max_top)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
+
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "┃",
+                Style::default()
+                    .fg(palette.accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            thumb_height
+        ])
+        .style(Style::default().bg(palette.chrome_alt)),
+        Rect {
+            x: area.x,
+            y: area.y + thumb_top as u16,
+            width: area.width,
+            height: thumb_height as u16,
+        },
+    );
+}
+
+fn open_with_scroll_top(selected: usize, row_count: usize, visible_rows: usize) -> usize {
+    if visible_rows == 0 || row_count <= visible_rows {
+        return 0;
+    }
+
+    selected
+        .saturating_add(1)
+        .saturating_sub(visible_rows)
+        .min(row_count.saturating_sub(visible_rows))
 }


### PR DESCRIPTION
## Summary

Improves the Open With menu so long app lists behave like a navigable menu instead of a shortcut-only list.

## What Changed

- Added selected-row navigation for the Open With menu.
- Let configured navigation keys move through apps and `Enter` confirm the selected app.
- Added mouse-wheel scrolling for long app lists.
- Added an overflow scrollbar when not all apps fit in the menu.
- Kept apps reachable even when no shortcut key is assigned.

## User Impact

Open With is easier to use, especially with many apps or in low-height terminals. Users can navigate with keys, scroll through long lists, and see when more apps are available.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Checked the Open With menu with long app lists and low terminal height.
- Verified keyboard navigation, Enter confirmation, scrolling, scrollbar visibility, and no dead space under the last visible app.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
