### PR TITLE
fix(ui): make help overlay responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `--chooser-file -` and `/dev/stdout` output when piped to tools such as `sed` or `awk`, keeping terminal UI escape sequences out of machine-readable chooser output. ([#186])
 - Fixed video thumbnails not appearing for the first file when starting elio inside a video folder. ([#195])
 - Fixed inline video preview redraws that could leave only partial metadata visible after navigating between videos.
+- Fixed the Help overlay in small windows and with large terminal fonts so overflowing controls remain readable and scrollable.
 
 ## [1.9.0] - 2026-06-17
 

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const HELP_FALLBACK_SCROLL_MAX: usize = 64;
+const HELP_FALLBACK_PAGE_STEP: usize = 8;
+
 impl App {
     pub fn handle_event(&mut self, event: Event) -> Result<()> {
         let result = match event {
@@ -13,6 +16,42 @@ impl App {
         }
 
         Ok(())
+    }
+
+    fn help_scroll_max(&self) -> usize {
+        if self.input.frame_state.help_rows_visible == 0 {
+            HELP_FALLBACK_SCROLL_MAX
+        } else {
+            self.input.frame_state.help_scroll_max
+        }
+    }
+
+    fn help_page_step(&self) -> usize {
+        if self.input.frame_state.help_rows_visible == 0 {
+            HELP_FALLBACK_PAGE_STEP
+        } else {
+            self.input
+                .frame_state
+                .help_rows_visible
+                .saturating_sub(2)
+                .max(1)
+        }
+    }
+
+    pub(in crate::app) fn scroll_help_by(&mut self, delta: isize) {
+        let max_scroll = self.help_scroll_max();
+        if delta.is_negative() {
+            self.overlays.help_scroll = self
+                .overlays
+                .help_scroll
+                .saturating_sub(delta.unsigned_abs());
+        } else {
+            self.overlays.help_scroll = self
+                .overlays
+                .help_scroll
+                .saturating_add(delta as usize)
+                .min(max_scroll);
+        }
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -74,11 +113,24 @@ impl App {
                 self.overlays.help = false;
                 return Ok(());
             }
-            if key.code == KeyCode::Esc {
-                self.overlays.help = false;
-            }
-            if is_help_shortcut(key) {
-                self.overlays.help = false;
+            match key.code {
+                KeyCode::Esc => self.overlays.help = false,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.scroll_help_by(-1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.scroll_help_by(1);
+                }
+                KeyCode::PageUp => {
+                    self.scroll_help_by(-(self.help_page_step() as isize));
+                }
+                KeyCode::PageDown => {
+                    self.scroll_help_by(self.help_page_step() as isize);
+                }
+                KeyCode::Home => self.overlays.help_scroll = 0,
+                KeyCode::End => self.overlays.help_scroll = self.help_scroll_max(),
+                _ if is_help_shortcut(key) => self.overlays.help = false,
+                _ => {}
             }
             return Ok(());
         }
@@ -182,6 +234,7 @@ impl App {
             }
             _ if is_help_shortcut(key) => {
                 self.clear_wheel_scroll();
+                self.overlays.help_scroll = 0;
                 self.overlays.help = true;
             }
             _ if configured_action.is_some() => {

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const HELP_WHEEL_LINES: isize = 2;
+
 impl App {
     pub(in crate::app) fn handle_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
         if self.overlays.trash.is_some() {
@@ -43,9 +45,18 @@ impl App {
         }
 
         if self.overlays.help {
-            if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
-                self.clear_wheel_scroll();
-                self.overlays.help = false;
+            match mouse.kind {
+                MouseEventKind::Down(MouseButton::Left) => {
+                    self.clear_wheel_scroll();
+                    self.overlays.help = false;
+                }
+                MouseEventKind::ScrollDown => {
+                    self.scroll_help_by(HELP_WHEEL_LINES);
+                }
+                MouseEventKind::ScrollUp => {
+                    self.scroll_help_by(-HELP_WHEEL_LINES);
+                }
+                _ => {}
             }
             return Ok(());
         }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -639,6 +639,7 @@ pub(crate) struct OverlayState {
     pub(in crate::app) open_with: Option<OpenWithOverlay>,
     pub(in crate::app) search: Option<SearchOverlay>,
     pub(crate) help: bool,
+    pub(crate) help_scroll: usize,
 }
 
 pub(in crate::app) struct JobRuntime {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -56,6 +56,8 @@ pub struct FrameState {
     pub open_with_panel: Option<Rect>,
     pub search_panel: Option<Rect>,
     pub help_panel: Option<Rect>,
+    pub help_scroll_max: usize,
+    pub help_rows_visible: usize,
     pub entries_panel: Option<Rect>,
     pub preview_panel: Option<Rect>,
     pub preview_body_area: Option<Rect>,

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1398,6 +1398,94 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
 }
 
 #[test]
+fn compact_help_overlay_scrolls_instead_of_truncating_small_terminals() {
+    let root = temp_path("compact-help-overlay");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    app.overlays.help = true;
+    let mut terminal = Terminal::new(TestBackend::new(60, 18)).expect("terminal should init");
+
+    let frame_state = draw_ui(&mut terminal, &mut app);
+    let rendered = buffer_text(terminal.backend().buffer());
+
+    assert!(
+        rendered.contains("Navigate"),
+        "compact help should start with the first section, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("? / Esc") && rendered.contains("close help"),
+        "compact help should keep the original footer, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("scroll") && !rendered.contains("PgUp/PgDn"),
+        "compact help should not add scrolling hints to the footer, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("┃"),
+        "scrollable compact help should draw a right-side scrollbar, got: {rendered:?}"
+    );
+    assert!(
+        frame_state.help_scroll_max > 0,
+        "compact help should publish its real scroll limit"
+    );
+    let max_scroll = frame_state.help_scroll_max;
+    let page_step = frame_state.help_rows_visible.saturating_sub(2).max(1);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::End)))
+        .expect("End should jump to the bottom of help");
+    assert_eq!(
+        app.overlays.help_scroll, max_scroll,
+        "End should use the real scroll limit instead of an arbitrary sentinel"
+    );
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::PageUp)))
+        .expect("PageUp should move by a viewport-sized step");
+    assert_eq!(
+        app.overlays.help_scroll,
+        max_scroll.saturating_sub(page_step),
+        "PageUp should keep context instead of jumping by a fixed magic number"
+    );
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::End)))
+        .expect("End should return to the bottom of help");
+    draw_ui(&mut terminal, &mut app);
+    let rendered = buffer_text(terminal.backend().buffer());
+
+    assert!(
+        rendered.contains("View") && rendered.contains("toggle grid / list"),
+        "compact help should keep late sections reachable, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("?/Esc") || rendered.contains("? / Esc"),
+        "compact help should keep the close hint visible, got: {rendered:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn medium_help_overlay_uses_two_columns_before_scrolling() {
+    let root = temp_path("medium-help-overlay");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+
+    let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+    app.overlays.help = true;
+    let mut terminal = Terminal::new(TestBackend::new(92, 37)).expect("terminal should init");
+
+    draw_ui(&mut terminal, &mut app);
+    let rendered = buffer_text(terminal.backend().buffer());
+
+    assert!(
+        rendered.contains("Navigate") && rendered.contains("File Actions"),
+        "medium help should use both sides instead of a sparse single column, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("create file or folder"),
+        "right-side actions should be visible before scrolling, got: {rendered:?}"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn chooser_help_overlay_uses_chooser_actions_without_changing_esc() {
     let root = temp_path("chooser-help-overlay");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -15,6 +15,7 @@ pub(super) fn render_help(
     frame: &mut Frame<'_>,
     area: Rect,
     mode: HelpMode,
+    scroll_top: usize,
     state: &mut FrameState,
     palette: Palette,
 ) {
@@ -39,8 +40,8 @@ pub(super) fn render_help(
         keys.action(&kb.trash, "trash (delete if in trash)"),
         keys.action(&kb.delete_permanently, "delete permanently"),
         keys.action(&kb.rename, "rename (bulk if selection)"),
-        keys.action(&kb.extract_archive, "extract archive"),
         keys.action_with_suffix(&kb.restore_from_trash, " (in trash)", "restore from trash"),
+        keys.action(&kb.extract_archive, "extract archive"),
         keys.action(&kb.shell, "open shell here"),
         keys.action(&kb.open, "open with default app"),
         keys.action(&kb.open_with, "open with"),
@@ -88,7 +89,7 @@ pub(super) fn render_help(
         e("Wheel", "scroll"),
         e("Shift+Wheel", "scroll sideways"),
     ];
-    let left_sections = vec![
+    let sections = vec![
         HelpSection {
             title: "Navigate",
             entries: navigation_entries,
@@ -101,8 +102,6 @@ pub(super) fn render_help(
             title: "Selection & Clipboard",
             entries: clipboard_entries,
         },
-    ];
-    let right_sections = vec![
         HelpSection {
             title: "Search",
             entries: search_entries,
@@ -121,7 +120,17 @@ pub(super) fn render_help(
         },
     ];
 
-    let popup = helpers::centered_rect(area, 90, 36);
+    let popup_width = if area.width >= 92 {
+        90
+    } else {
+        area.width.saturating_sub(4).clamp(44, 90)
+    };
+    let popup_height = if area.height >= 38 {
+        36
+    } else {
+        area.height.saturating_sub(2).clamp(10, 36)
+    };
+    let popup = helpers::centered_rect(area, popup_width, popup_height);
     state.help_panel = Some(popup);
     frame.render_widget(Clear, popup);
     frame.render_widget(
@@ -147,12 +156,32 @@ pub(super) fn render_help(
             .border_style(Style::default().fg(palette.border)),
         popup,
     );
+
     let inner = helpers::inner_with_padding(popup);
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(8), Constraint::Length(1)])
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
+    if rows[0].width >= 88 && rows[0].height >= 33 {
+        render_wide_help(frame, rows[0], rows[1], &sections, state, palette);
+    } else {
+        render_compact_help(
+            frame, rows[0], rows[1], &sections, scroll_top, state, palette,
+        );
+    }
+}
+
+fn render_wide_help(
+    frame: &mut Frame<'_>,
+    body: Rect,
+    footer: Rect,
+    sections: &[HelpSection],
+    state: &mut FrameState,
+    palette: Palette,
+) {
+    state.help_scroll_max = 0;
+    state.help_rows_visible = body.height as usize;
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
@@ -160,10 +189,10 @@ pub(super) fn render_help(
             Constraint::Length(3),
             Constraint::Length(46),
         ])
-        .split(rows[0]);
+        .split(body);
 
     frame.render_widget(
-        Paragraph::new(help_column_lines(cols[0].width, &left_sections, palette))
+        Paragraph::new(help_column_lines(cols[0].width, &sections[..3], palette))
             .style(Style::default().bg(palette.chrome_alt).fg(palette.text))
             .wrap(Wrap { trim: false }),
         cols[0],
@@ -180,12 +209,164 @@ pub(super) fn render_help(
     );
 
     frame.render_widget(
-        Paragraph::new(help_column_lines(cols[2].width, &right_sections, palette))
+        Paragraph::new(help_column_lines(cols[2].width, &sections[3..], palette))
             .style(Style::default().bg(palette.chrome_alt).fg(palette.text))
             .wrap(Wrap { trim: false }),
         cols[2],
     );
+    render_help_footer(frame, footer, palette);
+}
 
+fn render_compact_help(
+    frame: &mut Frame<'_>,
+    body: Rect,
+    footer: Rect,
+    sections: &[HelpSection],
+    scroll_top: usize,
+    state: &mut FrameState,
+    palette: Palette,
+) {
+    let visible = body.height as usize;
+    let mut content = body;
+    let mut lines = flowing_help_lines(content.width, sections, palette);
+    let mut total = lines.len();
+    let mut scrollbar = None;
+
+    if total > visible.max(1) && body.width >= 6 {
+        content.width = body.width.saturating_sub(1);
+        scrollbar = Some(Rect {
+            x: body.x + content.width,
+            y: body.y,
+            width: 1,
+            height: body.height,
+        });
+        lines = flowing_help_lines(content.width, sections, palette);
+        total = lines.len();
+    }
+
+    let max_scroll = total.saturating_sub(visible);
+    state.help_scroll_max = max_scroll;
+    state.help_rows_visible = visible;
+    let scroll_top = scroll_top.min(max_scroll);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .style(Style::default().bg(palette.chrome_alt).fg(palette.text))
+            .scroll((scroll_top as u16, 0))
+            .wrap(Wrap { trim: false }),
+        content,
+    );
+    if let Some(area) = scrollbar {
+        render_help_scrollbar(frame, area, total, visible, scroll_top, palette);
+    }
+    render_help_footer(frame, footer, palette);
+}
+
+fn flowing_help_lines(
+    width: u16,
+    sections: &[HelpSection],
+    palette: Palette,
+) -> Vec<Line<'static>> {
+    if width >= 70 && sections.len() >= 4 {
+        return two_column_help_lines(width, &sections[..3], &sections[3..], palette);
+    }
+    help_column_lines(width, sections, palette)
+}
+
+fn two_column_help_lines(
+    width: u16,
+    left_sections: &[HelpSection],
+    right_sections: &[HelpSection],
+    palette: Palette,
+) -> Vec<Line<'static>> {
+    let gap_width = 3usize;
+    let left_width = ((width as usize).saturating_sub(gap_width)) / 2;
+    let right_width = (width as usize).saturating_sub(left_width + gap_width);
+    let left = help_column_lines(left_width as u16, left_sections, palette);
+    let right = help_column_lines(right_width as u16, right_sections, palette);
+    let rows = left.len().max(right.len());
+    let mut lines = Vec::with_capacity(rows);
+
+    for index in 0..rows {
+        let left_line = left.get(index).cloned().unwrap_or_default();
+        let right_line = right.get(index).cloned().unwrap_or_default();
+        let left_line_width = line_width(&left_line);
+        let mut spans = left_line.spans;
+        spans.push(Span::raw(
+            " ".repeat(left_width.saturating_sub(left_line_width) + gap_width),
+        ));
+        spans.extend(right_line.spans);
+        lines.push(Line::from(spans));
+    }
+
+    lines
+}
+
+fn line_width(line: &Line<'_>) -> usize {
+    line.spans
+        .iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum()
+}
+
+fn render_help_scrollbar(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    total_rows: usize,
+    visible_rows: usize,
+    scroll_row: usize,
+    palette: Palette,
+) {
+    if area.height == 0 || total_rows <= visible_rows.max(1) {
+        frame.render_widget(
+            Paragraph::new(" ").style(Style::default().bg(palette.chrome_alt).fg(palette.border)),
+            area,
+        );
+        return;
+    }
+
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "│",
+                Style::default().fg(palette.border)
+            ));
+            area.height as usize
+        ])
+        .style(Style::default().bg(palette.chrome_alt)),
+        area,
+    );
+
+    let thumb_height = ((visible_rows.max(1) * area.height as usize) / total_rows)
+        .max(1)
+        .min(area.height as usize);
+    let max_scroll = total_rows.saturating_sub(visible_rows.max(1));
+    let thumb_max_top = area.height as usize - thumb_height;
+    let thumb_top = scroll_row
+        .checked_mul(thumb_max_top)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
+    let thumb = Rect {
+        x: area.x,
+        y: area.y + thumb_top as u16,
+        width: area.width,
+        height: thumb_height as u16,
+    };
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "┃",
+                Style::default()
+                    .fg(palette.accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            thumb.height as usize
+        ])
+        .style(Style::default().bg(palette.chrome_alt)),
+        thumb,
+    );
+}
+
+fn render_help_footer(frame: &mut Frame<'_>, area: Rect, palette: Palette) {
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled(
@@ -199,7 +380,7 @@ pub(super) fn render_help(
         ]))
         .alignment(Alignment::Right)
         .style(Style::default().bg(palette.chrome_alt).fg(palette.muted)),
-        rows[1],
+        area,
     );
 }
 
@@ -427,14 +608,14 @@ fn help_entry_lines(
         wrapped_action.push(String::new());
     }
 
-    let key_padding =
-        " ".repeat(key_width.saturating_sub(UnicodeWidthStr::width(entry.key.as_str())));
+    let key = helpers::clamp_label(&entry.key, key_width);
+    let key_padding = " ".repeat(key_width.saturating_sub(UnicodeWidthStr::width(key.as_str())));
     let continuation = " ".repeat(key_width + 2);
     let mut lines = Vec::with_capacity(wrapped_action.len());
 
     lines.push(Line::from(vec![
         Span::styled(
-            entry.key.clone(),
+            key,
             Style::default()
                 .fg(palette.accent_text)
                 .add_modifier(Modifier::BOLD),

--- a/src/ui/overlay_manager/mod.rs
+++ b/src/ui/overlay_manager/mod.rs
@@ -132,7 +132,7 @@ pub(super) fn render_help(
     } else {
         HelpMode::Normal
     };
-    help::render_help(frame, area, mode, state, palette);
+    help::render_help(frame, area, mode, app.overlays.help_scroll, state, palette);
 }
 
 fn compute_scroll_top(cursor_line: usize, visible: usize) -> usize {


### PR DESCRIPTION
## Summary

Keep the Help overlay readable in small windows and with large terminal fonts.

When the available space is limited, Help now adapts to the window and lets overflowing controls scroll instead of becoming cramped or cut off.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed