### PR TITLE
refactor(ui): remove Fuzzy Find footer hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefer native archive listing for `.7z`, `.tar.xz`, `.tar.bz2`, and `.tar.zst` previews before falling back to external archive tools, and keep encrypted `.7z` previews visible with a password-required notice. ([#90])
 - Places now switches to an icon-only rail in narrow windows before labels become overly truncated. ([#184])
 - Changed Open With to keep `$VISUAL` and `$EDITOR` labels on matching MIME-associated editors and place them directly below the system default association. ([#199])
-- Added a scrollbar to fuzzy search so long result lists show the current position and whether more matches are above or below.
+- Added a scrollbar to Fuzzy Find and made more room for results by removing footer hints.
 
 ### Fixed
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1192,8 +1192,24 @@ fn search_overlay_scrolls_selected_results_and_tracks_hit_rects() {
         x: inner.x,
         y: inner.y + 4,
         width: inner.width,
-        height: inner.height.saturating_sub(5),
+        height: inner.height.saturating_sub(4),
     };
+    let bottom_row = rect_row_text(
+        terminal.backend().buffer(),
+        Rect {
+            x: results_area.x,
+            y: results_area.y + results_area.height.saturating_sub(1),
+            width: results_area.width,
+            height: 1,
+        },
+        results_area.y + results_area.height.saturating_sub(1),
+    );
+    assert!(
+        !bottom_row.contains("Enter open")
+            && !bottom_row.contains("Esc close")
+            && !bottom_row.contains("move"),
+        "search results bottom row should not render generic key hints, got: {bottom_row:?}"
+    );
     let right_column = (results_area.y..results_area.y + results_area.height)
         .map(|y| terminal.backend().buffer()[(results_area.x + results_area.width - 1, y)].symbol())
         .collect::<String>();

--- a/src/ui/overlay_manager/search.rs
+++ b/src/ui/overlay_manager/search.rs
@@ -6,7 +6,7 @@ use crate::ui::{
 };
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Margin, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Clear, Paragraph},
@@ -38,7 +38,6 @@ pub(super) fn render_search_overlay(
             Constraint::Length(1),
             Constraint::Length(3),
             Constraint::Min(4),
-            Constraint::Length(1),
         ])
         .split(inner);
 
@@ -263,13 +262,6 @@ pub(super) fn render_search_overlay(
             palette,
         );
     }
-
-    frame.render_widget(
-        Paragraph::new("Enter open  Esc close  ↑↓ move")
-            .alignment(Alignment::Right)
-            .style(Style::default().bg(palette.chrome_alt).fg(palette.muted)),
-        rows[3],
-    );
 }
 
 fn render_query_line(


### PR DESCRIPTION
## Summary

Remove the footer hints from Fuzzy Find.

Result lists now use that space for matches, keeping the overlay fuller while the scrollbar shows position and overflow.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed