### PR TITLE
fix(chooser): confirm double-clicked items and flush stdout output

### DIFF
--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -106,7 +106,11 @@ impl App {
                     };
                     self.select_index(hit.index);
                     if self.is_double_click(&path) {
-                        self.open_entry_at_index(hit.index)?;
+                        if self.chooser_mode {
+                            self.confirm_chooser_path(&path);
+                        } else {
+                            self.open_entry_at_index(hit.index)?;
+                        }
                     }
                     self.input.last_click = Some(ClickState {
                         path,

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -90,6 +90,16 @@ impl App {
         self.should_quit = true;
     }
 
+    pub(in crate::app) fn confirm_chooser_path(&mut self, path: &Path) {
+        if !self.chooser_mode {
+            return;
+        }
+        self.chooser_exit = Some(ChooserExit::Confirmed(vec![
+            self.absolute_chooser_path(path),
+        ]));
+        self.should_quit = true;
+    }
+
     pub(in crate::app) fn cancel_chooser(&mut self) {
         if !self.chooser_mode {
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ fn run_with_startup_state(
         reveal_hidden_start_focus,
         chooser_file.is_some(),
     );
-    restore_terminal(&mut terminal)?;
+    restore_terminal(&mut terminal, &drainer)?;
     let app_exit = result?;
     if let Some(final_cwd) = app_exit.final_cwd {
         write_cwd_file_if_requested(cwd_file.as_deref(), &final_cwd)?;
@@ -459,7 +459,7 @@ fn apply_zoxide_query_result(app: &mut App, result: zoxide::QueryResult) {
     }
 }
 
-fn restore_terminal(terminal: &mut AppTerminal) -> Result<()> {
+fn restore_terminal(terminal: &mut AppTerminal, drainer: &Drainer) -> Result<()> {
     // Disable in reverse order and do it before leaving the alternate screen so the
     // terminal processes the escape sequences while still in the right mode.
     let backend = terminal.backend_mut();
@@ -476,9 +476,8 @@ fn restore_terminal(terminal: &mut AppTerminal) -> Result<()> {
     )?;
     disable_raw_mode()?;
     terminal.show_cursor()?;
-    // Remaining queued bytes (these restore writes included) are flushed when the
-    // terminal — and with it the ThreadedWriter — is dropped right after run()
-    // returns; ThreadedWriter::drop drains the writer thread before exit.
+    terminal.backend_mut().flush()?;
+    drainer.drain();
     Ok(())
 }
 

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -75,7 +75,14 @@ pub(super) fn render_help(
     ]);
     let mouse_entries = vec![
         e("Click", "select item"),
-        e("Double-click", "open item"),
+        e(
+            "Double-click",
+            if mode.is_chooser() {
+                "confirm clicked item"
+            } else {
+                "open item"
+            },
+        ),
         e("Wheel", "scroll"),
         e("Shift+Wheel", "scroll sideways"),
     ];


### PR DESCRIPTION
## Summary

Fix chooser-mode double-click behavior and make `--chooser-file -` stdout output reliable.

## What Changed

- Confirm the clicked item on chooser-mode double-click instead of opening or entering it.
- Flush and drain terminal restore before writing chooser output to stdout.
- Update chooser-mode help text for double-click.

## User Impact

Chooser mode now treats double-click as confirmation, including for folders.

`--chooser-file -` prints confirmed paths reliably after leaving the alternate screen.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested interactive chooser output to stdout and to a file with single, multiple, and mixed file/folder selections.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed