### PR TITLE
fix(open-with): prefer configured editors after default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Places now switches to an icon-only rail in narrow windows before labels become overly truncated. ([#184])
+- Changed Open With to keep `$VISUAL` and `$EDITOR` labels on matching MIME-associated editors and place them directly below the system default association. ([#199])
 
 ### Fixed
 
@@ -280,3 +281,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#184]: https://github.com/elio-fm/elio/issues/184
 [#186]: https://github.com/elio-fm/elio/issues/186
 [#195]: https://github.com/elio-fm/elio/issues/195
+[#199]: https://github.com/elio-fm/elio/issues/199

--- a/src/app/open_with/discovery/editor.rs
+++ b/src/app/open_with/discovery/editor.rs
@@ -15,17 +15,12 @@ pub(super) fn append_editor_fallback(
         return;
     }
 
+    let mut insert_index = env_editor_insert_index(apps);
     for var in ["VISUAL", "EDITOR"] {
         let Some(app) = editor_app_for_path(var, path) else {
             continue;
         };
-        if let Some(existing) = matching_discovered_app_mut(&app, apps) {
-            if !is_env_editor_label(&existing.display_name) {
-                existing.display_name = app.display_name;
-            }
-        } else {
-            apps.push(app);
-        }
+        insert_index = promote_env_editor_app(apps, app, insert_index);
     }
 }
 
@@ -78,13 +73,44 @@ fn editor_app_from_command(var: &str, command: &str, path: &Path) -> Option<Open
     })
 }
 
-fn matching_discovered_app_mut<'a>(
-    editor: &OpenWithApp,
-    apps: &'a mut [OpenWithApp],
-) -> Option<&'a mut OpenWithApp> {
+fn promote_env_editor_app(
+    apps: &mut Vec<OpenWithApp>,
+    app: OpenWithApp,
+    insert_index: usize,
+) -> usize {
+    let Some(position) = matching_discovered_app_index(&app, apps) else {
+        let index = insert_index.min(apps.len());
+        apps.insert(index, app);
+        return index + 1;
+    };
+
+    if apps[position].is_default || is_env_editor_label(&apps[position].display_name) {
+        if !is_env_editor_label(&apps[position].display_name) {
+            apps[position].display_name = app.display_name;
+        }
+        return insert_index;
+    }
+
+    let mut existing = apps.remove(position);
+    existing.display_name = app.display_name;
+    let index = if position < insert_index {
+        insert_index.saturating_sub(1)
+    } else {
+        insert_index
+    }
+    .min(apps.len());
+    apps.insert(index, existing);
+    index + 1
+}
+
+fn env_editor_insert_index(apps: &[OpenWithApp]) -> usize {
+    apps.iter().take_while(|app| app.is_default).count()
+}
+
+fn matching_discovered_app_index(editor: &OpenWithApp, apps: &[OpenWithApp]) -> Option<usize> {
     let editor_program = program_key(&editor.program);
-    apps.iter_mut()
-        .find(|app| program_key(&app.program) == editor_program)
+    apps.iter()
+        .position(|app| program_key(&app.program) == editor_program)
 }
 
 fn is_env_editor_label(display_name: &str) -> bool {
@@ -232,22 +258,34 @@ mod tests {
         let _visual = EnvGuard::remove("VISUAL");
         let _editor = EnvGuard::set("EDITOR", "hx");
 
-        let mut apps = vec![OpenWithApp {
-            display_name: "Text Editor".to_string(),
-            desktop_id: Some("org.gnome.gedit.desktop".to_string()),
-            program: "gedit".to_string(),
-            args: vec![file.display().to_string()],
-            is_default: true,
-            requires_terminal: false,
-        }];
+        let mut apps = vec![
+            OpenWithApp {
+                display_name: "Text Editor".to_string(),
+                desktop_id: Some("org.gnome.gedit.desktop".to_string()),
+                program: "gedit".to_string(),
+                args: vec![file.display().to_string()],
+                is_default: true,
+                requires_terminal: false,
+            },
+            OpenWithApp {
+                display_name: "Other App".to_string(),
+                desktop_id: Some("other.desktop".to_string()),
+                program: "other-app".to_string(),
+                args: vec![file.display().to_string()],
+                is_default: false,
+                requires_terminal: false,
+            },
+        ];
         append_editor_fallback(&mut apps, &file, true);
         let _ = fs::remove_dir_all(&root);
 
-        assert_eq!(apps.len(), 2);
+        assert_eq!(apps.len(), 3);
+        assert_eq!(apps[0].display_name, "Text Editor");
         assert_eq!(apps[1].display_name, "hx ($EDITOR)");
         assert_eq!(apps[1].program, "hx");
         assert_eq!(apps[1].args, vec![file.display().to_string()]);
         assert!(apps[1].requires_terminal);
+        assert_eq!(apps[2].display_name, "Other App");
     }
 
     #[test]

--- a/src/app/open_with/discovery/editor.rs
+++ b/src/app/open_with/discovery/editor.rs
@@ -19,7 +19,11 @@ pub(super) fn append_editor_fallback(
         let Some(app) = editor_app_for_path(var, path) else {
             continue;
         };
-        if !duplicates_discovered_app(&app, apps) {
+        if let Some(existing) = matching_discovered_app_mut(&app, apps) {
+            if !is_env_editor_label(&existing.display_name) {
+                existing.display_name = app.display_name;
+            }
+        } else {
             apps.push(app);
         }
     }
@@ -74,10 +78,17 @@ fn editor_app_from_command(var: &str, command: &str, path: &Path) -> Option<Open
     })
 }
 
-fn duplicates_discovered_app(editor: &OpenWithApp, apps: &[OpenWithApp]) -> bool {
+fn matching_discovered_app_mut<'a>(
+    editor: &OpenWithApp,
+    apps: &'a mut [OpenWithApp],
+) -> Option<&'a mut OpenWithApp> {
     let editor_program = program_key(&editor.program);
-    apps.iter()
-        .any(|app| program_key(&app.program) == editor_program)
+    apps.iter_mut()
+        .find(|app| program_key(&app.program) == editor_program)
+}
+
+fn is_env_editor_label(display_name: &str) -> bool {
+    display_name.contains("($VISUAL)") || display_name.contains("($EDITOR)")
 }
 
 fn program_key(program: &str) -> Option<String> {
@@ -266,5 +277,36 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
 
         assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].display_name, "hx ($EDITOR)");
