### PR TITLE
polish(ui): simplify create and help hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated shell integration scripts to pass `--chooser-file` invocations directly to `elio`, so chooser mode does not change the parent shell directory. Re-run `elio shell install` after upgrading to refresh existing shell integration.
 - Improved the Open With menu with keyboard navigation, scrolling, and an overflow scrollbar for long app lists.
 - Improved narrow browser pane resizing so Places gives up space sooner, preview remains useful longer, and stacked preview layouts behave more consistently.
+- Simplified Create and Help overlay hints.
 
 ### Fixed
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1312,6 +1312,10 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
         "expected help overlay to list the zoxide shortcut, got: {rendered:?}"
     );
     assert!(
+        rendered.contains("/… or …/") && rendered.contains("folder in create prompt"),
+        "expected help overlay to show the create prompt folder-name hint, got: {rendered:?}"
+    );
+    assert!(
         rendered.contains("Alt/Shift+Enter"),
         "expected help overlay to show the current create prompt newline hint, got: {rendered:?}"
     );

--- a/src/ui/overlay_manager/create.rs
+++ b/src/ui/overlay_manager/create.rs
@@ -6,7 +6,7 @@ use crate::ui::{
 };
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Margin, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Clear, Paragraph},
@@ -22,7 +22,7 @@ pub(super) fn render_create_overlay(
     let line_count = app.create_line_count().max(1);
     let visible_lines = line_count.min(8) as u16;
     let popup_width = area.width.saturating_sub(8).clamp(36, 64);
-    let popup_height = visible_lines + 6;
+    let popup_height = visible_lines + 5;
     let popup = helpers::centered_rect(area, popup_width, popup_height);
     state.create_panel = Some(popup);
 
@@ -39,41 +39,14 @@ pub(super) fn render_create_overlay(
     let inner = helpers::inner_with_padding(popup);
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(visible_lines + 2),
-            Constraint::Length(1),
-        ])
+        .constraints([Constraint::Length(visible_lines + 2), Constraint::Length(1)])
         .split(inner);
-
-    let header_cols = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(1), Constraint::Length(18)])
-        .split(rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("󰜄", Style::default().fg(palette.accent)),
-            Span::raw("  "),
-            Span::styled("/ → folder", Style::default().fg(palette.muted)),
-        ]))
-        .style(Style::default().bg(palette.chrome_alt)),
-        header_cols[0],
-    );
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("Alt+Enter", Style::default().fg(palette.text)),
-            Span::styled(" new line", Style::default().fg(palette.muted)),
-        ]))
-        .alignment(Alignment::Right)
-        .style(Style::default().bg(palette.chrome_alt)),
-        header_cols[1],
-    );
 
     frame.render_widget(
         helpers::rounded_block(palette.path_bg, palette.border),
-        rows[1],
+        rows[0],
     );
-    let list_area = rows[1].inner(Margin {
+    let list_area = rows[0].inner(Margin {
         horizontal: 1,
         vertical: 1,
     });
@@ -212,11 +185,11 @@ pub(super) fn render_create_overlay(
     if let Some(error) = app.create_line_error(cursor_line) {
         frame.render_widget(
             Paragraph::new(Line::from(vec![Span::styled(
-                helpers::clamp_label(error, rows[2].width.saturating_sub(2) as usize),
+                helpers::clamp_label(error, rows[1].width.saturating_sub(2) as usize),
                 Style::default().fg(palette.accent),
             )]))
             .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
-            rows[2],
+            rows[1],
         );
     }
 }

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -34,6 +34,7 @@ pub(super) fn render_help(
     let clipboard_entries = clipboard_entries(&keys);
     let files_entries = entries([
         keys.action(&kb.create, "create file or folder"),
+        e("/… or …/", "folder in create prompt"),
         e("Alt/Shift+Enter", "add line in create prompt"),
         keys.action(&kb.trash, "trash (delete if in trash)"),
         keys.action(&kb.delete_permanently, "delete permanently"),
@@ -148,32 +149,8 @@ pub(super) fn render_help(
     let inner = helpers::inner_with_padding(popup);
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Min(8),
-            Constraint::Length(1),
-        ])
+        .constraints([Constraint::Min(8), Constraint::Length(1)])
         .split(inner);
-
-    frame.render_widget(
-        Paragraph::new(vec![Line::from(vec![
-            helpers::chip_span("navigate", palette.accent_soft, palette.accent_text, true),
-            Span::raw(" "),
-            helpers::chip_span("search", palette.accent_soft, palette.accent_text, true),
-            Span::raw(" "),
-            helpers::chip_span("selection", palette.accent_soft, palette.accent_text, true),
-            Span::raw(" "),
-            helpers::chip_span("mouse", palette.accent_soft, palette.accent_text, true),
-            Span::raw(" "),
-            helpers::chip_span("actions", palette.accent_soft, palette.accent_text, true),
-            Span::raw(" "),
-            helpers::chip_span("preview", palette.accent_soft, palette.accent_text, true),
-            Span::raw(" "),
-            helpers::chip_span("view", palette.accent_soft, palette.accent_text, true),
-        ])])
-        .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
-        rows[0],
-    );
 
     let cols = Layout::default()
         .direction(Direction::Horizontal)
@@ -182,7 +159,7 @@ pub(super) fn render_help(
             Constraint::Length(3),
             Constraint::Length(46),
         ])
-        .split(rows[1]);
+        .split(rows[0]);
 
     frame.render_widget(
         Paragraph::new(help_column_lines(cols[0].width, &left_sections, palette))
@@ -221,7 +198,7 @@ pub(super) fn render_help(
         ]))
         .alignment(Alignment::Right)
         .style(Style::default().bg(palette.chrome_alt).fg(palette.muted)),
-        rows[2],
+        rows[1],
     );
 }
 


### PR DESCRIPTION
## Summary

Simplify the Create prompt and Help overlay hint presentation.

## What Changed

- Removed the hint row from the Create prompt and  Added the folder-name pattern to the Help overlay instead.
- Removed the Help overlay category chip row.

## User Impact

The Create prompt is cleaner, while folder creation and multi-line create hints remain discoverable in the Help overlay.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed