### PR TITLE
feat(archive): support compressed tar extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added native archive extraction for focused `.zip`, `.tar`, `.tar.gz`, and `.tgz` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, and unique sibling destination folders. ([#90])
+- Added native archive extraction for focused `.zip`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, and unique sibling destination folders. ([#90])
 - Added a `progress_bar` theme palette color for active background operation chips, used by archive extraction progress.
 - Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +135,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -351,6 +362,7 @@ version = "1.9.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bzip2",
  "cfb",
  "color_quant",
  "crossterm",
@@ -374,8 +386,10 @@ dependencies = [
  "toml_edit",
  "trash",
  "unicode-width",
+ "xz2",
  "yaml_serde",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -512,6 +526,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -687,6 +713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +774,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -855,6 +897,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1189,6 +1242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "ratatui"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,7 +1338,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
@@ -1760,6 +1819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2201,15 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]
@@ -2187,6 +2270,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ unicode-width = "0.2"
 zip = { version = "8.6", default-features = false, features = ["deflate"] }
 trash = "5.2.5"
 rusqlite = { version = "0.40", features = ["bundled"] }
+xz2 = { version = "0.1.7", features = ["static"] }
+bzip2 = "0.6.1"
+zstd = { version = "0.13.3", default-features = false }
 
 [build-dependencies]
 syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "yaml-load", "regex-onig"] }

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -49,7 +49,7 @@ fn e_reports_unsupported_archive_format() {
 
     assert_eq!(
         app.status_message(),
-        "Extraction supports ZIP, TAR, and TAR.GZ"
+        "Extraction supports ZIP, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST"
     );
     assert!(app.jobs.archive_extract_progress.is_none());
 

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -1,4 +1,4 @@
-use super::format::{ExtractFormat, unique_destination};
+use super::format::{ExtractBackend, ExtractFormat, unique_destination};
 use anyhow::{Context, Result, anyhow, bail};
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
@@ -14,7 +14,7 @@ use zstd::stream::read::Decoder as ZstdDecoder;
 pub(crate) struct ExtractPlan {
     pub(crate) archive_path: PathBuf,
     pub(crate) dest_dir: PathBuf,
-    pub(crate) format: ExtractFormat,
+    pub(crate) backend: ExtractBackend,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -31,9 +31,8 @@ pub(crate) struct ExtractSummary {
 }
 
 pub(crate) fn plan_extract(path: &Path) -> Result<ExtractPlan> {
-    let format = ExtractFormat::detect(path).ok_or_else(|| {
-        anyhow!("Extraction supports ZIP, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST")
-    })?;
+    let format =
+        ExtractFormat::detect(path).ok_or_else(|| anyhow!(ExtractFormat::SUPPORTED_MESSAGE))?;
     let parent = path
         .parent()
         .ok_or_else(|| anyhow!("Cannot determine archive parent directory"))?;
@@ -42,7 +41,7 @@ pub(crate) fn plan_extract(path: &Path) -> Result<ExtractPlan> {
     Ok(ExtractPlan {
         archive_path: path.to_path_buf(),
         dest_dir: unique_destination(parent, &stem),
-        format,
+        backend: format.backend(),
     })
 }
 
@@ -57,13 +56,9 @@ where
 {
     fs::create_dir(&plan.dest_dir)
         .with_context(|| format!("Could not create {}", plan.dest_dir.display()))?;
-    match plan.format {
-        ExtractFormat::Zip => extract_zip(plan, &mut progress, cancelled),
-        ExtractFormat::Tar => extract_tar(plan, &mut progress, cancelled),
-        ExtractFormat::TarGzip => extract_tar_gzip(plan, &mut progress, cancelled),
-        ExtractFormat::TarXz => extract_tar_xz(plan, &mut progress, cancelled),
-        ExtractFormat::TarBzip2 => extract_tar_bzip2(plan, &mut progress, cancelled),
-        ExtractFormat::TarZstd => extract_tar_zstd(plan, &mut progress, cancelled),
+    match plan.backend {
+        ExtractBackend::NativeZip => extract_zip(plan, &mut progress, cancelled),
+        ExtractBackend::NativeTar(format) => extract_tar(format, plan, &mut progress, cancelled),
     }
 }
 
@@ -130,15 +125,8 @@ where
     })
 }
 
-fn extract_tar<F, C>(plan: &ExtractPlan, progress: &mut F, cancelled: C) -> Result<ExtractSummary>
-where
-    F: FnMut(ExtractProgress),
-    C: FnMut() -> bool,
-{
-    extract_tar_with(plan, "TAR", |file| Ok(file), progress, cancelled)
-}
-
-fn extract_tar_gzip<F, C>(
+fn extract_tar<F, C>(
+    format: ExtractFormat,
     plan: &ExtractPlan,
     progress: &mut F,
     cancelled: C,
@@ -147,66 +135,39 @@ where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
 {
-    extract_tar_with(
-        plan,
-        "TAR.GZ",
-        |file| Ok(GzDecoder::new(file)),
-        progress,
-        cancelled,
-    )
-}
-
-fn extract_tar_xz<F, C>(
-    plan: &ExtractPlan,
-    progress: &mut F,
-    cancelled: C,
-) -> Result<ExtractSummary>
-where
-    F: FnMut(ExtractProgress),
-    C: FnMut() -> bool,
-{
-    extract_tar_with(
-        plan,
-        "TAR.XZ",
-        |file| Ok(XzDecoder::new(file)),
-        progress,
-        cancelled,
-    )
-}
-
-fn extract_tar_bzip2<F, C>(
-    plan: &ExtractPlan,
-    progress: &mut F,
-    cancelled: C,
-) -> Result<ExtractSummary>
-where
-    F: FnMut(ExtractProgress),
-    C: FnMut() -> bool,
-{
-    extract_tar_with(
-        plan,
-        "TAR.BZ2",
-        |file| Ok(BzDecoder::new(file)),
-        progress,
-        cancelled,
-    )
-}
-
-fn extract_tar_zstd<F, C>(
-    plan: &ExtractPlan,
-    progress: &mut F,
-    cancelled: C,
-) -> Result<ExtractSummary>
-where
-    F: FnMut(ExtractProgress),
-    C: FnMut() -> bool,
-{
-    extract_tar_with(plan, "TAR.ZST", ZstdDecoder::new, progress, cancelled)
+    match format {
+        ExtractFormat::Tar => extract_tar_with(format, plan, Ok, progress, cancelled),
+        ExtractFormat::TarGzip => extract_tar_with(
+            format,
+            plan,
+            |file| Ok(GzDecoder::new(file)),
+            progress,
+            cancelled,
+        ),
+        ExtractFormat::TarXz => extract_tar_with(
+            format,
+            plan,
+            |file| Ok(XzDecoder::new(file)),
+            progress,
+            cancelled,
+        ),
+        ExtractFormat::TarBzip2 => extract_tar_with(
+            format,
+            plan,
+            |file| Ok(BzDecoder::new(file)),
+            progress,
+            cancelled,
+        ),
+        ExtractFormat::TarZstd => {
+            extract_tar_with(format, plan, ZstdDecoder::new, progress, cancelled)
+        }
+        ExtractFormat::Zip => unreachable!("ZIP archives use the native ZIP backend"),
+    }
 }
 
 fn extract_tar_with<R, D, F, C>(
+    format: ExtractFormat,
     plan: &ExtractPlan,
-    label: &str,
     decoder: D,
     progress: &mut F,
     cancelled: C,
@@ -220,7 +181,7 @@ where
     let count_file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
     let total = count_tar_entries(decoder(count_file)?)
-        .with_context(|| format!("Could not read {label} archive"))?;
+        .with_context(|| format!("Could not read {} archive", format.label()))?;
     let file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
     extract_tar_reader(plan, decoder(file)?, Some(total), progress, cancelled)

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -1,11 +1,14 @@
 use super::format::{ExtractFormat, unique_destination};
 use anyhow::{Context, Result, anyhow, bail};
+use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use std::{
     fs::{self, File},
     io::{self, Read},
     path::{Component, Path, PathBuf},
 };
+use xz2::read::XzDecoder;
+use zstd::stream::read::Decoder as ZstdDecoder;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ExtractPlan {
@@ -28,8 +31,9 @@ pub(crate) struct ExtractSummary {
 }
 
 pub(crate) fn plan_extract(path: &Path) -> Result<ExtractPlan> {
-    let format = ExtractFormat::detect(path)
-        .ok_or_else(|| anyhow!("Extraction supports ZIP, TAR, and TAR.GZ"))?;
+    let format = ExtractFormat::detect(path).ok_or_else(|| {
+        anyhow!("Extraction supports ZIP, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST")
+    })?;
     let parent = path
         .parent()
         .ok_or_else(|| anyhow!("Cannot determine archive parent directory"))?;
@@ -57,6 +61,9 @@ where
         ExtractFormat::Zip => extract_zip(plan, &mut progress, cancelled),
         ExtractFormat::Tar => extract_tar(plan, &mut progress, cancelled),
         ExtractFormat::TarGzip => extract_tar_gzip(plan, &mut progress, cancelled),
+        ExtractFormat::TarXz => extract_tar_xz(plan, &mut progress, cancelled),
+        ExtractFormat::TarBzip2 => extract_tar_bzip2(plan, &mut progress, cancelled),
+        ExtractFormat::TarZstd => extract_tar_zstd(plan, &mut progress, cancelled),
     }
 }
 
@@ -128,12 +135,7 @@ where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
 {
-    let count_file = File::open(&plan.archive_path)
-        .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    let total = count_tar_entries(count_file).context("Could not read TAR archive")?;
-    let file = File::open(&plan.archive_path)
-        .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    extract_tar_reader(plan, file, Some(total), progress, cancelled)
+    extract_tar_with(plan, "TAR", |file| Ok(file), progress, cancelled)
 }
 
 fn extract_tar_gzip<F, C>(
@@ -145,13 +147,83 @@ where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
 {
+    extract_tar_with(
+        plan,
+        "TAR.GZ",
+        |file| Ok(GzDecoder::new(file)),
+        progress,
+        cancelled,
+    )
+}
+
+fn extract_tar_xz<F, C>(
+    plan: &ExtractPlan,
+    progress: &mut F,
+    cancelled: C,
+) -> Result<ExtractSummary>
+where
+    F: FnMut(ExtractProgress),
+    C: FnMut() -> bool,
+{
+    extract_tar_with(
+        plan,
+        "TAR.XZ",
+        |file| Ok(XzDecoder::new(file)),
+        progress,
+        cancelled,
+    )
+}
+
+fn extract_tar_bzip2<F, C>(
+    plan: &ExtractPlan,
+    progress: &mut F,
+    cancelled: C,
+) -> Result<ExtractSummary>
+where
+    F: FnMut(ExtractProgress),
+    C: FnMut() -> bool,
+{
+    extract_tar_with(
+        plan,
+        "TAR.BZ2",
+        |file| Ok(BzDecoder::new(file)),
+        progress,
+        cancelled,
+    )
+}
+
+fn extract_tar_zstd<F, C>(
+    plan: &ExtractPlan,
+    progress: &mut F,
+    cancelled: C,
+) -> Result<ExtractSummary>
+where
+    F: FnMut(ExtractProgress),
+    C: FnMut() -> bool,
+{
+    extract_tar_with(plan, "TAR.ZST", ZstdDecoder::new, progress, cancelled)
+}
+
+fn extract_tar_with<R, D, F, C>(
+    plan: &ExtractPlan,
+    label: &str,
+    decoder: D,
+    progress: &mut F,
+    cancelled: C,
+) -> Result<ExtractSummary>
+where
+    R: Read,
+    D: Fn(File) -> Result<R, std::io::Error>,
+    F: FnMut(ExtractProgress),
+    C: FnMut() -> bool,
+{
     let count_file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    let total =
-        count_tar_entries(GzDecoder::new(count_file)).context("Could not read TAR.GZ archive")?;
+    let total = count_tar_entries(decoder(count_file)?)
+        .with_context(|| format!("Could not read {label} archive"))?;
     let file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    extract_tar_reader(plan, GzDecoder::new(file), Some(total), progress, cancelled)
+    extract_tar_reader(plan, decoder(file)?, Some(total), progress, cancelled)
 }
 
 fn count_tar_entries<R: Read>(reader: R) -> Result<usize> {
@@ -343,5 +415,103 @@ mod tests {
             "hello"
         );
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn extracts_tar_xz_archive() {
+        let root = temp_path("txz");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.tar.xz");
+        write_compressed_tar(&archive_path, |file| {
+            Ok(xz2::write::XzEncoder::new(file, 6))
+        });
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn extracts_tar_bzip2_archive() {
+        let root = temp_path("tbz2");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.tar.bz2");
+        write_compressed_tar(&archive_path, |file| {
+            Ok(bzip2::write::BzEncoder::new(
+                file,
+                bzip2::Compression::default(),
+            ))
+        });
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn extracts_tar_zstd_archive() {
+        let root = temp_path("tzst");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.tar.zst");
+        write_zstd_tar(&archive_path);
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn write_compressed_tar<W, D>(archive_path: &Path, encoder: D)
+    where
+        W: Write,
+        D: FnOnce(File) -> std::result::Result<W, std::io::Error>,
+    {
+        let root = archive_path.parent().unwrap();
+        let source = root.join("source");
+        fs::create_dir_all(source.join("dir")).unwrap();
+        fs::write(source.join("dir/file.txt"), "hello").unwrap();
+
+        let file = File::create(archive_path).unwrap();
+        let writer = encoder(file).unwrap();
+        let mut tar = tar::Builder::new(writer);
+        tar.append_dir("dir", source.join("dir")).unwrap();
+        tar.append_path_with_name(source.join("dir/file.txt"), "dir/file.txt")
+            .unwrap();
+        tar.finish().unwrap();
+    }
+
+    fn write_zstd_tar(archive_path: &Path) {
+        let root = archive_path.parent().unwrap();
+        let source = root.join("source");
+        fs::create_dir_all(source.join("dir")).unwrap();
+        fs::write(source.join("dir/file.txt"), "hello").unwrap();
+
+        let mut tar_bytes = Vec::new();
+        {
+            let mut tar = tar::Builder::new(&mut tar_bytes);
+            tar.append_dir("dir", source.join("dir")).unwrap();
+            tar.append_path_with_name(source.join("dir/file.txt"), "dir/file.txt")
+                .unwrap();
+            tar.finish().unwrap();
+        }
+        let compressed = zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap();
+        fs::write(archive_path, compressed).unwrap();
     }
 }

--- a/src/archive/format.rs
+++ b/src/archive/format.rs
@@ -10,7 +10,16 @@ pub(crate) enum ExtractFormat {
     TarZstd,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExtractBackend {
+    NativeZip,
+    NativeTar(ExtractFormat),
+}
+
 impl ExtractFormat {
+    pub(crate) const SUPPORTED_MESSAGE: &'static str =
+        "Extraction supports ZIP, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST";
+
     pub(crate) fn detect(path: &Path) -> Option<Self> {
         let name = path
             .file_name()
@@ -59,6 +68,26 @@ impl ExtractFormat {
         } else {
             trimmed.to_string()
         })
+    }
+
+    pub(crate) fn backend(self) -> ExtractBackend {
+        match self {
+            Self::Zip => ExtractBackend::NativeZip,
+            Self::Tar | Self::TarGzip | Self::TarXz | Self::TarBzip2 | Self::TarZstd => {
+                ExtractBackend::NativeTar(self)
+            }
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Zip => "ZIP",
+            Self::Tar => "TAR",
+            Self::TarGzip => "TAR.GZ",
+            Self::TarXz => "TAR.XZ",
+            Self::TarBzip2 => "TAR.BZ2",
+            Self::TarZstd => "TAR.ZST",
+        }
     }
 }
 
@@ -137,6 +166,31 @@ mod tests {
         assert_eq!(
             ExtractFormat::detect(Path::new("app.tzst")),
             Some(ExtractFormat::TarZstd)
+        );
+    }
+
+    #[test]
+    fn maps_formats_to_native_backends() {
+        assert_eq!(ExtractFormat::Zip.backend(), ExtractBackend::NativeZip);
+        assert_eq!(
+            ExtractFormat::Tar.backend(),
+            ExtractBackend::NativeTar(ExtractFormat::Tar)
+        );
+        assert_eq!(
+            ExtractFormat::TarGzip.backend(),
+            ExtractBackend::NativeTar(ExtractFormat::TarGzip)
+        );
+        assert_eq!(
+            ExtractFormat::TarXz.backend(),
+            ExtractBackend::NativeTar(ExtractFormat::TarXz)
+        );
+        assert_eq!(
+            ExtractFormat::TarBzip2.backend(),
+            ExtractBackend::NativeTar(ExtractFormat::TarBzip2)
+        );
+        assert_eq!(
+            ExtractFormat::TarZstd.backend(),
+            ExtractBackend::NativeTar(ExtractFormat::TarZstd)
         );
     }
 

--- a/src/archive/format.rs
+++ b/src/archive/format.rs
@@ -5,6 +5,9 @@ pub(crate) enum ExtractFormat {
     Zip,
     Tar,
     TarGzip,
+    TarXz,
+    TarBzip2,
+    TarZstd,
 }
 
 impl ExtractFormat {
@@ -15,6 +18,15 @@ impl ExtractFormat {
             .to_ascii_lowercase();
         if name.ends_with(".tar.gz") || name.ends_with(".tgz") {
             return Some(Self::TarGzip);
+        }
+        if name.ends_with(".tar.xz") || name.ends_with(".txz") {
+            return Some(Self::TarXz);
+        }
+        if name.ends_with(".tar.bz2") || name.ends_with(".tbz2") || name.ends_with(".tbz") {
+            return Some(Self::TarBzip2);
+        }
+        if name.ends_with(".tar.zst") || name.ends_with(".tzst") {
+            return Some(Self::TarZstd);
         }
         match path
             .extension()
@@ -31,16 +43,16 @@ impl ExtractFormat {
     pub(crate) fn stem_for_destination(path: &Path) -> Option<String> {
         let name = path.file_name()?.to_string_lossy();
         let lower = name.to_ascii_lowercase();
-        let stem = if lower.ends_with(".tar.gz") {
-            &name[..name.len().saturating_sub(7)]
-        } else if lower.ends_with(".tgz") {
-            &name[..name.len().saturating_sub(4)]
-        } else if lower.ends_with(".zip") || lower.ends_with(".tar") {
-            let cut = name.rfind('.')?;
-            &name[..cut]
-        } else {
-            return None;
-        };
+        let stem = [
+            ".tar.bz2", ".tar.zst", ".tar.gz", ".tar.xz", ".tbz2", ".tzst", ".tgz", ".txz", ".tbz",
+            ".zip", ".tar",
+        ]
+        .iter()
+        .find_map(|suffix| {
+            lower
+                .ends_with(suffix)
+                .then(|| &name[..name.len() - suffix.len()])
+        })?;
         let trimmed = stem.trim();
         Some(if trimmed.is_empty() {
             "archive".to_string()
@@ -98,7 +110,34 @@ mod tests {
             ExtractFormat::detect(Path::new("app.tgz")),
             Some(ExtractFormat::TarGzip)
         );
-        assert_eq!(ExtractFormat::detect(Path::new("app.tar.xz")), None);
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.tar.xz")),
+            Some(ExtractFormat::TarXz)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.txz")),
+            Some(ExtractFormat::TarXz)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.tar.bz2")),
+            Some(ExtractFormat::TarBzip2)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.tbz2")),
+            Some(ExtractFormat::TarBzip2)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.tbz")),
+            Some(ExtractFormat::TarBzip2)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.tar.zst")),
+            Some(ExtractFormat::TarZstd)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.tzst")),
+            Some(ExtractFormat::TarZstd)
+        );
     }
 
     #[test]
@@ -117,6 +156,34 @@ mod tests {
         );
         assert_eq!(
             ExtractFormat::stem_for_destination(Path::new("app.tgz")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.tar.xz")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.txz")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.tar.bz2")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.tbz2")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.tbz")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.tar.zst")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.tzst")).as_deref(),
             Some("app")
         );
     }


### PR DESCRIPTION
## Summary

Add native extraction support for focused `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` archives.

The new formats use the existing `e` / `extract_archive` flow with background progress, cancellation, safe path checks, and unique sibling destination folders.

Refs #90.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