+    }
+
+    #[test]
+    fn editor_fallback_keeps_visual_label_when_editor_matches_visual() {
+        let _lock = env_lock().lock().expect("lock env");
+        let root = temp_dir("visual-before-editor");
+        fs::create_dir_all(&root).expect("create root");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("create bin");
+        write_executable(&bin.join("nvim"));
+        let file = root.join("note.txt");
+        fs::write(&file, "hello\n").expect("write text file");
+
+        let _path = EnvGuard::set("PATH", &bin);
+        let _visual = EnvGuard::set("VISUAL", "nvim");
+        let _editor = EnvGuard::set("EDITOR", "nvim");
+
+        let mut apps = vec![OpenWithApp {
+            display_name: "Neovim".to_string(),
+            desktop_id: Some("nvim.desktop".to_string()),
+            program: bin.join("nvim").display().to_string(),
+            args: vec![file.display().to_string()],
+            is_default: false,
+            requires_terminal: true,
+        }];
+        append_editor_fallback(&mut apps, &file, true);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].display_name, "Neovim ($VISUAL)");
     }
 }

--- a/src/app/open_with/discovery/macos.rs
+++ b/src/app/open_with/discovery/macos.rs
@@ -243,14 +243,14 @@ fn discover_terminal_editor_apps(path_str: &str) -> Vec<OpenWithApp> {
         let Some(app) = terminal_editor_app_from_command(var, &value, path_str) else {
             continue;
         };
-        let key = app.display_name.to_ascii_lowercase();
+        let key = terminal_editor_key(&app.program);
         if seen_editors.insert(key) {
             result.push(app);
         }
     }
 
     for &(program, display_name) in COMMON_TERMINAL_EDITORS {
-        if !seen_editors.insert(display_name.to_ascii_lowercase()) {
+        if !seen_editors.insert(terminal_editor_key(program)) {
             continue;
         }
         if !command_exists(program) {
@@ -431,6 +431,7 @@ fn sort_open_with_apps(apps: &mut [OpenWithApp]) {
     apps.sort_unstable_by(|a, b| {
         b.is_default
             .cmp(&a.is_default)
+            .then_with(|| is_env_editor_app(b).cmp(&is_env_editor_app(a)))
             .then_with(|| a.requires_terminal.cmp(&b.requires_terminal))
             .then_with(|| {
                 a.display_name
@@ -438,6 +439,18 @@ fn sort_open_with_apps(apps: &mut [OpenWithApp]) {
                     .cmp(&b.display_name.to_ascii_lowercase())
             })
     });
+}
+
+fn is_env_editor_app(app: &OpenWithApp) -> bool {
+    app.display_name.contains("($VISUAL)") || app.display_name.contains("($EDITOR)")
+}
+
+fn terminal_editor_key(program: &str) -> String {
+    Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program)
+        .to_ascii_lowercase()
 }
 
 fn open_with_app_identity_key(app: &OpenWithApp) -> String {

--- a/src/app/open_with/discovery/macos.rs
+++ b/src/app/open_with/discovery/macos.rs
@@ -240,7 +240,7 @@ fn discover_terminal_editor_apps(path_str: &str) -> Vec<OpenWithApp> {
         let Some(value) = env::var_os(var).and_then(|value| value.into_string().ok()) else {
             continue;
         };
-        let Some(app) = terminal_editor_app_from_command(&value, path_str) else {
+        let Some(app) = terminal_editor_app_from_command(var, &value, path_str) else {
             continue;
         };
         let key = app.display_name.to_ascii_lowercase();
@@ -455,7 +455,11 @@ fn open_with_app_identity_key(app: &OpenWithApp) -> String {
     )
 }
 
-fn terminal_editor_app_from_command(command: &str, path_str: &str) -> Option<OpenWithApp> {
+fn terminal_editor_app_from_command(
+    var: &str,
+    command: &str,
+    path_str: &str,
+) -> Option<OpenWithApp> {
     let mut tokens = tokenize_exec(command);
     if tokens.is_empty() {
         return None;
@@ -474,7 +478,7 @@ fn terminal_editor_app_from_command(command: &str, path_str: &str) -> Option<Ope
 
     tokens.push(path_str.to_string());
     Some(OpenWithApp {
-        display_name: display_name.to_string(),
+        display_name: format!("{display_name} (${var})"),
         desktop_id: None,
         program,
         args: tokens,

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -201,7 +201,7 @@ fn build_open_with_overlay(apps: Vec<OpenWithApp>, reserved_shortcuts: &[char]) 
         .map(|app| {
             let shortcut = shortcuts.next();
             let mut label = app.display_name.clone();
-            if app.requires_terminal {
+            if app.requires_terminal && !is_env_editor_label(&label) {
                 label.push_str(" (terminal)");
             }
             if app.is_default {
@@ -228,6 +228,10 @@ fn open_with_shortcuts(reserved: &[char]) -> impl Iterator<Item = char> + '_ {
     OPEN_WITH_SHORTCUTS
         .chars()
         .filter(move |shortcut| !reserved.contains(shortcut))
+}
+
+fn is_env_editor_label(display_name: &str) -> bool {
+    display_name.contains("($VISUAL)") || display_name.contains("($EDITOR)")
 }
 
 fn open_with_fallback(path: &Path) -> std::result::Result<FallbackOpenOutcome, String> {

--- a/src/app/open_with/tests.rs
+++ b/src/app/open_with/tests.rs
@@ -160,6 +160,29 @@ fn single_terminal_app_queues_pending_command_without_overlay() {
 }
 
 #[test]
+fn env_editor_label_does_not_repeat_terminal_suffix() {
+    let root = temp_dir_path("env-editor-label-root");
+    fs::create_dir_all(&root).expect("create temp root");
+    let path = root.join("file.txt");
+    fs::write(&path, "hello").expect("write temp file");
+
+    let mut app = App::new_at(root.clone()).expect("create app");
+    app.handle_discovered_open_with_apps(
+        &path,
+        vec![
+            fake_terminal_app("Neovim ($VISUAL)"),
+            fake_open_with_app("Gedit"),
+        ],
+        |_| unreachable!(),
+        |_| unreachable!(),
+    );
+
+    assert_eq!(app.open_with_row_label(0), "Neovim ($VISUAL)");
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn confirm_terminal_app_from_overlay_queues_pending_command() {
     let root = temp_dir_path("terminal-overlay-root");
     fs::create_dir_all(&root).expect("create temp root");


### PR DESCRIPTION
## Summary

Place `$VISUAL` and `$EDITOR` editors directly below the system default in Open With, while keeping their environment labels when they match a MIME-associated app.

Fixes #199.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested Open With on Linux and macOS with the same app set as both `$VISUAL` and `$EDITOR`.
- Tested Open With on Linux and macOS with different apps set as `$VISUAL` and `$EDITOR`.

Result:

All checks passed locally. Configured editors stay reachable below the system default and keep their `$VISUAL` / `$EDITOR` labels.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed