### PR TITLE
feat(status): show git branch state in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added highlighted previews and icons for LaTeX, TeX, and BibTeX files (`.tex`, `.ltx`, `.sty`, `.cls`, `.bib`).
+- Show the current git branch in the footer while browsing repositories, with a `*` marker for local changes. ([#157])
 - Made Open With work on directories too, using the same app picker and system directory handlers. ([#157])
 - Added `--chooser-file FILE [PATH]` to run elio as a file chooser, writing the confirmed selection as absolute paths, one per line, to `FILE` or stdout with `-`; cancel exits silently with a nonzero status. ([#153])
 - Added persistent multi-path selection across directories, allowing chooser confirmation and bulk actions to use selected paths from multiple folders.

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -193,6 +193,7 @@ impl App {
         if cwd_changed {
             self.reset_directory_watch();
         }
+        self.refresh_git_branch();
 
         match load.history_mode {
             DirectoryHistoryMode::None => {}

--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -1,5 +1,8 @@
-use super::{App, GitBranchProbe};
-use std::{path::Path, process::Command, thread};
+use super::{
+    App,
+    jobs::{GitStatusBuild, GitStatusRequest},
+};
+use std::{path::Path, process::Command};
 
 impl App {
     pub(crate) fn git_branch(&self) -> Option<&str> {
@@ -20,30 +23,18 @@ impl App {
         }
         self.git.token = self.git.token.wrapping_add(1);
         let token = self.git.token;
-        let result_tx = self.git.result_tx.clone();
-        thread::spawn(move || {
-            let (branch, dirty) = current_status(&cwd);
-            let _ = result_tx.send(GitBranchProbe {
-                token,
-                cwd,
-                branch,
-                dirty,
-            });
-        });
+        self.jobs
+            .scheduler
+            .submit_git_status(GitStatusRequest { token, cwd });
     }
 
-    pub(in crate::app) fn process_git_branch_results(&mut self) -> bool {
-        let mut dirty = false;
-        while let Ok(result) = self.git.result_rx.try_recv() {
-            if result.token != self.git.token || result.cwd != self.git.cwd {
-                continue;
-            }
-            if self.git.branch != result.branch || self.git.dirty != result.dirty {
-                self.git.branch = result.branch;
-                self.git.dirty = result.dirty;
-                dirty = true;
-            }
+    pub(in crate::app) fn apply_git_status_result(&mut self, result: GitStatusBuild) -> bool {
+        if result.token != self.git.token || result.cwd != self.git.cwd {
+            return false;
         }
+        let dirty = self.git.branch != result.branch || self.git.dirty != result.dirty;
+        self.git.branch = result.branch;
+        self.git.dirty = result.dirty;
         dirty
     }
 
@@ -58,7 +49,7 @@ impl App {
     }
 }
 
-fn current_status(cwd: &Path) -> (Option<String>, bool) {
+pub(in crate::app) fn current_status(cwd: &Path) -> (Option<String>, bool) {
     if git_command(cwd, ["rev-parse", "--is-inside-work-tree"])
         .is_none_or(|output| output.trim() != "true")
     {
@@ -114,6 +105,15 @@ mod tests {
         std::env::temp_dir().join(format!("elio-git-{label}-{unique}"))
     }
 
+    fn git_available() -> bool {
+        Command::new("git")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
     fn git(root: &PathBuf, args: &[&str]) {
         let status = Command::new("git")
             .arg("-C")
@@ -128,6 +128,11 @@ mod tests {
 
     #[test]
     fn current_status_marks_untracked_files_dirty() {
+        if !git_available() {
+            eprintln!("skipping git dirty-status integration test because git is unavailable");
+            return;
+        }
+
         let root = temp_path("dirty");
         fs::create_dir_all(&root).expect("failed to create temp dir");
 

--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -1,0 +1,157 @@
+use super::{App, GitBranchProbe};
+use std::{path::Path, process::Command, thread};
+
+impl App {
+    pub(crate) fn git_branch(&self) -> Option<&str> {
+        self.git.branch.as_deref()
+    }
+
+    pub(crate) fn git_dirty(&self) -> bool {
+        self.git.dirty
+    }
+
+    pub(in crate::app) fn refresh_git_branch(&mut self) {
+        let cwd = self.navigation.cwd.clone();
+        let cwd_changed = self.git.cwd != cwd;
+        self.git.cwd = cwd.clone();
+        if cwd_changed {
+            self.git.branch = None;
+            self.git.dirty = false;
+        }
+        self.git.token = self.git.token.wrapping_add(1);
+        let token = self.git.token;
+        let result_tx = self.git.result_tx.clone();
+        thread::spawn(move || {
+            let (branch, dirty) = current_status(&cwd);
+            let _ = result_tx.send(GitBranchProbe {
+                token,
+                cwd,
+                branch,
+                dirty,
+            });
+        });
+    }
+
+    pub(in crate::app) fn process_git_branch_results(&mut self) -> bool {
+        let mut dirty = false;
+        while let Ok(result) = self.git.result_rx.try_recv() {
+            if result.token != self.git.token || result.cwd != self.git.cwd {
+                continue;
+            }
+            if self.git.branch != result.branch || self.git.dirty != result.dirty {
+                self.git.branch = result.branch;
+                self.git.dirty = result.dirty;
+                dirty = true;
+            }
+        }
+        dirty
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_git_branch_for_test(&mut self, branch: Option<&str>) {
+        self.git.branch = branch.map(str::to_string);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_git_dirty_for_test(&mut self, dirty: bool) {
+        self.git.dirty = dirty;
+    }
+}
+
+fn current_status(cwd: &Path) -> (Option<String>, bool) {
+    if git_command(cwd, ["rev-parse", "--is-inside-work-tree"])
+        .is_none_or(|output| output.trim() != "true")
+    {
+        return (None, false);
+    }
+
+    let branch = git_command(cwd, ["branch", "--show-current"])
+        .and_then(non_empty_trimmed)
+        .or_else(|| git_command(cwd, ["rev-parse", "--short", "HEAD"]).and_then(non_empty_trimmed));
+    let dirty = git_command(
+        cwd,
+        ["status", "--porcelain=v1", "--untracked-files=normal"],
+    )
+    .is_some_and(|output| !output.trim().is_empty());
+
+    (branch, dirty)
+}
+
+fn git_command<const N: usize>(cwd: &Path, args: [&str; N]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("--no-optional-locks")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn non_empty_trimmed(output: String) -> Option<String> {
+    let branch = output.trim();
+    (!branch.is_empty()).then(|| branch.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::current_status;
+    use std::{
+        fs,
+        path::PathBuf,
+        process::{Command, Stdio},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-git-{label}-{unique}"))
+    }
+
+    fn git(root: &PathBuf, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("git command should run");
+        assert!(status.success(), "git command should succeed: {args:?}");
+    }
+
+    #[test]
+    fn current_status_marks_untracked_files_dirty() {
+        let root = temp_path("dirty");
+        fs::create_dir_all(&root).expect("failed to create temp dir");
+
+        git(&root, &["init", "-b", "main"]);
+        fs::write(root.join("tracked.txt"), "tracked").expect("failed to write tracked file");
+        git(&root, &["add", "tracked.txt"]);
+        git(
+            &root,
+            &[
+                "-c",
+                "user.name=elio tests",
+                "-c",
+                "user.email=elio@example.invalid",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+
+        assert_eq!(current_status(&root), (Some("main".to_string()), false));
+
+        fs::write(root.join("untracked.txt"), "dirty").expect("failed to write dirty file");
+        assert_eq!(current_status(&root), (Some("main".to_string()), true));
+
+        fs::remove_dir_all(root).expect("failed to remove temp dir");
+    }
+}

--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -13,7 +13,7 @@ impl App {
         self.git.dirty
     }
 
-    pub(in crate::app) fn refresh_git_branch(&mut self) {
+    pub(crate) fn refresh_git_branch(&mut self) {
         let cwd = self.navigation.cwd.clone();
         let cwd_changed = self.git.cwd != cwd;
         self.git.cwd = cwd.clone();

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -14,11 +14,11 @@ use self::sync::{lock_unpoison, wait_unpoison};
 pub(super) use self::types::{
     DirectoryBuild, DirectoryFingerprintBuild, DirectoryFingerprintRequest,
     DirectoryItemCountBuild, DirectoryItemCountRequest, DirectoryRequest, DirectoryStatsBuild,
-    DirectoryStatsRequest, ImageJobPriority, ImagePrepareBuild, ImagePrepareRequest, JobResult,
-    PasteBuild, PasteRequest, PdfJobPriority, PdfProbeBuild, PdfProbeRequest, PdfRenderBuild,
-    PdfRenderRequest, PreviewBuild, PreviewLineCountBuild, PreviewLineCountRequest,
-    PreviewPriority, PreviewRequest, RestoreBuild, RestoreRequest, SearchBatchBuild, SearchBuild,
-    SearchRequest, SixelPrepareConfig, TrashBuild, TrashRequest,
+    DirectoryStatsRequest, GitStatusBuild, GitStatusRequest, ImageJobPriority, ImagePrepareBuild,
+    ImagePrepareRequest, JobResult, PasteBuild, PasteRequest, PdfJobPriority, PdfProbeBuild,
+    PdfProbeRequest, PdfRenderBuild, PdfRenderRequest, PreviewBuild, PreviewLineCountBuild,
+    PreviewLineCountRequest, PreviewPriority, PreviewRequest, RestoreBuild, RestoreRequest,
+    SearchBatchBuild, SearchBuild, SearchRequest, SixelPrepareConfig, TrashBuild, TrashRequest,
 };
 use self::{config::SchedulerConfig, metrics::SchedulerMetrics};
 #[cfg(test)]

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -46,7 +46,7 @@ impl App {
     }
 
     pub fn process_background_jobs(&mut self) -> bool {
-        let mut dirty = false;
+        let mut dirty = self.process_git_branch_results();
         let started_at = Instant::now();
         let mut processed = 0usize;
 

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -46,7 +46,7 @@ impl App {
     }
 
     pub fn process_background_jobs(&mut self) -> bool {
-        let mut dirty = self.process_git_branch_results();
+        let mut dirty = false;
         let started_at = Instant::now();
         let mut processed = 0usize;
 
@@ -129,6 +129,9 @@ impl App {
                         &build.path,
                         build.result,
                     );
+                }
+                JobResult::GitStatus(build) => {
+                    dirty |= self.apply_git_status_result(build);
                 }
                 JobResult::PreviewLineCount(build) => {
                     dirty |= self.apply_preview_line_count_result(

--- a/src/app/jobs/results/tests/helpers.rs
+++ b/src/app/jobs/results/tests/helpers.rs
@@ -342,6 +342,17 @@ pub(super) fn wait_for_directory_load(app: &mut App) {
     panic!("timed out waiting for directory load");
 }
 
+pub(super) fn wait_for_background_idle(app: &mut App) {
+    for _ in 0..200 {
+        let _ = app.process_background_jobs();
+        if !app.has_pending_background_work() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for background work to finish");
+}
+
 pub(super) fn write_docx_fixture(path: &Path) {
     write_zip_entries(
         path,

--- a/src/app/jobs/results/tests/scheduler.rs
+++ b/src/app/jobs/results/tests/scheduler.rs
@@ -8,6 +8,7 @@ fn background_job_processing_yields_after_a_burst_of_results() {
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     wait_for_directory_load(&mut app);
+    wait_for_background_idle(&mut app);
 
     for index in 0..20 {
         app.jobs

--- a/src/app/jobs/scheduler.rs
+++ b/src/app/jobs/scheduler.rs
@@ -7,7 +7,7 @@ use super::{
     pool::{preview::PreviewPool, search::SearchPool},
     tasks::{
         directory::DirectoryPool, directory_fingerprint::DirectoryFingerprintPool,
-        directory_stats::DirectoryStatsPool, image::ImagePreparePool,
+        directory_stats::DirectoryStatsPool, git_status::GitStatusPool, image::ImagePreparePool,
         item_count::DirectoryItemCountPool, line_count::PreviewLineCountPool, paste::PastePool,
         pdf_probe::PdfProbePool, pdf_render::PdfRenderPool, restore::RestorePool, trash::TrashPool,
     },
@@ -28,6 +28,7 @@ pub(in crate::app) struct JobScheduler {
     restore: RestorePool,
     directory_item_count: DirectoryItemCountPool,
     directory_stats: DirectoryStatsPool,
+    git_status: GitStatusPool,
     preview_line_count: PreviewLineCountPool,
     image_prepare: ImagePreparePool,
     pdf_probe: PdfProbePool,
@@ -70,6 +71,7 @@ impl JobScheduler {
                 config.directory_stats_worker_count(),
                 result_tx.clone(),
             ),
+            git_status: GitStatusPool::new(result_tx.clone()),
             preview_line_count: PreviewLineCountPool::new(
                 config.preview_line_count_worker_count,
                 config.preview_line_count_queue_limit,
@@ -136,6 +138,10 @@ impl JobScheduler {
 
     pub(in crate::app) fn cancel_directory_stats(&self) {
         self.directory_stats.cancel_all();
+    }
+
+    pub(in crate::app) fn submit_git_status(&self, request: GitStatusRequest) -> bool {
+        self.git_status.submit(request)
     }
 
     pub(in crate::app) fn submit_preview_line_count(
@@ -261,6 +267,7 @@ impl JobScheduler {
             || self.restore.has_pending_work()
             || self.directory_item_count.has_pending_work()
             || self.directory_stats.has_pending_work()
+            || self.git_status.has_pending_work()
             || self.preview_line_count.has_pending_work()
             || self.image_prepare.has_pending_work()
             || self.pdf_probe.has_pending_work()

--- a/src/app/jobs/tasks/git_status.rs
+++ b/src/app/jobs/tasks/git_status.rs
@@ -1,0 +1,107 @@
+use super::*;
+use std::{
+    sync::{Arc, Condvar, Mutex, mpsc},
+    thread,
+};
+
+pub(in crate::app::jobs) struct GitStatusPool {
+    shared: Arc<GitStatusShared>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+struct GitStatusShared {
+    state: Mutex<GitStatusState>,
+    available: Condvar,
+}
+
+struct GitStatusState {
+    pending: Option<GitStatusRequest>,
+    active: bool,
+    closed: bool,
+}
+
+impl GitStatusPool {
+    pub(in crate::app::jobs) fn new(result_tx: mpsc::Sender<JobResult>) -> Self {
+        let shared = Arc::new(GitStatusShared {
+            state: Mutex::new(GitStatusState {
+                pending: None,
+                active: false,
+                closed: false,
+            }),
+            available: Condvar::new(),
+        });
+        let worker_shared = Arc::clone(&shared);
+        let worker = thread::spawn(move || {
+            while let Some(request) = GitStatusShared::pop(&worker_shared) {
+                let (branch, dirty) = crate::app::git::current_status(&request.cwd);
+                GitStatusShared::finish(&worker_shared);
+                if result_tx
+                    .send(JobResult::GitStatus(GitStatusBuild {
+                        token: request.token,
+                        cwd: request.cwd,
+                        branch,
+                        dirty,
+                    }))
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+        Self {
+            shared,
+            worker: Some(worker),
+        }
+    }
+
+    pub(in crate::app::jobs) fn submit(&self, request: GitStatusRequest) -> bool {
+        let mut state = lock_unpoison(&self.shared.state);
+        if state.closed {
+            return false;
+        }
+        state.pending = Some(request);
+        self.shared.available.notify_one();
+        true
+    }
+
+    pub(in crate::app::jobs) fn has_pending_work(&self) -> bool {
+        let state = lock_unpoison(&self.shared.state);
+        state.pending.is_some() || state.active
+    }
+}
+
+impl Drop for GitStatusPool {
+    fn drop(&mut self) {
+        {
+            let mut state = lock_unpoison(&self.shared.state);
+            state.closed = true;
+            state.pending = None;
+        }
+        self.shared.available.notify_all();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl GitStatusShared {
+    fn pop(shared: &Arc<Self>) -> Option<GitStatusRequest> {
+        let mut state = lock_unpoison(&shared.state);
+        loop {
+            if state.closed {
+                return None;
+            }
+            if let Some(request) = state.pending.take() {
+                state.active = true;
+                return Some(request);
+            }
+            state = wait_unpoison(&shared.available, state);
+        }
+    }
+
+    fn finish(shared: &Arc<Self>) {
+        let mut state = lock_unpoison(&shared.state);
+        state.active = false;
+        shared.available.notify_all();
+    }
+}

--- a/src/app/jobs/tasks/mod.rs
+++ b/src/app/jobs/tasks/mod.rs
@@ -3,6 +3,7 @@ pub(super) use super::*;
 pub(super) mod directory;
 pub(super) mod directory_fingerprint;
 pub(super) mod directory_stats;
+pub(super) mod git_status;
 pub(super) mod image;
 pub(super) mod item_count;
 pub(super) mod line_count;

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -128,6 +128,20 @@ pub(in crate::app) struct DirectoryStatsRequest {
 }
 
 #[derive(Debug)]
+pub(in crate::app) struct GitStatusBuild {
+    pub(in crate::app) token: u64,
+    pub(in crate::app) cwd: PathBuf,
+    pub(in crate::app) branch: Option<String>,
+    pub(in crate::app) dirty: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::app) struct GitStatusRequest {
+    pub(in crate::app) token: u64,
+    pub(in crate::app) cwd: PathBuf,
+}
+
+#[derive(Debug)]
 pub(in crate::app) struct PreviewLineCountBuild {
     pub(in crate::app) path: PathBuf,
     pub(in crate::app) size: u64,
@@ -298,6 +312,7 @@ pub(in crate::app) enum JobResult {
     DirectoryFingerprint(DirectoryFingerprintBuild),
     DirectoryItemCount(DirectoryItemCountBuild),
     DirectoryStats(DirectoryStatsBuild),
+    GitStatus(GitStatusBuild),
     PreviewLineCount(PreviewLineCountBuild),
     ImagePrepare(ImagePrepareBuild),
     PdfProbe(PdfProbeBuild),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ mod clipboard;
 mod constants;
 mod create;
 mod directory_counts;
+mod git;
 mod input;
 mod jobs;
 mod open_with;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -852,7 +852,6 @@ impl App {
         app.remember_current_directory_view();
         app.refresh_preview();
         app.reset_directory_watch();
-        app.refresh_git_branch();
         Ok(app)
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     env,
     path::PathBuf,
-    sync::{Arc, mpsc},
+    sync::Arc,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -676,20 +676,11 @@ pub(crate) enum ChooserExit {
     Cancelled,
 }
 
-pub(in crate::app) struct GitBranchProbe {
-    pub(in crate::app) token: u64,
-    pub(in crate::app) cwd: PathBuf,
-    pub(in crate::app) branch: Option<String>,
-    pub(in crate::app) dirty: bool,
-}
-
 pub(in crate::app) struct GitRuntime {
     pub(in crate::app) token: u64,
     pub(in crate::app) cwd: PathBuf,
     pub(in crate::app) branch: Option<String>,
     pub(in crate::app) dirty: bool,
-    pub(in crate::app) result_tx: mpsc::Sender<GitBranchProbe>,
-    pub(in crate::app) result_rx: mpsc::Receiver<GitBranchProbe>,
 }
 
 pub struct App {
@@ -726,7 +717,6 @@ impl App {
     ) -> Result<Self> {
         let scheduler = JobScheduler::new();
         let (directory_watch_tx, directory_watch_rx) = std::sync::mpsc::channel();
-        let (git_result_tx, git_result_rx) = mpsc::channel();
         let mut app = Self {
             navigation: NavigationState {
                 cwd,
@@ -830,8 +820,6 @@ impl App {
                 cwd: PathBuf::new(),
                 branch: None,
                 dirty: false,
-                result_tx: git_result_tx,
-                result_rx: git_result_rx,
             },
             status: String::new(),
             should_quit: false,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     env,
     path::PathBuf,
-    sync::Arc,
+    sync::{Arc, mpsc},
     time::{Duration, Instant, SystemTime},
 };
 
@@ -676,12 +676,29 @@ pub(crate) enum ChooserExit {
     Cancelled,
 }
 
+pub(in crate::app) struct GitBranchProbe {
+    pub(in crate::app) token: u64,
+    pub(in crate::app) cwd: PathBuf,
+    pub(in crate::app) branch: Option<String>,
+    pub(in crate::app) dirty: bool,
+}
+
+pub(in crate::app) struct GitRuntime {
+    pub(in crate::app) token: u64,
+    pub(in crate::app) cwd: PathBuf,
+    pub(in crate::app) branch: Option<String>,
+    pub(in crate::app) dirty: bool,
+    pub(in crate::app) result_tx: mpsc::Sender<GitBranchProbe>,
+    pub(in crate::app) result_rx: mpsc::Receiver<GitBranchProbe>,
+}
+
 pub struct App {
     pub(crate) navigation: NavigationState,
     pub(in crate::app) preview: PreviewRuntime,
     pub(crate) overlays: OverlayState,
     pub(in crate::app) jobs: JobRuntime,
     pub(in crate::app) input: InputRuntime,
+    pub(in crate::app) git: GitRuntime,
     pub(in crate::app) status: String,
     pub(crate) should_quit: bool,
     pub(crate) should_change_directory_on_quit: bool,
@@ -709,6 +726,7 @@ impl App {
     ) -> Result<Self> {
         let scheduler = JobScheduler::new();
         let (directory_watch_tx, directory_watch_rx) = std::sync::mpsc::channel();
+        let (git_result_tx, git_result_rx) = mpsc::channel();
         let mut app = Self {
             navigation: NavigationState {
                 cwd,
@@ -807,6 +825,14 @@ impl App {
                 // Initialize to far past so the first keypress is always Immediate.
                 last_key_nav_at: Instant::now() - Duration::from_secs(1),
             },
+            git: GitRuntime {
+                token: 0,
+                cwd: PathBuf::new(),
+                branch: None,
+                dirty: false,
+                result_tx: git_result_tx,
+                result_rx: git_result_rx,
+            },
             status: String::new(),
             should_quit: false,
             should_change_directory_on_quit: true,
@@ -838,6 +864,7 @@ impl App {
         app.remember_current_directory_view();
         app.refresh_preview();
         app.reset_directory_watch();
+        app.refresh_git_branch();
         Ok(app)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,6 +619,7 @@ fn run_app(
     if chooser_enabled {
         app.enable_chooser_mode();
     }
+    app.refresh_git_branch();
 
     // Enable terminal image previews. Detection handles the current policy:
     // Kitty, Ghostty, Warp, WezTerm, iTerm2, and Konsole auto-enable supported

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -112,6 +112,7 @@ pub(super) fn render_toolbar(
 const STATUS_MIN_LEFT_WIDTH: u16 = 24;
 const STATUS_IDLE_RIGHT_WIDTH: u16 = 34;
 const STATUS_RIGHT_PADDING: usize = 2;
+const GIT_BRANCH_MAX_WIDTH: usize = 24;
 
 pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palette: Palette) {
     helpers::fill_area(frame, area, palette.chrome, palette.text);
@@ -226,13 +227,38 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
             spans.push(Span::raw("  "));
         }
 
-        let summary_width = sections[0].width.saturating_sub(chips_width) as usize;
+        let git_label = app.git_branch().map(|branch| {
+            let branch = helpers::truncate_middle(branch, GIT_BRANCH_MAX_WIDTH);
+            if app.git_dirty() {
+                format!(" {branch} *")
+            } else {
+                format!(" {branch}")
+            }
+        });
+        let git_width = git_label
+            .as_deref()
+            .map(|label| helpers::display_width(" │ ") + helpers::display_width(label))
+            .unwrap_or(0) as u16;
+
+        let summary_width = sections[0]
+            .width
+            .saturating_sub(chips_width)
+            .saturating_sub(git_width) as usize;
         spans.push(Span::styled(
             helpers::truncate_middle(&app.selection_summary(), summary_width),
             Style::default()
                 .fg(palette.text)
                 .add_modifier(Modifier::BOLD),
         ));
+        if let Some(label) = git_label {
+            spans.push(Span::styled(" │ ", Style::default().fg(palette.muted)));
+            spans.push(Span::styled(
+                label,
+                Style::default()
+                    .fg(palette.muted)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
 
         Line::from(spans)
     };
@@ -313,6 +339,61 @@ mod tests {
     #[test]
     fn idle_hint_stays_unchanged() {
         assert_eq!(status_idle_hint(), "f folders  ^F files  ? help");
+    }
+
+    #[test]
+    fn git_branch_renders_after_position_summary() {
+        let root = temp_path("git-chip");
+        fs::create_dir_all(&root).expect("failed to create temp dir");
+        fs::write(root.join("logo.png"), "png").expect("failed to write file");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        app.set_git_branch_for_test(Some("main"));
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(' '))))
+            .expect("selection shortcut should succeed");
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 1)).expect("terminal should init");
+        terminal
+            .draw(|frame| render_status(frame, frame.area(), &app, theme::palette()))
+            .expect("status should render");
+
+        let rendered = row_text(terminal.backend().buffer(), 0);
+        assert!(
+            rendered.contains(" 1 selected   1/1  logo.png │  main"),
+            "status row should place git branch after position summary, got: {rendered:?}"
+        );
+
+        app.set_frame_state(FrameState::default());
+        drop(app);
+        fs::remove_dir_all(root).expect("failed to remove temp dir");
+    }
+
+    #[test]
+    fn dirty_git_branch_renders_star_suffix() {
+        let root = temp_path("dirty-git-chip");
+        fs::create_dir_all(&root).expect("failed to create temp dir");
+        fs::write(root.join("logo.png"), "png").expect("failed to write file");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        app.set_git_branch_for_test(Some("main"));
+        app.set_git_dirty_for_test(true);
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(' '))))
+            .expect("selection shortcut should succeed");
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 1)).expect("terminal should init");
+        terminal
+            .draw(|frame| render_status(frame, frame.area(), &app, theme::palette()))
+            .expect("status should render");
+
+        let rendered = row_text(terminal.backend().buffer(), 0);
+        assert!(
+            rendered.contains(" 1 selected   1/1  logo.png │  main *"),
+            "status row should mark dirty git branches, got: {rendered:?}"
+        );
+
+        app.set_frame_state(FrameState::default());
+        drop(app);
+        fs::remove_dir_all(root).expect("failed to remove temp dir");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Show git branch context in the footer while browsing repositories.

Refs #157.

## What Changed

- Added async git probing for the current directory.
- Show the current branch after the focused entry summary in the footer.
- Mark worktrees with local changes using a spaced `*` marker.
- Hide the git footer segment outside git worktrees or when `git` is unavailable.
- Added a changelog entry for the user-visible footer change.

## User Impact

When browsing inside a git repository, elio now shows the current branch in the footer:

```text
6/17 target/ │  feat/git-branch-status
```

If the worktree has local changes, elio marks it with `*`:

```text
6/17 target/ │  feat/git-branch-status *
```

Outside repositories, the footer stays unchanged.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested clean repositories show the branch without a dirty marker.
- Tested repositories with local changes show the `*` dirty marker.
- Tested switching between different repositories updates the displayed branch.
- Tested directories outside git repositories keep the footer unchanged.
- Tested the footer layout with selection state and focused entry summaries.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
