### PR TITLE
feat(open-with): support directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added highlighted previews and icons for LaTeX, TeX, and BibTeX files (`.tex`, `.ltx`, `.sty`, `.cls`, `.bib`).
+- Made Open With work on directories too, using the same app picker and system directory handlers. ([#157])
 - Added `--chooser-file FILE [PATH]` to run elio as a file chooser, writing the confirmed selection as absolute paths, one per line, to `FILE` or stdout with `-`; cancel exits silently with a nonzero status. ([#153])
 - Added persistent multi-path selection across directories, allowing chooser confirmation and bulk actions to use selected paths from multiple folders.
 - `elio <path>` now accepts file paths as well as directories, opening the parent directory and focusing the file entry, including hidden files, file symlinks, and broken symlinks.
@@ -249,6 +250,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#140]: https://github.com/elio-fm/elio/issues/140
 [#141]: https://github.com/elio-fm/elio/issues/141
 [#153]: https://github.com/elio-fm/elio/issues/153
+[#157]: https://github.com/elio-fm/elio/issues/157
 [#159]: https://github.com/elio-fm/elio/issues/159
 [#162]: https://github.com/elio-fm/elio/issues/162
 [#168]: https://github.com/elio-fm/elio/issues/168

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -1724,7 +1724,7 @@ fn capital_o_opens_open_with_overlay_for_selected_file() {
 }
 
 #[test]
-fn capital_o_on_directory_sets_status_without_opening_overlay() {
+fn capital_o_on_directory_uses_open_with_instead_of_file_only_error() {
     let root = temp_path("open-with-overlay-dir");
     let child = root.join("subdir");
     fs::create_dir_all(&child).expect("failed to create child dir");
@@ -1736,11 +1736,10 @@ fn capital_o_on_directory_sets_status_without_opening_overlay() {
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('O'))))
         .expect("O on a directory should not fail");
 
-    assert!(
-        app.overlays.open_with.is_none(),
-        "overlay should not open for a directory"
+    assert_ne!(
+        app.status, "Open With is for files",
+        "directories should use Open With instead of the old file-only error"
     );
-    assert_eq!(app.status, "Open With is for files");
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/open_with/discovery/editor.rs
+++ b/src/app/open_with/discovery/editor.rs
@@ -6,12 +6,22 @@ use std::{
 use super::super::super::state::OpenWithApp;
 use super::exec::tokenize_exec;
 
-pub(super) fn append_editor_fallback(apps: &mut Vec<OpenWithApp>, path: &Path) {
-    let Some(app) = editor_fallback_for_path(path) else {
+pub(super) fn append_editor_fallback(
+    apps: &mut Vec<OpenWithApp>,
+    path: &Path,
+    require_text_like: bool,
+) {
+    if require_text_like && !super::super::path_is_text_like(path) {
         return;
-    };
-    if !duplicates_discovered_app(&app, apps) {
-        apps.push(app);
+    }
+
+    for var in ["VISUAL", "EDITOR"] {
+        let Some(app) = editor_app_for_path(var, path) else {
+            continue;
+        };
+        if !duplicates_discovered_app(&app, apps) {
+            apps.push(app);
+        }
     }
 }
 
@@ -20,13 +30,8 @@ pub(super) fn editor_fallback_for_path(path: &Path) -> Option<OpenWithApp> {
         return None;
     }
 
-    let path_str = path.to_str()?;
-
     for var in ["VISUAL", "EDITOR"] {
-        let Some(value) = env::var_os(var).and_then(|value| value.into_string().ok()) else {
-            continue;
-        };
-        if let Some(app) = editor_app_from_command(var, &value, path_str) {
+        if let Some(app) = editor_app_for_path(var, path) {
             return Some(app);
         }
     }
@@ -34,7 +39,13 @@ pub(super) fn editor_fallback_for_path(path: &Path) -> Option<OpenWithApp> {
     None
 }
 
-fn editor_app_from_command(var: &str, command: &str, path_str: &str) -> Option<OpenWithApp> {
+pub(super) fn editor_app_for_path(var: &'static str, path: &Path) -> Option<OpenWithApp> {
+    let value = env::var_os(var).and_then(|value| value.into_string().ok())?;
+    editor_app_from_command(var, &value, path)
+}
+
+fn editor_app_from_command(var: &str, command: &str, path: &Path) -> Option<OpenWithApp> {
+    let path_str = path.to_str()?;
     let mut tokens = tokenize_exec(command);
     if tokens.is_empty() {
         return None;
@@ -76,7 +87,7 @@ fn program_key(program: &str) -> Option<String> {
         .map(|name| name.to_ascii_lowercase())
 }
 
-fn resolve_executable(program: &str) -> Option<PathBuf> {
+pub(super) fn resolve_executable(program: &str) -> Option<PathBuf> {
     if program.is_empty() {
         return None;
     }
@@ -218,7 +229,7 @@ mod tests {
             is_default: true,
             requires_terminal: false,
         }];
-        append_editor_fallback(&mut apps, &file);
+        append_editor_fallback(&mut apps, &file, true);
         let _ = fs::remove_dir_all(&root);
 
         assert_eq!(apps.len(), 2);
@@ -251,7 +262,7 @@ mod tests {
             is_default: true,
             requires_terminal: true,
         }];
-        append_editor_fallback(&mut apps, &file);
+        append_editor_fallback(&mut apps, &file, true);
         let _ = fs::remove_dir_all(&root);
 
         assert_eq!(apps.len(), 1);

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -49,7 +49,11 @@ fn discover_open_with_apps_inner(
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        discover_xdg(path, display_name, include_editor_fallback)
+        if path.is_dir() {
+            discover_xdg_for_mime("inode/directory", path, true, false)
+        } else {
+            discover_xdg(path, display_name, include_editor_fallback)
+        }
     }
     #[cfg(not(any(target_os = "macos", all(unix, not(target_os = "macos")))))]
     {
@@ -123,18 +127,33 @@ fn discover_xdg(
         return vec![];
     };
 
+    discover_xdg_for_mime(&mime_type, path, include_editor_fallback, true)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn discover_xdg_for_mime(
+    mime_type: &str,
+    path: &Path,
+    include_env_editor_fallback: bool,
+    require_text_like_editor: bool,
+) -> Vec<OpenWithApp> {
+    use std::time::{Duration, Instant};
+
+    let deadline = Instant::now() + Duration::from_millis(3000);
+    let canceled = || Instant::now() > deadline;
+
     // Primary: gio handles MIME inheritance (e.g. text/markdown → text/plain),
     // aliases, and added/removed associations from mimeapps.list.
-    let mut apps = match gio::discover_via_gio(&mime_type, path, &canceled) {
+    let mut apps = match gio::discover_via_gio(mime_type, path, &canceled) {
         Some(apps) if !apps.is_empty() => apps,
         _ => {
             // Fallback: manual desktop-file scan with exact MIME match.
-            scan::discover_via_desktop_scan(&mime_type, path)
+            scan::discover_via_desktop_scan(mime_type, path)
         }
     };
 
-    if include_editor_fallback {
-        editor::append_editor_fallback(&mut apps, path);
+    if include_env_editor_fallback {
+        editor::append_editor_fallback(&mut apps, path, require_text_like_editor);
     }
     apps
 }

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -74,10 +74,6 @@ impl App {
             self.status = "Nothing selected".to_string();
             return;
         };
-        if entry.is_dir() {
-            self.status = "Open With is for files".to_string();
-            return;
-        }
         let entry = entry.clone();
         let path = entry.path.clone();
 


### PR DESCRIPTION
## Summary

Make elio's existing Open With menu work for directories too.

Refs #157. This handles the directory hand-off part of the issue; git branch/dirty awareness remains separate.

## What Changed

- Removed the file-only guard from Open With.
- Discover directory apps through the existing Open With pipeline using `inode/directory`.
- Reused the same Open With overlay, selection, shortcuts, and launch flow for files and directories.
- Allowed `$VISUAL` / `$EDITOR` to appear for directories as explicit user editor preferences.
- Kept file Open With behavior on the existing MIME-based path.
- Added tests for opening the Open With menu on directories.
- Added a changelog entry.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

Manual checks:

- Pressed `O` on a directory and confirmed the existing Open With menu appears.
- Confirmed directory apps come from system `inode/directory` handlers.
- Confirmed `$VISUAL` / `$EDITOR` only appear when set.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed