### PR TITLE
fix(runtime): keep chooser output clean when piped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--chooser-file -` and `/dev/stdout` output when piped to tools such as `sed` or `awk`, keeping terminal UI escape sequences out of machine-readable chooser output. ([#186])
+
 ## [1.9.0] - 2026-06-17
 
 ### Added
@@ -262,3 +266,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#162]: https://github.com/elio-fm/elio/issues/162
 [#168]: https://github.com/elio-fm/elio/issues/168
 [#174]: https://github.com/elio-fm/elio/issues/174
+[#186]: https://github.com/elio-fm/elio/issues/186

--- a/src/runtime/session_files.rs
+++ b/src/runtime/session_files.rs
@@ -51,7 +51,17 @@ fn write_chooser_file(chooser_file: &Path, paths: &[PathBuf]) -> Result<()> {
 }
 
 fn chooser_file_is_stdout(chooser_file: &Path) -> bool {
-    chooser_file == Path::new("-")
+    chooser_file == Path::new("-") || chooser_file_is_dev_stdout(chooser_file)
+}
+
+#[cfg(unix)]
+fn chooser_file_is_dev_stdout(chooser_file: &Path) -> bool {
+    chooser_file == Path::new("/dev/stdout")
+}
+
+#[cfg(not(unix))]
+fn chooser_file_is_dev_stdout(_chooser_file: &Path) -> bool {
+    false
 }
 
 #[cfg(unix)]
@@ -126,10 +136,13 @@ mod tests {
     }
 
     #[test]
-    fn chooser_file_hyphen_targets_stdout() {
+    fn chooser_file_hyphen_and_dev_stdout_target_stdout() {
         assert!(chooser_file_is_stdout(Path::new("-")));
-        assert!(!chooser_file_is_stdout(Path::new("./-")));
+        #[cfg(unix)]
+        assert!(chooser_file_is_stdout(Path::new("/dev/stdout")));
+        #[cfg(not(unix))]
         assert!(!chooser_file_is_stdout(Path::new("/dev/stdout")));
+        assert!(!chooser_file_is_stdout(Path::new("./-")));
     }
 
     #[test]

--- a/src/runtime/terminal.rs
+++ b/src/runtime/terminal.rs
@@ -12,8 +12,10 @@ use crossterm::{
     },
 };
 use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect};
+#[cfg(unix)]
+use std::fs::OpenOptions;
 use std::{
-    io::{self, ErrorKind, Write},
+    io::{self, ErrorKind, IsTerminal, Write},
     sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock, PoisonError},
     thread,
 };
@@ -65,7 +67,7 @@ pub(super) struct ThreadedWriter {
 }
 
 impl ThreadedWriter {
-    fn new() -> Self {
+    fn new(output: Box<dyn Write + Send>) -> Self {
         let channel = Arc::new(WriterChannel {
             state: Mutex::new(WriterShared {
                 buf: Vec::new(),
@@ -77,7 +79,7 @@ impl ThreadedWriter {
         });
         let writer_channel = Arc::clone(&channel);
         thread::spawn(move || {
-            let mut out = io::stdout();
+            let mut out = output;
             let mut batch = Vec::new();
             loop {
                 {
@@ -198,9 +200,9 @@ pub(super) fn init_terminal() -> Result<(AppTerminal, Drainer)> {
 
 fn try_init_terminal() -> Result<(AppTerminal, Drainer)> {
     enable_raw_mode()?;
-    let mut stdout = io::stdout();
+    let (mut terminal_output, frame_output) = terminal_output_handles()?;
     execute!(
-        stdout,
+        terminal_output,
         EnterAlternateScreen,
         event::EnableMouseCapture,
         EnableFocusChange
@@ -213,26 +215,39 @@ fn try_init_terminal() -> Result<(AppTerminal, Drainer)> {
     //   1002 = button-event tracking (drag with button held)
     //   1003 = any-event tracking (all motion, needed for hover-based scroll routing)
     //   1006 = SGR extended coordinates (required for columns > 223)
-    write!(stdout, "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h")?;
+    write!(
+        terminal_output,
+        "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h"
+    )?;
 
     // Ask the terminal to forward Shift+mouse to the app instead of using it for text
     // selection. Ghostty and some xterm-compatible terminals honor XTSHIFTESCAPE.
     // Terminals that don't support it ignore this silently.
-    write!(stdout, "\x1b[>4;1m")?;
+    write!(terminal_output, "\x1b[>4;1m")?;
 
-    stdout.flush()?;
-    push_keyboard_enhancement_if_supported(&mut stdout)?;
+    terminal_output.flush()?;
+    push_keyboard_enhancement_if_supported(&mut terminal_output)?;
 
-    // The startup escapes above go straight to stdout (the backend doesn't exist
-    // yet and they're already flushed). From here on, all frame output flows
-    // through the background writer so the event loop never blocks on it.
-    let writer = ThreadedWriter::new();
+    // Startup escapes go to the controlling terminal, not stdout, so chooser
+    // output can remain machine-readable when stdout is piped.
+    let writer = ThreadedWriter::new(frame_output);
     let drainer = writer.drainer();
     let backend = CrosstermBackend::new(writer);
     let mut terminal = Terminal::new(backend)?;
     clear_for_full_repaint(&mut terminal)?;
     terminal.hide_cursor()?;
     Ok((terminal, drainer))
+}
+
+#[cfg(unix)]
+fn terminal_output_handles() -> io::Result<(Box<dyn Write + Send>, Box<dyn Write + Send>)> {
+    let tty = OpenOptions::new().read(true).write(true).open("/dev/tty")?;
+    Ok((Box::new(tty.try_clone()?), Box::new(tty)))
+}
+
+#[cfg(not(unix))]
+fn terminal_output_handles() -> io::Result<(Box<dyn Write + Send>, Box<dyn Write + Send>)> {
+    Ok((Box::new(io::stdout()), Box::new(io::stdout())))
 }
 
 /// Clears the alternate screen and forces a full repaint on the next draw,
@@ -332,22 +347,33 @@ pub(super) fn restore_terminal(terminal: &mut AppTerminal, drainer: &Drainer) ->
 }
 
 fn cleanup_terminal_state() -> io::Result<()> {
-    let mut stdout = io::stdout();
-    let _ = write!(stdout, "\x1b[>4;0m");
-    let _ = write!(stdout, "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l");
-    let _ = stdout.flush();
-    let _ = execute!(
-        stdout,
-        event::DisableMouseCapture,
-        DisableFocusChange,
-        SetCursorStyle::DefaultUserShape,
-        LeaveAlternateScreen,
-    );
+    if let Ok((mut terminal_output, _)) = terminal_output_handles() {
+        let _ = write!(terminal_output, "\x1b[>4;0m");
+        let _ = write!(
+            terminal_output,
+            "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l"
+        );
+        let _ = terminal_output.flush();
+        let _ = execute!(
+            terminal_output,
+            event::DisableMouseCapture,
+            DisableFocusChange,
+            SetCursorStyle::DefaultUserShape,
+            LeaveAlternateScreen,
+        );
+    }
     disable_raw_mode()?;
     Ok(())
 }
 
 fn push_keyboard_enhancement_if_supported<W: Write>(writer: &mut W) -> io::Result<()> {
+    // The capability probe talks through crossterm's default stdout handle. When
+    // stdout is piped for chooser output, skip the optional enhancement so the
+    // probe cannot contaminate the machine-readable stream.
+    if !io::stdout().is_terminal() {
+        return Ok(());
+    }
+
     // The probe writes a query to the terminal and blocks on the reply with a
     // 2-second crossterm timeout. Support cannot change within a session, so
     // probe once and reuse the answer — this runs again on every resume from

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -137,7 +137,7 @@ fn more_than_one_path_is_rejected() {
     fs::remove_dir_all(second).expect("second temp directory should be removed");
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn chooser_stdout_pipe_receives_only_selection() {
     use std::{

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -136,3 +136,120 @@ fn more_than_one_path_is_rejected() {
     fs::remove_dir_all(first).expect("first temp directory should be removed");
     fs::remove_dir_all(second).expect("second temp directory should be removed");
 }
+
+#[cfg(unix)]
+#[test]
+fn chooser_stdout_pipe_receives_only_selection() {
+    use std::{
+        fs::File,
+        io::{Read, Write},
+        os::{fd::FromRawFd, unix::process::CommandExt},
+        process::Stdio,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    let root = temp_path("chooser-stdout-pipe");
+    fs::create_dir_all(&root).expect("temp directory should be created");
+    let selected = root.join("picked.txt");
+    fs::write(&selected, "picked").expect("selected file should be written");
+
+    let mut master = 0;
+    let mut slave = 0;
+    let mut stdout_pipe = [0; 2];
+    unsafe {
+        assert_eq!(
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null()
+            ),
+            0
+        );
+        assert_eq!(libc::pipe(stdout_pipe.as_mut_ptr()), 0);
+    }
+
+    let tty_for_child = unsafe { libc::dup(slave) };
+    assert!(tty_for_child >= 0);
+
+    let slave_file = unsafe { File::from_raw_fd(slave) };
+    let stdout_writer = unsafe { File::from_raw_fd(stdout_pipe[1]) };
+    let mut stdout_reader = unsafe { File::from_raw_fd(stdout_pipe[0]) };
+    let mut tty_master = unsafe { File::from_raw_fd(master) };
+
+    let mut command = elio();
+    command
+        .arg("--chooser-file")
+        .arg("-")
+        .arg(&root)
+        .env("TERM", "xterm-256color")
+        .stdin(Stdio::from(slave_file))
+        .stdout(Stdio::from(stdout_writer))
+        .stderr(Stdio::null());
+
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(tty_for_child, libc::TIOCSCTTY, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            libc::close(tty_for_child);
+            Ok(())
+        });
+    }
+
+    let mut child = command.spawn().expect("elio should spawn under a pty");
+    unsafe {
+        libc::close(tty_for_child);
+    }
+    thread::sleep(Duration::from_millis(500));
+    tty_master
+        .write_all(b"\r")
+        .expect("enter key should be sent to pty");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while child
+        .try_wait()
+        .expect("child status should be readable")
+        .is_none()
+    {
+        if Instant::now() > deadline {
+            child.kill().expect("hung child should be killed");
+            panic!("elio did not exit after chooser confirmation");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    unsafe {
+        let flags = libc::fcntl(stdout_pipe[0], libc::F_GETFL);
+        assert!(flags >= 0);
+        assert_eq!(
+            libc::fcntl(stdout_pipe[0], libc::F_SETFL, flags | libc::O_NONBLOCK),
+            0
+        );
+    }
+
+    let mut stdout = Vec::new();
+    loop {
+        let mut chunk = [0; 1024];
+        match stdout_reader.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(count) => stdout.extend_from_slice(&chunk[..count]),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(error) => panic!("chooser stdout should be readable: {error}"),
+        }
+    }
+
+    let expected = format!("{}\n", selected.display());
+    assert_eq!(String::from_utf8_lossy(&stdout), expected);
+    assert!(
+        !stdout.contains(&0x1b),
+        "stdout contained terminal escape bytes"
+    );
+
+    fs::remove_dir_all(root).expect("temp directory should be removed");
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -163,8 +163,8 @@ fn chooser_stdout_pipe_receives_only_selection() {
                 &mut master,
                 &mut slave,
                 std::ptr::null_mut(),
-                std::ptr::null(),
-                std::ptr::null()
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
             ),
             0
         );
@@ -194,7 +194,7 @@ fn chooser_stdout_pipe_receives_only_selection() {
             if libc::setsid() == -1 {
                 return Err(std::io::Error::last_os_error());
             }
-            if libc::ioctl(tty_for_child, libc::TIOCSCTTY, 0) == -1 {
+            if libc::ioctl(tty_for_child, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
                 return Err(std::io::Error::last_os_error());
             }
             libc::close(tty_for_child);


### PR DESCRIPTION
## Summary

Fix chooser mode stdout contamination when `--chooser-file -` or `/dev/stdout` is piped to tools such as `sed` or `awk`.

Fixes #186.

## What Changed

- Route terminal UI/control output to the controlling terminal on Unix instead of process stdout.
- Keep stdout reserved for machine-readable chooser output.
- Treat `/dev/stdout` as stdout-equivalent for chooser output on Unix.
- Skip the optional keyboard enhancement probe when stdout is piped, avoiding terminal probe bytes in the data stream.
- Added a PTY regression test that verifies piped chooser stdout contains only the selected path.

## User Impact

`elio --chooser-file -` and `elio --chooser-file /dev/stdout` now work cleanly in pipelines without hanging-looking behavior or terminal escape artifacts leaking into downstream tools.

## Notes

The Unix terminal UI path now uses the controlling terminal for TUI output when stdout is redirected. Non-Unix terminal output behavior is unchanged.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Reproduced the issue on the latest public version with Kitty, WezTerm, and foot.
- Verified the branch in Kitty, WezTerm, and foot with `--chooser-file -` piped through `cat`, `sed`, and `awk`.
- Verified `/dev/stdout` chooser output through `cat`, `sed`, and `awk`.
- Verified raw`xxd` captures contain only the selected path and newline, with no ESC/UI bytes.

Result:

All checks passed locally. Piped chooser output is clean, and terminal UI escape sequences no longer reach machine-readable stdout.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed