### PR TITLE
feat(archive): prompt for encrypted zip passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added native archive extraction for focused `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, unique sibling destination folders, and password prompts for encrypted `.7z` archives. ([#90])
+- Added native archive extraction for focused `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, unique sibling destination folders, and password prompts for encrypted `.7z` and `.zip` archives. ([#90])
 - Added a `progress_bar` theme palette color for active background operation chips, used by archive extraction progress.
 - Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -217,6 +218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +248,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -315,6 +328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -397,6 +419,8 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -637,8 +661,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -687,6 +713,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -1261,6 +1296,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1672,17 @@ dependencies = [
  "lzma-rust2",
  "sha2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2400,16 +2456,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zip"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
+ "aes",
+ "constant_time_eq",
  "crc32fast",
  "flate2",
+ "getrandom 0.4.3",
+ "hmac",
  "indexmap",
  "memchr",
+ "pbkdf2",
+ "sha1",
  "typed-path",
+ "zeroize",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ yaml_serde = "0.10"
 toml = "1.1"
 toml_edit = "0.25"
 unicode-width = "0.2"
-zip = { version = "8.6", default-features = false, features = ["deflate"] }
+zip = { version = "8.6", default-features = false, features = ["aes-crypto", "deflate"] }
 trash = "5.2.5"
 rusqlite = { version = "0.40", features = ["bundled"] }
 xz2 = { version = "0.1.7", features = ["static"] }

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use super::helpers::{
-    temp_path, wait_for_directory_load, write_binary_zip_entries, write_encrypted_seven_zip_entries,
+    temp_path, wait_for_directory_load, write_binary_zip_entries,
+    write_encrypted_seven_zip_entries, write_encrypted_zip_entries,
 };
 use std::{fs, thread, time::Duration};
 
@@ -45,6 +46,62 @@ fn e_prompts_and_retries_encrypted_seven_zip_archive() {
     let password = archive_test_password(&root);
     let wrong_password = format!("{password}-wrong");
     write_encrypted_seven_zip_entries(&archive, &password, &[("dir/file.txt", b"hello")]);
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('e'))))
+        .expect("e should start archive extraction");
+    wait_for_archive_password_prompt(&mut app);
+
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_error(), None);
+    assert!(!root.join("sample").exists());
+
+    type_archive_password(&mut app, &wrong_password);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("enter should submit wrong password");
+    wait_for_archive_password_prompt(&mut app);
+
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_error(), Some("Wrong password"));
+    assert_eq!(app.archive_password_input(), "");
+
+    type_archive_password(&mut app, &password);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("enter should submit correct password");
+
+    let extracted_file = root.join("sample/dir/file.txt");
+    for _ in 0..200 {
+        let _ = app.process_background_jobs();
+        if extracted_file.exists()
+            && app.jobs.archive_extract_progress.is_none()
+            && !app.archive_password_is_open()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(fs::read_to_string(&extracted_file).unwrap(), "hello");
+    assert_eq!(app.status_message(), "Extracted 1 item to \"sample\"");
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.path.as_path()),
+        Some(root.join("sample").as_path())
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn e_prompts_and_retries_encrypted_zip_archive() {
+    let root = temp_path("extract-encrypted-zip-key");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let archive = root.join("sample.zip");
+    let password = archive_test_password(&root);
+    let wrong_password = format!("{password}-wrong");
+    write_encrypted_zip_entries(&archive, &password, &[("dir/file.txt", b"hello")]);
 
     let mut app = App::new_at(root.clone()).expect("failed to create app");
     wait_for_directory_load(&mut app);

--- a/src/app/input/tests/helpers.rs
+++ b/src/app/input/tests/helpers.rs
@@ -105,6 +105,25 @@ pub(super) fn write_binary_zip_entries(path: &Path, entries: &[(&str, &[u8])]) {
     zip.finish().expect("failed to finish zip");
 }
 
+pub(super) fn write_encrypted_zip_entries(path: &Path, password: &str, entries: &[(&str, &[u8])]) {
+    use zip::unstable::write::FileOptionsExt;
+
+    let file = File::create(path).expect("failed to create zip");
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .with_deprecated_encryption(password.as_bytes())
+        .expect("failed to configure zip encryption");
+
+    for (name, contents) in entries {
+        zip.start_file(name, options)
+            .expect("failed to start zip entry");
+        zip.write_all(contents).expect("failed to write zip entry");
+    }
+
+    zip.finish().expect("failed to finish zip");
+}
+
 pub(super) fn write_encrypted_seven_zip_entries(
     path: &Path,
     password: &str,

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -14,6 +14,7 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 use xz2::read::XzDecoder;
+use zip::result::ZipError;
 use zstd::stream::read::Decoder as ZstdDecoder;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -46,6 +47,10 @@ impl ArchivePassword {
 
     fn as_seven_zip_password(&self) -> SevenZipPassword {
         SevenZipPassword::new(&self.0)
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
     }
 }
 
@@ -128,7 +133,7 @@ where
         .with_context(|| format!("Could not create {}", staging_dir.display()))?;
 
     let result = match extraction_plan.backend {
-        ExtractBackend::Zip => extract_zip(&extraction_plan, &mut progress, cancelled),
+        ExtractBackend::Zip => extract_zip(&extraction_plan, password, &mut progress, cancelled),
         ExtractBackend::Tar(format) => {
             extract_tar(format, &extraction_plan, &mut progress, cancelled)
         }
@@ -173,19 +178,22 @@ where
     })
 }
 
-fn preflight_extract(plan: &ExtractPlan, _password: Option<&ArchivePassword>) -> ExtractResult<()> {
+fn preflight_extract(plan: &ExtractPlan, password: Option<&ArchivePassword>) -> ExtractResult<()> {
     match plan.backend {
-        ExtractBackend::Zip => preflight_zip(&plan.archive_path),
+        ExtractBackend::Zip => preflight_zip(&plan.archive_path, password),
         ExtractBackend::SevenZip | ExtractBackend::Tar(_) => Ok(()),
     }
 }
 
-fn preflight_zip(archive_path: &Path) -> ExtractResult<()> {
+fn preflight_zip(archive_path: &Path, password: Option<&ArchivePassword>) -> ExtractResult<()> {
     let file = File::open(archive_path)
         .with_context(|| format!("Could not open {}", archive_path.display()))?;
     let mut archive = zip::ZipArchive::new(file).context("Could not read ZIP archive")?;
     let total = archive.len();
-    reject_encrypted_zip_entries(&mut archive, total)
+    for index in 0..total {
+        let _entry = zip_entry_by_index(&mut archive, index, password)?;
+    }
+    Ok(())
 }
 
 fn staging_destination(dest_dir: &Path) -> Result<PathBuf> {
@@ -210,6 +218,7 @@ fn staging_destination(dest_dir: &Path) -> Result<PathBuf> {
 
 fn extract_zip<F, C>(
     plan: &ExtractPlan,
+    password: Option<&ArchivePassword>,
     progress: &mut F,
     mut cancelled: C,
 ) -> ExtractResult<ExtractSummary>
@@ -221,7 +230,6 @@ where
         .with_context(|| format!("Could not open {}", plan.archive_path.display()))?;
     let mut archive = zip::ZipArchive::new(file).context("Could not read ZIP archive")?;
     let total = archive.len();
-    reject_encrypted_zip_entries(&mut archive, total)?;
     let mut completed = 0usize;
     progress(ExtractProgress {
         completed,
@@ -232,9 +240,8 @@ where
         if cancelled() {
             break;
         }
-        let mut entry = archive
-            .by_index(index)
-            .context("Could not read ZIP entry")?;
+        let mut entry = zip_entry_by_index(&mut archive, index, password)?;
+        let encrypted = entry.encrypted();
         let Some(enclosed) = entry.enclosed_name() else {
             return Err(anyhow!("Archive entry escapes the destination: {}", entry.name()).into());
         };
@@ -249,8 +256,13 @@ where
             }
             let mut out = File::create(&out_path)
                 .with_context(|| format!("Could not create {}", out_path.display()))?;
-            io::copy(&mut entry, &mut out)
-                .with_context(|| format!("Could not write {}", out_path.display()))?;
+            if let Err(error) = io::copy(&mut entry, &mut out) {
+                if password.is_some() && encrypted && is_zip_bad_password_io(&error) {
+                    return Err(ExtractError::BadPassword);
+                }
+                return Err(error)
+                    .with_context(|| format!("Could not write {}", out_path.display()))?;
+            }
             #[cfg(unix)]
             if let Some(mode) = entry.unix_mode() {
                 use std::os::unix::fs::PermissionsExt;
@@ -272,23 +284,36 @@ where
     })
 }
 
-fn reject_encrypted_zip_entries<R: Read + io::Seek>(
-    archive: &mut zip::ZipArchive<R>,
-    total: usize,
-) -> ExtractResult<()> {
-    for index in 0..total {
-        let entry = match archive.by_index(index) {
-            Ok(entry) => entry,
-            Err(error) if error.to_string().contains("Password required") => {
-                return Err(ExtractError::UnsupportedEncryption);
-            }
-            Err(error) => return Err(anyhow!(error).context("Could not read ZIP entry").into()),
-        };
-        if entry.encrypted() {
-            return Err(ExtractError::UnsupportedEncryption);
+fn zip_entry_by_index<'a, R: Read + io::Seek>(
+    archive: &'a mut zip::ZipArchive<R>,
+    index: usize,
+    password: Option<&ArchivePassword>,
+) -> ExtractResult<zip::read::ZipFile<'a, R>> {
+    let entry = match password {
+        Some(password) => archive.by_index_decrypt(index, password.as_bytes()),
+        None => archive.by_index(index),
+    };
+    entry.map_err(map_zip_error)
+}
+
+fn map_zip_error(error: ZipError) -> ExtractError {
+    match error {
+        ZipError::UnsupportedArchive(ZipError::PASSWORD_REQUIRED) => ExtractError::PasswordRequired,
+        ZipError::InvalidPassword => ExtractError::BadPassword,
+        ZipError::UnsupportedArchive(message) if is_zip_unsupported_encryption(message) => {
+            ExtractError::UnsupportedEncryption
         }
+        error => ExtractError::Other(anyhow!(error).context("Could not read ZIP entry")),
     }
-    Ok(())
+}
+
+fn is_zip_unsupported_encryption(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("encrypt") || message.contains("decrypt") || message.contains("aes")
+}
+
+fn is_zip_bad_password_io(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::InvalidData && error.to_string().contains("Invalid checksum")
 }
 
 fn extract_tar<F, C>(
@@ -609,31 +634,113 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_zip_fails_before_creating_destination() {
-        use zip::unstable::write::FileOptionsExt;
-
-        let root = temp_path("zip-encrypted");
+    fn corrupt_zip_does_not_request_password() {
+        let root = temp_path("zip-corrupt");
         fs::create_dir_all(&root).unwrap();
         let archive_path = root.join("sample.zip");
-        {
-            let file = File::create(&archive_path).unwrap();
-            let mut zip = zip::ZipWriter::new(file);
-            let options = zip::write::SimpleFileOptions::default()
-                .with_deprecated_encryption(b"secret")
-                .unwrap();
-            zip.start_file("file.txt", options).unwrap();
-            zip.write_all(b"hello").unwrap();
-            zip.finish().unwrap();
-        }
+        fs::write(&archive_path, b"not a zip").unwrap();
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
+
+        assert!(matches!(error, ExtractError::Other(_)));
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_zip_requires_password() {
+        let root = temp_path("zip-encrypted-required");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        let password = archive_test_password(&root);
+        write_encrypted_zip(&archive_path, &password, ZipEncryption::Deprecated);
 
         let plan = plan_extract(&archive_path).unwrap();
         let error = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
 
         assert!(
-            matches!(error, ExtractError::UnsupportedEncryption),
-            "expected unsupported encryption, got {error:?}"
+            matches!(error, ExtractError::PasswordRequired),
+            "expected password required, got {error:?}"
         );
         assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_zip_rejects_wrong_password() {
+        let root = temp_path("zip-encrypted-wrong");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        let password = archive_test_password(&root);
+        write_encrypted_zip(&archive_path, &password, ZipEncryption::Deprecated);
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new(format!("{password}-wrong"))),
+            |_| {},
+            || false,
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(error, ExtractError::BadPassword),
+            "expected bad password, got {error:?}"
+        );
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_zip_extracts_with_password() {
+        let root = temp_path("zip-encrypted-ok");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        let password = archive_test_password(&root);
+        write_encrypted_zip(&archive_path, &password, ZipEncryption::Deprecated);
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new(password)),
+            |_| {},
+            || false,
+        )
+        .unwrap();
+
+        assert_eq!(summary.completed, 1);
+        assert_eq!(summary.total, Some(1));
+        assert_eq!(
+            fs::read_to_string(root.join("sample/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn aes_encrypted_zip_extracts_with_password() {
+        let root = temp_path("zip-aes-encrypted-ok");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        let password = archive_test_password(&root);
+        write_encrypted_zip(&archive_path, &password, ZipEncryption::Aes256);
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new(password)),
+            |_| {},
+            || false,
+        )
+        .unwrap();
+
+        assert_eq!(summary.completed, 1);
+        assert_eq!(summary.total, Some(1));
+        assert_eq!(
+            fs::read_to_string(root.join("sample/file.txt")).unwrap(),
+            "hello"
+        );
         let _ = fs::remove_dir_all(root);
     }
 
@@ -918,6 +1025,28 @@ mod tests {
         }
         let compressed = zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap();
         fs::write(archive_path, compressed).unwrap();
+    }
+
+    enum ZipEncryption {
+        Deprecated,
+        Aes256,
+    }
+
+    fn write_encrypted_zip(archive_path: &Path, password: &str, encryption: ZipEncryption) {
+        use zip::unstable::write::FileOptionsExt;
+
+        let file = File::create(archive_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = match encryption {
+            ZipEncryption::Deprecated => zip::write::SimpleFileOptions::default()
+                .with_deprecated_encryption(password.as_bytes())
+                .unwrap(),
+            ZipEncryption::Aes256 => zip::write::SimpleFileOptions::default()
+                .with_aes_encryption(zip::AesMode::Aes256, password),
+        };
+        zip.start_file("file.txt", options).unwrap();
+        zip.write_all(b"hello").unwrap();
+        zip.finish().unwrap();
     }
 
     fn write_seven_zip(archive_path: &Path, entries: &[(&str, Option<&[u8]>)]) {


### PR DESCRIPTION
## Summary

Prompt for a password when extracting encrypted `.zip` archives, then retry extraction with the provided password.

Encrypted ZIP extraction now uses the same password flow as encrypted `.7z` archives, including wrong-password retries and AES-encrypted ZIP support.

Refs #90.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed