### PR TITLE
feat(ui): add fuzzy search scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefer native archive listing for `.7z`, `.tar.xz`, `.tar.bz2`, and `.tar.zst` previews before falling back to external archive tools, and keep encrypted `.7z` previews visible with a password-required notice. ([#90])
 - Places now switches to an icon-only rail in narrow windows before labels become overly truncated. ([#184])
 - Changed Open With to keep `$VISUAL` and `$EDITOR` labels on matching MIME-associated editors and place them directly below the system default association. ([#199])
+- Added a scrollbar to fuzzy search so long result lists show the current position and whether more matches are above or below.
 
 ### Fixed
 

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -95,6 +95,14 @@ impl App {
             .collect()
     }
 
+    pub fn search_scroll_top(&self) -> usize {
+        self.overlays
+            .search
+            .as_ref()
+            .map(|search| search.scroll)
+            .unwrap_or(0)
+    }
+
     pub(in crate::app) fn open_fuzzy_finder(&mut self, scope: SearchScope) -> Result<()> {
         self.clear_wheel_scroll();
         self.overlays.help = false;

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1180,13 +1180,30 @@ fn search_overlay_scrolls_selected_results_and_tracks_hit_rects() {
     wait_for_search_index(&mut app);
 
     let initial_state = draw_ui(&mut terminal, &mut app);
-    assert!(
-        initial_state.search_panel.is_some(),
-        "search overlay should render a popup panel"
-    );
+    let search_panel = initial_state
+        .search_panel
+        .expect("search overlay should render a popup panel");
     assert!(
         initial_state.search_rows_visible > 0,
         "search overlay should expose the visible row budget through frame state"
+    );
+    let inner = helpers::inner_with_padding(search_panel);
+    let results_area = Rect {
+        x: inner.x,
+        y: inner.y + 4,
+        width: inner.width,
+        height: inner.height.saturating_sub(5),
+    };
+    let right_column = (results_area.y..results_area.y + results_area.height)
+        .map(|y| terminal.backend().buffer()[(results_area.x + results_area.width - 1, y)].symbol())
+        .collect::<String>();
+    assert!(
+        right_column.contains('┃'),
+        "overflowing search overlay should draw a scrollbar thumb"
+    );
+    assert!(
+        right_column.contains('│'),
+        "overflowing search overlay should draw a scrollbar track"
     );
 
     for _ in 0..8 {

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -1,4 +1,4 @@
-use super::HelpMode;
+use super::{HelpMode, scrollbar::render_overlay_scrollbar};
 use crate::app::FrameState;
 use crate::config::{KeyBindings, KeyList};
 use crate::ui::{helpers, theme::Palette};
@@ -256,7 +256,7 @@ fn render_compact_help(
         content,
     );
     if let Some(area) = scrollbar {
-        render_help_scrollbar(frame, area, total, visible, scroll_top, palette);
+        render_overlay_scrollbar(frame, area, total, visible, scroll_top, palette);
     }
     render_help_footer(frame, footer, palette);
 }
@@ -306,64 +306,6 @@ fn line_width(line: &Line<'_>) -> usize {
         .iter()
         .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
         .sum()
-}
-
-fn render_help_scrollbar(
-    frame: &mut Frame<'_>,
-    area: Rect,
-    total_rows: usize,
-    visible_rows: usize,
-    scroll_row: usize,
-    palette: Palette,
-) {
-    if area.height == 0 || total_rows <= visible_rows.max(1) {
-        frame.render_widget(
-            Paragraph::new(" ").style(Style::default().bg(palette.chrome_alt).fg(palette.border)),
-            area,
-        );
-        return;
-    }
-
-    frame.render_widget(
-        Paragraph::new(vec![
-            Line::from(Span::styled(
-                "│",
-                Style::default().fg(palette.border)
-            ));
-            area.height as usize
-        ])
-        .style(Style::default().bg(palette.chrome_alt)),
-        area,
-    );
-
-    let thumb_height = ((visible_rows.max(1) * area.height as usize) / total_rows)
-        .max(1)
-        .min(area.height as usize);
-    let max_scroll = total_rows.saturating_sub(visible_rows.max(1));
-    let thumb_max_top = area.height as usize - thumb_height;
-    let thumb_top = scroll_row
-        .checked_mul(thumb_max_top)
-        .and_then(|offset| offset.checked_div(max_scroll))
-        .unwrap_or(0);
-    let thumb = Rect {
-        x: area.x,
-        y: area.y + thumb_top as u16,
-        width: area.width,
-        height: thumb_height as u16,
-    };
-    frame.render_widget(
-        Paragraph::new(vec![
-            Line::from(Span::styled(
-                "┃",
-                Style::default()
-                    .fg(palette.accent)
-                    .add_modifier(Modifier::BOLD),
-            ));
-            thumb.height as usize
-        ])
-        .style(Style::default().bg(palette.chrome_alt)),
-        thumb,
-    );
 }
 
 fn render_help_footer(frame: &mut Frame<'_>, area: Rect, palette: Palette) {

--- a/src/ui/overlay_manager/mod.rs
+++ b/src/ui/overlay_manager/mod.rs
@@ -11,6 +11,7 @@ mod help;
 mod open_with;
 mod rename;
 mod restore;
+mod scrollbar;
 mod search;
 mod trash;
 

--- a/src/ui/overlay_manager/open_with.rs
+++ b/src/ui/overlay_manager/open_with.rs
@@ -1,9 +1,10 @@
+use super::scrollbar::render_overlay_scrollbar;
 use crate::app::{App, FrameState, OpenWithHit};
 use crate::ui::{helpers, theme::Palette};
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
@@ -115,7 +116,7 @@ pub(super) fn render_open_with_overlay(
     }
 
     if let Some(scrollbar) = scrollbar_area {
-        render_open_with_scrollbar(
+        render_overlay_scrollbar(
             frame,
             scrollbar,
             row_count,
@@ -124,60 +125,6 @@ pub(super) fn render_open_with_overlay(
             palette,
         );
     }
-}
-
-fn render_open_with_scrollbar(
-    frame: &mut Frame<'_>,
-    area: Rect,
-    total_rows: usize,
-    visible_rows: usize,
-    scroll_top: usize,
-    palette: Palette,
-) {
-    if area.height == 0 || total_rows <= visible_rows.max(1) {
-        return;
-    }
-
-    frame.render_widget(
-        Paragraph::new(vec![
-            Line::from(Span::styled(
-                "│",
-                Style::default().fg(palette.border)
-            ));
-            area.height as usize
-        ])
-        .style(Style::default().bg(palette.chrome_alt)),
-        area,
-    );
-
-    let thumb_height = ((visible_rows.max(1) * area.height as usize) / total_rows)
-        .max(1)
-        .min(area.height as usize);
-    let max_scroll = total_rows.saturating_sub(visible_rows.max(1));
-    let thumb_max_top = area.height as usize - thumb_height;
-    let thumb_top = scroll_top
-        .checked_mul(thumb_max_top)
-        .and_then(|offset| offset.checked_div(max_scroll))
-        .unwrap_or(0);
-
-    frame.render_widget(
-        Paragraph::new(vec![
-            Line::from(Span::styled(
-                "┃",
-                Style::default()
-                    .fg(palette.accent)
-                    .add_modifier(Modifier::BOLD),
-            ));
-            thumb_height
-        ])
-        .style(Style::default().bg(palette.chrome_alt)),
-        Rect {
-            x: area.x,
-            y: area.y + thumb_top as u16,
-            width: area.width,
-            height: thumb_height as u16,
-        },
-    );
 }
 
 fn open_with_scroll_top(selected: usize, row_count: usize, visible_rows: usize) -> usize {

--- a/src/ui/overlay_manager/scrollbar.rs
+++ b/src/ui/overlay_manager/scrollbar.rs
@@ -1,0 +1,66 @@
+use crate::ui::theme::Palette;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+pub(super) fn render_overlay_scrollbar(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    total_rows: usize,
+    visible_rows: usize,
+    scroll_row: usize,
+    palette: Palette,
+) {
+    if area.height == 0 || total_rows <= visible_rows.max(1) {
+        frame.render_widget(
+            Paragraph::new(" ").style(Style::default().bg(palette.chrome_alt).fg(palette.border)),
+            area,
+        );
+        return;
+    }
+
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "│",
+                Style::default().fg(palette.border)
+            ));
+            area.height as usize
+        ])
+        .style(Style::default().bg(palette.chrome_alt)),
+        area,
+    );
+
+    let thumb_height = ((visible_rows.max(1) * area.height as usize) / total_rows)
+        .max(1)
+        .min(area.height as usize);
+    let max_scroll = total_rows.saturating_sub(visible_rows.max(1));
+    let thumb_max_top = area.height as usize - thumb_height;
+    let thumb_top = scroll_row
+        .checked_mul(thumb_max_top)
+        .and_then(|offset| offset.checked_div(max_scroll))
+        .unwrap_or(0);
+
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "┃",
+                Style::default()
+                    .fg(palette.accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            thumb_height
+        ])
+        .style(Style::default().bg(palette.chrome_alt)),
+        Rect {
+            x: area.x,
+            y: area.y + thumb_top as u16,
+            width: area.width,
+            height: thumb_height as u16,
+        },
+    );
+}

--- a/src/ui/overlay_manager/search.rs
+++ b/src/ui/overlay_manager/search.rs
@@ -1,3 +1,4 @@
+use super::scrollbar::render_overlay_scrollbar;
 use crate::app::{App, FrameState, SearchHit, SearchScope};
 use crate::ui::{
     helpers,
@@ -119,9 +120,24 @@ pub(super) fn render_search_overlay(
     );
     frame.set_cursor_position((cursor_x, query_area.y));
 
-    let results_area = rows[2];
     let row_height = 2u16;
-    let visible_rows = (results_area.height / row_height).max(1) as usize;
+    let visible_rows = (rows[2].height / row_height).max(1) as usize;
+    let needs_scrollbar = app.search_match_count() > visible_rows;
+    let (results_area, scrollbar_area) = if needs_scrollbar && rows[2].width >= 6 {
+        (
+            Rect {
+                width: rows[2].width.saturating_sub(1),
+                ..rows[2]
+            },
+            Some(Rect {
+                x: rows[2].x + rows[2].width.saturating_sub(1),
+                width: 1,
+                ..rows[2]
+            }),
+        )
+    } else {
+        (rows[2], None)
+    };
     state.search_rows_visible = visible_rows;
 
     let rows_data = app.search_rows(visible_rows);
@@ -235,6 +251,17 @@ pub(super) fn render_search_overlay(
                 index: row.index,
             });
         }
+    }
+
+    if let Some(scrollbar) = scrollbar_area {
+        render_overlay_scrollbar(
+            frame,
+            scrollbar,
+            app.search_match_count(),
+            visible_rows,
+            app.search_scroll_top(),
+            palette,
+        );
     }
 
     frame.render_widget(


### PR DESCRIPTION
## Summary

Add a scrollbar to fuzzy search when long result lists overflow.

The scrollbar shows the current position in the result list and makes it clear when more matches are available above or below. Help and Open With now reuse the same overlay scrollbar rendering.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed