### PR TITLE
feat(archive): add native 7z extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added native archive extraction for focused `.zip`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, and unique sibling destination folders. ([#90])
+- Added native archive extraction for focused `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, and unique sibling destination folders. ([#90])
 - Added a `progress_bar` theme palette color for active background operation chips, used by archive extraction progress.
 - Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sevenz-rust2",
  "syntect",
  "tar",
  "toml",
@@ -898,6 +899,12 @@ checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
 
 [[package]]
 name = "lzma-sys"
@@ -1479,6 +1486,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sevenz-rust2"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081a399c6762c4a9bda9233f502aca74b6ca6a0caaff4d218b12887eac4b6adc"
+dependencies = [
+ "crc32fast",
+ "js-sys",
+ "lzma-rust2",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 xz2 = { version = "0.1.7", features = ["static"] }
 bzip2 = "0.6.1"
 zstd = { version = "0.13.3", default-features = false }
+sevenz-rust2 = { version = "0.21.1", default-features = false }
+
+[dev-dependencies]
+sevenz-rust2 = { version = "0.21.1", default-features = false, features = ["compress"] }
 
 [build-dependencies]
 syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "yaml-load", "regex-onig"] }

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -49,7 +49,7 @@ fn e_reports_unsupported_archive_format() {
 
     assert_eq!(
         app.status_message(),
-        "Extraction supports ZIP, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST"
+        "Extraction supports ZIP, 7z, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST"
     );
     assert!(app.jobs.archive_extract_progress.is_none());
 

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -2,6 +2,7 @@ use super::format::{ExtractBackend, ExtractFormat, unique_destination};
 use anyhow::{Context, Result, anyhow, bail};
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
+use sevenz_rust2::{ArchiveEntry as SevenZipEntry, ArchiveReader, Password};
 use std::{
     fs::{self, File},
     io::{self, Read},
@@ -57,8 +58,9 @@ where
     fs::create_dir(&plan.dest_dir)
         .with_context(|| format!("Could not create {}", plan.dest_dir.display()))?;
     match plan.backend {
-        ExtractBackend::NativeZip => extract_zip(plan, &mut progress, cancelled),
-        ExtractBackend::NativeTar(format) => extract_tar(format, plan, &mut progress, cancelled),
+        ExtractBackend::Zip => extract_zip(plan, &mut progress, cancelled),
+        ExtractBackend::Tar(format) => extract_tar(format, plan, &mut progress, cancelled),
+        ExtractBackend::SevenZip => extract_seven_zip(plan, &mut progress, cancelled),
     }
 }
 
@@ -161,8 +163,85 @@ where
         ExtractFormat::TarZstd => {
             extract_tar_with(format, plan, ZstdDecoder::new, progress, cancelled)
         }
-        ExtractFormat::Zip => unreachable!("ZIP archives use the native ZIP backend"),
+        ExtractFormat::Zip | ExtractFormat::SevenZip => {
+            unreachable!("non-TAR archives use their own native backends")
+        }
     }
+}
+
+fn extract_seven_zip<F, C>(
+    plan: &ExtractPlan,
+    progress: &mut F,
+    mut cancelled: C,
+) -> Result<ExtractSummary>
+where
+    F: FnMut(ExtractProgress),
+    C: FnMut() -> bool,
+{
+    let file = File::open(&plan.archive_path)
+        .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
+    let mut archive =
+        ArchiveReader::new(file, Password::empty()).context("Could not read 7z archive")?;
+    let total = archive.archive().files.len();
+    let mut completed = 0usize;
+    let mut extract_error = None;
+
+    progress(ExtractProgress {
+        completed,
+        total: Some(total),
+    });
+    archive
+        .for_each_entries(|entry, reader| {
+            if cancelled() {
+                return Ok(false);
+            }
+            if let Err(error) = extract_seven_zip_entry(plan, entry, reader) {
+                extract_error = Some(error);
+                return Ok(false);
+            }
+            completed += 1;
+            progress(ExtractProgress {
+                completed,
+                total: Some(total),
+            });
+            Ok(true)
+        })
+        .context("Could not read 7z entries")?;
+
+    if let Some(error) = extract_error {
+        return Err(error);
+    }
+    Ok(ExtractSummary {
+        dest_dir: plan.dest_dir.clone(),
+        completed,
+        total: Some(total),
+    })
+}
+
+fn extract_seven_zip_entry(
+    plan: &ExtractPlan,
+    entry: &SevenZipEntry,
+    reader: &mut dyn Read,
+) -> Result<()> {
+    if entry.is_anti_item {
+        return Ok(());
+    }
+    let out_path = checked_output_name(&plan.dest_dir, &entry.name)?;
+    if entry.is_directory {
+        fs::create_dir_all(&out_path)
+            .with_context(|| format!("Could not create {}", out_path.display()))?;
+    } else {
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Could not create {}", parent.display()))?;
+        }
+        let mut out = File::create(&out_path)
+            .with_context(|| format!("Could not create {}", out_path.display()))?;
+        let mut limited = reader.take(entry.size);
+        io::copy(&mut limited, &mut out)
+            .with_context(|| format!("Could not write {}", out_path.display()))?;
+    }
+    Ok(())
 }
 
 fn extract_tar_with<R, D, F, C>(
@@ -272,6 +351,11 @@ fn checked_output_path(dest_dir: &Path, entry_path: &Path) -> Result<PathBuf> {
         );
     }
     Ok(out)
+}
+
+fn checked_output_name(dest_dir: &Path, entry_name: &str) -> Result<PathBuf> {
+    let normalized = entry_name.replace('\\', "/");
+    checked_output_path(dest_dir, Path::new(&normalized))
 }
 
 #[cfg(test)]
@@ -439,6 +523,50 @@ mod tests {
         let _ = fs::remove_dir_all(root);
     }
 
+    #[test]
+    fn extracts_seven_zip_archive() {
+        let root = temp_path("7z");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.7z");
+        write_seven_zip(
+            &archive_path,
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let mut progress = Vec::new();
+        let summary = extract_archive(&plan, |update| progress.push(update), || false).unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.total, Some(2));
+        assert_eq!(
+            progress
+                .last()
+                .map(|update| (update.completed, update.total)),
+            Some((2, Some(2)))
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rejects_escaping_seven_zip_paths() {
+        let root = temp_path("7z-slip");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.7z");
+        write_seven_zip(&archive_path, &[("../evil.txt", Some(b"bad"))]);
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let err = extract_archive(&plan, |_| {}, || false).unwrap_err();
+
+        assert!(err.to_string().contains("escapes the destination"));
+        assert!(!root.join("evil.txt").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
     fn write_compressed_tar<W, D>(archive_path: &Path, encoder: D)
     where
         W: Write,
@@ -474,5 +602,25 @@ mod tests {
         }
         let compressed = zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap();
         fs::write(archive_path, compressed).unwrap();
+    }
+
+    fn write_seven_zip(archive_path: &Path, entries: &[(&str, Option<&[u8]>)]) {
+        let mut writer = sevenz_rust2::ArchiveWriter::create(archive_path).unwrap();
+        for (name, contents) in entries {
+            let entry = if contents.is_some() {
+                sevenz_rust2::ArchiveEntry::new_file(name)
+            } else {
+                sevenz_rust2::ArchiveEntry::new_directory(name)
+            };
+            match contents {
+                Some(contents) => {
+                    writer.push_archive_entry(entry, Some(*contents)).unwrap();
+                }
+                None => {
+                    writer.push_archive_entry::<&[u8]>(entry, None).unwrap();
+                }
+            }
+        }
+        writer.finish().unwrap();
     }
 }

--- a/src/archive/format.rs
+++ b/src/archive/format.rs
@@ -8,17 +8,19 @@ pub(crate) enum ExtractFormat {
     TarXz,
     TarBzip2,
     TarZstd,
+    SevenZip,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExtractBackend {
-    NativeZip,
-    NativeTar(ExtractFormat),
+    Zip,
+    Tar(ExtractFormat),
+    SevenZip,
 }
 
 impl ExtractFormat {
     pub(crate) const SUPPORTED_MESSAGE: &'static str =
-        "Extraction supports ZIP, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST";
+        "Extraction supports ZIP, 7z, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST";
 
     pub(crate) fn detect(path: &Path) -> Option<Self> {
         let name = path
@@ -44,6 +46,7 @@ impl ExtractFormat {
             .as_deref()
         {
             Some("zip") => Some(Self::Zip),
+            Some("7z") => Some(Self::SevenZip),
             Some("tar") => Some(Self::Tar),
             _ => None,
         }
@@ -54,7 +57,7 @@ impl ExtractFormat {
         let lower = name.to_ascii_lowercase();
         let stem = [
             ".tar.bz2", ".tar.zst", ".tar.gz", ".tar.xz", ".tbz2", ".tzst", ".tgz", ".txz", ".tbz",
-            ".zip", ".tar",
+            ".zip", ".7z", ".tar",
         ]
         .iter()
         .find_map(|suffix| {
@@ -72,9 +75,10 @@ impl ExtractFormat {
 
     pub(crate) fn backend(self) -> ExtractBackend {
         match self {
-            Self::Zip => ExtractBackend::NativeZip,
+            Self::Zip => ExtractBackend::Zip,
+            Self::SevenZip => ExtractBackend::SevenZip,
             Self::Tar | Self::TarGzip | Self::TarXz | Self::TarBzip2 | Self::TarZstd => {
-                ExtractBackend::NativeTar(self)
+                ExtractBackend::Tar(self)
             }
         }
     }
@@ -87,6 +91,7 @@ impl ExtractFormat {
             Self::TarXz => "TAR.XZ",
             Self::TarBzip2 => "TAR.BZ2",
             Self::TarZstd => "TAR.ZST",
+            Self::SevenZip => "7z",
         }
     }
 }
@@ -132,6 +137,10 @@ mod tests {
             Some(ExtractFormat::Tar)
         );
         assert_eq!(
+            ExtractFormat::detect(Path::new("app.7z")),
+            Some(ExtractFormat::SevenZip)
+        );
+        assert_eq!(
             ExtractFormat::detect(Path::new("app.tar.gz")),
             Some(ExtractFormat::TarGzip)
         );
@@ -171,27 +180,28 @@ mod tests {
 
     #[test]
     fn maps_formats_to_native_backends() {
-        assert_eq!(ExtractFormat::Zip.backend(), ExtractBackend::NativeZip);
+        assert_eq!(ExtractFormat::Zip.backend(), ExtractBackend::Zip);
         assert_eq!(
             ExtractFormat::Tar.backend(),
-            ExtractBackend::NativeTar(ExtractFormat::Tar)
+            ExtractBackend::Tar(ExtractFormat::Tar)
         );
         assert_eq!(
             ExtractFormat::TarGzip.backend(),
-            ExtractBackend::NativeTar(ExtractFormat::TarGzip)
+            ExtractBackend::Tar(ExtractFormat::TarGzip)
         );
         assert_eq!(
             ExtractFormat::TarXz.backend(),
-            ExtractBackend::NativeTar(ExtractFormat::TarXz)
+            ExtractBackend::Tar(ExtractFormat::TarXz)
         );
         assert_eq!(
             ExtractFormat::TarBzip2.backend(),
-            ExtractBackend::NativeTar(ExtractFormat::TarBzip2)
+            ExtractBackend::Tar(ExtractFormat::TarBzip2)
         );
         assert_eq!(
             ExtractFormat::TarZstd.backend(),
-            ExtractBackend::NativeTar(ExtractFormat::TarZstd)
+            ExtractBackend::Tar(ExtractFormat::TarZstd)
         );
+        assert_eq!(ExtractFormat::SevenZip.backend(), ExtractBackend::SevenZip);
     }
 
     #[test]
@@ -202,6 +212,10 @@ mod tests {
         );
         assert_eq!(
             ExtractFormat::stem_for_destination(Path::new("app.tar")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.7z")).as_deref(),
             Some("app")
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

Add native extraction support for focused `.7z` archives using `sevenz-rust2`.

Normal builds keep `sevenz-rust2` default features disabled; `compress` is enabled only for tests that generate real `.7z` fixtures.

Refs #90.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
