### PR TITLE
fix(status): improve status bar behavior in narrow windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed UI freezes when selecting all items in very large folders.
 - Fixed Linux/BSD Open With (`O`) behavior by reporting missing handlers accurately, showing the app used for direct single-app launches, and offering `$VISUAL` or `$EDITOR` in the current terminal for text/code files when the editor is not registered as a desktop app; `o` / `Enter` uses the same editor fallback only when no desktop handler is available. ([#168])
 - Fixed folder item counts lagging behind during fast mouse-wheel navigation.
+- Improved status bar behavior in narrow terminals by prioritizing focused item context, shortening open-file messages, and removing redundant idle hints. ([#174])
 
 ## [1.8.0] - 2026-06-06
 
@@ -255,3 +256,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#159]: https://github.com/elio-fm/elio/issues/159
 [#162]: https://github.com/elio-fm/elio/issues/162
 [#168]: https://github.com/elio-fm/elio/issues/168
+[#174]: https://github.com/elio-fm/elio/issues/174

--- a/src/app/actions/directory.rs
+++ b/src/app/actions/directory.rs
@@ -336,7 +336,6 @@ impl App {
             self.remembered_view_for(&normalized)
                 .and_then(|view| view.selected_path)
         });
-        self.status = format!("Opening {}", crate::path_display::user_facing(&normalized));
         self.queue_directory_load(PendingDirectoryLoad {
             token: 0,
             target_cwd: normalized,

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -487,7 +487,7 @@ impl App {
         }
 
         self.status = match (total, opened, last_error) {
-            (1, 1, _) => format!("Opened {}", targets[0].display()),
+            (1, 1, _) => format!("Opened {}", open_status_name(&targets[0])),
             (_, opened, None) => format!("Opened {opened} items"),
             (1, 0, Some(error)) => error,
             (_, 0, Some(error)) => format!("Failed to open {total} items: {error}"),
@@ -530,6 +530,12 @@ impl App {
             .map(|entry| vec![entry.path.clone()])
             .unwrap_or_default()
     }
+}
+
+fn open_status_name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| crate::path_display::user_facing(path))
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]

--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -43,17 +43,12 @@ impl App {
         if paths.is_empty() {
             return;
         }
-        let count = paths.len();
         self.jobs.clipboard = Some(Clipboard {
             paths,
             op: ClipOp::Yank,
         });
         self.navigation.selected_paths.clear();
-        self.status = if count == 1 {
-            "Yanked 1 item".to_string()
-        } else {
-            format!("Yanked {count} items")
-        };
+        self.status.clear();
     }
 
     /// Cut-mark the current selection or the focused entry.
@@ -62,17 +57,12 @@ impl App {
         if paths.is_empty() {
             return;
         }
-        let count = paths.len();
         self.jobs.clipboard = Some(Clipboard {
             paths,
             op: ClipOp::Cut,
         });
         self.navigation.selected_paths.clear();
-        self.status = if count == 1 {
-            "Cut 1 item".to_string()
-        } else {
-            format!("Cut {count} items")
-        };
+        self.status.clear();
     }
 
     /// Paste the clipboard contents into the current directory (async with

--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -254,7 +254,7 @@ fn yank_allows_selected_parent_of_current_directory() {
 
     app.yank();
 
-    assert_eq!(app.status_message(), "Yanked 1 item");
+    assert_eq!(app.status_message(), "");
     assert_eq!(app.clipboard_info(), Some((1, ClipOp::Yank)));
     assert!(app.navigation.selected_paths.is_empty());
 
@@ -273,7 +273,7 @@ fn cut_allows_selected_parent_of_current_directory() {
 
     app.cut();
 
-    assert_eq!(app.status_message(), "Cut 1 item");
+    assert_eq!(app.status_message(), "");
     assert_eq!(app.clipboard_info(), Some((1, ClipOp::Cut)));
     assert!(app.navigation.selected_paths.is_empty());
 

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -803,7 +803,7 @@ fn open_action_keeps_system_opener_for_gui_default_app() {
     let opened = read_open_capture(&capture);
     assert_eq!(opened, file_path.display().to_string());
     assert_eq!(app.pending_terminal_task, None);
-    assert_eq!(app.status, format!("Opened {}", file_path.display()));
+    assert_eq!(app.status, "Opened note.txt");
 
     fs::remove_dir_all(root).ok();
 }

--- a/src/app/input/tests/mouse.rs
+++ b/src/app/input/tests/mouse.rs
@@ -63,7 +63,7 @@ fn double_click_opens_clicked_file_not_multi_selection() {
     let opened = read_open_capture(&capture);
     let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
     assert_eq!(opened, vec![beta.display().to_string()]);
-    assert_eq!(app.status, format!("Opened {}", beta.display()));
+    assert_eq!(app.status, "Opened beta.txt");
 
     fs::remove_dir_all(root).ok();
 }

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -33,6 +33,7 @@ impl App {
         };
         let path = entry.path.clone();
         if self.navigation.selected_paths.remove(&path) {
+            self.status.clear();
             if self.navigation.view_mode == ViewMode::List {
                 self.move_vertical(1);
             }
@@ -45,6 +46,7 @@ impl App {
         }
 
         self.navigation.selected_paths.insert(path);
+        self.status.clear();
         if self.navigation.view_mode == ViewMode::List {
             self.move_vertical(1);
         }
@@ -66,11 +68,16 @@ impl App {
         }
         if blocked {
             self.status = "Cannot select nested paths".to_string();
+        } else {
+            self.status.clear();
         }
     }
 
     pub(in crate::app) fn clear_selection(&mut self) {
-        self.navigation.selected_paths.clear();
+        if !self.navigation.selected_paths.is_empty() {
+            self.navigation.selected_paths.clear();
+            self.status.clear();
+        }
     }
 
     pub(crate) fn enable_chooser_mode(&mut self) {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -112,6 +112,8 @@ pub(super) fn render_toolbar(
 const STATUS_MIN_LEFT_WIDTH: u16 = 24;
 const STATUS_RIGHT_PADDING: usize = 2;
 const GIT_BRANCH_MAX_WIDTH: usize = 24;
+const FOOTER_MIN_NAME_WIDTH: usize = 6;
+const FOOTER_MIN_GIT_BRANCH_WIDTH: usize = 3;
 
 pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palette: Palette) {
     helpers::fill_area(frame, area, palette.chrome, palette.text);
@@ -222,25 +224,26 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
             spans.push(Span::raw("  "));
         }
 
-        let git_label = app.git_branch().map(|branch| {
-            let branch = helpers::truncate_middle(branch, GIT_BRANCH_MAX_WIDTH);
-            if app.git_dirty() {
-                format!(" {branch} *")
-            } else {
-                format!(" {branch}")
-            }
+        let available_after_chips = sections[0].width.saturating_sub(chips_width) as usize;
+        let summary = app.selection_summary();
+        let desired_summary_width = helpers::display_width(&summary).min(available_after_chips);
+        let git_label = app.git_branch().and_then(|branch| {
+            git_label_for_width(
+                branch,
+                app.git_dirty(),
+                available_after_chips
+                    .saturating_sub(desired_summary_width)
+                    .saturating_sub(helpers::display_width(" │ ")),
+            )
         });
         let git_width = git_label
             .as_deref()
             .map(|label| helpers::display_width(" │ ") + helpers::display_width(label))
-            .unwrap_or(0) as u16;
+            .unwrap_or(0);
 
-        let summary_width = sections[0]
-            .width
-            .saturating_sub(chips_width)
-            .saturating_sub(git_width) as usize;
+        let summary_width = available_after_chips.saturating_sub(git_width);
         spans.push(Span::styled(
-            helpers::truncate_middle(&app.selection_summary(), summary_width),
+            compact_footer_summary(&summary, summary_width),
             Style::default()
                 .fg(palette.text)
                 .add_modifier(Modifier::BOLD),
@@ -279,9 +282,39 @@ fn status_section_width(total_width: u16, status_message: &str) -> u16 {
     desired.min(max_right_width as usize).max(1) as u16
 }
 
+fn compact_footer_summary(summary: &str, width: usize) -> String {
+    let Some((position, name)) = summary.split_once("  ") else {
+        return helpers::truncate_middle(summary, width);
+    };
+    let position_width = helpers::display_width(position);
+    let min_name_width = helpers::display_width(name).min(FOOTER_MIN_NAME_WIDTH);
+    if width <= position_width || width < position_width + 2 + min_name_width {
+        return helpers::truncate_middle(position, width);
+    }
+
+    format!(
+        "{position}  {}",
+        helpers::truncate_middle(name, width - position_width - 2)
+    )
+}
+
+fn git_label_for_width(branch: &str, dirty: bool, width: usize) -> Option<String> {
+    let dirty_suffix = if dirty { " *" } else { "" };
+    let fixed_width = helpers::display_width(" ") + helpers::display_width(dirty_suffix);
+    let branch_width = width.saturating_sub(fixed_width).min(GIT_BRANCH_MAX_WIDTH);
+    if branch_width < FOOTER_MIN_GIT_BRANCH_WIDTH {
+        return None;
+    }
+
+    Some(format!(
+        " {}{dirty_suffix}",
+        helpers::truncate_middle(branch, branch_width)
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{render_status, status_section_width};
+    use super::{compact_footer_summary, git_label_for_width, render_status, status_section_width};
     use crate::{
         app::{App, FrameState},
         ui::{helpers, theme},
@@ -322,6 +355,29 @@ mod tests {
     fn narrow_status_messages_truncate_at_the_end() {
         let rendered = helpers::clamp_label("Clipboard helper not found", 18);
         assert_eq!(rendered, "Clipboard helper …");
+    }
+
+    #[test]
+    fn compact_footer_summary_keeps_position_before_name() {
+        assert_eq!(compact_footer_summary("11/17  CHANGELOG.md", 8), "11/17");
+        assert_eq!(compact_footer_summary("5/17  src/", 10), "5/17  src/");
+        assert_eq!(
+            compact_footer_summary("11/17  CHANGELOG.md", 14),
+            "11/17  CHA….md"
+        );
+    }
+
+    #[test]
+    fn git_label_uses_the_available_width_before_hiding() {
+        assert_eq!(git_label_for_width("chore/footer-cleanup", true, 5), None);
+        assert_eq!(
+            git_label_for_width("chore/footer-cleanup", true, 8).as_deref(),
+            Some(" ch…p *")
+        );
+        assert_eq!(
+            git_label_for_width("chore/footer-cleanup", true, 16).as_deref(),
+            Some(" chore/…eanup *")
+        );
     }
 
     #[test]

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -110,7 +110,6 @@ pub(super) fn render_toolbar(
 }
 
 const STATUS_MIN_LEFT_WIDTH: u16 = 24;
-const STATUS_IDLE_RIGHT_WIDTH: u16 = 34;
 const STATUS_RIGHT_PADDING: usize = 2;
 const GIT_BRANCH_MAX_WIDTH: usize = 24;
 
@@ -126,11 +125,7 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
         ])
         .split(area);
 
-    let right_text = if status_message.is_empty() {
-        status_idle_hint().to_string()
-    } else {
-        helpers::clamp_label(status_message, sections[1].width as usize)
-    };
+    let right_text = helpers::clamp_label(status_message, sections[1].width as usize);
     let clip = app.clipboard_info();
     let sel_count = app.selection_count();
     let paste_prog = app.paste_progress();
@@ -277,23 +272,16 @@ pub(super) fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App, palett
 fn status_section_width(total_width: u16, status_message: &str) -> u16 {
     let max_right_width = total_width.saturating_sub(STATUS_MIN_LEFT_WIDTH).max(1);
     if status_message.is_empty() {
-        return STATUS_IDLE_RIGHT_WIDTH.min(max_right_width).max(1);
+        return 1;
     }
 
     let desired = helpers::display_width(status_message).saturating_add(STATUS_RIGHT_PADDING);
-    desired
-        .max(STATUS_IDLE_RIGHT_WIDTH as usize)
-        .min(max_right_width as usize)
-        .max(1) as u16
-}
-
-fn status_idle_hint() -> &'static str {
-    "f folders  ^F files  ? help"
+    desired.min(max_right_width as usize).max(1) as u16
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{render_status, status_idle_hint, status_section_width};
+    use super::{render_status, status_section_width};
     use crate::{
         app::{App, FrameState},
         ui::{helpers, theme},
@@ -321,24 +309,19 @@ mod tests {
     }
 
     #[test]
-    fn idle_status_keeps_the_compact_help_width() {
-        assert_eq!(status_section_width(100, ""), 34);
+    fn idle_status_keeps_the_message_area_empty() {
+        assert_eq!(status_section_width(100, ""), 1);
     }
 
     #[test]
-    fn real_status_messages_expand_beyond_the_idle_width() {
-        assert!(status_section_width(100, "Clipboard helper not found while copying") > 34);
+    fn real_status_messages_expand_to_fit_their_text() {
+        assert!(status_section_width(100, "Clipboard helper not found while copying") > 1);
     }
 
     #[test]
     fn narrow_status_messages_truncate_at_the_end() {
         let rendered = helpers::clamp_label("Clipboard helper not found", 18);
         assert_eq!(rendered, "Clipboard helper …");
-    }
-
-    #[test]
-    fn idle_hint_stays_unchanged() {
-        assert_eq!(status_idle_hint(), "f folders  ^F files  ? help");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Improve status bar behavior in narrow terminal/sidebar-style layouts and remove redundant status noise.

Closes #174.

## What Changed

- Removed redundant idle and transient status bar messages.
- Cleared stale messages when chip-backed selection or clipboard state takes over.
- Shortened single-file open success messages.
- Improved narrow status bar fitting so focused item context is prioritized before git branch text.
- Added a changelog entry.

## User Impact

The status bar stays more useful at narrow widths: focused item context is preserved longer, git branch text shrinks first, and stale or redundant messages are less likely to crowd the bar.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested narrow status bar resizing with focused entries, status messages, and git branch state.
- Confirmed focused item context remains visible longer than lower-priority git branch text.
- Confirmed long git branch text shrinks without orphan separators or unused status bar gaps.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
