### PR TITLE
fix(preview): refresh startup media thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `--chooser-file -` and `/dev/stdout` output when piped to tools such as `sed` or `awk`, keeping terminal UI escape sequences out of machine-readable chooser output. ([#186])
+- Fixed video thumbnails not appearing for the first file when starting elio inside a video folder. ([#195])
+- Fixed inline video preview redraws that could leave only partial metadata visible after navigating between videos.
 
 ## [1.9.0] - 2026-06-17
 
@@ -272,3 +274,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#168]: https://github.com/elio-fm/elio/issues/168
 [#174]: https://github.com/elio-fm/elio/issues/174
 [#186]: https://github.com/elio-fm/elio/issues/186
+[#195]: https://github.com/elio-fm/elio/issues/195

--- a/src/app/actions/preview/cache.rs
+++ b/src/app/actions/preview/cache.rs
@@ -10,11 +10,13 @@ impl App {
         variant: &PreviewRequestOptions,
     ) -> Option<PreviewContent> {
         let code_line_limit = self.preview_code_line_limit_for_entry(entry);
+        let ffmpeg_available = self.preview_cache_ffmpeg_available_for_entry(entry);
 
         // Try the complete render first.
         let complete_key = PreviewCacheKey {
             path: entry.path.clone(),
             variant: variant.clone(),
+            ffmpeg_available,
             code_line_limit,
             code_render_limit: code_line_limit,
         };
@@ -29,6 +31,7 @@ impl App {
         let partial_key = PreviewCacheKey {
             path: entry.path.clone(),
             variant: variant.clone(),
+            ffmpeg_available,
             code_line_limit,
             code_render_limit: 0, // placeholder — will search by prefix below
         };
@@ -40,6 +43,7 @@ impl App {
             .find(|(key, cached)| {
                 key.path == entry.path
                     && key.variant == *variant
+                    && key.ffmpeg_available == ffmpeg_available
                     && key.code_line_limit == code_line_limit
                     && cached.size == entry.size
                     && cached.modified == entry.modified
@@ -53,11 +57,13 @@ impl App {
         variant: &PreviewRequestOptions,
     ) -> Option<PreviewContent> {
         let code_line_limit = self.preview_code_line_limit_for_entry(entry);
+        let ffmpeg_available = self.preview_cache_ffmpeg_available_for_entry(entry);
 
         // Try the complete render first (prefer it even when stale).
         let complete_key = PreviewCacheKey {
             path: entry.path.clone(),
             variant: variant.clone(),
+            ffmpeg_available,
             code_line_limit,
             code_render_limit: code_line_limit,
         };
@@ -73,6 +79,7 @@ impl App {
             .find(|(key, _)| {
                 key.path == entry.path
                     && key.variant == *variant
+                    && key.ffmpeg_available == ffmpeg_available
                     && key.code_line_limit == code_line_limit
             })
             .map(|(_, cached)| cached.preview.clone())
@@ -91,6 +98,7 @@ impl App {
             variant,
             code_line_limit,
             code_line_limit,
+            self.preview_cache_ffmpeg_available_for_entry(entry),
             preview,
         );
     }
@@ -111,6 +119,7 @@ impl App {
             variant,
             code_line_limit,
             code_render_limit,
+            self.preview_cache_ffmpeg_available_for_entry(entry),
             preview,
         );
     }
@@ -121,11 +130,13 @@ impl App {
         variant: &PreviewRequestOptions,
         code_line_limit: usize,
         code_render_limit: usize,
+        ffmpeg_available: bool,
         preview: &PreviewContent,
     ) {
         let key = PreviewCacheKey {
             path: entry.path.clone(),
             variant: variant.clone(),
+            ffmpeg_available: ffmpeg_available && preview_cache_entry_uses_ffmpeg(entry),
             code_line_limit,
             code_render_limit,
         };
@@ -187,4 +198,17 @@ impl App {
             .keys()
             .any(|key| key.path == path)
     }
+
+    pub(in crate::app) fn preview_cache_ffmpeg_available_for_entry(&self, entry: &Entry) -> bool {
+        preview_cache_entry_uses_ffmpeg(entry)
+            && self.terminal_image_overlay_available()
+            && self.preview.media.ffmpeg_available != Some(false)
+    }
+}
+
+fn preview_cache_entry_uses_ffmpeg(entry: &Entry) -> bool {
+    matches!(
+        crate::file_info::inspect_entry_cached(entry).builtin_class,
+        FileClass::Audio | FileClass::Video
+    )
 }

--- a/src/app/actions/preview/mod.rs
+++ b/src/app/actions/preview/mod.rs
@@ -10,6 +10,7 @@ use super::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::overlays::inline_image::{ImageProtocol, TerminalIdentity};
     use crate::preview::{
         PreviewContent, PreviewKind, PreviewRequestOptions, default_code_preview_line_limit,
     };
@@ -233,6 +234,84 @@ mod tests {
 
         assert!(request.ffprobe_available);
         assert!(!request.ffmpeg_available);
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn enabling_image_support_refreshes_startup_video_preview_for_thumbnail() {
+        let root = temp_path("startup-video-image-support");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("clip.mp4");
+        fs::write(&path, b"video").expect("failed to write video fixture");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        app.set_media_ffprobe_available_for_tests(true);
+        app.set_media_ffmpeg_available_for_tests(true);
+        assert_eq!(app.preview.state.content.kind, PreviewKind::Video);
+        assert!(app.preview.state.content.preview_visual.is_none());
+        let before = app.scheduler_metrics();
+
+        app.set_terminal_image_protocol_for_tests(
+            ImageProtocol::KittyGraphics,
+            TerminalIdentity::Kitty,
+        );
+        app.refresh_current_media_preview_after_image_support_enabled();
+
+        let after = app.scheduler_metrics();
+        assert_eq!(
+            after.preview_jobs_submitted_high,
+            before.preview_jobs_submitted_high + 1
+        );
+        assert!(matches!(
+            app.preview.state.load_state,
+            Some(PreviewLoadState::Placeholder(ref loading_path)) if loading_path == &path
+        ));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    fn cached_startup_video_without_ffmpeg_is_not_reused_after_image_support() {
+        let root = temp_path("startup-video-cache-mode");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let path = root.join("clip.mp4");
+        fs::write(&path, b"video").expect("failed to write video fixture");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        let entry = app
+            .selected_entry()
+            .cloned()
+            .expect("video entry should be selected");
+        let variant = app.current_preview_request_options();
+        let stale_without_thumbnail = PreviewContent::new(PreviewKind::Video, Vec::new());
+        app.cache_preview_result_with_limits(
+            &entry,
+            &variant,
+            default_code_preview_line_limit(),
+            default_code_preview_line_limit(),
+            false,
+            &stale_without_thumbnail,
+        );
+        app.set_media_ffprobe_available_for_tests(true);
+        app.set_media_ffmpeg_available_for_tests(true);
+        app.set_terminal_image_protocol_for_tests(
+            ImageProtocol::KittyGraphics,
+            TerminalIdentity::Kitty,
+        );
+        let before = app.scheduler_metrics();
+
+        app.refresh_preview();
+
+        let after = app.scheduler_metrics();
+        assert_eq!(
+            after.preview_jobs_submitted_high,
+            before.preview_jobs_submitted_high + 1
+        );
+        assert!(matches!(
+            app.preview.state.load_state,
+            Some(PreviewLoadState::Placeholder(ref loading_path)) if loading_path == &path
+        ));
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
     }

--- a/src/app/jobs/pool/preview.rs
+++ b/src/app/jobs/pool/preview.rs
@@ -50,6 +50,7 @@ pub(in crate::app::jobs) struct PreviewJobKey {
     pub(in crate::app::jobs) size: u64,
     pub(in crate::app::jobs) modified: Option<SystemTime>,
     pub(in crate::app::jobs) variant: PreviewRequestOptions,
+    pub(in crate::app::jobs) ffmpeg_available: bool,
     pub(in crate::app::jobs) code_line_limit: usize,
     /// Included so that an initial partial render and its extension job are
     /// treated as distinct keys and not deduplicated against each other.
@@ -106,6 +107,7 @@ impl PreviewPool {
                             variant: request.variant,
                             code_line_limit: request.code_line_limit,
                             code_render_limit: request.code_render_limit,
+                            ffmpeg_available: request.ffmpeg_available,
                             result,
                         })))
                         .is_err()
@@ -307,6 +309,7 @@ impl PreviewJobKey {
             size: request.entry.size,
             modified: request.entry.modified,
             variant: request.variant.clone(),
+            ffmpeg_available: request.ffmpeg_available,
             code_line_limit: request.code_line_limit,
             code_render_limit: request.code_render_limit,
         }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -401,6 +401,7 @@ impl App {
                         &build.variant,
                         build.code_line_limit,
                         build.code_render_limit,
+                        build.ffmpeg_available,
                         &build.result,
                     );
                     let build_is_comic = build.result.kind == preview::PreviewKind::Comic;

--- a/src/app/jobs/results/tests/cache.rs
+++ b/src/app/jobs/results/tests/cache.rs
@@ -183,6 +183,7 @@ fn stale_preview_results_are_counted_in_metrics() {
             variant: preview::PreviewRequestOptions::Default,
             code_line_limit: 0,
             code_render_limit: 0,
+            ffmpeg_available: false,
             result: preview::PreviewContent::new(
                 preview::PreviewKind::Text,
                 vec![ratatui::text::Line::from("stale preview")],

--- a/src/app/jobs/tests.rs
+++ b/src/app/jobs/tests.rs
@@ -37,6 +37,7 @@ fn preview_job_key(path: &str, size: u64) -> PreviewJobKey {
         size,
         modified: None,
         variant: PreviewRequestOptions::Default,
+        ffmpeg_available: false,
         code_line_limit: default_code_preview_line_limit(),
         code_render_limit: default_code_preview_line_limit(),
     }

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -236,6 +236,7 @@ pub(in crate::app) struct PreviewBuild {
     /// The actual line limit used for this render pass. May be less than
     /// `code_line_limit` for initial incremental renders.
     pub(in crate::app) code_render_limit: usize,
+    pub(in crate::app) ffmpeg_available: bool,
     pub(in crate::app) result: preview::PreviewContent,
 }
 

--- a/src/app/overlays/comic.rs
+++ b/src/app/overlays/comic.rs
@@ -422,6 +422,7 @@ impl App {
             .contains_key(&PreviewCacheKey {
                 path: path.to_path_buf(),
                 variant: preview::PreviewRequestOptions::ComicPage(page),
+                ffmpeg_available: false,
                 code_line_limit: preview::default_code_preview_line_limit(),
                 code_render_limit: preview::default_code_preview_line_limit(),
             })

--- a/src/app/overlays/epub.rs
+++ b/src/app/overlays/epub.rs
@@ -302,6 +302,7 @@ impl App {
             .contains_key(&PreviewCacheKey {
                 path: path.to_path_buf(),
                 variant: preview::PreviewRequestOptions::EpubSection(section),
+                ffmpeg_available: false,
                 code_line_limit: preview::default_code_preview_line_limit(),
                 code_render_limit: preview::default_code_preview_line_limit(),
             })

--- a/src/app/overlays/images/present.rs
+++ b/src/app/overlays/images/present.rs
@@ -230,12 +230,7 @@ impl App {
     fn static_image_clear_area(&self, request: &StaticImageOverlayRequest) -> Rect {
         if self.preview.terminal_images.protocol.is_raster() {
             if request.mode == StaticImageOverlayMode::Inline {
-                return self
-                    .input
-                    .frame_state
-                    .preview_body_area
-                    .or_else(|| self.preview_body_area())
-                    .unwrap_or(request.area);
+                return request.area;
             }
             return self
                 .input
@@ -244,18 +239,6 @@ impl App {
                 .unwrap_or(request.area);
         }
         request.area
-    }
-
-    fn preview_body_area(&self) -> Option<Rect> {
-        match (
-            self.input.frame_state.preview_media_area,
-            self.input.frame_state.preview_content_area,
-        ) {
-            (Some(media), Some(content)) => Some(union_rect(media, content)),
-            (Some(media), None) => Some(media),
-            (None, Some(content)) => Some(content),
-            (None, None) => None,
-        }
     }
 
     fn static_image_display_area(
@@ -314,20 +297,5 @@ impl App {
             inline_payload,
             Some(window_size),
         )
-    }
-}
-
-fn union_rect(a: Rect, b: Rect) -> Rect {
-    let left = a.x.min(b.x);
-    let top = a.y.min(b.y);
-    let right = a.x.saturating_add(a.width).max(b.x.saturating_add(b.width));
-    let bottom =
-        a.y.saturating_add(a.height)
-            .max(b.y.saturating_add(b.height));
-    Rect {
-        x: left,
-        y: top,
-        width: right.saturating_sub(left),
-        height: bottom.saturating_sub(top),
     }
 }

--- a/src/app/overlays/images/state.rs
+++ b/src/app/overlays/images/state.rs
@@ -212,6 +212,14 @@ impl App {
             .map(|displayed| displayed.clear_area)
     }
 
+    pub(in crate::app) fn displayed_static_image_mode(&self) -> Option<StaticImageOverlayMode> {
+        self.preview
+            .image
+            .displayed
+            .as_ref()
+            .map(|displayed| displayed.mode)
+    }
+
     pub(in crate::app) fn clear_displayed_static_image(&mut self) {
         self.preview.image.displayed = None;
         self.preview.image.displayed_excluded.clear();

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -132,6 +132,7 @@ pub(in crate::app) struct RenderedImageDimensions {
 
 impl App {
     pub(crate) fn enable_terminal_image_previews(&mut self) {
+        let was_available = self.terminal_image_overlay_available();
         let identity = detect_terminal_identity();
         let image_previews_override = env::var_os("ELIO_IMAGE_PREVIEWS").is_some();
         let protocol = select_image_protocol(identity, image_previews_override);
@@ -164,6 +165,23 @@ impl App {
             self.preview.terminal_images.window
         ));
         self.sync_pdf_preview_selection();
+        if !was_available && self.terminal_image_overlay_available() {
+            self.refresh_current_media_preview_after_image_support_enabled();
+        }
+    }
+
+    pub(in crate::app) fn refresh_current_media_preview_after_image_support_enabled(&mut self) {
+        if !self.terminal_image_overlay_available()
+            || self.preview.state.content.preview_visual.is_some()
+            || !matches!(
+                self.preview.state.content.kind,
+                crate::preview::PreviewKind::Audio | crate::preview::PreviewKind::Video
+            )
+        {
+            return;
+        }
+
+        self.refresh_preview();
     }
 
     pub(crate) fn handle_terminal_image_resize(&mut self) {
@@ -417,15 +435,25 @@ impl App {
         }
         let mut expanded_areas = Vec::with_capacity(areas.len());
         for area in areas {
+            let (expand_right, expand_bottom) = if self.displayed_static_image_mode()
+                == Some(crate::app::overlays::images::StaticImageOverlayMode::Inline)
+            {
+                (0, 0)
+            } else if self.preview.terminal_images.identity == TerminalIdentity::WindowsTerminal
+                && self.preview.terminal_images.protocol == ImageProtocol::Sixel
+            {
+                (1, 1)
+            } else {
+                (0, 2)
+            };
             geometry::push_unique_rect(
                 &mut expanded_areas,
-                if self.preview.terminal_images.identity == TerminalIdentity::WindowsTerminal
-                    && self.preview.terminal_images.protocol == ImageProtocol::Sixel
-                {
-                    iterm::expand_raster_erase_area(&self.input.frame_state, area, 1, 1)
-                } else {
-                    iterm::expand_raster_erase_area(&self.input.frame_state, area, 0, 2)
-                },
+                iterm::expand_raster_erase_area(
+                    &self.input.frame_state,
+                    area,
+                    expand_right,
+                    expand_bottom,
+                ),
             );
         }
         expanded_areas

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -307,13 +307,18 @@ fn large_inline_cover_uses_more_height_without_hiding_details() {
 }
 
 #[test]
-fn iterm_inline_page_image_clear_area_covers_preview_body_without_header() {
+fn iterm_inline_page_image_clear_area_stays_inside_media_area() {
     let root = temp_root("iterm-inline-clear-area");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let page = root.join("page.png");
     write_test_raster_image(&page, ImageFormat::Png, 900, 1400);
     let page_size = fs::metadata(&page)
         .expect("page image metadata should exist")
+        .len();
+    let next_page = root.join("next-page.png");
+    write_test_raster_image(&next_page, ImageFormat::Png, 1200, 800);
+    let next_page_size = fs::metadata(&next_page)
+        .expect("next page image metadata should exist")
         .len();
 
     let mut app = App::new_at(root.clone()).expect("app should initialize");
@@ -356,9 +361,24 @@ fn iterm_inline_page_image_clear_area_covers_preview_body_without_header() {
             x: 2,
             y: 3,
             width: 48,
-            height: 20,
+            height: 12,
         })
     );
+
+    app.preview.state.content = PreviewContent::new(PreviewKind::Comic, Vec::new())
+        .with_preview_visual(PreviewVisual {
+            kind: PreviewVisualKind::PageImage,
+            layout: PreviewVisualLayout::Inline,
+            path: next_page,
+            size: next_page_size,
+            modified: None,
+        });
+    assert!(!app.displayed_static_image_matches_active());
+    app.queue_forced_iterm_preview_erase();
+    let erase =
+        String::from_utf8(app.iterm_pre_draw_erase()).expect("iTerm erase should be valid utf8");
+    assert!(erase.contains("\x1b[4;3H"));
+    assert!(!erase.contains("\x1b[16;3H"));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -286,6 +286,7 @@ pub(super) struct CachedPreview {
 pub(super) struct PreviewCacheKey {
     pub(super) path: PathBuf,
     pub(super) variant: preview::PreviewRequestOptions,
+    pub(super) ffmpeg_available: bool,
     pub(super) code_line_limit: usize,
     /// The render limit used for this cache entry. Partial (incremental)
     /// renders have `code_render_limit < code_line_limit`; complete renders


### PR DESCRIPTION
## Summary

Fix video thumbnails not appearing for the first file when starting elio inside a video folder.

Fixes #195.

## What Changed

- Refresh the current media preview when terminal image support becomes available after startup.
- Include media thumbnail capability in preview cache/job identity so startup previews rendered before image support are not reused incorrectly.
- Tighten inline raster preview clear/erase areas so video metadata rows stay visible while navigating between videos.
- Added regression coverage for startup video thumbnail refresh and inline preview redraw bounds.

## User Impact

Video thumbnails now appear for the initially selected file when launching elio directly inside a folder of videos. Inline video previews also keep their metadata visible after moving between videos.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Verified video previews when launching directly inside a video folder.
- Verified navigating away from videos and back keeps thumbnail and metadata visible.
- Tested in Kitty, Ghostty, WezTerm, Konsole, and foot.

Result:

All checks passed locally. Startup video thumbnails and inline video preview redraws behave correctly across the tested terminals.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed