### PR TITLE
style(ui): simplify help overlay hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Made create and bulk rename overlays show more rows before scrolling, adapt better on short terminals, and use consistent scrollbar styling.
+- Dimmed help overlay key separators and removed the bottom close hint.
 
 ## [1.10.0] - 2026-06-30
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1478,12 +1478,8 @@ fn compact_help_overlay_scrolls_instead_of_truncating_small_terminals() {
         "compact help should start with the first section, got: {rendered:?}"
     );
     assert!(
-        rendered.contains("? / Esc") && rendered.contains("close help"),
-        "compact help should keep the original footer, got: {rendered:?}"
-    );
-    assert!(
-        !rendered.contains("scroll") && !rendered.contains("PgUp/PgDn"),
-        "compact help should not add scrolling hints to the footer, got: {rendered:?}"
+        !rendered.contains("? / Esc") && !rendered.contains("close help"),
+        "compact help should not render an obvious close footer, got: {rendered:?}"
     );
     assert!(
         rendered.contains("┃"),
@@ -1518,8 +1514,8 @@ fn compact_help_overlay_scrolls_instead_of_truncating_small_terminals() {
         "compact help should keep late sections reachable, got: {rendered:?}"
     );
     assert!(
-        rendered.contains("?/Esc") || rendered.contains("? / Esc"),
-        "compact help should keep the close hint visible, got: {rendered:?}"
+        !rendered.contains("?/Esc") && !rendered.contains("? / Esc"),
+        "compact help should not keep the obvious close hint visible, got: {rendered:?}"
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -553,17 +553,29 @@ fn help_entry_lines(
     let continuation = " ".repeat(key_width + 2);
     let mut lines = Vec::with_capacity(wrapped_action.len());
 
-    lines.push(Line::from(vec![
-        Span::styled(
-            key,
-            Style::default()
-                .fg(palette.accent_text)
-                .add_modifier(Modifier::BOLD),
-        ),
+    let key_style = Style::default()
+        .fg(palette.accent_text)
+        .add_modifier(Modifier::BOLD);
+    let separator_style = Style::default().fg(palette.muted);
+    let key_len = key.chars().count();
+    let mut spans: Vec<_> = key
+        .chars()
+        .enumerate()
+        .map(|(i, ch)| {
+            let style = if ch == '/' && i > 0 && i + 1 < key_len {
+                separator_style
+            } else {
+                key_style
+            };
+            Span::styled(ch.to_string(), style)
+        })
+        .collect();
+    spans.extend([
         Span::raw(key_padding),
         Span::raw("  "),
         Span::styled(wrapped_action.remove(0), Style::default().fg(palette.muted)),
-    ]));
+    ]);
+    lines.push(Line::from(spans));
 
     for line in wrapped_action {
         lines.push(Line::from(vec![

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -4,7 +4,7 @@ use crate::config::{KeyBindings, KeyList};
 use crate::ui::{helpers, theme::Palette};
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap},
@@ -126,7 +126,7 @@ pub(super) fn render_help(
     } else {
         area.width.saturating_sub(4).clamp(44, 90)
     };
-    let popup_height = area.height.saturating_sub(2).clamp(10, 37);
+    let popup_height = area.height.saturating_sub(3).clamp(9, 36);
     let popup = helpers::centered_rect(area, popup_width, popup_height);
     state.help_panel = Some(popup);
     frame.render_widget(Clear, popup);
@@ -155,24 +155,16 @@ pub(super) fn render_help(
     );
 
     let inner = helpers::inner_with_padding(popup);
-    let rows = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
-
-    if rows[0].width >= 88 && rows[0].height >= 33 {
-        render_wide_help(frame, rows[0], rows[1], &sections, state, palette);
+    if inner.width >= 88 && inner.height >= 33 {
+        render_wide_help(frame, inner, &sections, state, palette);
     } else {
-        render_compact_help(
-            frame, rows[0], rows[1], &sections, scroll_top, state, palette,
-        );
+        render_compact_help(frame, inner, &sections, scroll_top, state, palette);
     }
 }
 
 fn render_wide_help(
     frame: &mut Frame<'_>,
     body: Rect,
-    footer: Rect,
     sections: &[HelpSection],
     state: &mut FrameState,
     palette: Palette,
@@ -211,13 +203,11 @@ fn render_wide_help(
             .wrap(Wrap { trim: false }),
         cols[2],
     );
-    render_help_footer(frame, footer, palette);
 }
 
 fn render_compact_help(
     frame: &mut Frame<'_>,
     body: Rect,
-    footer: Rect,
     sections: &[HelpSection],
     scroll_top: usize,
     state: &mut FrameState,
@@ -255,7 +245,6 @@ fn render_compact_help(
     if let Some(area) = scrollbar {
         render_overlay_scrollbar(frame, area, total, visible, scroll_top, palette);
     }
-    render_help_footer(frame, footer, palette);
 }
 
 fn flowing_help_lines(
@@ -303,24 +292,6 @@ fn line_width(line: &Line<'_>) -> usize {
         .iter()
         .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
         .sum()
-}
-
-fn render_help_footer(frame: &mut Frame<'_>, area: Rect, palette: Palette) {
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(
-                "? / Esc",
-                Style::default()
-                    .fg(palette.accent)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(" "),
-            Span::styled("close help", Style::default().fg(palette.muted)),
-        ]))
-        .alignment(Alignment::Right)
-        .style(Style::default().bg(palette.chrome_alt).fg(palette.muted)),
-        area,
-    );
 }
 
 impl HelpMode {


### PR DESCRIPTION
## Summary

Simplify the help overlay hints.

Key separator slashes are now dimmer so multiple bindings read more clearly, and the bottom close hint footer was removed to keep the overlay cleaner.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed