### PR TITLE
fix(ui): correct caret position for long names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed video thumbnails not appearing for the first file when starting elio inside a video folder. ([#195])
 - Fixed inline video preview redraws that could leave only partial metadata visible after navigating between videos.
 - Fixed the Help overlay in small windows and with large terminal fonts so overflowing controls remain readable and scrollable.
+- Fixed editing very long names in rename, create, bulk rename, fuzzy find, and `/` filters.
 
 ## [1.9.0] - 2026-06-17
 

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -8,7 +8,6 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Paragraph},
 };
-use unicode_width::UnicodeWidthChar;
 
 pub(super) fn render_toolbar(
     frame: &mut Frame<'_>,
@@ -319,50 +318,21 @@ fn render_local_filter_status(frame: &mut Frame<'_>, area: Rect, app: &App, pale
 
     let query = app.local_filter_query();
     let text = format!("/{query}");
-    let (rendered, hidden_width) = local_filter_visible_text(&text, area.width as usize);
+    let (rendered, cursor_offset) = helpers::input_window(
+        &text,
+        app.local_filter_cursor().saturating_add(1),
+        area.width,
+    );
     frame.render_widget(
         Paragraph::new(rendered).style(Style::default().bg(palette.chrome).fg(palette.text)),
         area,
     );
 
-    let cursor_offset = helpers::display_width("/").saturating_add(helpers::display_width(
-        &query
-            .chars()
-            .take(app.local_filter_cursor())
-            .collect::<String>(),
-    )) as u16;
     let cursor_x = area
         .x
-        .saturating_add(cursor_offset.saturating_sub(hidden_width as u16))
+        .saturating_add(cursor_offset)
         .min(area.x + area.width.saturating_sub(1));
     frame.set_cursor_position((cursor_x, area.y));
-}
-
-fn local_filter_visible_text(text: &str, width: usize) -> (String, usize) {
-    let text_width = helpers::display_width(text);
-    if text_width <= width {
-        return (text.to_string(), 0);
-    }
-    if width <= 1 {
-        return ("…".to_string(), text_width.saturating_sub(1));
-    }
-
-    let suffix_width_limit = width - 1;
-    let mut suffix = Vec::new();
-    let mut suffix_width = 0usize;
-    for ch in text.chars().rev() {
-        let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if suffix_width + char_width > suffix_width_limit {
-            break;
-        }
-        suffix.push(ch);
-        suffix_width += char_width;
-    }
-    let suffix = suffix.into_iter().rev().collect::<String>();
-    (
-        format!("…{suffix}"),
-        text_width.saturating_sub(suffix_width),
-    )
 }
 
 fn local_filter_indicator(query: &str) -> String {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -270,6 +270,58 @@ pub(super) fn display_width(text: &str) -> usize {
     UnicodeWidthStr::width(text)
 }
 
+pub(super) fn input_window(input: &str, cursor_col: usize, width: u16) -> (String, u16) {
+    if width == 0 {
+        return (String::new(), 0);
+    }
+
+    let chars: Vec<char> = input.chars().collect();
+    let cursor_col = cursor_col.min(chars.len());
+    let max_before_cursor = width.saturating_sub(1) as usize;
+    let mut start = cursor_col;
+    let mut before_cursor_width = 0usize;
+
+    while start > 0 {
+        let candidate_start = start - 1;
+        let char_width = chars[candidate_start].width().unwrap_or(0);
+        let ellipsis_width = usize::from(candidate_start > 0);
+        if before_cursor_width + char_width + ellipsis_width > max_before_cursor {
+            break;
+        }
+        before_cursor_width += char_width;
+        start = candidate_start;
+    }
+
+    let mut visible = String::new();
+    let mut visible_width = 0usize;
+    let ellipsis_width = if start > 0 {
+        visible.push('…');
+        visible_width = 1;
+        1
+    } else {
+        0
+    };
+
+    for ch in chars.iter().skip(start) {
+        let char_width = ch.width().unwrap_or(0);
+        if visible_width + char_width > width as usize {
+            break;
+        }
+        visible.push(*ch);
+        visible_width += char_width;
+    }
+
+    let cursor_x = ellipsis_width
+        + chars[start..cursor_col]
+            .iter()
+            .map(|ch| ch.width().unwrap_or(0))
+            .sum::<usize>();
+    (
+        visible,
+        cursor_x.min(width.saturating_sub(1) as usize) as u16,
+    )
+}
+
 fn take_prefix_width(text: &str, max_width: usize) -> String {
     if max_width == 0 {
         return String::new();
@@ -321,5 +373,26 @@ pub(super) fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
         y: area.y + area.height.saturating_sub(height) / 2,
         width,
         height,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::input_window;
+
+    #[test]
+    fn long_input_keeps_a_cell_for_the_end_cursor() {
+        let (visible, cursor_x) = input_window("abcdefghijklmnopqrstuvwxyz", 26, 10);
+
+        assert_eq!(cursor_x, 9);
+        assert_eq!(visible, "…stuvwxyz");
+    }
+
+    #[test]
+    fn wide_chars_do_not_push_the_cursor_past_the_field() {
+        let (visible, cursor_x) = input_window("aaaaaaaa猫猫", 10, 8);
+
+        assert_eq!(cursor_x, 7);
+        assert_eq!(visible, "…aa猫猫");
     }
 }

--- a/src/ui/overlay_manager/archive_password.rs
+++ b/src/ui/overlay_manager/archive_password.rs
@@ -48,12 +48,9 @@ pub(super) fn render_archive_password_overlay(
 
     let input = app.archive_password_input();
     let cursor_col = app.archive_password_cursor_col();
-    let char_count = input.chars().count();
-    let col = cursor_col.min(char_count);
-    let available = input_area.width as usize;
-    let h_start = col.saturating_sub(available);
-    let visible_count = char_count.saturating_sub(h_start).min(available);
-    let visible_text = "*".repeat(visible_count);
+    let masked_input = "*".repeat(input.chars().count());
+    let (visible_text, visible_cursor_col) =
+        helpers::input_window(&masked_input, cursor_col, input_area.width);
 
     let line = if input.is_empty() {
         Line::from(Span::styled(
@@ -73,9 +70,8 @@ pub(super) fn render_archive_password_overlay(
         input_area,
     );
 
-    let visible_cursor_col = col.saturating_sub(h_start);
-    let cursor_x = (input_area.x + visible_cursor_col as u16)
-        .min(input_area.x + input_area.width.saturating_sub(1));
+    let cursor_x =
+        (input_area.x + visible_cursor_col).min(input_area.x + input_area.width.saturating_sub(1));
     frame.set_cursor_position((cursor_x, input_area.y));
 
     if let Some(error) = app.archive_password_error() {

--- a/src/ui/overlay_manager/bulk_rename.rs
+++ b/src/ui/overlay_manager/bulk_rename.rs
@@ -89,22 +89,13 @@ pub(super) fn render_bulk_rename_overlay(
             theme::path_color(&live_path, is_dir, palette),
         );
 
+        let prefix_width = helpers::display_width(icon).saturating_add(2) as u16;
         let text_width = list_area
             .width
-            .saturating_sub(3)
-            .saturating_sub(if show_scrollbar { 2 } else { 0 }) as usize;
-        let chars: Vec<char> = new_name.chars().collect();
-        let col = if is_cursor_line {
-            cursor_col.min(chars.len())
-        } else {
-            0
-        };
-        let h_start = col.saturating_sub(text_width);
-        let mut visible_text: String = chars.iter().skip(h_start).take(text_width).collect();
-        if h_start > 0 && !visible_text.is_empty() {
-            visible_text.remove(0);
-            visible_text.insert(0, '…');
-        }
+            .saturating_sub(prefix_width)
+            .saturating_sub(if show_scrollbar { 2 } else { 0 });
+        let col = if is_cursor_line { cursor_col } else { 0 };
+        let (visible_text, visible_col) = helpers::input_window(new_name, col, text_width);
 
         let text_style = if is_cursor_line {
             Style::default()
@@ -151,8 +142,7 @@ pub(super) fn render_bulk_rename_overlay(
         }
 
         if is_cursor_line {
-            let visible_col = col.saturating_sub(h_start);
-            let cursor_x = (row_rect.x + 3 + visible_col as u16)
+            let cursor_x = (row_rect.x + prefix_width + visible_col)
                 .min(row_rect.x + row_rect.width.saturating_sub(1));
             cursor_screen_pos = Some((cursor_x, row_rect.y));
         }

--- a/src/ui/overlay_manager/create.rs
+++ b/src/ui/overlay_manager/create.rs
@@ -96,23 +96,13 @@ pub(super) fn render_create_overlay(
             )
         };
 
+        let prefix_width = helpers::display_width(icon).saturating_add(2) as u16;
         let text_width = list_area
             .width
-            .saturating_sub(3)
-            .saturating_sub(if show_scrollbar { 2 } else { 0 }) as usize;
-        let chars: Vec<char> = line_text.chars().collect();
-        let col = if is_cursor_line {
-            cursor_col.min(chars.len())
-        } else {
-            0
-        };
-        let h_start = col.saturating_sub(text_width);
-
-        let mut visible_text: String = chars.iter().skip(h_start).take(text_width).collect();
-        if h_start > 0 && !visible_text.is_empty() {
-            visible_text.remove(0);
-            visible_text.insert(0, '…');
-        }
+            .saturating_sub(prefix_width)
+            .saturating_sub(if show_scrollbar { 2 } else { 0 });
+        let col = if is_cursor_line { cursor_col } else { 0 };
+        let (visible_text, visible_col) = helpers::input_window(line_text, col, text_width);
 
         let text_style = if is_cursor_line {
             Style::default()
@@ -171,8 +161,7 @@ pub(super) fn render_create_overlay(
         }
 
         if is_cursor_line {
-            let visible_col = col.saturating_sub(h_start);
-            let cursor_x = row_rect.x + 3 + visible_col as u16;
+            let cursor_x = row_rect.x + prefix_width + visible_col;
             let cursor_x = cursor_x.min(row_rect.x + row_rect.width.saturating_sub(1));
             cursor_screen_pos = Some((cursor_x, row_rect.y));
         }

--- a/src/ui/overlay_manager/rename.rs
+++ b/src/ui/overlay_manager/rename.rs
@@ -48,16 +48,6 @@ pub(super) fn render_rename_overlay(
 
     let input = app.rename_input();
     let cursor_col = app.rename_cursor_col();
-    let chars: Vec<char> = input.chars().collect();
-    let col = cursor_col.min(chars.len());
-    let available = input_area.width.saturating_sub(3) as usize;
-    let h_start = col.saturating_sub(available);
-
-    let mut visible_text: String = chars.iter().skip(h_start).take(available).collect();
-    if h_start > 0 && !visible_text.is_empty() {
-        visible_text.remove(0);
-        visible_text.insert(0, '…');
-    }
 
     let is_dir = app.rename_item_is_dir();
     let live_path = app.navigation.cwd.join(app.rename_input());
@@ -65,6 +55,9 @@ pub(super) fn render_rename_overlay(
         theme::path_symbol(&live_path, is_dir),
         theme::path_color(&live_path, is_dir, palette),
     );
+    let prefix_width = helpers::display_width(icon).saturating_add(2) as u16;
+    let text_width = input_area.width.saturating_sub(prefix_width);
+    let (visible_text, visible_cursor_col) = helpers::input_window(input, cursor_col, text_width);
 
     let line = if input.is_empty() {
         Line::from(vec![
@@ -95,8 +88,7 @@ pub(super) fn render_rename_overlay(
         input_area,
     );
 
-    let visible_cursor_col = col.saturating_sub(h_start);
-    let cursor_x = (input_area.x + 3 + visible_cursor_col as u16)
+    let cursor_x = (input_area.x + prefix_width + visible_cursor_col)
         .min(input_area.x + input_area.width.saturating_sub(1));
     frame.set_cursor_position((cursor_x, input_area.y));
 

--- a/src/ui/overlay_manager/search.rs
+++ b/src/ui/overlay_manager/search.rs
@@ -271,25 +271,13 @@ fn render_query_line(
     origin_x: u16,
     palette: Palette,
 ) -> (Line<'static>, u16) {
-    let chars = query.chars().collect::<Vec<_>>();
-    let cursor = cursor.min(chars.len());
-    let available = width.saturating_sub(3) as usize;
-
-    let mut start = 0usize;
-    if cursor > available {
-        start = cursor - available;
-    }
-    let mut visible = chars.iter().skip(start).take(available).collect::<String>();
-    if start > 0 && !visible.is_empty() {
-        visible.remove(0);
-        visible.insert(0, '…');
-    }
-
-    let visible_chars = visible.chars().collect::<Vec<_>>();
-    let visible_cursor = cursor.saturating_sub(start).min(visible_chars.len());
+    let icon = "󰍉";
+    let prefix_width = helpers::display_width(icon).saturating_add(2) as u16;
+    let (visible, visible_cursor) =
+        helpers::input_window(query, cursor, width.saturating_sub(prefix_width));
 
     let mut spans = vec![
-        Span::styled("󰍉", Style::default().fg(palette.accent)),
+        Span::styled(icon, Style::default().fg(palette.accent)),
         Span::raw("  "),
     ];
     spans.push(Span::styled(
@@ -300,8 +288,8 @@ fn render_query_line(
     ));
 
     let cursor_x = origin_x
-        .saturating_add(3)
-        .saturating_add(visible_cursor as u16)
+        .saturating_add(prefix_width)
+        .saturating_add(visible_cursor)
         .min(origin_x.saturating_add(width.saturating_sub(1)));
     (Line::from(spans), cursor_x)
 }


### PR DESCRIPTION
## Summary

Fix editing very long names in text inputs.

Long names now keep the caret positioned correctly at the end, so typing, deleting, and moving around stays reliable in rename, create, bulk rename, fuzzy find, and `/` filters.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested editing long names in create, rename, bulk rename, fuzzy find, and `/` filters.

Result:

All checks passed locally.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed