### PR TITLE
feat(archive): add rar extraction via 7z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added native archive extraction for focused `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, `.tar.bz2`/`.tbz2`/`.tbz`, and `.tar.zst`/`.tzst` files, with a configurable `extract_archive` (`e`) shortcut, background progress, cancellation, unique sibling destination folders, and password prompts for encrypted `.7z` and `.zip` archives. ([#90])
+- Added RAR extraction through the external 7-Zip backend (`7z`, `7zz`, or `7za`), including password prompts for encrypted RAR5 archives and staged extraction safety checks. ([#90])
 - Added a `progress_bar` theme palette color for active background operation chips, used by archive extraction progress.
 - Made Go To entries configurable, allowing built-ins to be changed and custom entries to be added. ([#166])
 

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -95,6 +95,62 @@ fn e_prompts_and_retries_encrypted_seven_zip_archive() {
 }
 
 #[test]
+fn e_prompts_and_retries_encrypted_rar_archive() {
+    let root = temp_path("extract-encrypted-rar-key");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let archive = root.join("sample.rar");
+    let password = archive_test_password(&root);
+    let wrong_password = format!("{password}-wrong");
+    write_encrypted_seven_zip_entries(&archive, &password, &[("dir/file.txt", b"hello")]);
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('e'))))
+        .expect("e should start archive extraction");
+    wait_for_archive_password_prompt(&mut app);
+
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_error(), None);
+    assert!(!root.join("sample").exists());
+
+    type_archive_password(&mut app, &wrong_password);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("enter should submit wrong password");
+    wait_for_archive_password_prompt(&mut app);
+
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_error(), Some("Wrong password"));
+    assert_eq!(app.archive_password_input(), "");
+
+    type_archive_password(&mut app, &password);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("enter should submit correct password");
+
+    let extracted_file = root.join("sample/dir/file.txt");
+    for _ in 0..200 {
+        let _ = app.process_background_jobs();
+        if extracted_file.exists()
+            && app.jobs.archive_extract_progress.is_none()
+            && !app.archive_password_is_open()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(fs::read_to_string(&extracted_file).unwrap(), "hello");
+    assert_eq!(app.status_message(), "Extracted 1 item to \"sample\"");
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.path.as_path()),
+        Some(root.join("sample").as_path())
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn e_prompts_and_retries_encrypted_zip_archive() {
     let root = temp_path("extract-encrypted-zip-key");
     fs::create_dir_all(&root).expect("failed to create temp root");
@@ -164,7 +220,7 @@ fn e_reports_unsupported_archive_format() {
 
     assert_eq!(
         app.status_message(),
-        "Extraction supports ZIP, 7z, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST"
+        "Extraction supports ZIP, 7z, RAR, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST"
     );
     assert!(app.jobs.archive_extract_progress.is_none());
 

--- a/src/app/jobs/tasks/archive_extract.rs
+++ b/src/app/jobs/tasks/archive_extract.rs
@@ -201,7 +201,7 @@ fn run_extract(
                 .file_name()
                 .and_then(|name| name.to_str())
                 .unwrap_or("archive");
-            (None, format!("Could not extract \"{name}\": {error}"))
+            (None, format!("Cannot extract \"{name}\" — {error}"))
         }
     };
 

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -7,11 +7,14 @@ use sevenz_rust2::{
     Password as SevenZipPassword,
 };
 use std::{
+    env,
     error::Error,
     fmt::{self, Display},
-    fs::{self, File},
+    fs::{self, File, OpenOptions},
     io::{self, Read},
     path::{Component, Path, PathBuf},
+    process::{Command, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
 };
 use xz2::read::XzDecoder;
 use zip::result::ZipError;
@@ -65,6 +68,9 @@ pub(crate) enum ExtractError {
     PasswordRequired,
     BadPassword,
     UnsupportedEncryption,
+    MissingTool(&'static str),
+    UnsafeArchivePath,
+    ExternalFailed(&'static str),
     Other(anyhow::Error),
 }
 
@@ -74,6 +80,9 @@ impl Display for ExtractError {
             Self::PasswordRequired => f.write_str("archive requires a password"),
             Self::BadPassword => f.write_str("wrong password"),
             Self::UnsupportedEncryption => f.write_str("unsupported encrypted archive"),
+            Self::MissingTool(tool) => write!(f, "install {tool}"),
+            Self::UnsafeArchivePath => f.write_str("archive contains unsafe paths"),
+            Self::ExternalFailed(tool) => write!(f, "{tool} failed"),
             Self::Other(error) => Display::fmt(error, f),
         }
     }
@@ -140,6 +149,9 @@ where
         ExtractBackend::SevenZip => {
             extract_seven_zip(&extraction_plan, password, &mut progress, cancelled)
         }
+        ExtractBackend::ExternalSevenZip => {
+            extract_external_seven_zip(&extraction_plan, password, &mut progress, cancelled)
+        }
     };
     let summary = match result {
         Ok(summary) => summary,
@@ -182,6 +194,9 @@ fn preflight_extract(plan: &ExtractPlan, password: Option<&ArchivePassword>) -> 
     match plan.backend {
         ExtractBackend::Zip => preflight_zip(&plan.archive_path, password),
         ExtractBackend::SevenZip | ExtractBackend::Tar(_) => Ok(()),
+        ExtractBackend::ExternalSevenZip => {
+            preflight_external_seven_zip(&plan.archive_path, password)
+        }
     }
 }
 
@@ -352,8 +367,8 @@ where
         ExtractFormat::TarZstd => {
             extract_tar_with(format, plan, ZstdDecoder::new, progress, cancelled)
         }
-        ExtractFormat::Zip | ExtractFormat::SevenZip => {
-            unreachable!("non-TAR archives use their own native backends")
+        ExtractFormat::Zip | ExtractFormat::SevenZip | ExtractFormat::Rar => {
+            unreachable!("non-TAR archives use their own extraction backends")
         }
     }
 }
@@ -436,6 +451,315 @@ fn extract_seven_zip_entry(
             .with_context(|| format!("Could not write {}", out_path.display()))?;
     }
     Ok(())
+}
+
+const EXTERNAL_SEVEN_ZIP_PROGRAMS: &[&str] = &["7z", "7zz", "7za"];
+static EXTERNAL_COMMAND_OUTPUT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+struct ExternalCommandOutputFiles {
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl ExternalCommandOutputFiles {
+    fn create() -> ExtractResult<(Self, File, File)> {
+        let temp_dir = env::temp_dir();
+        let pid = std::process::id();
+        for _ in 0..16 {
+            let id = EXTERNAL_COMMAND_OUTPUT_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let base = temp_dir.join(format!("elio-7z-output-{pid}-{id}"));
+            let stdout_path = base.with_extension("stdout");
+            let stderr_path = base.with_extension("stderr");
+            let stdout = match create_external_command_capture(&stdout_path) {
+                Ok(file) => file,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(ExtractError::Other(
+                        anyhow!(error).context("Could not create 7z stdout capture"),
+                    ));
+                }
+            };
+            let stderr = match create_external_command_capture(&stderr_path) {
+                Ok(file) => file,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    let _ = fs::remove_file(&stdout_path);
+                    continue;
+                }
+                Err(error) => {
+                    let _ = fs::remove_file(&stdout_path);
+                    return Err(ExtractError::Other(
+                        anyhow!(error).context("Could not create 7z stderr capture"),
+                    ));
+                }
+            };
+            return Ok((
+                Self {
+                    stdout_path,
+                    stderr_path,
+                },
+                stdout,
+                stderr,
+            ));
+        }
+
+        Err(ExtractError::Other(anyhow!(
+            "Could not create unique 7z output capture files"
+        )))
+    }
+
+    fn read(&self) -> ExtractResult<(Vec<u8>, Vec<u8>)> {
+        let stdout = fs::read(&self.stdout_path).map_err(|error| {
+            ExtractError::Other(anyhow!(error).context("Could not read 7z stdout capture"))
+        })?;
+        let stderr = fs::read(&self.stderr_path).map_err(|error| {
+            ExtractError::Other(anyhow!(error).context("Could not read 7z stderr capture"))
+        })?;
+        Ok((stdout, stderr))
+    }
+}
+
+fn create_external_command_capture(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+impl Drop for ExternalCommandOutputFiles {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.stdout_path);
+        let _ = fs::remove_file(&self.stderr_path);
+    }
+}
+
+fn extract_external_seven_zip<F, C>(
+    plan: &ExtractPlan,
+    password: Option<&ArchivePassword>,
+    progress: &mut F,
+    mut cancelled: C,
+) -> ExtractResult<ExtractSummary>
+where
+    F: FnMut(ExtractProgress),
+    C: FnMut() -> bool,
+{
+    let program = available_external_seven_zip()?;
+    let entries = list_external_seven_zip_entries(program, &plan.archive_path, password)?;
+    for entry in &entries {
+        validate_external_entry_path(&plan.dest_dir, entry)?;
+    }
+
+    let total = Some(entries.len());
+    progress(ExtractProgress {
+        completed: 0,
+        total,
+    });
+    if cancelled() {
+        return Ok(ExtractSummary {
+            dest_dir: plan.dest_dir.clone(),
+            completed: 0,
+            total,
+        });
+    }
+
+    let mut command = Command::new(program);
+    command.arg("x").arg("-y");
+    command.arg(format!("-o{}", plan.dest_dir.display()));
+    if let Some(password) = password {
+        command.arg(seven_zip_password_arg(password));
+    }
+    command.arg("--").arg(&plan.archive_path);
+    run_external_seven_zip_command(command, password.is_some(), &mut cancelled)?;
+
+    let completed = entries.len();
+    progress(ExtractProgress { completed, total });
+    Ok(ExtractSummary {
+        dest_dir: plan.dest_dir.clone(),
+        completed,
+        total,
+    })
+}
+
+fn seven_zip_password_arg(password: &ArchivePassword) -> String {
+    // 7z's reliable non-interactive interface takes passwords as -pPASSWORD.
+    // Keep stdin closed so archive extraction jobs cannot hang on password prompts.
+    format!("-p{}", password.0)
+}
+
+fn available_external_seven_zip() -> ExtractResult<&'static str> {
+    let mut last_error = None;
+    for &program in EXTERNAL_SEVEN_ZIP_PROGRAMS {
+        match Command::new(program)
+            .arg("i")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+        {
+            Ok(status) if status.success() => return Ok(program),
+            Ok(_) => continue,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    if let Some(error) = last_error {
+        Err(ExtractError::Other(
+            anyhow!(error).context("Could not run 7z"),
+        ))
+    } else {
+        Err(ExtractError::MissingTool("7z"))
+    }
+}
+
+fn preflight_external_seven_zip(
+    archive_path: &Path,
+    password: Option<&ArchivePassword>,
+) -> ExtractResult<()> {
+    let program = available_external_seven_zip()?;
+    list_external_seven_zip_entries(program, archive_path, password)?;
+    Ok(())
+}
+
+fn list_external_seven_zip_entries(
+    program: &'static str,
+    archive_path: &Path,
+    password: Option<&ArchivePassword>,
+) -> ExtractResult<Vec<String>> {
+    let mut command = Command::new(program);
+    command.arg("l").arg("-slt");
+    if let Some(password) = password {
+        command.arg(seven_zip_password_arg(password));
+    }
+    command.arg("--").arg(archive_path);
+    let output = command
+        .stdin(Stdio::null())
+        .output()
+        .map_err(map_external_seven_zip_io_error)?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !output.status.success() {
+        return Err(map_external_seven_zip_status(
+            &output.stdout,
+            &output.stderr,
+            password.is_some(),
+        ));
+    }
+    if password.is_none() && external_seven_zip_listing_has_encrypted_entries(&stdout) {
+        return Err(ExtractError::PasswordRequired);
+    }
+    Ok(parse_external_seven_zip_entries(&stdout))
+}
+
+fn external_seven_zip_listing_has_encrypted_entries(output: &str) -> bool {
+    output
+        .lines()
+        .any(|line| line.trim_end().eq_ignore_ascii_case("Encrypted = +"))
+}
+
+fn parse_external_seven_zip_entries(output: &str) -> Vec<String> {
+    let mut entries = Vec::new();
+    let mut in_entries = false;
+    for raw_line in output.lines() {
+        let line = raw_line.trim_end();
+        if line == "----------" {
+            in_entries = true;
+            continue;
+        }
+        if !in_entries {
+            continue;
+        }
+        match line.strip_prefix("Path = ") {
+            Some(path) if !path.trim().is_empty() => entries.push(path.to_string()),
+            _ => {}
+        }
+    }
+    entries
+}
+
+fn validate_external_entry_path(dest_dir: &Path, entry: &str) -> ExtractResult<()> {
+    checked_output_name(dest_dir, entry).map_err(|_| ExtractError::UnsafeArchivePath)?;
+    Ok(())
+}
+
+fn run_external_seven_zip_command<C>(
+    mut command: Command,
+    password_provided: bool,
+    cancelled: &mut C,
+) -> ExtractResult<()>
+where
+    C: FnMut() -> bool,
+{
+    let (output_files, stdout, stderr) = ExternalCommandOutputFiles::create()?;
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .map_err(map_external_seven_zip_io_error)?;
+
+    loop {
+        if cancelled() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    return Ok(());
+                }
+                let (stdout, stderr) = output_files.read()?;
+                return Err(map_external_seven_zip_status(
+                    &stdout,
+                    &stderr,
+                    password_provided,
+                ));
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(50)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(map_external_seven_zip_io_error(error));
+            }
+        }
+    }
+}
+
+fn map_external_seven_zip_io_error(error: io::Error) -> ExtractError {
+    if error.kind() == io::ErrorKind::NotFound {
+        ExtractError::MissingTool("7z")
+    } else {
+        ExtractError::Other(anyhow!(error).context("Could not run 7z"))
+    }
+}
+
+fn map_external_seven_zip_status(
+    stdout: &[u8],
+    stderr: &[u8],
+    password_provided: bool,
+) -> ExtractError {
+    let message = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    )
+    .to_ascii_lowercase();
+    if message.contains("wrong password") || message.contains("can not open encrypted archive") {
+        if password_provided {
+            ExtractError::BadPassword
+        } else {
+            ExtractError::PasswordRequired
+        }
+    } else if !password_provided
+        && (message.contains("enter password") || message.contains("encrypted"))
+    {
+        ExtractError::PasswordRequired
+    } else {
+        ExtractError::ExternalFailed("7z")
+    }
 }
 
 fn extract_tar_with<R, D, F, C>(
@@ -607,6 +931,37 @@ mod tests {
             checked_output_path(dest, Path::new("ok/file.txt")).unwrap(),
             dest.join("ok/file.txt")
         );
+    }
+
+    #[test]
+    fn parses_external_7z_listing_paths() {
+        let output = r#"
+Path = sample.rar
+Type = Rar5
+----------
+Path = dir
+Folder = +
+
+Path = dir/file.txt
+Folder = -
+Size = 5
+"#;
+
+        assert_eq!(
+            parse_external_seven_zip_entries(output),
+            vec!["dir".to_string(), "dir/file.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_external_7z_listing_paths() {
+        let dest = Path::new("/tmp/out");
+
+        assert!(validate_external_entry_path(dest, "ok/file.txt").is_ok());
+        let error = validate_external_entry_path(dest, "../evil.txt").unwrap_err();
+        assert!(matches!(error, ExtractError::UnsafeArchivePath));
+        let error = validate_external_entry_path(dest, "/evil.txt").unwrap_err();
+        assert!(matches!(error, ExtractError::UnsafeArchivePath));
     }
 
     #[test]
@@ -890,6 +1245,152 @@ mod tests {
     }
 
     #[test]
+    fn extracts_rar_with_external_seven_zip_fallback() {
+        if !external_seven_zip_available() {
+            return;
+        }
+        let root = temp_path("rar-external-7z");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.rar");
+        write_seven_zip(
+            &archive_path,
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        assert_eq!(plan.backend, ExtractBackend::ExternalSevenZip);
+        let mut progress = Vec::new();
+        let summary =
+            extract_archive_with_password(&plan, None, |update| progress.push(update), || false)
+                .unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.total, Some(2));
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn external_seven_zip_rejects_unsafe_paths_before_extracting() {
+        if !external_seven_zip_available() {
+            return;
+        }
+        let root = temp_path("rar-external-7z-slip");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.rar");
+        write_seven_zip(&archive_path, &[("../evil.txt", Some(b"bad"))]);
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
+
+        assert!(matches!(error, ExtractError::UnsafeArchivePath));
+        assert!(!root.join("evil.txt").exists());
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn external_seven_zip_command_handles_large_failure_output() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(
+            "i=0; while [ $i -lt 5000 ]; do printf 'ERROR: Wrong password\\n' >&2; i=$((i+1)); done; exit 2",
+        );
+
+        let error = run_external_seven_zip_command(command, true, &mut || false).unwrap_err();
+
+        assert!(matches!(error, ExtractError::BadPassword));
+    }
+
+    #[test]
+    fn encrypted_rar_requires_password_before_staging() {
+        if !external_seven_zip_available() {
+            return;
+        }
+        let root = temp_path("rar-encrypted-required");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.rar");
+        let password = archive_test_password(&root);
+        write_encrypted_seven_zip(
+            &archive_path,
+            &password,
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap_err();
+
+        assert!(matches!(error, ExtractError::PasswordRequired));
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_rar_rejects_wrong_password_before_staging() {
+        if !external_seven_zip_available() {
+            return;
+        }
+        let root = temp_path("rar-encrypted-wrong");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.rar");
+        let password = archive_test_password(&root);
+        write_encrypted_seven_zip(
+            &archive_path,
+            &password,
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let error = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new(format!("{password}-wrong"))),
+            |_| {},
+            || false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ExtractError::BadPassword));
+        assert!(!plan.dest_dir.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn encrypted_rar_extracts_with_password() {
+        if !external_seven_zip_available() {
+            return;
+        }
+        let root = temp_path("rar-encrypted-ok");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.rar");
+        let password = archive_test_password(&root);
+        write_encrypted_seven_zip(
+            &archive_path,
+            &password,
+            &[("dir", None), ("dir/file.txt", Some(b"hello"))],
+        );
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(
+            &plan,
+            Some(&ArchivePassword::new(password)),
+            |_| {},
+            || false,
+        )
+        .unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.total, Some(2));
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn archive_password_debug_is_redacted() {
         let password = std::any::type_name::<ArchivePassword>();
         let rendered = format!("{:?}", ArchivePassword::new(password));
@@ -1025,6 +1526,10 @@ mod tests {
         }
         let compressed = zstd::stream::encode_all(tar_bytes.as_slice(), 0).unwrap();
         fs::write(archive_path, compressed).unwrap();
+    }
+
+    fn external_seven_zip_available() -> bool {
+        available_external_seven_zip().is_ok()
     }
 
     enum ZipEncryption {

--- a/src/archive/format.rs
+++ b/src/archive/format.rs
@@ -9,6 +9,7 @@ pub(crate) enum ExtractFormat {
     TarBzip2,
     TarZstd,
     SevenZip,
+    Rar,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -16,11 +17,12 @@ pub(crate) enum ExtractBackend {
     Zip,
     Tar(ExtractFormat),
     SevenZip,
+    ExternalSevenZip,
 }
 
 impl ExtractFormat {
     pub(crate) const SUPPORTED_MESSAGE: &'static str =
-        "Extraction supports ZIP, 7z, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST";
+        "Extraction supports ZIP, 7z, RAR, TAR, TAR.GZ, TAR.XZ, TAR.BZ2, and TAR.ZST";
 
     pub(crate) fn detect(path: &Path) -> Option<Self> {
         let name = path
@@ -47,6 +49,7 @@ impl ExtractFormat {
         {
             Some("zip") => Some(Self::Zip),
             Some("7z") => Some(Self::SevenZip),
+            Some("rar") => Some(Self::Rar),
             Some("tar") => Some(Self::Tar),
             _ => None,
         }
@@ -57,7 +60,7 @@ impl ExtractFormat {
         let lower = name.to_ascii_lowercase();
         let stem = [
             ".tar.bz2", ".tar.zst", ".tar.gz", ".tar.xz", ".tbz2", ".tzst", ".tgz", ".txz", ".tbz",
-            ".zip", ".7z", ".tar",
+            ".zip", ".7z", ".rar", ".tar",
         ]
         .iter()
         .find_map(|suffix| {
@@ -77,6 +80,7 @@ impl ExtractFormat {
         match self {
             Self::Zip => ExtractBackend::Zip,
             Self::SevenZip => ExtractBackend::SevenZip,
+            Self::Rar => ExtractBackend::ExternalSevenZip,
             Self::Tar | Self::TarGzip | Self::TarXz | Self::TarBzip2 | Self::TarZstd => {
                 ExtractBackend::Tar(self)
             }
@@ -92,6 +96,7 @@ impl ExtractFormat {
             Self::TarBzip2 => "TAR.BZ2",
             Self::TarZstd => "TAR.ZST",
             Self::SevenZip => "7z",
+            Self::Rar => "RAR",
         }
     }
 }
@@ -139,6 +144,10 @@ mod tests {
         assert_eq!(
             ExtractFormat::detect(Path::new("app.7z")),
             Some(ExtractFormat::SevenZip)
+        );
+        assert_eq!(
+            ExtractFormat::detect(Path::new("app.rar")),
+            Some(ExtractFormat::Rar)
         );
         assert_eq!(
             ExtractFormat::detect(Path::new("app.tar.gz")),
@@ -202,6 +211,10 @@ mod tests {
             ExtractBackend::Tar(ExtractFormat::TarZstd)
         );
         assert_eq!(ExtractFormat::SevenZip.backend(), ExtractBackend::SevenZip);
+        assert_eq!(
+            ExtractFormat::Rar.backend(),
+            ExtractBackend::ExternalSevenZip
+        );
     }
 
     #[test]
@@ -216,6 +229,10 @@ mod tests {
         );
         assert_eq!(
             ExtractFormat::stem_for_destination(Path::new("app.7z")).as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            ExtractFormat::stem_for_destination(Path::new("app.rar")).as_deref(),
             Some("app")
         );
         assert_eq!(

--- a/src/preview/container/archive/external.rs
+++ b/src/preview/container/archive/external.rs
@@ -11,6 +11,7 @@ use std::{
 
 const ARCHIVE_EXTERNAL_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 const ARCHIVE_EXTERNAL_COMMAND_POLL: Duration = Duration::from_millis(20);
+const SEVEN_ZIP_PROGRAMS: &[&str] = &["7z", "7zz", "7za"];
 
 static ARCHIVE_OUTPUT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -87,8 +88,14 @@ pub(super) fn collect_archive_listing_with_7z<F>(
 where
     F: Fn() -> bool,
 {
-    let output = run_archive_listing_command("7z", &["l", "-slt"], path, canceled)?;
-    parse_7z_listing(&String::from_utf8_lossy(&output))
+    for &program in SEVEN_ZIP_PROGRAMS {
+        if let Some(listing) = run_archive_listing_command(program, &["l", "-slt"], path, canceled)
+            .and_then(|output| parse_7z_listing(&String::from_utf8_lossy(&output)))
+        {
+            return Some(listing);
+        }
+    }
+    None
 }
 
 fn run_archive_listing_command<F>(


### PR DESCRIPTION
## Summary

Add RAR extraction for focused `.rar` archives through the external 7-Zip backend.

RAR extraction now uses `7z`, `7zz`, or `7za`, keeps extraction staged, rejects unsafe archive paths before writing files, and reuses the archive password prompt flow for encrypted RAR5 archives.

Refs #90.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed