### PR TITLE
fix(preview): stabilize unavailable archive previews

### DIFF
--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -130,8 +130,14 @@ impl App {
             return preview_mode;
         };
         let variant = self.preview_request_options_for_entry(&entry);
-        let builtin_class = file_info::inspect_entry_cached(&entry).builtin_class;
-        let cold_heavy_preview = matches!(builtin_class, FileClass::Audio | FileClass::Video)
+        let facts = file_info::inspect_entry_cached(&entry);
+        let cold_navigation_heavy_preview =
+            matches!(facts.builtin_class, FileClass::Audio | FileClass::Video)
+                || matches!(
+                    facts.specific_type_label,
+                    Some("RAR archive" | "Comic RAR archive")
+                );
+        let cold_heavy_preview = cold_navigation_heavy_preview
             && preview_work_class(&entry, &variant) == PreviewWorkClass::Heavy
             && self.cached_preview_for(&entry, &variant).is_none();
         let sixel_static_image = self.sixel_static_image_preview_for_entry(&entry);
@@ -544,4 +550,51 @@ fn entry_from_existing_file(path: &Path) -> Option<Entry> {
     crate::fs::entry_from_path(path.to_path_buf(), name)
         .ok()
         .filter(|entry| !entry.is_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-navigation-{label}-{unique}"))
+    }
+
+    #[test]
+    fn cold_rar_preview_navigation_defers_preview_job_until_idle() {
+        let root = temp_path("rar-deferred-preview");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(root.join("a.txt"), "ready").expect("failed to write text fixture");
+        let rar = root.join("b.rar");
+        fs::write(&rar, b"not-a-real-rar").expect("failed to write rar fixture");
+
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+        let before = app.scheduler_metrics();
+        let rar_index = app
+            .navigation
+            .entries
+            .iter()
+            .position(|entry| entry.path == rar)
+            .expect("rar fixture should be visible");
+
+        app.set_selected(rar_index);
+        let after = app.scheduler_metrics();
+
+        assert!(app.preview.state.deferred_refresh_at.is_some());
+        assert_eq!(
+            after.preview_jobs_submitted_high, before.preview_jobs_submitted_high,
+            "cold RAR selection should wait for the deferred refresh instead of immediately queuing heavy preview work"
+        );
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
 }

--- a/src/app/jobs/pool/preview.rs
+++ b/src/app/jobs/pool/preview.rs
@@ -141,6 +141,7 @@ impl PreviewPool {
                     lock_unpoison(&self.metrics).preview_promotions += 1;
                 }
                 let evicted = trim_preview_queue_for_high(&mut state);
+                discard_stale_pending_high_previews(&mut state, &key);
                 cancel_stale_active_previews(&state, &key);
                 state.queued_high_keys.insert(key);
                 state.pending_high.push_back(request);
@@ -399,6 +400,18 @@ fn preview_pending_len(state: &PreviewState) -> usize {
 
 fn preview_active_contains(state: &PreviewState, key: &PreviewJobKey) -> bool {
     state.active_jobs.iter().any(|job| job.key == *key)
+}
+
+fn discard_stale_pending_high_previews(state: &mut PreviewState, keep: &PreviewJobKey) {
+    state.pending_high.retain(|request| {
+        let key = PreviewJobKey::from_request(request);
+        if &key == keep {
+            true
+        } else {
+            state.queued_high_keys.remove(&key);
+            false
+        }
+    });
 }
 
 fn cancel_stale_active_previews(state: &PreviewState, keep: &PreviewJobKey) {

--- a/src/app/jobs/tests.rs
+++ b/src/app/jobs/tests.rs
@@ -380,6 +380,35 @@ fn high_priority_preview_cancels_active_stale_preview_work() {
 }
 
 #[test]
+fn high_priority_preview_drops_stale_pending_high_preview_work() {
+    let scheduler = JobScheduler::new_for_tests(0, 0, 4);
+
+    for (name, token) in [("stale.rar", 1), ("current.rar", 2)] {
+        assert!(scheduler.submit_preview(preview_request(
+            Entry {
+                path: PathBuf::from(name),
+                name: name.to_string(),
+                name_key: name.to_string(),
+                kind: EntryKind::File,
+                symlink: None,
+                size: token,
+                modified: None,
+                readonly: false,
+            },
+            token,
+            PreviewPriority::High,
+        )));
+    }
+
+    let snapshot = scheduler.snapshot();
+    assert_eq!(
+        snapshot.preview_pending_high,
+        vec![preview_job_key("current.rar", 2)]
+    );
+    assert!(snapshot.preview_pending_low.is_empty());
+}
+
+#[test]
 fn scheduler_reports_pending_work_when_jobs_are_queued() {
     let scheduler = JobScheduler::new_for_tests(0, 0, 2);
     assert!(!scheduler.has_pending_work());

--- a/src/preview/container/archive/external.rs
+++ b/src/preview/container/archive/external.rs
@@ -108,6 +108,7 @@ where
     let mut child = Command::new(program)
         .args(args)
         .arg(path)
+        .stdin(Stdio::null())
         .stdout(Stdio::from(output_file))
         .stderr(Stdio::null())
         .spawn()
@@ -331,6 +332,24 @@ images/
         assert!(
             started_at.elapsed() < Duration::from_secs(1),
             "canceled archive command should not wait for the child process to finish"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_archive_command_does_not_inherit_stdin() {
+        let started_at = Instant::now();
+        let output = run_archive_listing_command(
+            "sh",
+            &["-c", "read ignored || exit 7", "sh"],
+            std::path::Path::new("ignored.rar"),
+            &|| false,
+        );
+
+        assert!(output.is_none());
+        assert!(
+            started_at.elapsed() < Duration::from_secs(1),
+            "archive commands must not block the UI waiting for interactive password input"
         );
     }
 

--- a/src/preview/container/archive/mod.rs
+++ b/src/preview/container/archive/mod.rs
@@ -81,12 +81,19 @@ where
             entries: None,
             total_entries_hint: None,
             empty_label: ARCHIVE_EMPTY_LABEL,
-            unavailable_label: "Archive contents require a password",
+            unavailable_label: "Password-protected",
             extra_sections: Vec::new(),
             scan_truncated: false,
         }));
     }
-    build_external_archive_preview(path, format, type_detail, canceled)
+    if let Some(preview) = build_external_archive_preview(path, format, type_detail, canceled) {
+        return Some(preview);
+    }
+    if canceled() {
+        None
+    } else {
+        Some(build_unavailable_archive_preview(path, format, type_detail))
+    }
 }
 
 fn build_zip_archive_preview<F>(
@@ -225,7 +232,9 @@ where
     if canceled() {
         return None;
     }
-    if let Some(entries) = collect_preferred_archive_entries(path, format, canceled) {
+    if let Some(entries) = collect_preferred_archive_entries(path, format, canceled)
+        && !entries.is_empty()
+    {
         return Some(render_archive_preview(ArchiveRenderConfig {
             detail: detail.to_string(),
             metadata: ArchiveMetadata {
@@ -264,6 +273,7 @@ where
 
     if matches!(format, ArchiveFormat::Rar)
         && let Some(entries) = collect_archive_entries_with_unrar(path, canceled)
+        && !entries.is_empty()
     {
         return Some(render_archive_preview(ArchiveRenderConfig {
             detail: detail.to_string(),
@@ -285,6 +295,9 @@ where
         return None;
     }
     let entries = collect_archive_entries_with_bsdtar(path, canceled)?;
+    if entries.is_empty() {
+        return None;
+    }
 
     Some(render_archive_preview(ArchiveRenderConfig {
         detail: detail.to_string(),
@@ -299,6 +312,28 @@ where
         extra_sections: Vec::new(),
         scan_truncated: false,
     }))
+}
+
+fn build_unavailable_archive_preview(
+    path: &Path,
+    format: ArchiveFormat,
+    type_detail: Option<&'static str>,
+) -> PreviewContent {
+    let detail = type_detail.unwrap_or(archive_default_label(format));
+    render_archive_preview(ArchiveRenderConfig {
+        detail: detail.to_string(),
+        metadata: ArchiveMetadata {
+            format_label: Some(archive_format_name(format).to_string()),
+            physical_size: fs::metadata(path).ok().map(|metadata| metadata.len()),
+            ..ArchiveMetadata::default()
+        },
+        entries: None,
+        total_entries_hint: None,
+        empty_label: ARCHIVE_EMPTY_LABEL,
+        unavailable_label: "Unavailable",
+        extra_sections: Vec::new(),
+        scan_truncated: false,
+    })
 }
 
 #[cfg(test)]

--- a/src/preview/dispatch.rs
+++ b/src/preview/dispatch.rs
@@ -205,7 +205,8 @@ where
     {
         return preview;
     }
-    if facts.builtin_class == FileClass::Archive {
+    if facts.builtin_class == FileClass::Archive && preview_spec.kind != file_info::PreviewKind::Iso
+    {
         if let Some(preview) = container::build_archive_preview(
             &entry.path,
             type_detail,

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -396,7 +396,7 @@ fn encrypted_seven_zip_preview_stays_responsive_with_password_notice() {
     assert!(
         line_texts
             .iter()
-            .any(|text| text.contains("Archive contents require a password"))
+            .any(|text| text.contains("Password-protected"))
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
@@ -412,11 +412,72 @@ fn corrupt_seven_zip_preview_does_not_claim_password_required() {
     let preview = build_preview(&file_entry(path));
     let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
 
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("7z archive"));
+    assert!(
+        line_texts.iter().any(|text| text.contains("Unavailable")),
+        "corrupt 7z should stay in archive preview: {line_texts:?}"
+    );
     assert!(
         line_texts
             .iter()
             .all(|text| !text.contains("require a password")),
         "corrupt 7z must not be mislabeled as password-protected: {line_texts:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn corrupt_zip_preview_stays_archive_when_contents_are_unavailable() {
+    let root = temp_path("corrupt-zip-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("broken.zip");
+    fs::write(&path, b"not a zip archive").expect("failed to write broken zip");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("ZIP archive"));
+    assert!(line_texts.iter().any(|text| text == "Details"));
+    assert!(line_texts.iter().any(|text| text == "Contents"));
+    assert!(
+        line_texts.iter().any(|text| text.contains("Unavailable")),
+        "known archive failures should not fall through to binary preview: {line_texts:?}"
+    );
+    assert!(
+        line_texts
+            .iter()
+            .all(|text| !text.contains("Binary or unsupported file")),
+        "known archive failures should not render binary fallback: {line_texts:?}"
+    );
+    assert_eq!(preview.status_note.as_deref(), None);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn unreadable_rar_preview_stays_archive_when_contents_are_unavailable() {
+    let root = temp_path("unreadable-rar-preview");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("broken.rar");
+    fs::write(&path, b"not a rar archive").expect("failed to write broken rar");
+
+    let preview = build_preview(&file_entry(path));
+    let line_texts: Vec<_> = preview.lines.iter().map(line_text).collect();
+
+    assert_eq!(preview.kind, PreviewKind::Archive);
+    assert_eq!(preview.detail.as_deref(), Some("RAR archive"));
+    assert!(
+        line_texts.iter().any(|text| text.contains("Unavailable")),
+        "unreadable RAR should stay in archive preview: {line_texts:?}"
+    );
+    assert!(
+        line_texts
+            .iter()
+            .all(|text| !text.contains("Binary or unsupported file")),
+        "unreadable RAR should not render binary fallback: {line_texts:?}"
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");


### PR DESCRIPTION
## Summary

Keep hard-to-list archive previews responsive and in archive mode.

Archive preview helpers now run with stdin closed, so encrypted or unreadable archives cannot block waiting for interactive input. Rapid navigation also drops stale high-priority preview work and defers cold RAR/CBR previews until idle.

Unavailable archive listings now render under `Contents` as `Unavailable`, while encrypted `.7z` previews show `Password-protected`, instead of falling back to “Binary or unsupported file”.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked archives::`
- [x] `cargo test --locked high_priority_preview_drops_stale_pending_high_preview_work`
- [x] `cargo test --locked external_archive_command_does_not_inherit_stdin`
- [x] `cargo test --locked cold_rar_preview_navigation_defers_preview_job_until_idle`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `git diff --check`

Result:

All targeted checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed