### PR TITLE
feat(archive): add password-protected zip creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added ZIP archive creation for the focused item or current selection, with a configurable `create_archive` (`C`) shortcut, editable archive name, background progress, and cancellation. ([#215])
+- Added ZIP archive creation for the focused item or current selection, with editable archive names, optional password protection, background progress, cancellation, and a configurable `create_archive` (`C`) shortcut. ([#215])
 - Added a show/hide control to encrypted archive password prompts.
 
 ### Changed

--- a/src/app/actions/archive.rs
+++ b/src/app/actions/archive.rs
@@ -3,7 +3,7 @@ use crate::app::text_edit::{
     char_to_byte, next_delete_end, next_word_start, previous_delete_start, previous_word_start,
     remove_char_range,
 };
-use crate::archive::ArchivePassword;
+use crate::archive::{ArchiveEncryption, ArchivePassword};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use std::path::PathBuf;
 
@@ -39,13 +39,47 @@ impl App {
         self.overlays.archive_password.is_some()
     }
 
-    pub fn archive_password_archive_name(&self) -> &str {
-        self.overlays
-            .archive_password
-            .as_ref()
-            .and_then(|overlay| overlay.archive_path.file_name())
-            .and_then(|name| name.to_str())
-            .unwrap_or("archive")
+    pub fn archive_password_archive_name(&self) -> String {
+        let Some(overlay) = &self.overlays.archive_password else {
+            return "archive".to_string();
+        };
+        match &overlay.purpose {
+            ArchivePasswordPurpose::Extract { archive_path } => archive_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("archive")
+                .to_string(),
+            ArchivePasswordPurpose::Create => self.archive_create_input().to_string(),
+        }
+    }
+
+    pub fn archive_password_title_prefix(&self) -> &'static str {
+        let Some(overlay) = &self.overlays.archive_password else {
+            return "Password for";
+        };
+        match overlay.purpose {
+            ArchivePasswordPurpose::Extract { .. } => "Password for",
+            ArchivePasswordPurpose::Create
+                if self
+                    .overlays
+                    .archive_create
+                    .as_ref()
+                    .is_some_and(|create| create.options.encryption.is_password_set()) =>
+            {
+                "Change password for"
+            }
+            ArchivePasswordPurpose::Create => "New password for",
+        }
+    }
+
+    pub fn archive_password_placeholder(&self) -> &'static str {
+        let Some(overlay) = &self.overlays.archive_password else {
+            return "password…";
+        };
+        match overlay.purpose {
+            ArchivePasswordPurpose::Extract { .. } => "password…",
+            ArchivePasswordPurpose::Create => "new password…",
+        }
     }
 
     pub fn archive_password_input(&self) -> &str {
@@ -85,7 +119,7 @@ impl App {
         self.overlays.open_with = None;
         self.overlays.search = None;
         self.overlays.archive_password = Some(ArchivePasswordOverlay {
-            archive_path,
+            purpose: ArchivePasswordPurpose::Extract { archive_path },
             input: String::new(),
             cursor_col: 0,
             visible: false,
@@ -288,9 +322,22 @@ impl App {
             return Ok(());
         }
 
-        let archive_path = overlay.archive_path.clone();
-        if self.start_archive_extract(archive_path, Some(ArchivePassword::new(password)))? {
-            self.overlays.archive_password = None;
+        match &overlay.purpose {
+            ArchivePasswordPurpose::Extract { archive_path } => {
+                let archive_path = archive_path.clone();
+                if self.start_archive_extract(archive_path, Some(ArchivePassword::new(password)))? {
+                    self.overlays.archive_password = None;
+                }
+            }
+            ArchivePasswordPurpose::Create => {
+                if let Some(overlay) = &mut self.overlays.archive_create {
+                    overlay.options.encryption =
+                        ArchiveEncryption::Password(ArchivePassword::new(password));
+                    overlay.error = None;
+                    self.status.clear();
+                }
+                self.overlays.archive_password = None;
+            }
         }
         Ok(())
     }

--- a/src/app/actions/archive_create.rs
+++ b/src/app/actions/archive_create.rs
@@ -4,7 +4,7 @@ use crate::app::text_edit::{
     char_to_byte, next_delete_end, next_word_start, previous_delete_start, previous_word_start,
     remove_char_range,
 };
-use crate::archive::normalize_zip_output_name;
+use crate::archive::{ArchiveEncryption, CreateArchiveOptions, normalize_zip_output_name};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use std::path::PathBuf;
 
@@ -39,6 +39,32 @@ impl App {
             .archive_create
             .as_ref()
             .and_then(|overlay| overlay.error.as_deref())
+    }
+
+    pub fn archive_create_protection_label(&self) -> &'static str {
+        let Some(overlay) = &self.overlays.archive_create else {
+            return "";
+        };
+        if overlay.options.format.supports_encryption()
+            && overlay.options.encryption.is_password_set()
+        {
+            "Password set"
+        } else {
+            ""
+        }
+    }
+
+    pub fn archive_create_protection_hint(&self) -> &'static str {
+        let Some(overlay) = &self.overlays.archive_create else {
+            return "";
+        };
+        if !overlay.options.format.supports_encryption() {
+            ""
+        } else if overlay.options.encryption.is_password_set() {
+            "Alt+P change  Alt+R remove"
+        } else {
+            "Alt+P add password"
+        }
     }
 
     pub fn archive_create_source_names(&self) -> &[String] {
@@ -98,6 +124,7 @@ impl App {
             source_scroll: 0,
             cursor_col,
             input: default_name,
+            options: CreateArchiveOptions::default(),
             error: None,
         });
         self.status.clear();
@@ -132,6 +159,18 @@ impl App {
             KeyCode::Esc => self.overlays.archive_create = None,
             KeyCode::Enter if key.modifiers == KeyModifiers::NONE => {
                 self.confirm_archive_create()?
+            }
+            KeyCode::Char('p' | 'P')
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.open_archive_create_password_prompt();
+            }
+            KeyCode::Char('r' | 'R')
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.remove_archive_create_password();
             }
             KeyCode::PageUp if key.modifiers == KeyModifiers::NONE => {
                 self.scroll_archive_create_sources_by(-8, 8);
@@ -338,21 +377,28 @@ impl App {
             }
         };
         let sources = overlay.sources.clone();
-        if self.start_archive_create(sources, output_name)? {
+        let options = overlay.options.clone();
+        if self.start_archive_create(sources, output_name, options)? {
             self.overlays.archive_create = None;
         }
         Ok(())
     }
 
-    fn start_archive_create(&mut self, sources: Vec<PathBuf>, output_name: String) -> Result<bool> {
+    fn start_archive_create(
+        &mut self,
+        sources: Vec<PathBuf>,
+        output_name: String,
+        options: CreateArchiveOptions,
+    ) -> Result<bool> {
         if self.jobs.archive_create_progress.is_some() {
             self.status = "Archive creation already in progress".to_string();
             return Ok(false);
         }
-        if let Err(error) = crate::archive::plan_create_zip_archive(
+        if let Err(error) = crate::archive::plan_create_archive(
             &self.navigation.cwd,
             sources.clone(),
             &output_name,
+            options.clone(),
         ) {
             if let Some(overlay) = &mut self.overlays.archive_create {
                 overlay.error = Some(error.to_string());
@@ -380,6 +426,7 @@ impl App {
                 cwd: self.navigation.cwd.clone(),
                 sources,
                 output_name,
+                options,
             });
         if !submitted {
             self.jobs.archive_create_progress = None;
@@ -390,6 +437,43 @@ impl App {
         }
         self.clear_selection();
         Ok(true)
+    }
+
+    fn open_archive_create_password_prompt(&mut self) {
+        let Some(overlay) = &self.overlays.archive_create else {
+            return;
+        };
+        if !overlay.options.format.supports_encryption() {
+            if let Some(overlay) = &mut self.overlays.archive_create {
+                overlay.error = Some(format!(
+                    "{} does not support password protection",
+                    overlay.options.format.label()
+                ));
+            }
+            return;
+        }
+        let input = match &overlay.options.encryption {
+            ArchiveEncryption::Password(password) => password.as_str().to_string(),
+            ArchiveEncryption::None => String::new(),
+        };
+        let cursor_col = input.chars().count();
+        self.overlays.archive_password = Some(ArchivePasswordOverlay {
+            purpose: ArchivePasswordPurpose::Create,
+            input,
+            cursor_col,
+            visible: false,
+            error: None,
+        });
+    }
+
+    fn remove_archive_create_password(&mut self) {
+        if let Some(overlay) = &mut self.overlays.archive_create
+            && overlay.options.encryption.is_password_set()
+        {
+            overlay.options.encryption = ArchiveEncryption::None;
+            overlay.error = None;
+            self.status = "Archive password removed".to_string();
+        }
     }
 }
 

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -86,12 +86,12 @@ impl App {
             return self.handle_restore_key(key);
         }
 
-        if self.overlays.archive_create.is_some() {
-            return self.handle_archive_create_key(key);
-        }
-
         if self.overlays.archive_password.is_some() {
             return self.handle_archive_password_key(key);
+        }
+
+        if self.overlays.archive_create.is_some() {
+            return self.handle_archive_create_key(key);
         }
 
         if self.overlays.create.is_some() {

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -12,12 +12,12 @@ impl App {
             return self.handle_restore_mouse(mouse);
         }
 
-        if self.overlays.archive_create.is_some() {
-            return self.handle_archive_create_mouse(mouse);
-        }
-
         if self.overlays.archive_password.is_some() {
             return self.handle_archive_password_mouse(mouse);
+        }
+
+        if self.overlays.archive_create.is_some() {
+            return self.handle_archive_create_mouse(mouse);
         }
 
         if self.overlays.create.is_some() {

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -3,7 +3,7 @@ use super::helpers::{
     temp_path, wait_for_directory_load, write_binary_zip_entries,
     write_encrypted_seven_zip_entries, write_encrypted_zip_entries,
 };
-use std::{fs, thread, time::Duration};
+use std::{fs, io::Read, thread, time::Duration};
 
 #[test]
 fn e_extracts_focused_zip_archive() {
@@ -302,6 +302,106 @@ fn c_create_archive_clears_selection_when_started() {
         app.selected_entry().map(|entry| entry.path.as_path()),
         Some(archive.as_path())
     );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn archive_create_password_returns_to_create_overlay_before_creating() {
+    let root = temp_path("create-protected-zip");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('C'))))
+        .expect("C should open archive creation");
+    assert_eq!(app.archive_create_protection_label(), "");
+    assert_eq!(app.archive_create_protection_hint(), "Alt+P add password");
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('p'),
+        KeyModifiers::ALT,
+    )))
+    .expect("Alt+P should open password prompt");
+    assert!(app.archive_password_is_open());
+    assert_eq!(app.archive_password_title_prefix(), "New password for");
+
+    let password = archive_test_password(&root);
+    type_archive_password(&mut app, &password);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("password Enter should return to create overlay");
+
+    assert!(!app.archive_password_is_open());
+    assert!(app.archive_create_is_open());
+    assert!(!root.join("alpha.zip").exists());
+    assert_eq!(app.archive_create_protection_label(), "Password set");
+    assert_eq!(
+        app.archive_create_protection_hint(),
+        "Alt+P change  Alt+R remove"
+    );
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("create Enter should start archive creation");
+
+    let archive = root.join("alpha.txt.zip");
+    for _ in 0..200 {
+        let _ = app.process_background_jobs();
+        if archive.exists() && app.jobs.archive_create_progress.is_none() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.status_message(), "Created protected \"alpha.txt.zip\"");
+    let file = fs::File::open(&archive).expect("archive should exist");
+    let mut zip = zip::ZipArchive::new(file).expect("created archive should be a ZIP");
+    assert!(zip.by_name("alpha.txt").is_err());
+    let mut entry = zip
+        .by_name_decrypt("alpha.txt", password.as_bytes())
+        .expect("password should decrypt archived file");
+    let mut contents = String::new();
+    entry
+        .read_to_string(&mut contents)
+        .expect("encrypted entry should be readable");
+    assert_eq!(contents, "alpha");
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn archive_create_password_can_be_removed_before_creating() {
+    let root = temp_path("create-remove-password");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("alpha.txt"), "alpha").expect("failed to write alpha");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('C'))))
+        .expect("C should open archive creation");
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('p'),
+        KeyModifiers::ALT,
+    )))
+    .expect("Alt+P should open password prompt");
+    type_archive_password(&mut app, &archive_test_password(&root));
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("password Enter should return to create overlay");
+    assert_eq!(app.archive_create_protection_label(), "Password set");
+
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('r'),
+        KeyModifiers::ALT,
+    )))
+    .expect("Alt+R should remove password");
+
+    assert_eq!(app.archive_create_protection_label(), "");
+    assert_eq!(app.archive_create_protection_hint(), "Alt+P add password");
+    assert_eq!(app.status_message(), "Archive password removed");
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/app/jobs/tasks/archive_create.rs
+++ b/src/app/jobs/tasks/archive_create.rs
@@ -125,10 +125,11 @@ fn run_create(
     let mut last_progress_at: Option<Instant> = None;
     let stopped_early = AtomicBool::new(false);
 
-    let result = crate::archive::plan_create_zip_archive(
+    let result = crate::archive::plan_create_archive(
         &request.cwd,
         request.sources.clone(),
         &request.output_name,
+        request.options.clone(),
     )
     .and_then(|plan| {
         crate::archive::create_zip_archive(
@@ -161,16 +162,19 @@ fn run_create(
             Some("Archive creation cancelled".to_string()),
         ),
         Ok(summary) => {
+            let protected = request.options.encryption.is_password_set();
             let name = summary
                 .output_path
                 .file_name()
                 .and_then(|name| name.to_str())
                 .unwrap_or("archive.zip")
                 .to_string();
-            (
-                Some(summary.output_path),
-                Some(format!("Created \"{name}\"")),
-            )
+            let status = if protected {
+                format!("Created protected \"{name}\"")
+            } else {
+                format!("Created \"{name}\"")
+            };
+            (Some(summary.output_path), Some(status))
         }
         Err(error) if stopped_early.load(Ordering::Relaxed) => (None, Some(error.to_string())),
         Err(error) => {

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -262,6 +262,7 @@ pub(in crate::app) struct ArchiveCreateRequest {
     pub(in crate::app) cwd: PathBuf,
     pub(in crate::app) sources: Vec<PathBuf>,
     pub(in crate::app) output_name: String,
+    pub(in crate::app) options: crate::archive::CreateArchiveOptions,
 }
 
 #[derive(Debug)]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -155,18 +155,26 @@ pub(super) struct RestoreOverlay {
     pub(super) confirmed: bool,
 }
 
+#[derive(Debug)]
 pub(super) struct ArchiveCreateOverlay {
     pub(super) sources: Vec<PathBuf>,
     pub(super) source_names: Vec<String>,
     pub(super) source_scroll: usize,
     pub(super) input: String,
     pub(super) cursor_col: usize,
+    pub(super) options: crate::archive::CreateArchiveOptions,
     pub(super) error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum ArchivePasswordPurpose {
+    Extract { archive_path: PathBuf },
+    Create,
 }
 
 #[derive(Clone)]
 pub(super) struct ArchivePasswordOverlay {
-    pub(super) archive_path: PathBuf,
+    pub(super) purpose: ArchivePasswordPurpose,
     pub(super) input: String,
     pub(super) cursor_col: usize,
     pub(super) visible: bool,
@@ -176,7 +184,7 @@ pub(super) struct ArchivePasswordOverlay {
 impl fmt::Debug for ArchivePasswordOverlay {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ArchivePasswordOverlay")
-            .field("archive_path", &self.archive_path)
+            .field("purpose", &self.purpose)
             .field("input", &"<redacted>")
             .field("cursor_col", &self.cursor_col)
             .field("visible", &self.visible)

--- a/src/archive/create.rs
+++ b/src/archive/create.rs
@@ -1,3 +1,4 @@
+use super::extract::ArchivePassword;
 use anyhow::{Context, Result, anyhow, bail};
 use std::{
     collections::BTreeSet,
@@ -5,12 +6,66 @@ use std::{
     io,
     path::{Component, Path, PathBuf},
 };
-use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+use zip::{AesMode, CompressionMethod, ZipWriter, write::FileOptions};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CreateArchiveFormat {
+    Zip,
+}
+
+impl CreateArchiveFormat {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Zip => "ZIP",
+        }
+    }
+
+    pub(crate) fn supports_encryption(self) -> bool {
+        match self {
+            Self::Zip => true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ArchiveEncryption {
+    None,
+    Password(ArchivePassword),
+}
+
+impl ArchiveEncryption {
+    pub(crate) fn is_password_set(&self) -> bool {
+        matches!(self, Self::Password(_))
+    }
+
+    fn password(&self) -> Option<&ArchivePassword> {
+        match self {
+            Self::None => None,
+            Self::Password(password) => Some(password),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CreateArchiveOptions {
+    pub(crate) format: CreateArchiveFormat,
+    pub(crate) encryption: ArchiveEncryption,
+}
+
+impl Default for CreateArchiveOptions {
+    fn default() -> Self {
+        Self {
+            format: CreateArchiveFormat::Zip,
+            encryption: ArchiveEncryption::None,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct CreateArchivePlan {
     pub(crate) sources: Vec<PathBuf>,
     pub(crate) output_path: PathBuf,
+    pub(crate) options: CreateArchiveOptions,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -54,15 +109,31 @@ pub(crate) fn normalize_zip_output_name(input: &str) -> Result<String> {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn plan_create_zip_archive(
     cwd: &Path,
     sources: Vec<PathBuf>,
     output_name: &str,
 ) -> Result<CreateArchivePlan> {
+    plan_create_archive(cwd, sources, output_name, CreateArchiveOptions::default())
+}
+
+pub(crate) fn plan_create_archive(
+    cwd: &Path,
+    sources: Vec<PathBuf>,
+    output_name: &str,
+    options: CreateArchiveOptions,
+) -> Result<CreateArchivePlan> {
     if sources.is_empty() {
         bail!("Select items to archive");
     }
     let output_name = normalize_zip_output_name(output_name)?;
+    if options.encryption.is_password_set() && !options.format.supports_encryption() {
+        bail!(
+            "{} does not support password protection",
+            options.format.label()
+        );
+    }
     let output_path = cwd.join(output_name);
     if fs::symlink_metadata(&output_path).is_ok() {
         let name = output_path
@@ -95,6 +166,7 @@ pub(crate) fn plan_create_zip_archive(
     Ok(CreateArchivePlan {
         sources,
         output_path,
+        options,
     })
 }
 
@@ -123,21 +195,27 @@ where
         }
     };
 
-    let result = write_zip_archive(file, &plan.sources, total, &mut progress, cancelled).and_then(
-        |completed| {
-            fs::rename(&staging_path, &plan.output_path).with_context(|| {
-                format!(
-                    "Could not move {} to {}",
-                    staging_path.display(),
-                    plan.output_path.display()
-                )
-            })?;
-            Ok(CreateArchiveSummary {
-                output_path: plan.output_path.clone(),
-                completed,
-            })
-        },
-    );
+    let result = write_zip_archive(
+        file,
+        &plan.sources,
+        total,
+        plan.options.encryption.password(),
+        &mut progress,
+        cancelled,
+    )
+    .and_then(|completed| {
+        fs::rename(&staging_path, &plan.output_path).with_context(|| {
+            format!(
+                "Could not move {} to {}",
+                staging_path.display(),
+                plan.output_path.display()
+            )
+        })?;
+        Ok(CreateArchiveSummary {
+            output_path: plan.output_path.clone(),
+            completed,
+        })
+    });
 
     if result.is_err() {
         let _ = fs::remove_file(&staging_path);
@@ -150,6 +228,7 @@ fn write_zip_archive<F, C>(
     file: File,
     sources: &[PathBuf],
     total: usize,
+    password: Option<&ArchivePassword>,
     progress: &mut F,
     cancelled: C,
 ) -> Result<usize>
@@ -159,6 +238,7 @@ where
 {
     let mut writer = ZipWriter::new(file);
     let mut completed = 0usize;
+    let settings = ZipCreateSettings { total, password };
     let mut sorted_sources = sources.to_vec();
     sorted_sources.sort_by_key(|source| archive_name(source));
 
@@ -169,7 +249,7 @@ where
             &source,
             Path::new(&root_name),
             &mut completed,
-            total,
+            settings,
             progress,
             &cancelled,
         )?;
@@ -179,12 +259,18 @@ where
     Ok(completed)
 }
 
+#[derive(Clone, Copy)]
+struct ZipCreateSettings<'a> {
+    total: usize,
+    password: Option<&'a ArchivePassword>,
+}
+
 fn add_path_to_zip<F, C>(
     writer: &mut ZipWriter<File>,
     source: &Path,
     archive_path: &Path,
     completed: &mut usize,
-    total: usize,
+    settings: ZipCreateSettings<'_>,
     progress: &mut F,
     cancelled: &C,
 ) -> Result<()>
@@ -199,15 +285,15 @@ where
     let metadata = fs::symlink_metadata(source)
         .with_context(|| format!("Could not inspect {}", source.display()))?;
     if metadata.file_type().is_symlink() {
-        add_symlink(writer, source, archive_path, completed, total, progress)?;
+        add_symlink(writer, source, archive_path, completed, settings, progress)?;
         return Ok(());
     }
     if metadata.is_dir() {
-        add_directory(writer, archive_path, &metadata)?;
+        add_directory(writer, archive_path, &metadata, settings.password)?;
         *completed += 1;
         progress(CreateArchiveProgress {
             completed: *completed,
-            total,
+            total: settings.total,
         });
         let mut children = fs::read_dir(source)
             .with_context(|| format!("Could not read {}", source.display()))?
@@ -221,7 +307,7 @@ where
                 &child.path(),
                 &child_archive_path,
                 completed,
-                total,
+                settings,
                 progress,
                 cancelled,
             )?;
@@ -229,11 +315,11 @@ where
         return Ok(());
     }
     if metadata.is_file() {
-        add_file(writer, source, archive_path, &metadata)?;
+        add_file(writer, source, archive_path, &metadata, settings.password)?;
         *completed += 1;
         progress(CreateArchiveProgress {
             completed: *completed,
-            total,
+            total: settings.total,
         });
         return Ok(());
     }
@@ -250,10 +336,11 @@ fn add_file(
     source: &Path,
     archive_path: &Path,
     metadata: &fs::Metadata,
+    password: Option<&ArchivePassword>,
 ) -> Result<()> {
     let name = zip_entry_name(archive_path, false)?;
     writer
-        .start_file(name, file_options(metadata))
+        .start_file(name, file_options(metadata, password))
         .context("Could not write ZIP entry")?;
     let mut input =
         File::open(source).with_context(|| format!("Could not open {}", source.display()))?;
@@ -265,10 +352,11 @@ fn add_directory(
     writer: &mut ZipWriter<File>,
     archive_path: &Path,
     metadata: &fs::Metadata,
+    password: Option<&ArchivePassword>,
 ) -> Result<()> {
     let name = zip_entry_name(archive_path, true)?;
     writer
-        .add_directory(name, file_options(metadata))
+        .add_directory(name, file_options(metadata, password))
         .context("Could not write ZIP directory")?;
     Ok(())
 }
@@ -278,7 +366,7 @@ fn add_symlink<F>(
     source: &Path,
     archive_path: &Path,
     completed: &mut usize,
-    total: usize,
+    settings: ZipCreateSettings<'_>,
     progress: &mut F,
 ) -> Result<()>
 where
@@ -287,9 +375,12 @@ where
     let target = fs::read_link(source)
         .with_context(|| format!("Could not read symlink {}", source.display()))?;
     let name = zip_entry_name(archive_path, false)?;
-    let options = SimpleFileOptions::default()
-        .compression_method(CompressionMethod::Stored)
-        .unix_permissions(0o120777);
+    let options = apply_zip_encryption(
+        FileOptions::default()
+            .compression_method(CompressionMethod::Stored)
+            .unix_permissions(0o120777),
+        settings.password,
+    );
     writer
         .start_file(name, options)
         .context("Could not write ZIP symlink")?;
@@ -298,22 +389,38 @@ where
     *completed += 1;
     progress(CreateArchiveProgress {
         completed: *completed,
-        total,
+        total: settings.total,
     });
     Ok(())
 }
 
-fn file_options(metadata: &fs::Metadata) -> SimpleFileOptions {
-    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        options.unix_permissions(metadata.permissions().mode())
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = metadata;
-        options
+fn file_options<'a>(
+    metadata: &fs::Metadata,
+    password: Option<&'a ArchivePassword>,
+) -> FileOptions<'a, ()> {
+    let options = FileOptions::default().compression_method(CompressionMethod::Stored);
+    let options = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            options.unix_permissions(metadata.permissions().mode())
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = metadata;
+            options
+        }
+    };
+    apply_zip_encryption(options, password)
+}
+
+fn apply_zip_encryption<'a>(
+    options: FileOptions<'a, ()>,
+    password: Option<&'a ArchivePassword>,
+) -> FileOptions<'a, ()> {
+    match password {
+        Some(password) => options.with_aes_encryption(AesMode::Aes256, password.as_str()),
+        None => options,
     }
 }
 

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -48,6 +48,10 @@ impl ArchivePassword {
         Self(password.into())
     }
 
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
     fn as_seven_zip_password(&self) -> SevenZipPassword {
         SevenZipPassword::new(&self.0)
     }

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -3,7 +3,8 @@ mod extract;
 mod format;
 
 pub(crate) use self::create::{
-    create_zip_archive, normalize_zip_output_name, plan_create_zip_archive,
+    ArchiveEncryption, CreateArchiveOptions, create_zip_archive, normalize_zip_output_name,
+    plan_create_archive,
 };
 pub(crate) use self::extract::{
     ArchivePassword, ExtractError, extract_archive_with_password, plan_extract,

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -905,6 +905,37 @@ fn bulk_rename_overlay_scrolls_to_keep_the_active_row_visible() {
 }
 
 #[test]
+fn archive_create_overlay_adapts_contents_to_short_terminals() {
+    let root = temp_path("archive-create-short-terminal");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("source.txt"), "alpha").expect("failed to write source");
+
+    for (height, shows_contents) in [(8, false), (10, true)] {
+        let mut app = App::new_at(root.clone()).expect("app should load temp directory");
+        app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('C'))))
+            .expect("archive create overlay should open");
+        let mut terminal =
+            Terminal::new(TestBackend::new(94, height)).expect("terminal should init");
+
+        let state = draw_ui(&mut terminal, &mut app);
+        let panel = state
+            .archive_create_panel
+            .expect("archive create panel should render");
+
+        assert_eq!(
+            state.archive_create_list_area.is_some(),
+            shows_contents,
+            "contents visibility should track whether a complete row fits at height {height}"
+        );
+        if !shows_contents {
+            assert_eq!(panel.height, 6, "compact popup should not leave dead rows");
+        }
+    }
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn copy_overlay_renders_expected_labels_and_hit_rects() {
     let root = temp_path("copy-overlay-render");
     fs::create_dir_all(root.join("docs")).expect("failed to create docs dir");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -92,10 +92,10 @@ pub fn render(frame: &mut Frame<'_>, app: &App, state: &mut FrameState) {
         overlay_manager::render_trash_overlay(frame, area, app, state, palette);
     } else if app.restore_is_open() {
         overlay_manager::render_restore_overlay(frame, area, app, state, palette);
-    } else if app.archive_create_is_open() {
-        overlay_manager::render_archive_create_overlay(frame, area, app, state, palette);
     } else if app.archive_password_is_open() {
         overlay_manager::render_archive_password_overlay(frame, area, app, state, palette);
+    } else if app.archive_create_is_open() {
+        overlay_manager::render_archive_create_overlay(frame, area, app, state, palette);
     } else if app.create_is_open() {
         overlay_manager::render_create_overlay(frame, area, app, state, palette);
     } else if app.rename_is_open() {

--- a/src/ui/overlay_manager/archive_create.rs
+++ b/src/ui/overlay_manager/archive_create.rs
@@ -20,11 +20,26 @@ pub(super) fn render_archive_create_overlay(
     palette: Palette,
 ) {
     let item_count = app.archive_create_source_names().len();
-    let has_error = app.archive_create_error().is_some();
-    let visible_lines = edit_overlay_visible_rows(area, item_count, 7 + u16::from(has_error));
+    let visible_lines = edit_overlay_visible_rows(area, item_count, 8);
     let popup_width = area.width.saturating_sub(8).clamp(40, 68);
-    let popup_height = visible_lines + 7 + u16::from(has_error);
-    let popup = helpers::centered_rect(area, popup_width, popup_height);
+    let max_height = (visible_lines + 8).min(area.height.max(4));
+    let inner_height = max_height.saturating_sub(2);
+    let footer_height = u16::from(inner_height >= 4);
+    let content_lines = inner_height
+        .saturating_sub(3 + footer_height + 2)
+        .min(visible_lines);
+    let content_height = if content_lines > 0 {
+        content_lines + 2
+    } else {
+        0
+    };
+    let popup_height = (3 + content_height + footer_height).saturating_add(2);
+    let popup = Rect {
+        x: area.x + area.width.saturating_sub(popup_width) / 2,
+        y: area.y + area.height.saturating_sub(popup_height) / 2,
+        width: popup_width.min(area.width),
+        height: popup_height,
+    };
     state.archive_create_panel = Some(popup);
 
     frame.render_widget(Clear, popup);
@@ -38,30 +53,56 @@ pub(super) fn render_archive_create_overlay(
     );
 
     let inner = helpers::inner_with_padding(popup);
-    let error_height = u16::from(has_error);
+
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
-            Constraint::Length(error_height),
-            Constraint::Length(visible_lines + 2),
+            Constraint::Length(content_height),
+            Constraint::Length(footer_height),
         ])
         .split(inner);
 
     render_name_input(frame, rows[0], app, palette);
+    if content_lines > 0 {
+        render_contents_list(frame, rows[1], app, state, palette, content_lines as usize);
+    }
+    if footer_height > 0 {
+        render_protection_row(frame, rows[2], app, palette);
+    }
+}
 
+fn render_protection_row(frame: &mut Frame<'_>, area: Rect, app: &App, palette: Palette) {
     if let Some(error) = app.archive_create_error() {
         frame.render_widget(
             Paragraph::new(Line::from(vec![Span::styled(
-                helpers::clamp_label(error, rows[1].width.saturating_sub(2) as usize),
+                helpers::clamp_label(error, area.width as usize),
                 Style::default().fg(palette.accent),
             )]))
             .style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
-            rows[1],
+            area,
         );
+        return;
     }
 
-    render_contents_list(frame, rows[2], app, state, palette, visible_lines as usize);
+    let label = app.archive_create_protection_label();
+    let hint = app.archive_create_protection_hint();
+    let hint_width = hint.chars().count() as u16;
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(hint_width)])
+        .split(area);
+
+    frame.render_widget(
+        Paragraph::new(label).style(Style::default().bg(palette.chrome_alt).fg(palette.text)),
+        columns[0],
+    );
+    if !hint.is_empty() {
+        frame.render_widget(
+            Paragraph::new(hint).style(Style::default().bg(palette.chrome_alt).fg(palette.muted)),
+            columns[1],
+        );
+    }
 }
 
 fn render_name_input(frame: &mut Frame<'_>, area: Rect, app: &App, palette: Palette) {

--- a/src/ui/overlay_manager/archive_password.rs
+++ b/src/ui/overlay_manager/archive_password.rs
@@ -17,8 +17,9 @@ pub(super) fn render_archive_password_overlay(
 ) {
     let archive_name = app.archive_password_archive_name();
     let block_title = format!(
-        " Password for \"{}\" ",
-        helpers::clamp_label(archive_name, 30)
+        " {} \"{}\" ",
+        app.archive_password_title_prefix(),
+        helpers::clamp_label(&archive_name, 30)
     );
     let popup_width = area.width.saturating_sub(8).clamp(40, 64);
     let popup_height = if area.height >= 4 {
@@ -83,7 +84,7 @@ pub(super) fn render_archive_password_overlay(
 
     let line = if input.is_empty() {
         Line::from(Span::styled(
-            "password…",
+            app.archive_password_placeholder(),
             Style::default().fg(palette.muted),
         ))
     } else {


### PR DESCRIPTION
## Summary

Add optional password protection to ZIP archive creation.

The archive creation overlay now lets users set, change, or remove a password before creating the archive, then creates the protected ZIP in the background with the same progress and cancellation flow.

Refs #215.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed