### PR TITLE
fix(ui): use icon-only places in narrow windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
 
+### Changed
+
+- Places now switches to an icon-only rail in narrow windows before labels become overly truncated. ([#184])
+
 ### Fixed
 
 - Fixed `--chooser-file -` and `/dev/stdout` output when piped to tools such as `sed` or `awk`, keeping terminal UI escape sequences out of machine-readable chooser output. ([#186])
@@ -273,5 +277,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#166]: https://github.com/elio-fm/elio/issues/166
 [#168]: https://github.com/elio-fm/elio/issues/168
 [#174]: https://github.com/elio-fm/elio/issues/174
+[#184]: https://github.com/elio-fm/elio/issues/184
 [#186]: https://github.com/elio-fm/elio/issues/186
 [#195]: https://github.com/elio-fm/elio/issues/195

--- a/src/ui/browser/layout.rs
+++ b/src/ui/browser/layout.rs
@@ -9,7 +9,8 @@ use crate::{
 use ratatui::{Frame, layout::Rect};
 
 const LEGACY_WIDE_SIDEBAR_WIDTH: u16 = 20;
-const LEGACY_NARROW_SIDEBAR_WIDTH: u16 = 10;
+const LEGACY_LABEL_SIDEBAR_MIN_WIDTH: u16 = 11;
+const LEGACY_ICON_ONLY_SIDEBAR_WIDTH: u16 = 5;
 const LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR: u16 = 16;
 const LEGACY_HORIZONTAL_ENTRIES_MIN_WIDTH: u16 = 18;
 const LEGACY_HORIZONTAL_PREVIEW_MIN_WIDTH: u16 = 14;
@@ -102,7 +103,7 @@ fn legacy_horizontal_body_layout(area: Rect) -> Option<BodyLayout> {
     let (sidebar, content) = split_sidebar_and_content_with_comfort(
         area,
         LEGACY_WIDE_SIDEBAR_WIDTH,
-        LEGACY_NARROW_SIDEBAR_WIDTH,
+        LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
         LEGACY_HORIZONTAL_CONTENT_MIN_WIDTH,
         LEGACY_HORIZONTAL_SIDEBAR_SHRINK_START_WIDTH,
     )?;
@@ -137,8 +138,8 @@ fn legacy_horizontal_body_layout(area: Rect) -> Option<BodyLayout> {
 fn legacy_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
     let (sidebar, content) = split_sidebar_and_content(
         area,
-        LEGACY_NARROW_SIDEBAR_WIDTH,
-        LEGACY_NARROW_SIDEBAR_WIDTH,
+        LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
+        LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
         CUSTOM_ENTRIES_MIN_WIDTH.max(CUSTOM_PREVIEW_MIN_WIDTH),
     )?;
     let (entries, preview) = split_stacked_content_weighted_with_mins(
@@ -158,11 +159,11 @@ fn legacy_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
 
 fn legacy_best_effort_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
     let (sidebar, content) =
-        if area.width >= LEGACY_NARROW_SIDEBAR_WIDTH + LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR {
+        if area.width >= LEGACY_ICON_ONLY_SIDEBAR_WIDTH + LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR {
             split_sidebar_and_content(
                 area,
-                LEGACY_NARROW_SIDEBAR_WIDTH,
-                LEGACY_NARROW_SIDEBAR_WIDTH,
+                LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
+                LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
                 LEGACY_MIN_CONTENT_WIDTH_WITH_SIDEBAR,
             )?
         } else {
@@ -200,8 +201,8 @@ fn legacy_best_effort_stacked_body_layout(area: Rect) -> Option<BodyLayout> {
 fn legacy_sidebar_and_entries_layout(area: Rect) -> BodyLayout {
     if let Some((sidebar, entries)) = split_sidebar_and_content(
         area,
-        LEGACY_NARROW_SIDEBAR_WIDTH,
-        LEGACY_NARROW_SIDEBAR_WIDTH,
+        LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
+        LEGACY_ICON_ONLY_SIDEBAR_WIDTH,
         CUSTOM_ENTRIES_MIN_WIDTH,
     ) {
         return BodyLayout {
@@ -394,6 +395,11 @@ fn split_sidebar_and_content_with_comfort(
         .saturating_sub(shrink)
         .max(minimum_sidebar_width)
         .min(area.width.saturating_sub(minimum_content_width));
+    let sidebar_width = if sidebar_width < LEGACY_LABEL_SIDEBAR_MIN_WIDTH {
+        minimum_sidebar_width
+    } else {
+        sidebar_width
+    };
     let content_width = area.width.saturating_sub(sidebar_width);
 
     let sidebar = Rect {

--- a/src/ui/browser/sidebar.rs
+++ b/src/ui/browser/sidebar.rs
@@ -8,6 +8,8 @@ use ratatui::{
     widgets::Paragraph,
 };
 
+const ICON_ONLY_SIDEBAR_WIDTH: u16 = 5;
+
 pub(super) fn render_sidebar(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -15,9 +17,11 @@ pub(super) fn render_sidebar(
     state: &mut FrameState,
     palette: Palette,
 ) {
-    let block = helpers::panel_block(" Places ", palette.panel, palette);
-    frame.render_widget(block, area);
     let inner = helpers::inner_with_padding(area);
+    let icon_only = area.width <= ICON_ONLY_SIDEBAR_WIDTH;
+    let title = if icon_only { "" } else { " Places " };
+    let block = helpers::panel_block(title, palette.panel, palette);
+    frame.render_widget(block, area);
     helpers::fill_area(frame, inner, palette.panel, palette.text);
     let mut y = inner.y;
     let row_height = 1u16;
@@ -33,6 +37,9 @@ pub(super) fn render_sidebar(
         };
         match item {
             SidebarRow::Section { title } => {
+                if icon_only {
+                    continue;
+                }
                 let title_width = row.width.saturating_sub(1) as usize;
                 let line = Line::from(vec![
                     Span::raw(" "),
@@ -60,7 +67,7 @@ pub(super) fn render_sidebar(
                     1u16.saturating_add(helpers::display_width(item.icon.as_str()) as u16)
                         .saturating_add(2),
                 ) as usize;
-                let top_line = Line::from(vec![
+                let mut spans = vec![
                     Span::styled(
                         if active { "▌" } else { " " },
                         Style::default().fg(if active { palette.accent } else { bg }),
@@ -71,14 +78,19 @@ pub(super) fn render_sidebar(
                             .fg(palette.accent)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Span::raw("  "),
-                    Span::styled(
-                        helpers::clamp_label(&item.title, title_width),
-                        Style::default()
-                            .fg(palette.text)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                ]);
+                ];
+                if !icon_only {
+                    spans.extend([
+                        Span::raw("  "),
+                        Span::styled(
+                            helpers::clamp_label(&item.title, title_width),
+                            Style::default()
+                                .fg(palette.text)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]);
+                }
+                let top_line = Line::from(spans);
                 frame.render_widget(
                     Paragraph::new(vec![top_line]).style(Style::default().bg(bg).fg(palette.text)),
                     row,

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -248,9 +248,10 @@ fn narrowing_horizontal_browser_layout_starts_shrinking_sidebar_early() {
         (88, 16),
         (80, 14),
         (72, 12),
-        (64, 10),
-        (56, 10),
-        (46, 10),
+        (68, 11),
+        (64, 5),
+        (56, 5),
+        (46, 5),
     ] {
         let layout = resolve_body_layout(
             Rect {
@@ -293,7 +294,7 @@ fn narrow_legacy_layout_keeps_preview_without_starving_files() {
         let preview = layout.preview.expect("preview should be visible");
         assert_eq!(layout.sidebar.is_some(), expect_sidebar, "width {width}");
         if let Some(sidebar) = layout.sidebar {
-            assert_eq!(sidebar.width, 10, "width {width}");
+            assert_eq!(sidebar.width, 5, "width {width}");
         }
         if expect_stacked {
             assert_eq!(entries.x, preview.x, "width {width} should stay stacked");
@@ -560,6 +561,48 @@ fn sidebar_clamps_long_labels_when_width_is_tight() {
         rendered.contains("Downloa…"),
         "expected the narrow sidebar to clamp long labels, got: {rendered:?}"
     );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn sidebar_uses_icons_only_at_icon_width() {
+    let root = temp_path("sidebar-icon-only");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    app.navigation.sidebar = vec![
+        SidebarRow::Section { title: "Devices" },
+        SidebarRow::Item(SidebarItem::new(
+            SidebarItemKind::Downloads,
+            "Downloads Directory",
+            "D",
+            root.clone(),
+            root.clone(),
+        )),
+    ];
+
+    let mut terminal = Terminal::new(TestBackend::new(5, 5)).expect("terminal should init");
+    let mut frame_state = FrameState::default();
+    terminal
+        .draw(|frame| {
+            render_sidebar(
+                frame,
+                frame.area(),
+                &app,
+                &mut frame_state,
+                theme::palette(),
+            );
+        })
+        .expect("sidebar should render");
+
+    let rendered = buffer_text(terminal.backend().buffer());
+    assert!(rendered.contains("D"));
+    assert!(!rendered.contains("Places"));
+    assert!(!rendered.contains("Devices"));
+    assert!(!rendered.contains("Down"));
+    assert_eq!(frame_state.sidebar_hits.len(), 1);
+    assert_eq!(frame_state.sidebar_hits[0].path, root);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }


### PR DESCRIPTION
## Summary

The places pane now keeps names visible while they are useful, then switches to an icon-only rail when the window gets too narrow.

Fixes #184.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed