### PR TITLE
feat(archive): prompt for encrypted 7z passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added native archive extraction for focused `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, and unique sibling destination folders. ([#90])
+- Added native archive extraction for focused `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, unique sibling destination folders, and password prompts for encrypted `.7z` archives. ([#90])
 - Added a `progress_bar` theme palette color for active background operation chips, used by archive extraction progress.
 - Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
 
 ### Changed
 
-- Prefer native archive listing for `.7z`, `.tar.xz`, `.tar.bz2`, and `.tar.zst` previews before falling back to external archive tools. ([#90])
+- Prefer native archive listing for `.7z`, `.tar.xz`, `.tar.bz2`, and `.tar.zst` previews before falling back to external archive tools, and keep encrypted `.7z` previews visible with a password-required notice. ([#90])
 - Places now switches to an icon-only rail in narrow windows before labels become overly truncated. ([#184])
 - Changed Open With to keep `$VISUAL` and `$EDITOR` labels on matching MIME-associated editors and place them directly below the system default association. ([#199])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +83,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +256,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -237,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -308,6 +386,17 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -537,8 +626,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -587,6 +687,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -683,6 +792,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1255,6 +1374,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "ratatui"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,10 +1619,25 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "081a399c6762c4a9bda9233f502aca74b6ca6a0caaff4d218b12887eac4b6adc"
 dependencies = [
+ "aes",
+ "cbc",
  "crc32fast",
+ "getrandom 0.4.3",
  "js-sys",
  "lzma-rust2",
+ "sha2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1757,6 +1897,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 xz2 = { version = "0.1.7", features = ["static"] }
 bzip2 = "0.6.1"
 zstd = { version = "0.13.3", default-features = false }
-sevenz-rust2 = { version = "0.21.1", default-features = false }
+sevenz-rust2 = { version = "0.21.1", default-features = false, features = ["aes256"] }
 
 [dev-dependencies]
-sevenz-rust2 = { version = "0.21.1", default-features = false, features = ["compress"] }
+sevenz-rust2 = { version = "0.21.1", default-features = false, features = ["aes256", "compress"] }
 
 [build-dependencies]
 syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "yaml-load", "regex-onig"] }

--- a/src/app/actions/archive.rs
+++ b/src/app/actions/archive.rs
@@ -1,4 +1,11 @@
 use super::*;
+use crate::app::text_edit::{
+    char_to_byte, next_delete_end, next_word_start, previous_delete_start, previous_word_start,
+    remove_char_range,
+};
+use crate::archive::ArchivePassword;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use std::path::PathBuf;
 
 impl App {
     pub fn archive_extract_progress(&self) -> Option<(usize, Option<usize>)> {
@@ -24,9 +31,254 @@ impl App {
         }
 
         let archive_path = entry.path.clone();
+        let _ = self.start_archive_extract(archive_path, None)?;
+        Ok(())
+    }
+
+    pub fn archive_password_is_open(&self) -> bool {
+        self.overlays.archive_password.is_some()
+    }
+
+    pub fn archive_password_archive_name(&self) -> &str {
+        self.overlays
+            .archive_password
+            .as_ref()
+            .and_then(|overlay| overlay.archive_path.file_name())
+            .and_then(|name| name.to_str())
+            .unwrap_or("archive")
+    }
+
+    pub fn archive_password_input(&self) -> &str {
+        self.overlays
+            .archive_password
+            .as_ref()
+            .map_or("", |overlay| &overlay.input)
+    }
+
+    pub fn archive_password_cursor_col(&self) -> usize {
+        self.overlays
+            .archive_password
+            .as_ref()
+            .map_or(0, |overlay| overlay.cursor_col)
+    }
+
+    pub fn archive_password_error(&self) -> Option<&str> {
+        self.overlays
+            .archive_password
+            .as_ref()
+            .and_then(|overlay| overlay.error.as_deref())
+    }
+
+    pub(in crate::app) fn open_archive_password_prompt(
+        &mut self,
+        archive_path: PathBuf,
+        error: Option<String>,
+    ) {
+        self.overlays.help = false;
+        self.overlays.trash = None;
+        self.overlays.restore = None;
+        self.overlays.create = None;
+        self.overlays.rename = None;
+        self.overlays.bulk_rename = None;
+        self.overlays.goto = None;
+        self.overlays.copy = None;
+        self.overlays.open_with = None;
+        self.overlays.search = None;
+        self.overlays.archive_password = Some(ArchivePasswordOverlay {
+            archive_path,
+            input: String::new(),
+            cursor_col: 0,
+            error,
+        });
+        self.status.clear();
+    }
+
+    pub(in crate::app) fn handle_archive_password_key(&mut self, key: KeyEvent) -> Result<()> {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+            self.overlays.archive_password = None;
+            return Ok(());
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                self.overlays.archive_password = None;
+            }
+            KeyCode::Enter if key.modifiers == KeyModifiers::NONE => {
+                self.confirm_archive_password()?;
+            }
+            KeyCode::Left
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    overlay.cursor_col = previous_word_start(&overlay.input, overlay.cursor_col);
+                }
+            }
+            KeyCode::Right
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    overlay.cursor_col = next_word_start(&overlay.input, overlay.cursor_col);
+                }
+            }
+            KeyCode::Left if key.modifiers == KeyModifiers::NONE => {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    overlay.cursor_col = overlay.cursor_col.saturating_sub(1);
+                }
+            }
+            KeyCode::Right if key.modifiers == KeyModifiers::NONE => {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    let len = overlay.input.chars().count();
+                    if overlay.cursor_col < len {
+                        overlay.cursor_col += 1;
+                    }
+                }
+            }
+            KeyCode::Home if key.modifiers == KeyModifiers::NONE => {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    overlay.cursor_col = 0;
+                }
+            }
+            KeyCode::End if key.modifiers == KeyModifiers::NONE => {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    overlay.cursor_col = overlay.input.chars().count();
+                }
+            }
+            KeyCode::Backspace
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password
+                    && overlay.cursor_col > 0
+                {
+                    let start = previous_delete_start(&overlay.input, overlay.cursor_col);
+                    remove_char_range(&mut overlay.input, start, overlay.cursor_col);
+                    overlay.cursor_col = start;
+                    overlay.error = None;
+                }
+            }
+            KeyCode::Char('h' | 'w')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password
+                    && overlay.cursor_col > 0
+                {
+                    let start = previous_delete_start(&overlay.input, overlay.cursor_col);
+                    remove_char_range(&mut overlay.input, start, overlay.cursor_col);
+                    overlay.cursor_col = start;
+                    overlay.error = None;
+                }
+            }
+            KeyCode::Delete
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    let end = next_delete_end(&overlay.input, overlay.cursor_col);
+                    remove_char_range(&mut overlay.input, overlay.cursor_col, end);
+                    overlay.error = None;
+                }
+            }
+            KeyCode::Char('d')
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    let end = next_delete_end(&overlay.input, overlay.cursor_col);
+                    remove_char_range(&mut overlay.input, overlay.cursor_col, end);
+                    overlay.error = None;
+                }
+            }
+            KeyCode::Backspace if key.modifiers == KeyModifiers::NONE => {
+                if let Some(overlay) = &mut self.overlays.archive_password
+                    && overlay.cursor_col > 0
+                {
+                    let start = char_to_byte(&overlay.input, overlay.cursor_col - 1);
+                    let end = char_to_byte(&overlay.input, overlay.cursor_col);
+                    overlay.input.replace_range(start..end, "");
+                    overlay.cursor_col -= 1;
+                    overlay.error = None;
+                }
+            }
+            KeyCode::Delete if key.modifiers == KeyModifiers::NONE => {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    let len = overlay.input.chars().count();
+                    if overlay.cursor_col < len {
+                        let start = char_to_byte(&overlay.input, overlay.cursor_col);
+                        let end = char_to_byte(&overlay.input, overlay.cursor_col + 1);
+                        overlay.input.replace_range(start..end, "");
+                        overlay.error = None;
+                    }
+                }
+            }
+            KeyCode::Char(ch)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                if let Some(overlay) = &mut self.overlays.archive_password {
+                    let byte = char_to_byte(&overlay.input, overlay.cursor_col);
+                    overlay.input.insert(byte, ch);
+                    overlay.cursor_col += 1;
+                    overlay.error = None;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(in crate::app) fn handle_archive_password_mouse(
+        &mut self,
+        mouse: MouseEvent,
+    ) -> Result<()> {
+        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
+            let inside = self
+                .input
+                .frame_state
+                .archive_password_panel
+                .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
+            if !inside {
+                self.overlays.archive_password = None;
+            }
+        }
+        Ok(())
+    }
+
+    fn confirm_archive_password(&mut self) -> Result<()> {
+        let Some(overlay) = &self.overlays.archive_password else {
+            return Ok(());
+        };
+        let password = overlay.input.clone();
+        if password.is_empty() {
+            if let Some(overlay) = &mut self.overlays.archive_password {
+                overlay.error = Some("Password cannot be empty".to_string());
+            }
+            return Ok(());
+        }
+
+        let archive_path = overlay.archive_path.clone();
+        if self.start_archive_extract(archive_path, Some(ArchivePassword::new(password)))? {
+            self.overlays.archive_password = None;
+        }
+        Ok(())
+    }
+
+    fn start_archive_extract(
+        &mut self,
+        archive_path: PathBuf,
+        password: Option<ArchivePassword>,
+    ) -> Result<bool> {
+        if self.jobs.archive_extract_progress.is_some() {
+            self.status = "Extraction already in progress".to_string();
+            return Ok(false);
+        }
+
         if let Err(error) = crate::archive::plan_extract(&archive_path) {
             self.status = error.to_string();
-            return Ok(());
+            return Ok(false);
         }
 
         let token = self.jobs.archive_extract_token.wrapping_add(1);
@@ -36,6 +288,7 @@ impl App {
             total: None,
         });
         self.jobs.archive_extract_source_cwd = Some(self.navigation.cwd.clone());
+        self.jobs.archive_extract_path = Some(archive_path.clone());
         self.status.clear();
 
         let submitted = self
@@ -44,12 +297,15 @@ impl App {
             .submit_archive_extract(ArchiveExtractRequest {
                 token,
                 archive_path,
+                password,
             });
         if !submitted {
             self.jobs.archive_extract_progress = None;
             self.jobs.archive_extract_source_cwd = None;
+            self.jobs.archive_extract_path = None;
             self.status = "Extraction already in progress".to_string();
+            return Ok(false);
         }
-        Ok(())
+        Ok(true)
     }
 }

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -31,6 +31,10 @@ impl App {
             return self.handle_restore_key(key);
         }
 
+        if self.overlays.archive_password.is_some() {
+            return self.handle_archive_password_key(key);
+        }
+
         if self.overlays.create.is_some() {
             return self.handle_create_key(key);
         }

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -10,6 +10,10 @@ impl App {
             return self.handle_restore_mouse(mouse);
         }
 
+        if self.overlays.archive_password.is_some() {
+            return self.handle_archive_password_mouse(mouse);
+        }
+
         if self.overlays.create.is_some() {
             return self.handle_create_mouse(mouse);
         }

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -42,7 +42,9 @@ fn e_prompts_and_retries_encrypted_seven_zip_archive() {
     let root = temp_path("extract-encrypted-7z-key");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let archive = root.join("sample.7z");
-    write_encrypted_seven_zip_entries(&archive, "secret", &[("dir/file.txt", b"hello")]);
+    let password = archive_test_password(&root);
+    let wrong_password = format!("{password}-wrong");
+    write_encrypted_seven_zip_entries(&archive, &password, &[("dir/file.txt", b"hello")]);
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     wait_for_directory_load(&mut app);
@@ -55,7 +57,7 @@ fn e_prompts_and_retries_encrypted_seven_zip_archive() {
     assert_eq!(app.archive_password_error(), None);
     assert!(!root.join("sample").exists());
 
-    type_archive_password(&mut app, "wrong");
+    type_archive_password(&mut app, &wrong_password);
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
         .expect("enter should submit wrong password");
     wait_for_archive_password_prompt(&mut app);
@@ -64,7 +66,7 @@ fn e_prompts_and_retries_encrypted_seven_zip_archive() {
     assert_eq!(app.archive_password_error(), Some("Wrong password"));
     assert_eq!(app.archive_password_input(), "");
 
-    type_archive_password(&mut app, "secret");
+    type_archive_password(&mut app, &password);
     app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
         .expect("enter should submit correct password");
 
@@ -110,6 +112,13 @@ fn e_reports_unsupported_archive_format() {
     assert!(app.jobs.archive_extract_progress.is_none());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+fn archive_test_password(root: &std::path::Path) -> String {
+    root.file_name()
+        .expect("temp root should have a file name")
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn wait_for_archive_password_prompt(app: &mut App) {

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -1,5 +1,7 @@
 use super::super::*;
-use super::helpers::{temp_path, wait_for_directory_load, write_binary_zip_entries};
+use super::helpers::{
+    temp_path, wait_for_directory_load, write_binary_zip_entries, write_encrypted_seven_zip_entries,
+};
 use std::{fs, thread, time::Duration};
 
 #[test]
@@ -36,6 +38,60 @@ fn e_extracts_focused_zip_archive() {
 }
 
 #[test]
+fn e_prompts_and_retries_encrypted_seven_zip_archive() {
+    let root = temp_path("extract-encrypted-7z-key");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let archive = root.join("sample.7z");
+    write_encrypted_seven_zip_entries(&archive, "secret", &[("dir/file.txt", b"hello")]);
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('e'))))
+        .expect("e should start archive extraction");
+    wait_for_archive_password_prompt(&mut app);
+
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_error(), None);
+    assert!(!root.join("sample").exists());
+
+    type_archive_password(&mut app, "wrong");
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("enter should submit wrong password");
+    wait_for_archive_password_prompt(&mut app);
+
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_error(), Some("Wrong password"));
+    assert_eq!(app.archive_password_input(), "");
+
+    type_archive_password(&mut app, "secret");
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("enter should submit correct password");
+
+    let extracted_file = root.join("sample/dir/file.txt");
+    for _ in 0..200 {
+        let _ = app.process_background_jobs();
+        if extracted_file.exists()
+            && app.jobs.archive_extract_progress.is_none()
+            && !app.archive_password_is_open()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(fs::read_to_string(&extracted_file).unwrap(), "hello");
+    assert_eq!(app.status_message(), "Extracted 1 item to \"sample\"");
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.path.as_path()),
+        Some(root.join("sample").as_path())
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn e_reports_unsupported_archive_format() {
     let root = temp_path("extract-unsupported-key");
     fs::create_dir_all(&root).expect("failed to create temp root");
@@ -54,4 +110,22 @@ fn e_reports_unsupported_archive_format() {
     assert!(app.jobs.archive_extract_progress.is_none());
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+fn wait_for_archive_password_prompt(app: &mut App) {
+    for _ in 0..200 {
+        let _ = app.process_background_jobs();
+        if app.archive_password_is_open() && app.jobs.archive_extract_progress.is_none() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for archive password prompt");
+}
+
+fn type_archive_password(app: &mut App, password: &str) {
+    for ch in password.chars() {
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char(ch))))
+            .expect("password character should be handled");
+    }
 }

--- a/src/app/input/tests/helpers.rs
+++ b/src/app/input/tests/helpers.rs
@@ -105,6 +105,29 @@ pub(super) fn write_binary_zip_entries(path: &Path, entries: &[(&str, &[u8])]) {
     zip.finish().expect("failed to finish zip");
 }
 
+pub(super) fn write_encrypted_seven_zip_entries(
+    path: &Path,
+    password: &str,
+    entries: &[(&str, &[u8])],
+) {
+    let mut writer = sevenz_rust2::ArchiveWriter::create(path).expect("failed to create 7z");
+    writer.set_content_methods(vec![
+        sevenz_rust2::encoder_options::AesEncoderOptions::new(sevenz_rust2::Password::new(
+            password,
+        ))
+        .into(),
+        sevenz_rust2::encoder_options::Lzma2Options::default().into(),
+    ]);
+
+    for (name, contents) in entries {
+        writer
+            .push_archive_entry(sevenz_rust2::ArchiveEntry::new_file(name), Some(*contents))
+            .expect("failed to write 7z entry");
+    }
+
+    writer.finish().expect("failed to finish 7z");
+}
+
 pub(super) fn write_epub_fixture(path: &Path, sections: &[(&str, &str)]) {
     let file = File::create(path).expect("failed to create epub");
     let mut zip = ZipWriter::new(file);

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -12,14 +12,14 @@ pub(super) use self::metrics::SchedulerMetricsSnapshot;
 pub(super) use self::scheduler::JobScheduler;
 use self::sync::{lock_unpoison, wait_unpoison};
 pub(super) use self::types::{
-    ArchiveExtractBuild, ArchiveExtractRequest, DirectoryBuild, DirectoryFingerprintBuild,
-    DirectoryFingerprintRequest, DirectoryItemCountBuild, DirectoryItemCountRequest,
-    DirectoryRequest, DirectoryStatsBuild, DirectoryStatsRequest, GitStatusBuild, GitStatusRequest,
-    ImageJobPriority, ImagePrepareBuild, ImagePrepareRequest, JobResult, PasteBuild, PasteRequest,
-    PdfJobPriority, PdfProbeBuild, PdfProbeRequest, PdfRenderBuild, PdfRenderRequest, PreviewBuild,
-    PreviewLineCountBuild, PreviewLineCountRequest, PreviewPriority, PreviewRequest, RestoreBuild,
-    RestoreRequest, SearchBatchBuild, SearchBuild, SearchRequest, SixelPrepareConfig, TrashBuild,
-    TrashRequest,
+    ArchiveExtractBuild, ArchiveExtractRequest, ArchivePasswordPrompt, DirectoryBuild,
+    DirectoryFingerprintBuild, DirectoryFingerprintRequest, DirectoryItemCountBuild,
+    DirectoryItemCountRequest, DirectoryRequest, DirectoryStatsBuild, DirectoryStatsRequest,
+    GitStatusBuild, GitStatusRequest, ImageJobPriority, ImagePrepareBuild, ImagePrepareRequest,
+    JobResult, PasteBuild, PasteRequest, PdfJobPriority, PdfProbeBuild, PdfProbeRequest,
+    PdfRenderBuild, PdfRenderRequest, PreviewBuild, PreviewLineCountBuild, PreviewLineCountRequest,
+    PreviewPriority, PreviewRequest, RestoreBuild, RestoreRequest, SearchBatchBuild, SearchBuild,
+    SearchRequest, SixelPrepareConfig, TrashBuild, TrashRequest,
 };
 use self::{config::SchedulerConfig, metrics::SchedulerMetrics};
 #[cfg(test)]

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -242,6 +242,24 @@ impl App {
                     }
                     if build.done {
                         self.jobs.archive_extract_progress = None;
+                        if let Some(prompt) = build.password_prompt {
+                            let archive_path = self.jobs.archive_extract_path.take();
+                            self.jobs.archive_extract_source_cwd = None;
+                            if let Some(archive_path) = archive_path {
+                                let error = match prompt {
+                                    ArchivePasswordPrompt::Required => None,
+                                    ArchivePasswordPrompt::BadPassword => {
+                                        Some("Wrong password".to_string())
+                                    }
+                                };
+                                self.open_archive_password_prompt(archive_path, error);
+                            } else {
+                                self.status = "Archive requires a password".to_string();
+                            }
+                            dirty = true;
+                            continue;
+                        }
+                        self.jobs.archive_extract_path = None;
                         let source_cwd = self
                             .jobs
                             .archive_extract_source_cwd

--- a/src/app/jobs/tasks/archive_extract.rs
+++ b/src/app/jobs/tasks/archive_extract.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::archive::ExtractError;
 use std::{
     sync::{
         Arc, Condvar, Mutex,
@@ -125,31 +126,35 @@ fn run_extract(
     let mut last_progress_at: Option<Instant> = None;
     let mut stopped_early = false;
 
-    let result = crate::archive::plan_extract(&request.archive_path).and_then(|plan| {
-        crate::archive::extract_archive(
-            &plan,
-            |progress| {
-                completed = progress.completed;
-                total = progress.total;
-                let _ = send_extract_progress(
-                    result_tx,
-                    request.token,
-                    completed,
-                    total,
-                    &mut last_progress_at,
-                );
-            },
-            || {
-                let stop = cancelled.load(Ordering::Relaxed)
-                    || cancel_token.load(Ordering::Relaxed) == request.token;
-                if stop {
-                    stopped_early = true;
-                }
-                stop
-            },
-        )
-    });
+    let result = crate::archive::plan_extract(&request.archive_path)
+        .map_err(ExtractError::from)
+        .and_then(|plan| {
+            crate::archive::extract_archive_with_password(
+                &plan,
+                request.password.as_ref(),
+                |progress| {
+                    completed = progress.completed;
+                    total = progress.total;
+                    let _ = send_extract_progress(
+                        result_tx,
+                        request.token,
+                        completed,
+                        total,
+                        &mut last_progress_at,
+                    );
+                },
+                || {
+                    let stop = cancelled.load(Ordering::Relaxed)
+                        || cancel_token.load(Ordering::Relaxed) == request.token;
+                    if stop {
+                        stopped_early = true;
+                    }
+                    stop
+                },
+            )
+        });
 
+    let mut password_prompt = None;
     let (dest_dir, status) = match result {
         Ok(summary) if stopped_early => {
             let noun = if summary.completed == 1 {
@@ -182,6 +187,14 @@ fn run_extract(
                 format!("Extracted {} {noun} to \"{name}\"", summary.completed),
             )
         }
+        Err(ExtractError::PasswordRequired) => {
+            password_prompt = Some(ArchivePasswordPrompt::Required);
+            (None, String::new())
+        }
+        Err(ExtractError::BadPassword) => {
+            password_prompt = Some(ArchivePasswordPrompt::BadPassword);
+            (None, String::new())
+        }
         Err(error) => {
             let name = request
                 .archive_path
@@ -198,7 +211,8 @@ fn run_extract(
         total,
         done: true,
         dest_dir,
-        status: Some(status),
+        status: (!status.is_empty()).then_some(status),
+        password_prompt,
     }));
 }
 
@@ -222,6 +236,7 @@ fn send_extract_progress(
             done: false,
             dest_dir: None,
             status: None,
+            password_prompt: None,
         }))
         .is_ok()
 }

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -260,6 +260,13 @@ pub(in crate::app) struct PreviewRequest {
 pub(in crate::app) struct ArchiveExtractRequest {
     pub(in crate::app) token: u64,
     pub(in crate::app) archive_path: PathBuf,
+    pub(in crate::app) password: Option<crate::archive::ArchivePassword>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::app) enum ArchivePasswordPrompt {
+    Required,
+    BadPassword,
 }
 
 #[derive(Debug)]
@@ -273,6 +280,8 @@ pub(in crate::app) struct ArchiveExtractBuild {
     pub(in crate::app) dest_dir: Option<PathBuf>,
     /// Populated only when `done = true`.
     pub(in crate::app) status: Option<String>,
+    /// Populated only when `done = true` and extraction needs password input.
+    pub(in crate::app) password_prompt: Option<ArchivePasswordPrompt>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -626,6 +626,9 @@ impl App {
         if let Some(r) = self.input.frame_state.restore_panel {
             rects.push(r);
         }
+        if let Some(r) = self.input.frame_state.archive_password_panel {
+            rects.push(r);
+        }
         if let Some(r) = self.input.frame_state.create_panel {
             rects.push(r);
         }
@@ -653,6 +656,7 @@ impl App {
     fn any_modal_overlay_open(&self) -> bool {
         self.overlays.trash.is_some()
             || self.overlays.restore.is_some()
+            || self.overlays.archive_password.is_some()
             || self.overlays.create.is_some()
             || self.overlays.rename.is_some()
             || self.overlays.bulk_rename.is_some()

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    env,
+    env, fmt,
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant, SystemTime},
@@ -148,6 +148,25 @@ pub(super) struct RestoreOverlay {
     pub(super) targets: Vec<TrashTarget>,
     pub(super) scroll: usize,
     pub(super) confirmed: bool,
+}
+
+#[derive(Clone)]
+pub(super) struct ArchivePasswordOverlay {
+    pub(super) archive_path: PathBuf,
+    pub(super) input: String,
+    pub(super) cursor_col: usize,
+    pub(super) error: Option<String>,
+}
+
+impl fmt::Debug for ArchivePasswordOverlay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ArchivePasswordOverlay")
+            .field("archive_path", &self.archive_path)
+            .field("input", &"<redacted>")
+            .field("cursor_col", &self.cursor_col)
+            .field("error", &self.error)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -611,6 +630,7 @@ pub(in crate::app) struct PreviewRuntime {
 pub(crate) struct OverlayState {
     pub(in crate::app) trash: Option<TrashOverlay>,
     pub(in crate::app) restore: Option<RestoreOverlay>,
+    pub(in crate::app) archive_password: Option<ArchivePasswordOverlay>,
     pub(in crate::app) create: Option<CreateOverlay>,
     pub(in crate::app) rename: Option<RenameOverlay>,
     pub(in crate::app) bulk_rename: Option<BulkRenameOverlay>,
@@ -632,6 +652,7 @@ pub(in crate::app) struct JobRuntime {
     pub(in crate::app) archive_extract_token: u64,
     pub(in crate::app) archive_extract_progress: Option<ArchiveExtractProgress>,
     pub(in crate::app) archive_extract_source_cwd: Option<PathBuf>,
+    pub(in crate::app) archive_extract_path: Option<PathBuf>,
     pub(in crate::app) paste_token: u64,
     pub(in crate::app) paste_progress: Option<PasteProgress>,
     pub(in crate::app) queued_pastes: VecDeque<QueuedPaste>,
@@ -798,6 +819,7 @@ impl App {
                 archive_extract_token: 0,
                 archive_extract_progress: None,
                 archive_extract_source_cwd: None,
+                archive_extract_path: None,
                 paste_token: 0,
                 paste_progress: None,
                 queued_pastes: VecDeque::new(),

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -44,6 +44,7 @@ pub struct FrameState {
     pub restore_panel: Option<Rect>,
     pub restore_confirm_btn: Option<Rect>,
     pub restore_cancel_btn: Option<Rect>,
+    pub archive_password_panel: Option<Rect>,
     pub create_panel: Option<Rect>,
     pub rename_panel: Option<Rect>,
     pub create_list_area: Option<Rect>,

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -2,8 +2,13 @@ use super::format::{ExtractBackend, ExtractFormat, unique_destination};
 use anyhow::{Context, Result, anyhow, bail};
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
-use sevenz_rust2::{ArchiveEntry as SevenZipEntry, ArchiveReader, Password};
+use sevenz_rust2::{
+    ArchiveEntry as SevenZipEntry, ArchiveReader, Error as SevenZipError,
+    Password as SevenZipPassword,
+};
 use std::{
+    error::Error,
+    fmt::{self, Display},
     fs::{self, File},
     io::{self, Read},
     path::{Component, Path, PathBuf},
@@ -31,6 +36,61 @@ pub(crate) struct ExtractSummary {
     pub(crate) total: Option<usize>,
 }
 
+#[derive(Clone, Default, Eq, PartialEq)]
+pub(crate) struct ArchivePassword(String);
+
+impl ArchivePassword {
+    pub(crate) fn new(password: impl Into<String>) -> Self {
+        Self(password.into())
+    }
+
+    fn as_seven_zip_password(&self) -> SevenZipPassword {
+        SevenZipPassword::new(&self.0)
+    }
+}
+
+impl fmt::Debug for ArchivePassword {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ArchivePassword(<redacted>)")
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ExtractError {
+    PasswordRequired,
+    BadPassword,
+    UnsupportedEncryption,
+    Other(anyhow::Error),
+}
+
+impl Display for ExtractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PasswordRequired => f.write_str("archive requires a password"),
+            Self::BadPassword => f.write_str("wrong password"),
+            Self::UnsupportedEncryption => f.write_str("unsupported encrypted archive"),
+            Self::Other(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl Error for ExtractError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Other(error) => error.source(),
+            _ => None,
+        }
+    }
+}
+
+impl From<anyhow::Error> for ExtractError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Other(error)
+    }
+}
+
+type ExtractResult<T> = std::result::Result<T, ExtractError>;
+
 pub(crate) fn plan_extract(path: &Path) -> Result<ExtractPlan> {
     let format =
         ExtractFormat::detect(path).ok_or_else(|| anyhow!(ExtractFormat::SUPPORTED_MESSAGE))?;
@@ -46,29 +106,113 @@ pub(crate) fn plan_extract(path: &Path) -> Result<ExtractPlan> {
     })
 }
 
-pub(crate) fn extract_archive<F, C>(
+pub(crate) fn extract_archive_with_password<F, C>(
     plan: &ExtractPlan,
+    password: Option<&ArchivePassword>,
     mut progress: F,
     cancelled: C,
-) -> Result<ExtractSummary>
+) -> ExtractResult<ExtractSummary>
 where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
 {
-    fs::create_dir(&plan.dest_dir)
-        .with_context(|| format!("Could not create {}", plan.dest_dir.display()))?;
+    preflight_extract(plan, password)?;
+
+    let staging_dir = staging_destination(&plan.dest_dir)?;
+    let extraction_plan = ExtractPlan {
+        archive_path: plan.archive_path.clone(),
+        dest_dir: staging_dir.clone(),
+        backend: plan.backend,
+    };
+    fs::create_dir(&staging_dir)
+        .with_context(|| format!("Could not create {}", staging_dir.display()))?;
+
+    let result = match extraction_plan.backend {
+        ExtractBackend::Zip => extract_zip(&extraction_plan, &mut progress, cancelled),
+        ExtractBackend::Tar(format) => {
+            extract_tar(format, &extraction_plan, &mut progress, cancelled)
+        }
+        ExtractBackend::SevenZip => {
+            extract_seven_zip(&extraction_plan, password, &mut progress, cancelled)
+        }
+    };
+    let summary = match result {
+        Ok(summary) => summary,
+        Err(error) => {
+            let _ = fs::remove_dir_all(&staging_dir);
+            return Err(error);
+        }
+    };
+
+    let dest_dir = if plan.dest_dir.exists() {
+        let parent = plan
+            .dest_dir
+            .parent()
+            .ok_or_else(|| anyhow!("Cannot determine extraction parent"))?;
+        let name = plan
+            .dest_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| anyhow!("Cannot determine extraction folder name"))?;
+        unique_destination(parent, name)
+    } else {
+        plan.dest_dir.clone()
+    };
+    fs::rename(&staging_dir, &dest_dir).with_context(|| {
+        format!(
+            "Could not move {} to {}",
+            staging_dir.display(),
+            dest_dir.display()
+        )
+    })?;
+
+    Ok(ExtractSummary {
+        dest_dir,
+        completed: summary.completed,
+        total: summary.total,
+    })
+}
+
+fn preflight_extract(plan: &ExtractPlan, _password: Option<&ArchivePassword>) -> ExtractResult<()> {
     match plan.backend {
-        ExtractBackend::Zip => extract_zip(plan, &mut progress, cancelled),
-        ExtractBackend::Tar(format) => extract_tar(format, plan, &mut progress, cancelled),
-        ExtractBackend::SevenZip => extract_seven_zip(plan, &mut progress, cancelled),
+        ExtractBackend::Zip => preflight_zip(&plan.archive_path),
+        ExtractBackend::SevenZip | ExtractBackend::Tar(_) => Ok(()),
     }
+}
+
+fn preflight_zip(archive_path: &Path) -> ExtractResult<()> {
+    let file = File::open(archive_path)
+        .with_context(|| format!("Could not open {}", archive_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file).context("Could not read ZIP archive")?;
+    let total = archive.len();
+    reject_encrypted_zip_entries(&mut archive, total)
+}
+
+fn staging_destination(dest_dir: &Path) -> Result<PathBuf> {
+    let parent = dest_dir
+        .parent()
+        .ok_or_else(|| anyhow!("Cannot determine extraction parent"))?;
+    let name = dest_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("Cannot determine extraction folder name"))?;
+    for attempt in 0..1000 {
+        let candidate = parent.join(format!(
+            ".{name}.elio-extracting-{}-{attempt}",
+            std::process::id()
+        ));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    bail!("Could not reserve extraction workspace")
 }
 
 fn extract_zip<F, C>(
     plan: &ExtractPlan,
     progress: &mut F,
     mut cancelled: C,
-) -> Result<ExtractSummary>
+) -> ExtractResult<ExtractSummary>
 where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
@@ -77,6 +221,7 @@ where
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
     let mut archive = zip::ZipArchive::new(file).context("Could not read ZIP archive")?;
     let total = archive.len();
+    reject_encrypted_zip_entries(&mut archive, total)?;
     let mut completed = 0usize;
     progress(ExtractProgress {
         completed,
@@ -91,7 +236,7 @@ where
             .by_index(index)
             .context("Could not read ZIP entry")?;
         let Some(enclosed) = entry.enclosed_name() else {
-            bail!("Archive entry escapes the destination: {}", entry.name());
+            return Err(anyhow!("Archive entry escapes the destination: {}", entry.name()).into());
         };
         let out_path = checked_output_path(&plan.dest_dir, enclosed.as_ref())?;
         if entry.is_dir() {
@@ -127,12 +272,31 @@ where
     })
 }
 
+fn reject_encrypted_zip_entries<R: Read + io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    total: usize,
+) -> ExtractResult<()> {
+    for index in 0..total {
+        let entry = match archive.by_index(index) {
+            Ok(entry) => entry,
+            Err(error) if error.to_string().contains("Password required") => {
+                return Err(ExtractError::UnsupportedEncryption);
+            }
+            Err(error) => return Err(anyhow!(error).context("Could not read ZIP entry").into()),
+        };
+        if entry.encrypted() {
+            return Err(ExtractError::UnsupportedEncryption);
+        }
+    }
+    Ok(())
+}
+
 fn extract_tar<F, C>(
     format: ExtractFormat,
     plan: &ExtractPlan,
     progress: &mut F,
     cancelled: C,
-) -> Result<ExtractSummary>
+) -> ExtractResult<ExtractSummary>
 where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
@@ -171,17 +335,22 @@ where
 
 fn extract_seven_zip<F, C>(
     plan: &ExtractPlan,
+    password: Option<&ArchivePassword>,
     progress: &mut F,
     mut cancelled: C,
-) -> Result<ExtractSummary>
+) -> ExtractResult<ExtractSummary>
 where
     F: FnMut(ExtractProgress),
     C: FnMut() -> bool,
 {
     let file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    let mut archive =
-        ArchiveReader::new(file, Password::empty()).context("Could not read 7z archive")?;
+    let password_provided = password.is_some();
+    let password = password
+        .map(ArchivePassword::as_seven_zip_password)
+        .unwrap_or_else(SevenZipPassword::empty);
+    let mut archive = ArchiveReader::new(file, password)
+        .map_err(|error| map_seven_zip_error(error, password_provided))?;
     let total = archive.archive().files.len();
     let mut completed = 0usize;
     let mut extract_error = None;
@@ -206,7 +375,7 @@ where
             });
             Ok(true)
         })
-        .context("Could not read 7z entries")?;
+        .map_err(|error| map_seven_zip_error(error, password_provided))?;
 
     if let Some(error) = extract_error {
         return Err(error);
@@ -222,7 +391,7 @@ fn extract_seven_zip_entry(
     plan: &ExtractPlan,
     entry: &SevenZipEntry,
     reader: &mut dyn Read,
-) -> Result<()> {
+) -> ExtractResult<()> {
     if entry.is_anti_item {
         return Ok(());
     }
@@ -250,7 +419,7 @@ fn extract_tar_with<R, D, F, C>(
     decoder: D,
     progress: &mut F,
     cancelled: C,
-) -> Result<ExtractSummary>
+) -> ExtractResult<ExtractSummary>
 where
     R: Read,
     D: Fn(File) -> Result<R, std::io::Error>,
@@ -259,11 +428,17 @@ where
 {
     let count_file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    let total = count_tar_entries(decoder(count_file)?)
+    let total = count_tar_entries(decoder(count_file).context("Could not initialize TAR decoder")?)
         .with_context(|| format!("Could not read {} archive", format.label()))?;
     let file = File::open(&plan.archive_path)
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
-    extract_tar_reader(plan, decoder(file)?, Some(total), progress, cancelled)
+    extract_tar_reader(
+        plan,
+        decoder(file).context("Could not initialize TAR decoder")?,
+        Some(total),
+        progress,
+        cancelled,
+    )
 }
 
 fn count_tar_entries<R: Read>(reader: R) -> Result<usize> {
@@ -282,7 +457,7 @@ fn extract_tar_reader<R, F, C>(
     total: Option<usize>,
     progress: &mut F,
     mut cancelled: C,
-) -> Result<ExtractSummary>
+) -> ExtractResult<ExtractSummary>
 where
     R: Read,
     F: FnMut(ExtractProgress),
@@ -358,6 +533,23 @@ fn checked_output_name(dest_dir: &Path, entry_name: &str) -> Result<PathBuf> {
     checked_output_path(dest_dir, Path::new(&normalized))
 }
 
+fn map_seven_zip_error(error: SevenZipError, password_provided: bool) -> ExtractError {
+    match error {
+        SevenZipError::PasswordRequired => ExtractError::PasswordRequired,
+        SevenZipError::MaybeBadPassword(_) => ExtractError::BadPassword,
+        SevenZipError::ChecksumVerificationFailed if password_provided => ExtractError::BadPassword,
+        SevenZipError::UnsupportedCompressionMethod(method)
+            if method.to_ascii_lowercase().contains("aes") =>
+        {
+            ExtractError::UnsupportedEncryption
+        }
+        SevenZipError::Unsupported(message) if message.to_ascii_lowercase().contains("aes") => {
+            ExtractError::UnsupportedEncryption
+        }
+        error => ExtractError::Other(anyhow!("Could not read 7z archive: {error}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,12 +592,41 @@ mod tests {
             zip.finish().unwrap();
         }
         let plan = plan_extract(&archive_path).unwrap();
-        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
         assert_eq!(summary.completed, 2);
         assert_eq!(
             fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
             "hello"
         );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_zip_fails_before_creating_destination() {
+        use zip::unstable::write::FileOptionsExt;
+
+        let root = temp_path("zip-encrypted");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options = zip::write::SimpleFileOptions::default()
+                .with_deprecated_encryption(b"secret")
+                .unwrap();
+            zip.start_file("file.txt", options).unwrap();
+            zip.write_all(b"hello").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
+
+        assert!(
+            matches!(error, ExtractError::UnsupportedEncryption),
+            "expected unsupported encryption, got {error:?}"
+        );
+        assert!(!plan.dest_dir.exists());
         let _ = fs::remove_dir_all(root);
     }
 
@@ -426,7 +647,7 @@ mod tests {
             tar.finish().unwrap();
         }
         let plan = plan_extract(&archive_path).unwrap();
-        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
         assert_eq!(summary.completed, 2);
         assert_eq!(
             fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
@@ -453,7 +674,7 @@ mod tests {
             tar.finish().unwrap();
         }
         let plan = plan_extract(&archive_path).unwrap();
-        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
         assert_eq!(summary.completed, 2);
         assert_eq!(
             fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
@@ -472,7 +693,7 @@ mod tests {
         });
 
         let plan = plan_extract(&archive_path).unwrap();
-        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
 
         assert_eq!(summary.completed, 2);
         assert_eq!(
@@ -495,7 +716,7 @@ mod tests {
         });
 
         let plan = plan_extract(&archive_path).unwrap();
-        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
 
         assert_eq!(summary.completed, 2);
         assert_eq!(
@@ -513,7 +734,7 @@ mod tests {
         write_zstd_tar(&archive_path);
 
         let plan = plan_extract(&archive_path).unwrap();
-        let summary = extract_archive(&plan, |_| {}, || false).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
 
         assert_eq!(summary.completed, 2);
         assert_eq!(
@@ -535,7 +756,9 @@ mod tests {
 
         let plan = plan_extract(&archive_path).unwrap();
         let mut progress = Vec::new();
-        let summary = extract_archive(&plan, |update| progress.push(update), || false).unwrap();
+        let summary =
+            extract_archive_with_password(&plan, None, |update| progress.push(update), || false)
+                .unwrap();
 
         assert_eq!(summary.completed, 2);
         assert_eq!(summary.total, Some(2));
@@ -553,6 +776,87 @@ mod tests {
     }
 
     #[test]
+    fn archive_password_debug_is_redacted() {
+        let rendered = format!("{:?}", ArchivePassword::new("secret"));
+
+        assert_eq!(rendered, "ArchivePassword(<redacted>)");
+        assert!(!rendered.contains("secret"));
+    }
+
+    #[test]
+    fn encrypted_seven_zip_requires_password() {
+        let root = temp_path("7z-encrypted-required");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.7z");
+        write_encrypted_seven_zip(
+            &archive_path,
+            "secret",
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
+
+        assert!(matches!(error, ExtractError::PasswordRequired));
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_seven_zip_rejects_wrong_password() {
+        let root = temp_path("7z-encrypted-wrong");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.7z");
+        write_encrypted_seven_zip(
+            &archive_path,
+            "secret",
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new("wrong")),
+            |_| {},
+            || false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ExtractError::BadPassword));
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_seven_zip_extracts_with_password() {
+        let root = temp_path("7z-encrypted-ok");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.7z");
+        write_encrypted_seven_zip(
+            &archive_path,
+            "secret",
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new("secret")),
+            |_| {},
+            || false,
+        )
+        .unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.total, Some(2));
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn rejects_escaping_seven_zip_paths() {
         let root = temp_path("7z-slip");
         fs::create_dir_all(&root).unwrap();
@@ -560,7 +864,7 @@ mod tests {
         write_seven_zip(&archive_path, &[("../evil.txt", Some(b"bad"))]);
 
         let plan = plan_extract(&archive_path).unwrap();
-        let err = extract_archive(&plan, |_| {}, || false).unwrap_err();
+        let err = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
 
         assert!(err.to_string().contains("escapes the destination"));
         assert!(!root.join("evil.txt").exists());
@@ -606,6 +910,37 @@ mod tests {
 
     fn write_seven_zip(archive_path: &Path, entries: &[(&str, Option<&[u8]>)]) {
         let mut writer = sevenz_rust2::ArchiveWriter::create(archive_path).unwrap();
+        for (name, contents) in entries {
+            let entry = if contents.is_some() {
+                sevenz_rust2::ArchiveEntry::new_file(name)
+            } else {
+                sevenz_rust2::ArchiveEntry::new_directory(name)
+            };
+            match contents {
+                Some(contents) => {
+                    writer.push_archive_entry(entry, Some(*contents)).unwrap();
+                }
+                None => {
+                    writer.push_archive_entry::<&[u8]>(entry, None).unwrap();
+                }
+            }
+        }
+        writer.finish().unwrap();
+    }
+
+    fn write_encrypted_seven_zip(
+        archive_path: &Path,
+        password: &str,
+        entries: &[(&str, Option<&[u8]>)],
+    ) {
+        let mut writer = sevenz_rust2::ArchiveWriter::create(archive_path).unwrap();
+        writer.set_content_methods(vec![
+            sevenz_rust2::encoder_options::AesEncoderOptions::new(sevenz_rust2::Password::new(
+                password,
+            ))
+            .into(),
+            sevenz_rust2::encoder_options::Lzma2Options::default().into(),
+        ]);
         for (name, contents) in entries {
             let entry = if contents.is_some() {
                 sevenz_rust2::ArchiveEntry::new_file(name)

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -566,6 +566,13 @@ mod tests {
         std::env::temp_dir().join(format!("elio-archive-extract-{label}-{unique}"))
     }
 
+    fn archive_test_password(root: &Path) -> String {
+        root.file_name()
+            .expect("temp root should have a file name")
+            .to_string_lossy()
+            .into_owned()
+    }
+
     #[test]
     fn rejects_escaping_paths() {
         let dest = Path::new("/tmp/out");
@@ -777,10 +784,11 @@ mod tests {
 
     #[test]
     fn archive_password_debug_is_redacted() {
-        let rendered = format!("{:?}", ArchivePassword::new("secret"));
+        let password = std::any::type_name::<ArchivePassword>();
+        let rendered = format!("{:?}", ArchivePassword::new(password));
 
         assert_eq!(rendered, "ArchivePassword(<redacted>)");
-        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains(password));
     }
 
     #[test]
@@ -788,9 +796,10 @@ mod tests {
         let root = temp_path("7z-encrypted-required");
         fs::create_dir_all(&root).unwrap();
         let archive_path = root.join("sample.7z");
+        let password = archive_test_password(&root);
         write_encrypted_seven_zip(
             &archive_path,
-            "secret",
+            &password,
             &[("dir", None), ("dir/file.txt", Some(b"hello"))],
         );
 
@@ -807,16 +816,18 @@ mod tests {
         let root = temp_path("7z-encrypted-wrong");
         fs::create_dir_all(&root).unwrap();
         let archive_path = root.join("sample.7z");
+        let password = archive_test_password(&root);
+        let wrong_password = format!("{password}-wrong");
         write_encrypted_seven_zip(
             &archive_path,
-            "secret",
+            &password,
             &[("dir", None), ("dir/file.txt", Some(b"hello"))],
         );
 
         let plan = plan_extract(&archive_path).unwrap();
         let error = extract_archive_with_password(
             &plan,
-            Some(&ArchivePassword::new("wrong")),
+            Some(&ArchivePassword::new(wrong_password)),
             |_| {},
             || false,
         )
@@ -832,16 +843,17 @@ mod tests {
         let root = temp_path("7z-encrypted-ok");
         fs::create_dir_all(&root).unwrap();
         let archive_path = root.join("sample.7z");
+        let password = archive_test_password(&root);
         write_encrypted_seven_zip(
             &archive_path,
-            "secret",
+            &password,
             &[("dir", None), ("dir/file.txt", Some(b"hello"))],
         );
 
         let plan = plan_extract(&archive_path).unwrap();
         let summary = extract_archive_with_password(
             &plan,
-            Some(&ArchivePassword::new("secret")),
+            Some(&ArchivePassword::new(password)),
             |_| {},
             || false,
         )

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -1,4 +1,6 @@
 mod extract;
 mod format;
 
-pub(crate) use self::extract::{extract_archive, plan_extract};
+pub(crate) use self::extract::{
+    ArchivePassword, ExtractError, extract_archive_with_password, plan_extract,
+};

--- a/src/preview/container/archive/internal.rs
+++ b/src/preview/container/archive/internal.rs
@@ -3,7 +3,9 @@ use super::format::archive_format_name;
 use super::*;
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
-use sevenz_rust2::{ArchiveReader as SevenZipArchiveReader, Password as SevenZipPassword};
+use sevenz_rust2::{
+    ArchiveReader as SevenZipArchiveReader, Error as SevenZipError, Password as SevenZipPassword,
+};
 use std::{
     fs::{self, File},
     io::Read,
@@ -62,6 +64,23 @@ pub(super) fn collect_preferred_archive_entries(
     }
 
     None
+}
+
+pub(super) fn seven_zip_listing_requires_password(
+    path: &Path,
+    canceled: &impl Fn() -> bool,
+) -> bool {
+    if canceled() {
+        return false;
+    }
+    let Ok(file) = File::open(path) else {
+        return false;
+    };
+    let error = SevenZipArchiveReader::new(file, SevenZipPassword::empty()).err();
+    matches!(
+        error,
+        Some(SevenZipError::PasswordRequired | SevenZipError::MaybeBadPassword(_))
+    ) && !canceled()
 }
 
 fn collect_seven_zip_listing(

--- a/src/preview/container/archive/mod.rs
+++ b/src/preview/container/archive/mod.rs
@@ -21,7 +21,10 @@ use self::external::{
     collect_archive_listing_with_7z, fallback_single_file_archive_entry,
 };
 use self::format::{archive_default_label, archive_format_name, detect_archive_format};
-use self::internal::{collect_internal_archive_listing, collect_preferred_archive_entries};
+use self::internal::{
+    collect_internal_archive_listing, collect_preferred_archive_entries,
+    seven_zip_listing_requires_password,
+};
 use self::manifest::{ZipManifestMetadata, parse_zip_manifest, zip_manifest_sections};
 use self::render::{ArchiveRenderConfig, render_archive_preview};
 use super::*;
@@ -63,6 +66,25 @@ where
     }
     if let Some(preview) = build_internal_archive_preview(path, format, type_detail, canceled) {
         return Some(preview);
+    }
+    if matches!(format, ArchiveFormat::SevenZip)
+        && seven_zip_listing_requires_password(path, canceled)
+    {
+        let detail = type_detail.unwrap_or(archive_default_label(format));
+        return Some(render_archive_preview(ArchiveRenderConfig {
+            detail: detail.to_string(),
+            metadata: ArchiveMetadata {
+                format_label: Some(archive_format_name(format).to_string()),
+                physical_size: fs::metadata(path).ok().map(|metadata| metadata.len()),
+                ..ArchiveMetadata::default()
+            },
+            entries: None,
+            total_entries_hint: None,
+            empty_label: ARCHIVE_EMPTY_LABEL,
+            unavailable_label: "Archive contents require a password",
+            extra_sections: Vec::new(),
+            scan_truncated: false,
+        }));
     }
     build_external_archive_preview(path, format, type_detail, canceled)
 }

--- a/src/preview/container/archive/render.rs
+++ b/src/preview/container/archive/render.rs
@@ -5,9 +5,16 @@ use ratatui::text::Line;
 pub(super) fn render_archive_preview(config: ArchiveRenderConfig) -> PreviewContent {
     let palette = theme::palette();
     let mut lines = Vec::new();
-    let entries = expand_archive_entries(config.entries.unwrap_or_default());
-    let total_items = entries.len().max(config.total_entries_hint.unwrap_or(0));
-    let folder_count = entries.iter().filter(|entry| entry.is_dir).count();
+    let entries = config.entries.map(expand_archive_entries);
+    let total_items = entries
+        .as_ref()
+        .map(Vec::len)
+        .unwrap_or(0)
+        .max(config.total_entries_hint.unwrap_or(0));
+    let folder_count = entries
+        .as_ref()
+        .map(|entries| entries.iter().filter(|entry| entry.is_dir).count())
+        .unwrap_or(0);
     let file_count = total_items.saturating_sub(folder_count);
 
     let summary = vec![
@@ -48,47 +55,53 @@ pub(super) fn render_archive_preview(config: ArchiveRenderConfig) -> PreviewCont
     }
     lines.push(section_line("Contents", palette));
 
-    if entries.is_empty() {
-        lines.push(Line::from(if total_items == 0 {
-            config.empty_label.to_string()
-        } else {
-            config.unavailable_label.to_string()
-        }));
-    } else {
-        let mut root = ArchiveTreeNode::default();
-        for entry in &entries {
-            insert_archive_tree_entry(&mut root, entry);
+    match &entries {
+        None => {
+            lines.push(Line::from(config.unavailable_label.to_string()));
         }
-        let available_lines = PREVIEW_RENDER_LINE_LIMIT.saturating_sub(lines.len());
-        let mut remaining = available_lines;
-        if remaining == 0 {
-            tree_truncated = true;
-        } else {
-            let children = ordered_archive_children(&root.children);
-            render_archive_tree(
-                &children,
-                "",
-                &mut remaining,
-                &mut rendered_items,
-                &mut lines,
-                palette,
-            );
-            tree_truncated = rendered_items < entries.len();
+        Some(entries) if entries.is_empty() => {
+            lines.push(Line::from(if total_items == 0 {
+                config.empty_label.to_string()
+            } else {
+                config.unavailable_label.to_string()
+            }));
+        }
+        Some(entries) => {
+            let mut root = ArchiveTreeNode::default();
+            for entry in entries {
+                insert_archive_tree_entry(&mut root, entry);
+            }
+            let available_lines = PREVIEW_RENDER_LINE_LIMIT.saturating_sub(lines.len());
+            let mut remaining = available_lines;
+            if remaining == 0 {
+                tree_truncated = true;
+            } else {
+                let children = ordered_archive_children(&root.children);
+                render_archive_tree(
+                    &children,
+                    "",
+                    &mut remaining,
+                    &mut rendered_items,
+                    &mut lines,
+                    palette,
+                );
+                tree_truncated = rendered_items < entries.len();
+            }
         }
     }
 
+    let entry_count = entries.as_ref().map(Vec::len).unwrap_or(0);
     let mut notes = Vec::new();
     if config.scan_truncated {
         notes.push(format!(
             "scanned first {} of {} entries",
-            entries.len(),
-            total_items
+            entry_count, total_items
         ));
     }
     if tree_truncated {
         notes.push(format!(
             "showing first {} of {} entries",
-            rendered_items.max(entries.len().min(PREVIEW_RENDER_LINE_LIMIT)),
+            rendered_items.max(entry_count.min(PREVIEW_RENDER_LINE_LIMIT)),
             total_items
         ));
     }

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -366,6 +366,63 @@ fn zip_preview_renders_archive_details_and_tree() {
 }
 
 #[test]
+fn encrypted_seven_zip_preview_stays_responsive_with_password_notice() {
+    let root = temp_path("encrypted-7z-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("secret.7z");
+    let mut writer = sevenz_rust2::ArchiveWriter::create(&path).expect("failed to create 7z");
+    writer.set_content_methods(vec![
+        sevenz_rust2::encoder_options::AesEncoderOptions::new(sevenz_rust2::Password::new(
+            "secret",
+        ))
+        .into(),
+        sevenz_rust2::encoder_options::Lzma2Options::default().into(),
+    ]);
+    writer
+        .push_archive_entry(
+            sevenz_rust2::ArchiveEntry::new_file("dir/file.txt"),
+            Some(&b"hello"[..]),
+        )
+        .expect("failed to write 7z entry");
+    writer.finish().expect("failed to finish 7z");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("7z archive"));
+    assert!(line_texts.iter().any(|text| text == "Details"));
+    assert!(line_texts.iter().any(|text| text == "Contents"));
+    assert!(
+        line_texts
+            .iter()
+            .any(|text| text.contains("Archive contents require a password"))
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn corrupt_seven_zip_preview_does_not_claim_password_required() {
+    let root = temp_path("corrupt-7z-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("broken.7z");
+    fs::write(&path, b"not a seven zip archive").expect("failed to write broken 7z");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert!(
+        line_texts
+            .iter()
+            .all(|text| !text.contains("require a password")),
+        "corrupt 7z must not be mislabeled as password-protected: {line_texts:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn rar_preview_uses_external_listing_when_available() {
     let root = temp_path("rar-preview");
     fs::create_dir_all(root.join("docs")).expect("failed to create docs dir");

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -226,7 +226,8 @@ fn run_app(
         let wants_search_cursor = app.search_is_open()
             || app.create_is_open()
             || app.rename_is_open()
-            || app.bulk_rename_is_open();
+            || app.bulk_rename_is_open()
+            || app.archive_password_is_open();
         if wants_search_cursor != search_cursor_active {
             if wants_search_cursor {
                 terminal.show_cursor()?;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -26,6 +26,7 @@ pub fn render(frame: &mut Frame<'_>, app: &App, state: &mut FrameState) {
     state.restore_panel = None;
     state.restore_confirm_btn = None;
     state.restore_cancel_btn = None;
+    state.archive_password_panel = None;
     state.create_panel = None;
     state.rename_panel = None;
     state.create_list_area = None;
@@ -88,6 +89,8 @@ pub fn render(frame: &mut Frame<'_>, app: &App, state: &mut FrameState) {
         overlay_manager::render_trash_overlay(frame, area, app, state, palette);
     } else if app.restore_is_open() {
         overlay_manager::render_restore_overlay(frame, area, app, state, palette);
+    } else if app.archive_password_is_open() {
+        overlay_manager::render_archive_password_overlay(frame, area, app, state, palette);
     } else if app.create_is_open() {
         overlay_manager::render_create_overlay(frame, area, app, state, palette);
     } else if app.rename_is_open() {

--- a/src/ui/overlay_manager/archive_password.rs
+++ b/src/ui/overlay_manager/archive_password.rs
@@ -1,0 +1,91 @@
+use crate::app::{App, FrameState};
+use crate::ui::{helpers, theme::Palette};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Margin, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Clear, Paragraph},
+};
+
+pub(super) fn render_archive_password_overlay(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    state: &mut FrameState,
+    palette: Palette,
+) {
+    let archive_name = app.archive_password_archive_name();
+    let block_title = format!(
+        " Password for \"{}\" ",
+        helpers::clamp_label(archive_name, 30)
+    );
+    let popup_width = area.width.saturating_sub(8).clamp(40, 64);
+    let popup_height = 6u16;
+    let popup = helpers::centered_rect(area, popup_width, popup_height);
+    state.archive_password_panel = Some(popup);
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        helpers::panel_block(&block_title, palette.chrome_alt, palette),
+        popup,
+    );
+
+    let inner = helpers::inner_with_padding(popup);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Length(1)])
+        .split(inner);
+
+    frame.render_widget(
+        helpers::rounded_block(palette.path_bg, palette.border),
+        rows[0],
+    );
+    let input_area = rows[0].inner(Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
+
+    let input = app.archive_password_input();
+    let cursor_col = app.archive_password_cursor_col();
+    let char_count = input.chars().count();
+    let col = cursor_col.min(char_count);
+    let available = input_area.width as usize;
+    let h_start = col.saturating_sub(available);
+    let visible_count = char_count.saturating_sub(h_start).min(available);
+    let visible_text = "*".repeat(visible_count);
+
+    let line = if input.is_empty() {
+        Line::from(Span::styled(
+            "password…",
+            Style::default().fg(palette.muted),
+        ))
+    } else {
+        Line::from(Span::styled(
+            visible_text,
+            Style::default()
+                .fg(palette.text)
+                .add_modifier(Modifier::BOLD),
+        ))
+    };
+    frame.render_widget(
+        Paragraph::new(line).style(Style::default().bg(palette.path_bg).fg(palette.text)),
+        input_area,
+    );
+
+    let visible_cursor_col = col.saturating_sub(h_start);
+    let cursor_x = (input_area.x + visible_cursor_col as u16)
+        .min(input_area.x + input_area.width.saturating_sub(1));
+    frame.set_cursor_position((cursor_x, input_area.y));
+
+    if let Some(error) = app.archive_password_error() {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                helpers::clamp_label(error, rows[1].width.saturating_sub(2) as usize),
+                Style::default().fg(palette.accent),
+            )]))
+            .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
+            rows[1],
+        );
+    }
+}

--- a/src/ui/overlay_manager/mod.rs
+++ b/src/ui/overlay_manager/mod.rs
@@ -2,6 +2,7 @@ use crate::app::{App, FrameState};
 use crate::ui::theme::Palette;
 use ratatui::{Frame, layout::Rect};
 
+mod archive_password;
 mod bulk_rename;
 mod copy;
 mod create;
@@ -47,6 +48,16 @@ pub(super) fn render_create_overlay(
     palette: Palette,
 ) {
     create::render_create_overlay(frame, area, app, state, palette);
+}
+
+pub(super) fn render_archive_password_overlay(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    state: &mut FrameState,
+    palette: Palette,
+) {
+    archive_password::render_archive_password_overlay(frame, area, app, state, palette);
 }
 
 pub(super) fn render_rename_overlay(


### PR DESCRIPTION
## Summary

Prompt for a password when extracting encrypted `.7z` archives, then retry extraction with the provided password.

Encrypted `.7z` previews stay responsive and show a password-required notice instead of falling back to an empty or misleading archive view.

Refs #90.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed