### PR TITLE
fix(ui): improve narrow pane resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated shell integration scripts to pass `--chooser-file` invocations directly to `elio`, so chooser mode does not change the parent shell directory. Re-run `elio shell install` after upgrading to refresh existing shell integration.
 - Improved the Open With menu with keyboard navigation, scrolling, and an overflow scrollbar for long app lists.
+- Improved narrow browser pane resizing so Places gives up space sooner, preview remains useful longer, and stacked preview layouts behave more consistently.
 
 ### Fixed
 

--- a/src/ui/browser/layout.rs
+++ b/src/ui/browser/layout.rs
@@ -9,12 +9,19 @@ use crate::{
 use ratatui::{Frame, layout::Rect};
 
 const LEGACY_WIDE_SIDEBAR_WIDTH: u16 = 20;
-const LEGACY_NARROW_SIDEBAR_WIDTH: u16 = 22;
-const LEGACY_HORIZONTAL_SIDEBAR_MIN_WIDTH: u16 = 18;
-const LEGACY_HORIZONTAL_ENTRIES_MIN_WIDTH: u16 = 26;
-const LEGACY_HORIZONTAL_PREVIEW_MIN_WIDTH: u16 = 22;
+const LEGACY_NARROW_SIDEBAR_WIDTH: u16 = 10;
+const LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR: u16 = 16;
+const LEGACY_HORIZONTAL_ENTRIES_MIN_WIDTH: u16 = 18;
+const LEGACY_HORIZONTAL_PREVIEW_MIN_WIDTH: u16 = 14;
+const LEGACY_HORIZONTAL_CONTENT_MIN_WIDTH: u16 =
+    LEGACY_HORIZONTAL_ENTRIES_MIN_WIDTH.saturating_add(LEGACY_HORIZONTAL_PREVIEW_MIN_WIDTH);
+const LEGACY_HORIZONTAL_SIDEBAR_SHRINK_START_WIDTH: u16 = 104;
+const LEGACY_HORIZONTAL_SIDEBAR_SHRINK_STEP: u16 = 4;
+const LEGACY_STACKED_PREFERRED_MAX_WIDTH: u16 = 54;
 const LEGACY_STACKED_ENTRIES_WEIGHT: u16 = 54;
 const LEGACY_STACKED_PREVIEW_WEIGHT: u16 = 46;
+const LEGACY_STACKED_ENTRIES_MIN_HEIGHT: u16 = 12;
+const LEGACY_STACKED_PREVIEW_MIN_HEIGHT: u16 = 12;
 const CUSTOM_SIDEBAR_MIN_WIDTH: u16 = 16;
 const CUSTOM_ENTRIES_MIN_WIDTH: u16 = 28;
 const CUSTOM_PREVIEW_MIN_WIDTH: u16 = 24;
@@ -69,6 +76,13 @@ pub(super) fn resolve_body_layout(area: Rect, pane_weights: Option<PaneWeights>)
 }
 
 fn legacy_body_layout(area: Rect) -> BodyLayout {
+    let preferred_stacked = (area.width <= LEGACY_STACKED_PREFERRED_MAX_WIDTH)
+        .then(|| legacy_stacked_body_layout(area))
+        .flatten();
+    if let Some(layout) = preferred_stacked {
+        return layout;
+    }
+
     if let Some(layout) = legacy_horizontal_body_layout(area) {
         return layout;
     }
@@ -77,15 +91,20 @@ fn legacy_body_layout(area: Rect) -> BodyLayout {
         return layout;
     }
 
+    if let Some(layout) = legacy_best_effort_stacked_body_layout(area) {
+        return layout;
+    }
+
     legacy_sidebar_and_entries_layout(area)
 }
 
 fn legacy_horizontal_body_layout(area: Rect) -> Option<BodyLayout> {
-    let (sidebar, content) = split_sidebar_and_content(
+    let (sidebar, content) = split_sidebar_and_content_with_comfort(
         area,
         LEGACY_WIDE_SIDEBAR_WIDTH,
-        LEGACY_HORIZONTAL_SIDEBAR_MIN_WIDTH,
-        LEGACY_HORIZONTAL_ENTRIES_MIN_WIDTH.saturating_add(LEGACY_HORIZONTAL_PREVIEW_MIN_WIDTH),
+        LEGACY_NARROW_SIDEBAR_WIDTH,
+        LEGACY_HORIZONTAL_CONTENT_MIN_WIDTH,
+        LEGACY_HORIZONTAL_SIDEBAR_SHRINK_START_WIDTH,
     )?;
     let widths = allocate_weighted_lengths(content.width, vec![54, 46]);
     if widths.len() != 2
@@ -122,11 +141,54 @@ fn legacy_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
         LEGACY_NARROW_SIDEBAR_WIDTH,
         CUSTOM_ENTRIES_MIN_WIDTH.max(CUSTOM_PREVIEW_MIN_WIDTH),
     )?;
-    let (entries, preview) = split_stacked_content_weighted(
+    let (entries, preview) = split_stacked_content_weighted_with_mins(
         content,
         LEGACY_STACKED_ENTRIES_WEIGHT,
         LEGACY_STACKED_PREVIEW_WEIGHT,
+        LEGACY_STACKED_ENTRIES_MIN_HEIGHT,
+        LEGACY_STACKED_PREVIEW_MIN_HEIGHT,
     )?;
+
+    Some(BodyLayout {
+        sidebar: non_empty(sidebar),
+        entries: non_empty(entries),
+        preview: non_empty(preview),
+    })
+}
+
+fn legacy_best_effort_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
+    let (sidebar, content) =
+        if area.width >= LEGACY_NARROW_SIDEBAR_WIDTH + LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR {
+            split_sidebar_and_content(
+                area,
+                LEGACY_NARROW_SIDEBAR_WIDTH,
+                LEGACY_NARROW_SIDEBAR_WIDTH,
+                LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR,
+            )?
+        } else {
+            (Rect::default(), area)
+        };
+    if content.height < 2 || content.width < 2 {
+        return None;
+    }
+
+    let heights = allocate_weighted_lengths(
+        content.height,
+        vec![LEGACY_STACKED_ENTRIES_WEIGHT, LEGACY_STACKED_PREVIEW_WEIGHT],
+    );
+    let [entries_height, preview_height]: [u16; 2] = heights.try_into().ok()?;
+    let entries = Rect {
+        x: content.x,
+        y: content.y,
+        width: content.width,
+        height: entries_height,
+    };
+    let preview = Rect {
+        x: content.x,
+        y: content.y.saturating_add(entries_height),
+        width: content.width,
+        height: preview_height,
+    };
 
     Some(BodyLayout {
         sidebar: non_empty(sidebar),
@@ -139,7 +201,7 @@ fn legacy_sidebar_and_entries_layout(area: Rect) -> BodyLayout {
     if let Some((sidebar, entries)) = split_sidebar_and_content(
         area,
         LEGACY_NARROW_SIDEBAR_WIDTH,
-        CUSTOM_SIDEBAR_MIN_WIDTH,
+        LEGACY_NARROW_SIDEBAR_WIDTH,
         CUSTOM_ENTRIES_MIN_WIDTH,
     ) {
         return BodyLayout {
@@ -182,7 +244,10 @@ fn custom_body_layout(area: Rect, weights: PaneWeights) -> BodyLayout {
         return layout;
     }
 
-    if show_preview && let Some(layout) = stacked_body_layout_with_mins(area, weights) {
+    let stacked = show_preview
+        .then(|| stacked_body_layout_with_mins(area, weights))
+        .flatten();
+    if let Some(layout) = stacked {
         return layout;
     }
 
@@ -300,13 +365,35 @@ fn split_sidebar_and_content(
     minimum_sidebar_width: u16,
     minimum_content_width: u16,
 ) -> Option<(Rect, Rect)> {
+    split_sidebar_and_content_with_comfort(
+        area,
+        preferred_sidebar_width,
+        minimum_sidebar_width,
+        minimum_content_width,
+        minimum_content_width,
+    )
+}
+
+fn split_sidebar_and_content_with_comfort(
+    area: Rect,
+    preferred_sidebar_width: u16,
+    minimum_sidebar_width: u16,
+    minimum_content_width: u16,
+    sidebar_shrink_start_width: u16,
+) -> Option<(Rect, Rect)> {
     if area.width < minimum_sidebar_width.saturating_add(minimum_content_width) {
         return None;
     }
 
+    let shrink = sidebar_shrink_start_width
+        .saturating_sub(area.width)
+        .saturating_add(LEGACY_HORIZONTAL_SIDEBAR_SHRINK_STEP.saturating_sub(1))
+        .checked_div(LEGACY_HORIZONTAL_SIDEBAR_SHRINK_STEP)
+        .unwrap_or(0);
     let sidebar_width = preferred_sidebar_width
-        .min(area.width.saturating_sub(minimum_content_width))
-        .max(minimum_sidebar_width);
+        .saturating_sub(shrink)
+        .max(minimum_sidebar_width)
+        .min(area.width.saturating_sub(minimum_content_width));
     let content_width = area.width.saturating_sub(sidebar_width);
 
     let sidebar = Rect {
@@ -330,13 +417,26 @@ fn split_stacked_content_weighted(
     entries_weight: u16,
     preview_weight: u16,
 ) -> Option<(Rect, Rect)> {
+    split_stacked_content_weighted_with_mins(
+        area,
+        entries_weight,
+        preview_weight,
+        CUSTOM_STACKED_ENTRIES_MIN_HEIGHT,
+        CUSTOM_STACKED_PREVIEW_MIN_HEIGHT,
+    )
+}
+
+fn split_stacked_content_weighted_with_mins(
+    area: Rect,
+    entries_weight: u16,
+    preview_weight: u16,
+    entries_min_height: u16,
+    preview_min_height: u16,
+) -> Option<(Rect, Rect)> {
     let heights = allocate_weighted_lengths_with_mins(
         area.height,
         vec![entries_weight, preview_weight],
-        vec![
-            CUSTOM_STACKED_ENTRIES_MIN_HEIGHT,
-            CUSTOM_STACKED_PREVIEW_MIN_HEIGHT,
-        ],
+        vec![entries_min_height, preview_min_height],
     )?;
     let [entries_height, preview_height]: [u16; 2] = heights.try_into().ok()?;
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -220,53 +220,7 @@ fn list_view_ignores_grid_zoom_levels() {
 }
 
 #[test]
-fn narrow_browser_layout_stacks_preview_below_entries() {
-    let layout = resolve_body_layout(
-        Rect {
-            x: 0,
-            y: 0,
-            width: 65,
-            height: 20,
-        },
-        None,
-    );
-
-    let sidebar = layout.sidebar.expect("sidebar should be visible");
-    let entries = layout.entries.expect("entries should be visible");
-    let preview = layout.preview.expect("preview should be visible");
-
-    assert_eq!(sidebar.width, 22);
-    assert_eq!(entries.x, preview.x);
-    assert_eq!(entries.width, preview.width);
-    assert_eq!(entries.height, 11);
-    assert_eq!(preview.height, 9);
-}
-
-#[test]
-fn narrow_tall_browser_layout_gives_preview_more_vertical_space() {
-    let layout = resolve_body_layout(
-        Rect {
-            x: 0,
-            y: 0,
-            width: 65,
-            height: 60,
-        },
-        None,
-    );
-
-    let sidebar = layout.sidebar.expect("sidebar should be visible");
-    let entries = layout.entries.expect("entries should be visible");
-    let preview = layout.preview.expect("preview should be visible");
-
-    assert_eq!(sidebar.width, 22);
-    assert_eq!(entries.x, preview.x);
-    assert_eq!(entries.width, preview.width);
-    assert_eq!(entries.height, 33);
-    assert_eq!(preview.height, 27);
-}
-
-#[test]
-fn wide_browser_layout_uses_the_narrower_default_sidebar_width() {
+fn wide_browser_layout_uses_default_sidebar_width() {
     let layout = resolve_body_layout(
         Rect {
             x: 0,
@@ -286,24 +240,79 @@ fn wide_browser_layout_uses_the_narrower_default_sidebar_width() {
 }
 
 #[test]
-fn narrow_browser_layout_drops_preview_when_height_is_too_limited() {
-    let layout = resolve_body_layout(
-        Rect {
-            x: 0,
-            y: 0,
-            width: 65,
-            height: 14,
-        },
-        None,
-    );
+fn narrowing_horizontal_browser_layout_starts_shrinking_sidebar_early() {
+    for (width, expected_sidebar_width) in [
+        (104, 20),
+        (100, 19),
+        (96, 18),
+        (88, 16),
+        (80, 14),
+        (72, 12),
+        (64, 10),
+        (56, 10),
+        (46, 10),
+    ] {
+        let layout = resolve_body_layout(
+            Rect {
+                x: 0,
+                y: 0,
+                width,
+                height: 20,
+            },
+            None,
+        );
 
-    let sidebar = layout.sidebar.expect("sidebar should be visible");
-    let entries = layout.entries.expect("entries should be visible");
+        assert_eq!(
+            layout.sidebar.expect("sidebar should be visible").width,
+            expected_sidebar_width
+        );
+    }
+}
 
-    assert!(sidebar.width >= 16);
-    assert_eq!(layout.preview, None);
-    assert_eq!(entries.y, 0);
-    assert_eq!(entries.height, 14);
+#[test]
+fn narrow_legacy_layout_keeps_preview_without_starving_files() {
+    for (width, height, expect_sidebar, expect_stacked) in [
+        (54, 24, true, true),
+        (45, 24, true, true),
+        (39, 28, true, true),
+        (46, 20, true, false),
+        (45, 23, true, false),
+        (20, 18, false, true),
+    ] {
+        let layout = resolve_body_layout(
+            Rect {
+                x: 0,
+                y: 0,
+                width,
+                height,
+            },
+            None,
+        );
+
+        let entries = layout.entries.expect("entries should be visible");
+        let preview = layout.preview.expect("preview should be visible");
+        assert_eq!(layout.sidebar.is_some(), expect_sidebar, "width {width}");
+        if let Some(sidebar) = layout.sidebar {
+            assert_eq!(sidebar.width, 10, "width {width}");
+        }
+        if expect_stacked {
+            assert_eq!(entries.x, preview.x, "width {width} should stay stacked");
+            assert!(
+                preview.y > entries.y,
+                "width {width} should keep preview below files"
+            );
+            assert_eq!(entries.width, preview.width);
+        } else {
+            assert_eq!(
+                entries.y, preview.y,
+                "width {width} should remain horizontal"
+            );
+            assert_eq!(
+                layout.sidebar.map_or(0, |sidebar| sidebar.width) + entries.width + preview.width,
+                width
+            );
+        }
+    }
 }
 
 #[test]
@@ -1441,7 +1450,7 @@ fn preview_header_detail_uses_compact_labels_before_final_clamp() {
     fs::write(root.join("report.txt"), contents).expect("failed to write temp file");
 
     let mut app = App::new_at(root.clone()).expect("app should load temp directory");
-    let mut terminal = Terminal::new(TestBackend::new(60, 24)).expect("terminal should init");
+    let mut terminal = Terminal::new(TestBackend::new(64, 28)).expect("terminal should init");
     wait_for_background_preview(&mut app);
 
     let state = draw_ui(&mut terminal, &mut app);
@@ -1454,10 +1463,7 @@ fn preview_header_detail_uses_compact_labels_before_final_clamp() {
         header_row.contains("Text"),
         "expected preview header row to contain the section label, got: {header_row:?}"
     );
-    let expected_line_coverage = format!(
-        "{} / {total_lines} lines shown",
-        default_code_preview_line_limit()
-    );
+    let expected_line_coverage = format!("{} / {total_lines}", default_code_preview_line_limit());
     assert!(
         header_row.contains(&expected_line_coverage),
         "expected preview header row to show semantic line coverage, got: {header_row:?}"


### PR DESCRIPTION
## Summary

Improve browser pane resizing in narrow terminal layouts.

## What Changed

- Make Places give up horizontal space sooner.
- Keep Preview usable longer in narrow layouts.
- Make stacked file/preview layouts resize more consistently.
- Preserve custom `[layout.panes]` behavior.
- Added regression coverage and a changelog entry.

## User Impact

Narrow terminal windows keep the file list and preview readable for longer, with less layout jumping while resizing.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested default narrow resizing across side-by-side, stacked, and very narrow layouts.
- Tested custom `[layout.panes]` weights and confirmed behavior remains compatible.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed