### PR TITLE
feat(preview): use native readers for 7z and tar previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Prefer native archive listing for `.7z`, `.tar.xz`, `.tar.bz2`, and `.tar.zst` previews before falling back to external archive tools. ([#90])
 - Places now switches to an icon-only rail in narrow windows before labels become overly truncated. ([#184])
 - Changed Open With to keep `$VISUAL` and `$EDITOR` labels on matching MIME-associated editors and place them directly below the system default association. ([#199])
 

--- a/src/preview/container/archive/internal.rs
+++ b/src/preview/container/archive/internal.rs
@@ -1,27 +1,50 @@
 use super::external::collect_archive_entries_with_bsdtar;
 use super::format::archive_format_name;
 use super::*;
+use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
+use sevenz_rust2::{ArchiveReader as SevenZipArchiveReader, Password as SevenZipPassword};
 use std::{
     fs::{self, File},
     io::Read,
     path::Path,
 };
 use tar::Archive as TarArchive;
+use xz2::read::XzDecoder;
+use zstd::stream::read::Decoder as ZstdDecoder;
 
 pub(super) fn collect_internal_archive_listing(
     path: &Path,
     format: ArchiveFormat,
+    canceled: &impl Fn() -> bool,
 ) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>, usize, bool)> {
+    if canceled() {
+        return None;
+    }
+
     match format {
         ArchiveFormat::Tar => {
             let file = File::open(path).ok()?;
-            collect_tar_listing_from_reader(file, path, format)
+            collect_tar_listing_from_reader(file, path, format, canceled)
         }
         ArchiveFormat::TarGzip => {
             let file = File::open(path).ok()?;
-            collect_tar_listing_from_reader(GzDecoder::new(file), path, format)
+            collect_tar_listing_from_reader(GzDecoder::new(file), path, format, canceled)
         }
+        ArchiveFormat::TarXz => {
+            let file = File::open(path).ok()?;
+            collect_tar_listing_from_reader(XzDecoder::new(file), path, format, canceled)
+        }
+        ArchiveFormat::TarBzip2 => {
+            let file = File::open(path).ok()?;
+            collect_tar_listing_from_reader(BzDecoder::new(file), path, format, canceled)
+        }
+        ArchiveFormat::TarZstd => {
+            let file = File::open(path).ok()?;
+            let decoder = ZstdDecoder::new(file).ok()?;
+            collect_tar_listing_from_reader(decoder, path, format, canceled)
+        }
+        ArchiveFormat::SevenZip => collect_seven_zip_listing(path, format, canceled),
         _ => None,
     }
 }
@@ -33,7 +56,7 @@ pub(super) fn collect_preferred_archive_entries(
 ) -> Option<Vec<ArchiveEntry>> {
     if prefers_internal_listing(format) {
         // If internal TAR parsing fails, keep bsdtar as the only tar-family CLI fallback.
-        return collect_internal_archive_listing(path, format)
+        return collect_internal_archive_listing(path, format, canceled)
             .map(|(_, entries, _, _)| entries)
             .or_else(|| collect_archive_entries_with_bsdtar(path, canceled));
     }
@@ -41,10 +64,68 @@ pub(super) fn collect_preferred_archive_entries(
     None
 }
 
+fn collect_seven_zip_listing(
+    path: &Path,
+    format: ArchiveFormat,
+    canceled: &impl Fn() -> bool,
+) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>, usize, bool)> {
+    let file = File::open(path).ok()?;
+    let archive = SevenZipArchiveReader::new(file, SevenZipPassword::empty()).ok()?;
+    if canceled() {
+        return None;
+    }
+
+    let files = &archive.archive().files;
+    let total_entries = files.len();
+    let mut entries = Vec::with_capacity(total_entries.min(ARCHIVE_ENTRY_SCAN_LIMIT));
+    let mut metadata = ArchiveMetadata {
+        format_label: Some(archive_format_name(format).to_string()),
+        physical_size: fs::metadata(path).ok().map(|metadata| metadata.len()),
+        ..ArchiveMetadata::default()
+    };
+
+    for entry in files.iter().take(ARCHIVE_ENTRY_SCAN_LIMIT) {
+        if canceled() {
+            return None;
+        }
+        if entry.is_anti_item {
+            continue;
+        }
+
+        metadata.unpacked_size = Some(
+            metadata
+                .unpacked_size
+                .unwrap_or(0)
+                .saturating_add(entry.size),
+        );
+        metadata.compressed_size = Some(
+            metadata
+                .compressed_size
+                .unwrap_or(0)
+                .saturating_add(entry.compressed_size),
+        );
+
+        if let Some(path) = normalize_archive_path(&entry.name, false) {
+            entries.push(ArchiveEntry {
+                path,
+                is_dir: entry.is_directory,
+            });
+        }
+    }
+
+    Some((
+        metadata,
+        entries,
+        total_entries,
+        total_entries > ARCHIVE_ENTRY_SCAN_LIMIT,
+    ))
+}
+
 fn collect_tar_listing_from_reader<R: Read>(
     reader: R,
     path: &Path,
     format: ArchiveFormat,
+    canceled: &impl Fn() -> bool,
 ) -> Option<(ArchiveMetadata, Vec<ArchiveEntry>, usize, bool)> {
     let mut archive = TarArchive::new(reader);
     let entries = archive.entries().ok()?;
@@ -58,6 +139,10 @@ fn collect_tar_listing_from_reader<R: Read>(
     let mut scan_truncated = false;
 
     for entry in entries {
+        if canceled() {
+            return None;
+        }
+
         let entry = entry.ok()?;
         total_entries = total_entries.saturating_add(1);
         if total_entries > ARCHIVE_ENTRY_SCAN_LIMIT {
@@ -92,4 +177,148 @@ fn prefers_internal_listing(format: ArchiveFormat) -> bool {
             | ArchiveFormat::TarBzip2
             | ArchiveFormat::TarZstd
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs::{self, File},
+        io::Write,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn collects_native_compressed_tar_listings() {
+        let root = temp_path("native-compressed-tar-listing");
+
+        let tar_xz = root.join("sample.tar.xz");
+        write_compressed_tar(&tar_xz, |file| Ok(xz2::write::XzEncoder::new(file, 6)));
+        assert_sample_listing(&tar_xz, ArchiveFormat::TarXz, "TAR.XZ");
+
+        let tar_bz2 = root.join("sample.tar.bz2");
+        write_compressed_tar(&tar_bz2, |file| {
+            Ok(bzip2::write::BzEncoder::new(
+                file,
+                bzip2::Compression::best(),
+            ))
+        });
+        assert_sample_listing(&tar_bz2, ArchiveFormat::TarBzip2, "TAR.BZ2");
+
+        let tar_zst = root.join("sample.tar.zst");
+        write_zstd_tar(&tar_zst);
+        assert_sample_listing(&tar_zst, ArchiveFormat::TarZstd, "TAR.ZST");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn collects_native_seven_zip_listing() {
+        let root = temp_path("native-7z-listing");
+        let archive_path = root.join("sample.7z");
+        write_seven_zip(&archive_path);
+
+        let (metadata, entries, total_entries, scan_truncated) =
+            collect_internal_archive_listing(&archive_path, ArchiveFormat::SevenZip, &|| false)
+                .expect("7z listing should be collected natively");
+
+        assert_eq!(metadata.format_label.as_deref(), Some("7z"));
+        assert_eq!(metadata.unpacked_size, Some(5));
+        assert_eq!(total_entries, 2);
+        assert!(!scan_truncated);
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "dir" && entry.is_dir)
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "dir/file.txt" && !entry.is_dir)
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn assert_sample_listing(path: &Path, format: ArchiveFormat, label: &str) {
+        let (metadata, entries, total_entries, scan_truncated) =
+            collect_internal_archive_listing(path, format, &|| false)
+                .expect("archive listing should be collected natively");
+
+        assert_eq!(metadata.format_label.as_deref(), Some(label));
+        assert_eq!(metadata.unpacked_size, Some(5));
+        assert_eq!(total_entries, 2);
+        assert!(!scan_truncated);
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "dir" && entry.is_dir)
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path == "dir/file.txt" && !entry.is_dir)
+        );
+    }
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("elio-{label}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_compressed_tar<W, D>(archive_path: &Path, encoder: D)
+    where
+        W: Write,
+        D: FnOnce(File) -> std::io::Result<W>,
+    {
+        let file = File::create(archive_path).unwrap();
+        let writer = encoder(file).unwrap();
+        write_tar(writer);
+    }
+
+    fn write_zstd_tar(archive_path: &Path) {
+        let mut tar_bytes = Vec::new();
+        write_tar(&mut tar_bytes);
+        let compressed = zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap();
+        fs::write(archive_path, compressed).unwrap();
+    }
+
+    fn write_tar<W: Write>(writer: W) {
+        let mut tar = tar::Builder::new(writer);
+        let mut dir = tar::Header::new_gnu();
+        dir.set_entry_type(tar::EntryType::Directory);
+        dir.set_size(0);
+        dir.set_mode(0o755);
+        dir.set_cksum();
+        tar.append_data(&mut dir, "dir", std::io::empty()).unwrap();
+
+        let contents = b"hello";
+        let mut file = tar::Header::new_gnu();
+        file.set_size(contents.len() as u64);
+        file.set_mode(0o644);
+        file.set_cksum();
+        tar.append_data(&mut file, "dir/file.txt", contents.as_slice())
+            .unwrap();
+        tar.finish().unwrap();
+    }
+
+    fn write_seven_zip(archive_path: &Path) {
+        let mut writer = sevenz_rust2::ArchiveWriter::create(archive_path).unwrap();
+        writer
+            .push_archive_entry::<&[u8]>(sevenz_rust2::ArchiveEntry::new_directory("dir"), None)
+            .unwrap();
+        writer
+            .push_archive_entry(
+                sevenz_rust2::ArchiveEntry::new_file("dir/file.txt"),
+                Some(&b"hello"[..]),
+            )
+            .unwrap();
+        writer.finish().unwrap();
+    }
 }

--- a/src/preview/container/archive/mod.rs
+++ b/src/preview/container/archive/mod.rs
@@ -61,7 +61,7 @@ where
     if let Some(preview) = build_zip_archive_preview(path, format, type_detail, canceled) {
         return Some(preview);
     }
-    if let Some(preview) = build_tar_archive_preview(path, format, type_detail) {
+    if let Some(preview) = build_internal_archive_preview(path, format, type_detail, canceled) {
         return Some(preview);
     }
     build_external_archive_preview(path, format, type_detail, canceled)
@@ -162,13 +162,17 @@ where
     Some(preview)
 }
 
-fn build_tar_archive_preview(
+fn build_internal_archive_preview<F>(
     path: &Path,
     format: ArchiveFormat,
     type_detail: Option<&'static str>,
-) -> Option<PreviewContent> {
+    canceled: &F,
+) -> Option<PreviewContent>
+where
+    F: Fn() -> bool,
+{
     let (metadata, entries, total_entries, scan_truncated) =
-        collect_internal_archive_listing(path, format)?;
+        collect_internal_archive_listing(path, format, canceled)?;
     let detail = type_detail.unwrap_or(archive_default_label(format));
 
     Some(render_archive_preview(ArchiveRenderConfig {
@@ -192,9 +196,9 @@ fn build_external_archive_preview<F>(
 where
     F: Fn() -> bool,
 {
-    // Common ZIP and TAR previews are handled internally above. This path is for
-    // recovery and uncommon archive types, where 7z provides the broadest coverage
-    // and bsdtar remains a final generic fallback.
+    // Common ZIP, TAR, and 7z previews are handled internally above. This path
+    // is for recovery and uncommon archive types, where 7z provides the
+    // broadest coverage and bsdtar remains a final generic fallback.
     let detail = type_detail.unwrap_or(archive_default_label(format));
     if canceled() {
         return None;


### PR DESCRIPTION
## Summary

Show `.7z` and compressed TAR archive previews using elio's native archive readers before falling back to external tools.

This improves preview availability on systems without `7z`/`bsdtar` while keeping those tools as fallback coverage for uncommon or unsupported archives.

Refs #90.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked preview::container::archive::internal`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed
