### PR TITLE
feat(config): add configurable goto entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
+
 ### Fixed
 
 - Fixed `--chooser-file -` and `/dev/stdout` output when piped to tools such as `sed` or `awk`, keeping terminal UI escape sequences out of machine-readable chooser output. ([#186])
@@ -264,6 +268,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#157]: https://github.com/elio-fm/elio/issues/157
 [#159]: https://github.com/elio-fm/elio/issues/159
 [#162]: https://github.com/elio-fm/elio/issues/162
+[#166]: https://github.com/elio-fm/elio/issues/166
 [#168]: https://github.com/elio-fm/elio/issues/168
 [#174]: https://github.com/elio-fm/elio/issues/174
 [#186]: https://github.com/elio-fm/elio/issues/186

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Keys marked with `*` are configurable in `[keys]` in `config.toml`; the defaults
 | `h` / `←` / `Backspace` `*` | Go to parent directory |
 | `l` / `→` `*` | Enter folder |
 | `Enter` `*` | Enter folder / open file or selection |
-| `g` `*` | Go-to menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash) |
+| `g` `*` | Go To menu (`g` top, `d` downloads, `h` home, `c` config folder, `t` trash; configurable in `[goto]`) |
 | `Home` `*` | Jump to first item |
 | `G` / `End` `*` | Jump to last item |
 | `PageUp` / `PageDown` `*` | Page up / down |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -35,6 +35,27 @@
 #   "trash",
 # ]
 #
+# Customize the Go To menu. `entries` controls the items in order.
+# Omit [goto] entirely to keep the default Go To menu.
+#
+# Built-in names: top, downloads, home, config, trash
+# Entry forms:
+# - "downloads"
+# - { builtin = "downloads", key = "D" }
+# - { title = "tmp", path = "/tmp", key = "T" }
+#
+# Duplicate keys are skipped after the first matching entry.
+#
+# [goto]
+# entries = [
+#   "top",
+#   { builtin = "downloads", key = "D" },
+#   "home",
+#   "config",
+#   "trash",
+#   { title = "tmp", path = "/tmp", key = "T" },
+# ]
+#
 # Optional pane weights for the browser body. Values are relative: in
 # side-by-side layouts they control horizontal width, and when Preview stacks
 # below Files they control the Files / Preview vertical split.

--- a/src/app/actions/goto.rs
+++ b/src/app/actions/goto.rs
@@ -2,7 +2,10 @@ use super::super::{
     App, SidebarItemKind,
     state::{GoToDestination, GoToOverlay, GoToOverlayRow},
 };
-use crate::fs::{rect_contains, trash_dir};
+use crate::{
+    config::{BuiltinGoto, GotoEntrySpec},
+    fs::{rect_contains, trash_dir},
+};
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use std::path::PathBuf;
@@ -63,16 +66,13 @@ impl App {
             KeyCode::Esc => {
                 self.overlays.goto = None;
             }
-            KeyCode::Char(ch)
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                if let Some(index) = self.goto_row_index_for_shortcut(ch) {
+            _ => {
+                if let Some(index) = crate::config::normalized_plain_key_char(key)
+                    .and_then(|ch| self.goto_row_index_for_shortcut(ch))
+                {
                     self.confirm_goto_index(index)?;
                 }
             }
-            _ => {}
         }
 
         Ok(())
@@ -106,13 +106,10 @@ impl App {
     }
 
     fn goto_row_index_for_shortcut(&self, ch: char) -> Option<usize> {
-        let needle = ch.to_ascii_lowercase();
-        self.overlays.goto.as_ref().and_then(|overlay| {
-            overlay
-                .rows
-                .iter()
-                .position(|row| row.shortcut.to_ascii_lowercase() == needle)
-        })
+        self.overlays
+            .goto
+            .as_ref()
+            .and_then(|overlay| overlay.rows.iter().position(|row| row.shortcut == ch))
     }
 
     fn confirm_goto_index(&mut self, index: usize) -> Result<()> {
@@ -144,24 +141,54 @@ impl App {
 }
 
 fn build_goto_overlay(app: &App) -> GoToOverlay {
-    let rows = vec![
-        build_goto_row('g', "top", GoToDestination::Top),
-        build_goto_row(
-            'd',
+    let rows = crate::config::goto()
+        .entries
+        .iter()
+        .map(|entry| build_configured_goto_row(app, entry))
+        .collect();
+
+    GoToOverlay {
+        title: "Go to".to_string(),
+        rows,
+    }
+}
+
+fn build_configured_goto_row(app: &App, entry: &GotoEntrySpec) -> GoToOverlayRow {
+    match entry {
+        GotoEntrySpec::Builtin { destination, key } => {
+            let (label, destination) = builtin_goto_destination(app, *destination);
+            build_goto_row(*key, label, destination)
+        }
+        GotoEntrySpec::Custom { title, path, key } => {
+            let destination = if path.exists() {
+                GoToDestination::Path(path.clone())
+            } else {
+                GoToDestination::Missing(format!("{title} not available"))
+            };
+            build_goto_row(*key, title, destination)
+        }
+    }
+}
+
+fn builtin_goto_destination(
+    app: &App,
+    destination: BuiltinGoto,
+) -> (&'static str, GoToDestination) {
+    match destination {
+        BuiltinGoto::Top => ("top", GoToDestination::Top),
+        BuiltinGoto::Downloads => (
             "downloads",
             downloads_destination(app)
                 .map(GoToDestination::Path)
                 .unwrap_or_else(|| GoToDestination::Missing("Downloads not available".to_string())),
         ),
-        build_goto_row(
-            'h',
+        BuiltinGoto::Home => (
             "home",
             crate::fs::home_dir()
                 .map(GoToDestination::Path)
                 .unwrap_or_else(|| GoToDestination::Missing("Home not available".to_string())),
         ),
-        build_goto_row(
-            'c',
+        BuiltinGoto::Config => (
             config_label(),
             config_directory()
                 .map(GoToDestination::Path)
@@ -169,18 +196,12 @@ fn build_goto_overlay(app: &App) -> GoToOverlay {
                     GoToDestination::Missing(format!("{} not available", config_label()))
                 }),
         ),
-        build_goto_row(
-            't',
+        BuiltinGoto::Trash => (
             "trash",
             trash_destination(app)
                 .map(GoToDestination::Path)
                 .unwrap_or_else(|| GoToDestination::Missing("Trash not available".to_string())),
         ),
-    ];
-
-    GoToOverlay {
-        title: "Go to".to_string(),
-        rows,
     }
 }
 
@@ -231,4 +252,56 @@ fn trash_destination(app: &App) -> Option<PathBuf> {
         .find(|item| item.kind == SidebarItemKind::Trash)
         .map(|item| item.path.clone())
         .or_else(|| crate::fs::home_dir().and_then(|home| trash_dir(&home)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEventKind, KeyEventState};
+    use std::{fs, time::SystemTime};
+
+    #[test]
+    fn goto_shortcuts_respect_caps_lock_normalization() {
+        let root = temp_dir("goto-caps-lock-root");
+        fs::create_dir_all(&root).expect("failed to create temp dir");
+        for name in ["a.txt", "b.txt"] {
+            fs::write(root.join(name), name).expect("failed to write temp file");
+        }
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        app.jump_last();
+        app.overlays.goto = Some(GoToOverlay {
+            title: "Go to".to_string(),
+            rows: vec![GoToOverlayRow {
+                shortcut: 'W',
+                label: "top".to_string(),
+                destination: GoToDestination::Top,
+            }],
+        });
+
+        app.handle_goto_key(caps_lock_char('w', KeyModifiers::NONE))
+            .expect("caps-lock W shortcut should activate");
+
+        assert_eq!(app.navigation.selected, 0);
+        assert!(app.overlays.goto.is_none());
+
+        fs::remove_dir_all(root).expect("failed to remove temp dir");
+    }
+
+    fn caps_lock_char(c: char, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new_with_kind_and_state(
+            KeyCode::Char(c),
+            modifiers,
+            KeyEventKind::Press,
+            KeyEventState::CAPS_LOCK,
+        )
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-{name}-{unique}"))
+    }
 }

--- a/src/config/goto.rs
+++ b/src/config/goto.rs
@@ -1,0 +1,241 @@
+use serde::Deserialize;
+use std::{collections::HashMap, path::PathBuf};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GotoConfig {
+    pub entries: Vec<GotoEntrySpec>,
+}
+
+impl Default for GotoConfig {
+    fn default() -> Self {
+        Self {
+            entries: vec![
+                GotoEntrySpec::builtin(BuiltinGoto::Top),
+                GotoEntrySpec::builtin(BuiltinGoto::Downloads),
+                GotoEntrySpec::builtin(BuiltinGoto::Home),
+                GotoEntrySpec::builtin(BuiltinGoto::Config),
+                GotoEntrySpec::builtin(BuiltinGoto::Trash),
+            ],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BuiltinGoto {
+    Top,
+    Downloads,
+    Home,
+    Config,
+    Trash,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum GotoEntrySpec {
+    Builtin {
+        destination: BuiltinGoto,
+        key: char,
+    },
+    Custom {
+        title: String,
+        path: PathBuf,
+        key: char,
+    },
+}
+
+#[derive(Deserialize, Default)]
+pub(super) struct GotoConfigOverride {
+    entries: Option<Vec<toml::Value>>,
+}
+
+impl GotoConfig {
+    pub(super) fn from_override(overrides: GotoConfigOverride, defaults: &Self) -> Self {
+        let Some(entries) = overrides.entries else {
+            return defaults.clone();
+        };
+
+        let mut owners = HashMap::new();
+        let entries = entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| {
+                let field_name = format!("goto.entries[{index}]");
+                let entry = GotoEntrySpec::from_toml_value(entry, &field_name)?;
+                let key = entry.key();
+                if let Some(owner) = owners.get(&key) {
+                    eprintln!(
+                        "elio: {field_name}: key '{}' is already used by {owner}; skipping entry",
+                        entry.key()
+                    );
+                    return None;
+                }
+                owners.insert(key, entry.name().to_string());
+                Some(entry)
+            })
+            .collect();
+
+        Self { entries }
+    }
+}
+
+impl GotoEntrySpec {
+    fn builtin(destination: BuiltinGoto) -> Self {
+        Self::Builtin {
+            destination,
+            key: destination.default_key(),
+        }
+    }
+
+    fn from_toml_value(value: &toml::Value, field_name: &str) -> Option<Self> {
+        match value {
+            toml::Value::String(name) => BuiltinGoto::parse(name).map(Self::builtin),
+            toml::Value::Table(table) => {
+                if let Some(builtin) = table.get("builtin") {
+                    let Some(name) = builtin
+                        .as_str()
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                    else {
+                        eprintln!(
+                            "elio: {field_name}: builtin goto entries require a non-empty string builtin name; \
+                             skipping entry"
+                        );
+                        return None;
+                    };
+                    let destination = BuiltinGoto::parse(name)?;
+                    if table.contains_key("title") || table.contains_key("path") {
+                        eprintln!(
+                            "elio: {field_name}: builtin goto entries only support {{ builtin, key }}; \
+                             ignoring extra fields"
+                        );
+                    }
+                    let key = parse_goto_key(table.get("key"), field_name)
+                        .unwrap_or_else(|| destination.default_key());
+                    return Some(Self::Builtin { destination, key });
+                }
+
+                let title = table
+                    .get("title")
+                    .and_then(toml::Value::as_str)
+                    .map(str::trim)
+                    .filter(|title| !title.is_empty());
+                let Some(title) = title else {
+                    eprintln!(
+                        "elio: {field_name}: custom goto entries require a non-empty string title; \
+                         skipping entry"
+                    );
+                    return None;
+                };
+
+                let path = table
+                    .get("path")
+                    .and_then(toml::Value::as_str)
+                    .map(str::trim)
+                    .filter(|path| !path.is_empty());
+                let Some(path) = path else {
+                    eprintln!(
+                        "elio: {field_name}: custom goto entries require a non-empty string path; \
+                         skipping entry"
+                    );
+                    return None;
+                };
+
+                let Some(key) = parse_goto_key(table.get("key"), field_name) else {
+                    eprintln!(
+                        "elio: {field_name}: custom goto entries require a single-character string key; \
+                         skipping entry"
+                    );
+                    return None;
+                };
+
+                match crate::config::places::expand_custom_place_path(path) {
+                    Ok(path) => Some(Self::Custom {
+                        title: title.to_string(),
+                        path,
+                        key,
+                    }),
+                    Err(error) => {
+                        eprintln!("elio: {field_name}: {error}; skipping entry");
+                        None
+                    }
+                }
+            }
+            _ => {
+                eprintln!(
+                    "elio: {field_name}: expected a built-in name, {{ builtin, key? }}, or \
+                     {{ title, path, key }} object; skipping entry"
+                );
+                None
+            }
+        }
+    }
+
+    pub(crate) fn key(&self) -> char {
+        match self {
+            Self::Builtin { key, .. } | Self::Custom { key, .. } => *key,
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            Self::Builtin { destination, .. } => destination.name(),
+            Self::Custom { title, .. } => title,
+        }
+    }
+}
+
+fn parse_goto_key(value: Option<&toml::Value>, field_name: &str) -> Option<char> {
+    let value = value?;
+    let Some(key) = value.as_str().map(str::trim) else {
+        eprintln!("elio: {field_name}: goto key must be a string");
+        return None;
+    };
+    let mut chars = key.chars();
+    let Some(ch) = chars.next() else {
+        eprintln!("elio: {field_name}: goto key must not be empty");
+        return None;
+    };
+    if chars.next().is_some() {
+        eprintln!("elio: {field_name}: goto key must be a single character");
+        return None;
+    }
+    Some(ch)
+}
+
+impl BuiltinGoto {
+    fn parse(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "top" => Some(Self::Top),
+            "downloads" => Some(Self::Downloads),
+            "home" => Some(Self::Home),
+            "config" => Some(Self::Config),
+            "trash" => Some(Self::Trash),
+            _ => {
+                eprintln!(
+                    "elio: unknown goto entry {name:?}; expected one of: \
+                     top, downloads, home, config, trash"
+                );
+                None
+            }
+        }
+    }
+
+    fn default_key(self) -> char {
+        match self {
+            Self::Top => 'g',
+            Self::Downloads => 'd',
+            Self::Home => 'h',
+            Self::Config => 'c',
+            Self::Trash => 't',
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Top => "top",
+            Self::Downloads => "downloads",
+            Self::Home => "home",
+            Self::Config => "config",
+            Self::Trash => "trash",
+        }
+    }
+}

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -3,7 +3,9 @@ mod model;
 mod parse;
 mod validate;
 
-pub(crate) use self::model::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList};
+pub(crate) use self::model::{
+    Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList, normalized_plain_key_char,
+};
 pub(super) use self::parse::KeysConfigOverride;
 use self::validate::resolve_key_overrides;
 use crossterm::event::KeyEvent;

--- a/src/config/keys/model.rs
+++ b/src/config/keys/model.rs
@@ -226,6 +226,14 @@ pub(crate) struct KeySpec {
     pub(super) modifiers: KeyModifierSpec,
 }
 
+pub(crate) fn normalized_plain_key_char(key: KeyEvent) -> Option<char> {
+    let (code, modifiers) = normalize_key_event(key);
+    match (code, modifiers.is_empty()) {
+        (KeyCode::Char(ch), true) => Some(ch),
+        _ => None,
+    }
+}
+
 impl KeySpec {
     pub(super) fn char(c: char) -> Self {
         Self {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+mod goto;
 mod keys;
 mod layout;
 mod loading;
@@ -9,7 +10,8 @@ mod ui;
 use serde::Deserialize;
 
 pub(crate) use self::{
-    keys::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList},
+    goto::{BuiltinGoto, GotoConfig, GotoEntrySpec},
+    keys::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList, normalized_plain_key_char},
     layout::{LayoutConfig, PaneWeights},
     loading::config_dir,
     places::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
@@ -18,6 +20,7 @@ pub(crate) use self::{
 
 struct Config {
     ui: UiConfig,
+    goto: GotoConfig,
     places: PlacesConfig,
     layout: LayoutConfig,
     keys: KeyBindings,
@@ -26,6 +29,7 @@ struct Config {
 #[derive(Deserialize, Default)]
 struct ConfigFile {
     ui: Option<ui::UiConfigOverride>,
+    goto: Option<goto::GotoConfigOverride>,
     places: Option<places::PlacesConfigOverride>,
     layout: Option<layout::LayoutConfigOverride>,
     keys: Option<keys::KeysConfigOverride>,
@@ -37,6 +41,10 @@ pub(crate) fn initialize() {
 
 pub(crate) fn ui() -> UiConfig {
     loading::active_config().ui
+}
+
+pub(crate) fn goto() -> &'static GotoConfig {
+    &loading::active_config().goto
 }
 
 pub(crate) fn places() -> &'static PlacesConfig {
@@ -55,6 +63,7 @@ impl Config {
     fn default_config() -> Self {
         Self {
             ui: UiConfig::default(),
+            goto: GotoConfig::default(),
             places: PlacesConfig::default(),
             layout: LayoutConfig::default(),
             keys: KeyBindings::default(),
@@ -66,6 +75,9 @@ impl Config {
         let mut resolved = Self::default_config();
         if let Some(ui) = parsed.ui {
             resolved.ui.apply_override(ui);
+        }
+        if let Some(goto) = parsed.goto {
+            resolved.goto = GotoConfig::from_override(goto, &resolved.goto);
         }
         if let Some(places) = parsed.places {
             resolved.places = PlacesConfig::from_override(places, &resolved.places);

--- a/src/config/places.rs
+++ b/src/config/places.rs
@@ -201,7 +201,7 @@ impl BuiltinPlace {
     }
 }
 
-fn expand_custom_place_path(path: &str) -> anyhow::Result<PathBuf> {
+pub(super) fn expand_custom_place_path(path: &str) -> anyhow::Result<PathBuf> {
     let expanded = if path == "~" {
         crate::fs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?
     } else if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {

--- a/src/config/tests/goto.rs
+++ b/src/config/tests/goto.rs
@@ -1,0 +1,138 @@
+use super::{super::*, toml_string};
+
+#[test]
+fn config_defaults_goto_to_builtin_entries() {
+    let config = Config::default_config();
+
+    assert_eq!(
+        config.goto.entries,
+        vec![
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Top,
+                key: 'g',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Downloads,
+                key: 'd',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Home,
+                key: 'h',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Config,
+                key: 'c',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Trash,
+                key: 't',
+            },
+        ]
+    );
+}
+
+#[test]
+fn config_can_customize_goto_entries() {
+    let workspace = std::env::temp_dir().join("elio-goto-workspace");
+    let tmp = std::env::temp_dir().join("elio-goto-tmp");
+    let workspace_toml = toml_string(&workspace.display().to_string());
+    let tmp_toml = toml_string(&tmp.display().to_string());
+    let config = Config::from_str(&format!(
+        r#"
+[goto]
+entries = [
+  "home",
+  {{ builtin = "downloads", key = "W" }},
+  {{ title = "projects", path = {}, key = "p" }},
+  {{ title = "temp", path = {}, key = "T" }},
+  "trash",
+]
+"#,
+        workspace_toml, tmp_toml
+    ))
+    .expect("config should parse");
+
+    assert_eq!(
+        config.goto.entries,
+        vec![
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Home,
+                key: 'h',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Downloads,
+                key: 'W',
+            },
+            GotoEntrySpec::Custom {
+                title: "projects".to_string(),
+                path: workspace,
+                key: 'p',
+            },
+            GotoEntrySpec::Custom {
+                title: "temp".to_string(),
+                path: tmp,
+                key: 'T',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Trash,
+                key: 't',
+            },
+        ]
+    );
+}
+
+#[test]
+fn config_goto_skips_duplicate_keys() {
+    let homelab = std::env::temp_dir().join("elio-goto-homelab");
+    let homelab_toml = toml_string(&homelab.display().to_string());
+    let config = Config::from_str(&format!(
+        r#"
+[goto]
+entries = [
+  "home",
+  {{ title = "homelab", path = {}, key = "h" }},
+  "trash",
+]
+"#,
+        homelab_toml
+    ))
+    .expect("config should parse");
+
+    assert_eq!(
+        config.goto.entries,
+        vec![
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Home,
+                key: 'h',
+            },
+            GotoEntrySpec::Builtin {
+                destination: BuiltinGoto::Trash,
+                key: 't',
+            },
+        ]
+    );
+}
+
+#[test]
+fn config_goto_skips_invalid_custom_entries() {
+    let config = Config::from_str(
+        r#"
+[goto]
+entries = [
+  { title = "relative", path = "workspace", key = "w" },
+  { title = "missing key", path = "/tmp" },
+  { title = "multi key", path = "/tmp", key = "tmp" },
+  "trash",
+]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config.goto.entries,
+        vec![GotoEntrySpec::Builtin {
+            destination: BuiltinGoto::Trash,
+            key: 't',
+        }]
+    );
+}

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -1,3 +1,4 @@
+mod goto;
 mod keys;
 mod layout;
 mod places;

--- a/src/ui/overlay_manager/goto.rs
+++ b/src/ui/overlay_manager/goto.rs
@@ -8,6 +8,8 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
+const MAX_GOTO_COLUMNS: usize = 5;
+
 pub(super) fn render_goto_overlay(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -15,9 +17,14 @@ pub(super) fn render_goto_overlay(
     state: &mut FrameState,
     palette: Palette,
 ) {
-    let row_count = app.goto_row_count().max(1);
+    let row_count = app.goto_row_count();
+    let columns = goto_column_count(row_count);
+    let visual_rows = row_count.div_ceil(columns).max(1);
     let popup_width = area.width.saturating_sub(8).clamp(70, 112);
-    let popup_height = 5;
+    let row_gap_count = visual_rows.saturating_sub(1) as u16;
+    let popup_height = (visual_rows as u16)
+        .saturating_add(row_gap_count)
+        .saturating_add(4);
     let popup = Rect {
         x: area.x + area.width.saturating_sub(popup_width) / 2,
         y: area.y + area.height.saturating_sub(popup_height + 2),
@@ -42,60 +49,108 @@ pub(super) fn render_goto_overlay(
     );
 
     let inner = helpers::inner_with_padding(popup);
-    let rows = Layout::default()
+    let available_rows = inner.height.saturating_sub(2) as usize;
+    if available_rows == 0 || row_count == 0 {
+        return;
+    }
+
+    let rendered_rows = visual_rows.min(available_rows.div_ceil(2));
+    let mut vertical_constraints =
+        Vec::with_capacity(rendered_rows.saturating_mul(2).saturating_sub(1));
+    for visual_row in 0..rendered_rows {
+        if visual_row > 0 {
+            vertical_constraints.push(Constraint::Length(1));
+        }
+        vertical_constraints.push(Constraint::Length(1));
+    }
+    let layout_height = rendered_rows
+        .saturating_mul(2)
+        .saturating_sub(1)
+        .min(available_rows) as u16;
+    let row_rects = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ])
-        .split(inner);
-    let action_row = rows[1];
-    let columns = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(20),
-            Constraint::Length(1),
-            Constraint::Percentage(20),
-            Constraint::Length(1),
-            Constraint::Percentage(20),
-            Constraint::Length(1),
-            Constraint::Percentage(20),
-            Constraint::Length(1),
-            Constraint::Percentage(20),
-        ])
-        .split(action_row);
-
-    for index in 0..row_count.min(5) {
-        let rect = columns[index * 2];
-        let shortcut = app
-            .goto_row_shortcut(index)
-            .unwrap_or('?')
-            .to_ascii_lowercase();
-        let label = helpers::clamp_label(
-            app.goto_row_label(index),
-            rect.width.saturating_sub(5) as usize,
-        );
-
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled(shortcut.to_string(), Style::default().fg(palette.accent)),
-                Span::styled(" -> ", Style::default().fg(palette.muted)),
-                Span::styled(label, Style::default().fg(palette.text)),
-            ]))
-            .alignment(Alignment::Center)
-            .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
-            rect,
-        );
-
-        state.goto_hits.push(GoToHit {
-            rect: Rect {
-                x: rect.x,
-                y: inner.y,
-                width: rect.width,
-                height: inner.height,
-            },
-            index,
+        .constraints(vertical_constraints)
+        .split(Rect {
+            y: inner.y + 1,
+            height: layout_height,
+            ..inner
         });
+
+    let column_constraints = std::iter::repeat_n(Constraint::Fill(1), columns).collect::<Vec<_>>();
+    for visual_row in 0..rendered_rows {
+        let first_index = visual_row * columns;
+        let row_items = columns.min(row_count.saturating_sub(first_index));
+        let column_rects = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(column_constraints.clone())
+            .split(row_rects[visual_row * 2]);
+        for column in 0..row_items {
+            let index = first_index + column;
+            render_goto_entry(frame, app, state, palette, column_rects[column], index);
+        }
+    }
+}
+
+fn render_goto_entry(
+    frame: &mut Frame<'_>,
+    app: &App,
+    state: &mut FrameState,
+    palette: Palette,
+    rect: Rect,
+    index: usize,
+) {
+    let shortcut = app.goto_row_shortcut(index).unwrap_or('?');
+    let label = helpers::clamp_label(
+        app.goto_row_label(index),
+        rect.width.saturating_sub(5) as usize,
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(shortcut.to_string(), Style::default().fg(palette.accent)),
+            Span::styled(" -> ", Style::default().fg(palette.muted)),
+            Span::styled(label, Style::default().fg(palette.text)),
+        ]))
+        .alignment(Alignment::Center)
+        .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
+        rect,
+    );
+
+    state.goto_hits.push(GoToHit { rect, index });
+}
+
+fn goto_column_count(row_count: usize) -> usize {
+    let max_columns = row_count.clamp(1, MAX_GOTO_COLUMNS);
+    if row_count > 10 {
+        return (1..=max_columns)
+            .rev()
+            .find(|&columns| row_count % columns != 1)
+            .unwrap_or(1);
+    }
+
+    (1..=max_columns)
+        .filter(|&columns| row_count == 1 || columns > 1)
+        .filter(|&columns| row_count <= columns || row_count % columns != 1)
+        .min_by_key(|&columns| {
+            let rows = row_count.div_ceil(columns);
+            (rows * columns - row_count, std::cmp::Reverse(columns))
+        })
+        .unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::goto_column_count;
+
+    #[test]
+    fn goto_columns_avoid_single_item_last_row() {
+        assert_eq!(goto_column_count(5), 5);
+        assert_eq!(goto_column_count(6), 3);
+        assert_eq!(goto_column_count(7), 4);
+        assert_eq!(goto_column_count(8), 4);
+        assert_eq!(goto_column_count(10), 5);
+        assert_eq!(goto_column_count(11), 4);
+        assert_eq!(goto_column_count(13), 5);
+        assert_eq!(goto_column_count(14), 5);
     }
 }


### PR DESCRIPTION
## Summary

Make Go To entries configurable.

Closes #166.

## What Changed

The Go To menu can now be configured with `[goto].entries`. Built-in entries can be reordered, removed, or assigned different shortcuts, and custom folder entries can be added with their own title, path, and key.

Invalid entries and duplicate shortcuts are skipped with warnings, while omitting `[goto]` keeps the existing default Go To menu unchanged. The Go To layout, docs, changelog, and tests were updated for the new configurable menu.

## User Impact

Users can now customize the Go To menu.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested configured Go To menus with 1–15, 25, 35, and 45 entries.
- Tested existing custom paths, unavailable paths, duplicate shortcuts, and rebinding built-ins.

Result:

All checks passed locally. Configured Go To entries work as expected, and the default menu remains unchanged without `[goto]`.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed