### PR TITLE
fix(browser): keep folder counts live while scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the active sidebar item highlight in the terminal ANSI and transparent example themes.
 - Fixed UI freezes when selecting all items in very large folders.
 - Fixed Linux/BSD Open With (`O`) behavior by reporting missing handlers accurately, showing the app used for direct single-app launches, and offering `$VISUAL` or `$EDITOR` in the current terminal for text/code files when the editor is not registered as a desktop app; `o` / `Enter` uses the same editor fallback only when no desktop handler is available. ([#168])
+- Fixed folder item counts lagging behind during fast mouse-wheel navigation.
 
 ## [1.8.0] - 2026-06-06
 

--- a/src/app/directory_counts.rs
+++ b/src/app/directory_counts.rs
@@ -54,18 +54,16 @@ impl App {
             return;
         }
         self.navigation.directory_count_viewport = Some(viewport);
-        self.navigation.directory_item_count_ready_at =
-            Some(Instant::now() + DIRECTORY_ITEM_COUNT_IDLE_DELAY);
+        self.navigation
+            .directory_item_count_ready_at
+            .get_or_insert_with(|| Instant::now() + DIRECTORY_ITEM_COUNT_IDLE_DELAY);
     }
 
     pub(crate) fn process_directory_item_count_timer(&mut self) -> bool {
         let Some(deadline) = self.navigation.directory_item_count_ready_at else {
             return false;
         };
-        if Instant::now() < deadline
-            || self.browser_wheel_burst_active()
-            || self.preview.state.deferred_refresh_at.is_some()
-        {
+        if Instant::now() < deadline {
             return false;
         }
 

--- a/src/app/input/tests/browser_wheel.rs
+++ b/src/app/input/tests/browser_wheel.rs
@@ -1,6 +1,23 @@
 use super::super::*;
 use super::helpers::temp_path;
-use std::{fs, thread, time::Duration};
+use std::{
+    fs, thread,
+    time::{Duration, Instant},
+};
+
+fn wait_for_selected_directory_count(app: &mut App) {
+    for _ in 0..100 {
+        let _ = app.process_background_jobs();
+        if app
+            .selected_entry()
+            .is_some_and(|entry| app.directory_item_count_label(entry).is_some())
+        {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for selected directory count");
+}
 
 #[test]
 fn wheel_burst_smoothing_coalesces_dense_input() {
@@ -292,6 +309,146 @@ fn browser_wheel_preserves_preview_when_selection_does_not_change() {
     assert_eq!(app.navigation.scroll_row, 0);
     assert_eq!(app.navigation.selected, 0);
     assert_eq!(app.preview.state.token, initial_preview_token);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn high_frequency_browser_wheel_keeps_visible_directory_counts_live_during_burst() {
+    let root = temp_path("wheel-directory-count-live");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    for index in 0..3 {
+        let dir = root.join(format!("dir-{index}"));
+        fs::create_dir_all(&dir).expect("failed to create child directory");
+        fs::write(dir.join("child.txt"), "child").expect("failed to write child file");
+    }
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    app.input.wheel_profile = WheelProfile::HighFrequency;
+    app.select_index(0);
+    let frame_state = FrameState {
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 8,
+        }),
+        metrics: ViewMetrics {
+            cols: 1,
+            rows_visible: 1,
+        },
+        ..FrameState::default()
+    };
+    app.set_frame_state(frame_state.clone());
+
+    app.handle_event(Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 1,
+        row: 1,
+        modifiers: KeyModifiers::NONE,
+    }))
+    .expect("scroll down should be handled");
+    assert!(app.browser_wheel_burst_active());
+    app.set_frame_state(frame_state);
+
+    thread::sleep(DIRECTORY_ITEM_COUNT_IDLE_DELAY + Duration::from_millis(10));
+    assert!(app.browser_wheel_burst_active());
+    let _ = app.process_directory_item_count_timer();
+    wait_for_selected_directory_count(&mut app);
+
+    let selected = app.selected_entry().expect("selection should exist");
+    assert_eq!(selected.name, "dir-1");
+    assert_eq!(
+        app.directory_item_count_label(selected).as_deref(),
+        Some("1 item")
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn directory_count_timer_uses_latest_viewport_without_debouncing_every_scroll_step() {
+    let root = temp_path("directory-count-throttle-latest");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    for index in 0..3 {
+        let dir = root.join(format!("dir-{index}"));
+        fs::create_dir_all(&dir).expect("failed to create child directory");
+        fs::write(dir.join("child.txt"), "child").expect("failed to write child file");
+    }
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    let frame_state = FrameState {
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 8,
+        }),
+        metrics: ViewMetrics {
+            cols: 1,
+            rows_visible: 1,
+        },
+        ..FrameState::default()
+    };
+    app.select_index(0);
+    app.set_frame_state(frame_state.clone());
+
+    thread::sleep(DIRECTORY_ITEM_COUNT_IDLE_DELAY / 2);
+    app.select_index(1);
+    app.set_frame_state(frame_state);
+    thread::sleep(DIRECTORY_ITEM_COUNT_IDLE_DELAY / 2 + Duration::from_millis(10));
+
+    let _ = app.process_directory_item_count_timer();
+    wait_for_selected_directory_count(&mut app);
+
+    let selected = app.selected_entry().expect("selection should exist");
+    assert_eq!(selected.name, "dir-1");
+    assert_eq!(
+        app.directory_item_count_label(selected).as_deref(),
+        Some("1 item")
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn directory_count_timer_is_not_blocked_by_deferred_preview_refresh() {
+    let root = temp_path("directory-count-preview-deferred");
+    let dir = root.join("dir");
+    fs::create_dir_all(&dir).expect("failed to create child directory");
+    fs::write(dir.join("child.txt"), "child").expect("failed to write child file");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.view_mode = ViewMode::List;
+    app.select_index(0);
+    app.set_frame_state(FrameState {
+        entries_panel: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 8,
+        }),
+        metrics: ViewMetrics {
+            cols: 1,
+            rows_visible: 1,
+        },
+        ..FrameState::default()
+    });
+    app.preview.state.deferred_refresh_at =
+        Some(Instant::now() + HIGH_FREQUENCY_PREVIEW_REFRESH_DELAY);
+
+    thread::sleep(DIRECTORY_ITEM_COUNT_IDLE_DELAY + Duration::from_millis(10));
+    let _ = app.process_directory_item_count_timer();
+    wait_for_selected_directory_count(&mut app);
+
+    let selected = app.selected_entry().expect("selection should exist");
+    assert_eq!(
+        app.directory_item_count_label(selected).as_deref(),
+        Some("1 item")
+    );
+    assert!(app.preview.state.deferred_refresh_at.is_some());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/input/tests/browser_wheel.rs
+++ b/src/app/input/tests/browser_wheel.rs
@@ -352,7 +352,7 @@ fn high_frequency_browser_wheel_keeps_visible_directory_counts_live_during_burst
     assert!(app.browser_wheel_burst_active());
     app.set_frame_state(frame_state);
 
-    thread::sleep(DIRECTORY_ITEM_COUNT_IDLE_DELAY + Duration::from_millis(10));
+    app.navigation.directory_item_count_ready_at = Some(Instant::now());
     assert!(app.browser_wheel_burst_active());
     let _ = app.process_directory_item_count_timer();
     wait_for_selected_directory_count(&mut app);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -66,9 +66,7 @@ impl App {
             self.refresh_preview();
             dirty = true;
         }
-        if !self.browser_wheel_burst_active() {
-            self.queue_visible_directory_item_counts();
-        }
+        self.queue_visible_directory_item_counts();
         self.refresh_static_image_preloads_if_needed();
         self.remember_current_directory_view();
         dirty

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -249,7 +249,7 @@ fn open_with_fallback(path: &Path) -> std::result::Result<FallbackOpenOutcome, S
         Err("No apps found".to_string())
     }
 
-    #[cfg(any(not(unix), test))]
+    #[cfg(all(any(not(unix), test), not(target_os = "macos")))]
     open_in_system(path).map(|()| FallbackOpenOutcome::DefaultApp)
 }
 

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -293,6 +293,14 @@ impl App {
         self.preview.terminal_images.identity = identity;
     }
 
+    /// Pushes the resize-settle deadline far enough into the future that tests
+    /// can assert pending-settle behavior without depending on scheduler timing.
+    #[cfg(test)]
+    pub(in crate::app) fn defer_terminal_image_resize_settle_for_tests(&mut self) {
+        self.preview.terminal_images.resize_settled_at =
+            Some(Instant::now() + Duration::from_secs(60));
+    }
+
     /// Jumps past the resize-settle window so tests can exercise the placement
     /// that follows a resize without waiting out the real delay.
     #[cfg(test)]

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -697,6 +697,7 @@ fn resize_settle_holds_image_placement_until_window_expires() {
 
     app.handle_terminal_image_resize();
     configure_iterm_image_support(&mut app);
+    app.defer_terminal_image_resize_settle_for_tests();
     assert!(
         !app.process_terminal_image_resize_settle_timer(),
         "settle timer should still be pending immediately after a resize"


### PR DESCRIPTION
## Summary

Fixes folder item counts lagging behind during fast mouse-wheel navigation.

## What Changed

- Keep visible folder item-count scheduling active during high-frequency wheel scrolling.
- Submit count jobs on the existing short timer without resetting it on every viewport change.
- Keep directory item counts independent from deferred preview refreshes.
- Silence a macOS test-build unreachable-code warning in the Open With fallback path.

## User Impact

Folder item counts now appear much sooner while scrolling quickly instead of mostly updating after navigation stops.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested fast navigation in folders with many subfolders and confirmed folder item counts update much sooner while scrolling.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
