### PR TITLE
feat(archive): add tar archive creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added ZIP archive creation for the focused item or current selection, with editable archive names, optional password protection, background progress, cancellation, and a configurable `create_archive` (`C`) shortcut. ([#215])
+- Added archive creation for the focused item or current selection, with editable archive names, background progress, cancellation, and a configurable `create_archive` (`C`) shortcut. ([#215])
+- Added ZIP password protection for archive creation. ([#215])
+- Added TAR, TAR.GZ, and TGZ output formats for archive creation. ([#215])
 - Added a show/hide control to encrypted archive password prompts.
 
 ### Changed

--- a/src/app/actions/archive_create.rs
+++ b/src/app/actions/archive_create.rs
@@ -4,7 +4,9 @@ use crate::app::text_edit::{
     char_to_byte, next_delete_end, next_word_start, previous_delete_start, previous_word_start,
     remove_char_range,
 };
-use crate::archive::{ArchiveEncryption, CreateArchiveOptions, normalize_zip_output_name};
+use crate::archive::{
+    ArchiveEncryption, CreateArchiveFormat, CreateArchiveOptions, normalize_archive_output_name,
+};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use std::path::PathBuf;
 
@@ -45,9 +47,7 @@ impl App {
         let Some(overlay) = &self.overlays.archive_create else {
             return "";
         };
-        if overlay.options.format.supports_encryption()
-            && overlay.options.encryption.is_password_set()
-        {
+        if overlay.options.encryption.is_password_set() {
             "Password set"
         } else {
             ""
@@ -58,12 +58,21 @@ impl App {
         let Some(overlay) = &self.overlays.archive_create else {
             return "";
         };
-        if !overlay.options.format.supports_encryption() {
-            ""
-        } else if overlay.options.encryption.is_password_set() {
-            "Alt+P change  Alt+R remove"
-        } else {
-            "Alt+P add password"
+        match archive_create_effective_format(overlay) {
+            Some(format) if format.supports_encryption() => {
+                if overlay.options.encryption.is_password_set() {
+                    "Alt+P change  Alt+R remove"
+                } else {
+                    "Alt+P add password"
+                }
+            }
+            Some(_) | None => {
+                if overlay.options.encryption.is_password_set() {
+                    "Switch format or remove"
+                } else {
+                    ""
+                }
+            }
         }
     }
 
@@ -367,8 +376,8 @@ impl App {
         let Some(overlay) = &self.overlays.archive_create else {
             return Ok(());
         };
-        let output_name = match normalize_zip_output_name(&overlay.input) {
-            Ok(name) => name,
+        let (output_name, format) = match normalize_archive_output_name(&overlay.input) {
+            Ok(normalized) => normalized,
             Err(error) => {
                 if let Some(overlay) = &mut self.overlays.archive_create {
                     overlay.error = Some(error.to_string());
@@ -377,7 +386,14 @@ impl App {
             }
         };
         let sources = overlay.sources.clone();
-        let options = overlay.options.clone();
+        let mut options = overlay.options.clone();
+        options.format = format;
+        if options.encryption.is_password_set() && !options.format.supports_encryption() {
+            if let Some(overlay) = &mut self.overlays.archive_create {
+                overlay.error = None;
+            }
+            return Ok(());
+        }
         if self.start_archive_create(sources, output_name, options)? {
             self.overlays.archive_create = None;
         }
@@ -443,12 +459,16 @@ impl App {
         let Some(overlay) = &self.overlays.archive_create else {
             return;
         };
-        if !overlay.options.format.supports_encryption() {
-            if let Some(overlay) = &mut self.overlays.archive_create {
-                overlay.error = Some(format!(
-                    "{} does not support password protection",
-                    overlay.options.format.label()
-                ));
+        let password_set = overlay.options.encryption.is_password_set();
+        let Some(format) = archive_create_effective_format(overlay) else {
+            if !password_set {
+                self.show_archive_password_format_hint();
+            }
+            return;
+        };
+        if !format.supports_encryption() {
+            if !password_set {
+                self.show_archive_password_format_hint();
             }
             return;
         }
@@ -466,6 +486,12 @@ impl App {
         });
     }
 
+    fn show_archive_password_format_hint(&mut self) {
+        if let Some(overlay) = &mut self.overlays.archive_create {
+            overlay.error = Some("Use ZIP for passwords".to_string());
+        }
+    }
+
     fn remove_archive_create_password(&mut self) {
         if let Some(overlay) = &mut self.overlays.archive_create
             && overlay.options.encryption.is_password_set()
@@ -480,6 +506,12 @@ impl App {
 fn archive_create_default_cursor_col(name: &str) -> usize {
     let base = name.strip_suffix(".zip").unwrap_or(name);
     base.chars().count()
+}
+
+fn archive_create_effective_format(overlay: &ArchiveCreateOverlay) -> Option<CreateArchiveFormat> {
+    normalize_archive_output_name(&overlay.input)
+        .map(|(_, format)| format)
+        .ok()
 }
 
 fn archive_source_label(path: &std::path::Path) -> String {

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -407,6 +407,62 @@ fn archive_create_password_can_be_removed_before_creating() {
 }
 
 #[test]
+fn archive_create_unsupported_format_disables_password_prompt() {
+    for (label, input) in [
+        ("create-tar-no-password", "alpha.tar"),
+        ("create-unknown-extension-no-password", "alpha.z"),
+    ] {
+        let (root, mut app) = archive_create_app(label);
+        open_archive_create_with_input(&mut app, input);
+
+        assert_eq!(app.archive_create_protection_label(), "");
+        assert_eq!(app.archive_create_protection_hint(), "");
+        app.handle_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('p'),
+            KeyModifiers::ALT,
+        )))
+        .expect("Alt+P should be handled");
+
+        assert!(!app.archive_password_is_open());
+        assert_eq!(app.archive_create_error(), Some("Use ZIP for passwords"));
+
+        fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+}
+
+#[test]
+fn archive_create_tar_with_existing_password_shows_actionable_conflict() {
+    let (root, mut app) = archive_create_app("create-tar-password-conflict");
+    open_archive_create_with_input(&mut app, "alpha.txt.zip");
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('p'),
+        KeyModifiers::ALT,
+    )))
+    .expect("Alt+P should open password prompt");
+    type_archive_password(&mut app, &archive_test_password(&root));
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("password Enter should return to create overlay");
+    set_archive_create_input(&mut app, "alpha.tar");
+
+    assert_eq!(app.archive_create_protection_label(), "Password set");
+    assert_eq!(
+        app.archive_create_protection_hint(),
+        "Switch format or remove"
+    );
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Enter)))
+        .expect("Enter should validate archive creation");
+    assert_eq!(app.archive_create_error(), None);
+    assert_eq!(app.archive_create_protection_label(), "Password set");
+    assert_eq!(
+        app.archive_create_protection_hint(),
+        "Switch format or remove"
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn cancel_keys_clear_selection_before_cancelling_archive_creation() {
     for (label, key) in [
         ("esc", KeyEvent::from(KeyCode::Esc)),
@@ -498,6 +554,31 @@ fn archive_create_contents_list_scrolls_with_mouse_wheel() {
     );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+fn archive_create_app(label: &str) -> (std::path::PathBuf, App) {
+    let root = temp_path(label);
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    fs::write(root.join("alpha.txt"), "alpha").expect("failed to write alpha");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    (root, app)
+}
+
+fn open_archive_create_with_input(app: &mut App, input: &str) {
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('C'))))
+        .expect("C should open archive creation");
+    set_archive_create_input(app, input);
+}
+
+fn set_archive_create_input(app: &mut App, input: &str) {
+    let overlay = app
+        .overlays
+        .archive_create
+        .as_mut()
+        .expect("archive create overlay should be open");
+    overlay.input = input.to_string();
+    overlay.cursor_col = overlay.input.chars().count();
 }
 
 fn archive_test_password(root: &std::path::Path) -> String {

--- a/src/app/jobs/tasks/archive_create.rs
+++ b/src/app/jobs/tasks/archive_create.rs
@@ -132,7 +132,7 @@ fn run_create(
         request.options.clone(),
     )
     .and_then(|plan| {
-        crate::archive::create_zip_archive(
+        crate::archive::create_archive(
             &plan,
             |progress| {
                 completed = progress.completed;

--- a/src/archive/create.rs
+++ b/src/archive/create.rs
@@ -864,13 +864,14 @@ mod tests {
         let root = temp_path("tar-password");
         fs::create_dir_all(&root).unwrap();
         fs::write(root.join("README.md"), "readme").unwrap();
+        let password = root.file_name().unwrap().to_string_lossy().into_owned();
         let error = plan_create_archive(
             &root,
             vec![root.join("README.md")],
             "archive.tar",
             CreateArchiveOptions {
                 format: CreateArchiveFormat::Zip,
-                encryption: ArchiveEncryption::Password(ArchivePassword::new("secret")),
+                encryption: ArchiveEncryption::Password(ArchivePassword::new(&password)),
             },
         )
         .unwrap_err();

--- a/src/archive/create.rs
+++ b/src/archive/create.rs
@@ -1,9 +1,10 @@
 use super::extract::ArchivePassword;
 use anyhow::{Context, Result, anyhow, bail};
+use flate2::{Compression, write::GzEncoder};
 use std::{
     collections::BTreeSet,
     fs::{self, File},
-    io,
+    io::{self, Write},
     path::{Component, Path, PathBuf},
 };
 use zip::{AesMode, CompressionMethod, ZipWriter, write::FileOptions};
@@ -11,18 +12,28 @@ use zip::{AesMode, CompressionMethod, ZipWriter, write::FileOptions};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CreateArchiveFormat {
     Zip,
+    Tar,
+    TarGzip,
 }
 
 impl CreateArchiveFormat {
-    pub(crate) fn label(self) -> &'static str {
-        match self {
-            Self::Zip => "ZIP",
-        }
-    }
-
     pub(crate) fn supports_encryption(self) -> bool {
         match self {
             Self::Zip => true,
+            Self::Tar | Self::TarGzip => false,
+        }
+    }
+
+    fn detect_from_name(name: &str) -> Option<Self> {
+        let lower = name.to_ascii_lowercase();
+        if lower.ends_with(".tar.gz") || lower.ends_with(".tgz") {
+            Some(Self::TarGzip)
+        } else if lower.ends_with(".tar") {
+            Some(Self::Tar)
+        } else if lower.ends_with(".zip") {
+            Some(Self::Zip)
+        } else {
+            None
         }
     }
 }
@@ -80,7 +91,7 @@ pub(crate) struct CreateArchiveSummary {
     pub(crate) completed: usize,
 }
 
-pub(crate) fn normalize_zip_output_name(input: &str) -> Result<String> {
+pub(crate) fn normalize_archive_output_name(input: &str) -> Result<(String, CreateArchiveFormat)> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         bail!("Name cannot be empty");
@@ -99,13 +110,12 @@ pub(crate) fn normalize_zip_output_name(input: &str) -> Result<String> {
         bail!("Use a filename, not a path");
     }
 
-    let lower = trimmed.to_ascii_lowercase();
-    if lower.ends_with(".zip") {
-        Ok(trimmed.to_string())
+    if let Some(format) = CreateArchiveFormat::detect_from_name(trimmed) {
+        Ok((trimmed.to_string(), format))
     } else if path.extension().is_none() {
-        Ok(format!("{trimmed}.zip"))
+        Ok((format!("{trimmed}.zip"), CreateArchiveFormat::Zip))
     } else {
-        bail!("Archive creation supports ZIP");
+        bail!("Archive creation supports ZIP, TAR, and TAR.GZ");
     }
 }
 
@@ -122,17 +132,15 @@ pub(crate) fn plan_create_archive(
     cwd: &Path,
     sources: Vec<PathBuf>,
     output_name: &str,
-    options: CreateArchiveOptions,
+    mut options: CreateArchiveOptions,
 ) -> Result<CreateArchivePlan> {
     if sources.is_empty() {
         bail!("Select items to archive");
     }
-    let output_name = normalize_zip_output_name(output_name)?;
+    let (output_name, format) = normalize_archive_output_name(output_name)?;
+    options.format = format;
     if options.encryption.is_password_set() && !options.format.supports_encryption() {
-        bail!(
-            "{} does not support password protection",
-            options.format.label()
-        );
+        bail!("Password not supported for this format");
     }
     let output_path = cwd.join(output_name);
     if fs::symlink_metadata(&output_path).is_ok() {
@@ -168,6 +176,22 @@ pub(crate) fn plan_create_archive(
         output_path,
         options,
     })
+}
+
+pub(crate) fn create_archive<F, C>(
+    plan: &CreateArchivePlan,
+    progress: F,
+    cancelled: C,
+) -> Result<CreateArchiveSummary>
+where
+    F: FnMut(CreateArchiveProgress),
+    C: Fn() -> bool,
+{
+    match plan.options.format {
+        CreateArchiveFormat::Zip => create_zip_archive(plan, progress, cancelled),
+        CreateArchiveFormat::Tar => create_tar_archive(plan, progress, cancelled),
+        CreateArchiveFormat::TarGzip => create_tar_gzip_archive(plan, progress, cancelled),
+    }
 }
 
 pub(crate) fn create_zip_archive<F, C>(
@@ -257,6 +281,192 @@ where
 
     writer.finish().context("Could not finish ZIP archive")?;
     Ok(completed)
+}
+
+fn create_tar_archive<F, C>(
+    plan: &CreateArchivePlan,
+    progress: F,
+    cancelled: C,
+) -> Result<CreateArchiveSummary>
+where
+    F: FnMut(CreateArchiveProgress),
+    C: Fn() -> bool,
+{
+    create_tar_with(plan, TarSink::Plain, progress, cancelled)
+}
+
+fn create_tar_gzip_archive<F, C>(
+    plan: &CreateArchivePlan,
+    progress: F,
+    cancelled: C,
+) -> Result<CreateArchiveSummary>
+where
+    F: FnMut(CreateArchiveProgress),
+    C: Fn() -> bool,
+{
+    create_tar_with(plan, TarSink::Gzip, progress, cancelled)
+}
+
+enum TarSink {
+    Plain,
+    Gzip,
+}
+
+fn create_tar_with<F, C>(
+    plan: &CreateArchivePlan,
+    sink: TarSink,
+    mut progress: F,
+    cancelled: C,
+) -> Result<CreateArchiveSummary>
+where
+    F: FnMut(CreateArchiveProgress),
+    C: Fn() -> bool,
+{
+    let total = count_archive_items(&plan.sources)?;
+    progress(CreateArchiveProgress {
+        completed: 0,
+        total,
+    });
+
+    let staging_path = unique_staging_path(&plan.output_path)?;
+    let file = File::create_new(&staging_path)
+        .with_context(|| format!("Could not create {}", staging_path.display()))?;
+    let result = match sink {
+        TarSink::Plain => write_tar_archive(file, &plan.sources, total, &mut progress, cancelled),
+        TarSink::Gzip => {
+            let encoder = GzEncoder::new(file, Compression::default());
+            write_tar_archive(encoder, &plan.sources, total, &mut progress, cancelled)
+        }
+    }
+    .and_then(|completed| {
+        fs::rename(&staging_path, &plan.output_path).with_context(|| {
+            format!(
+                "Could not move {} to {}",
+                staging_path.display(),
+                plan.output_path.display()
+            )
+        })?;
+        Ok(CreateArchiveSummary {
+            output_path: plan.output_path.clone(),
+            completed,
+        })
+    });
+
+    if result.is_err() {
+        let _ = fs::remove_file(&staging_path);
+    }
+
+    result
+}
+
+fn write_tar_archive<W, F, C>(
+    writer: W,
+    sources: &[PathBuf],
+    total: usize,
+    progress: &mut F,
+    cancelled: C,
+) -> Result<usize>
+where
+    W: Write,
+    F: FnMut(CreateArchiveProgress),
+    C: Fn() -> bool,
+{
+    let mut builder = tar::Builder::new(writer);
+    let mut completed = 0usize;
+    let mut sorted_sources = sources.to_vec();
+    sorted_sources.sort_by_key(|source| archive_name(source));
+
+    for source in sorted_sources {
+        let root_name = archive_name(&source);
+        add_path_to_tar(
+            &mut builder,
+            &source,
+            Path::new(&root_name),
+            &mut completed,
+            total,
+            progress,
+            &cancelled,
+        )?;
+    }
+
+    builder.finish().context("Could not finish TAR archive")?;
+    Ok(completed)
+}
+
+fn add_path_to_tar<W, F, C>(
+    builder: &mut tar::Builder<W>,
+    source: &Path,
+    archive_path: &Path,
+    completed: &mut usize,
+    total: usize,
+    progress: &mut F,
+    cancelled: &C,
+) -> Result<()>
+where
+    W: Write,
+    F: FnMut(CreateArchiveProgress),
+    C: Fn() -> bool,
+{
+    if cancelled() {
+        bail!("Archive creation cancelled");
+    }
+
+    let metadata = fs::symlink_metadata(source)
+        .with_context(|| format!("Could not inspect {}", source.display()))?;
+    if metadata.file_type().is_symlink() {
+        let name = source
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("item");
+        bail!("TAR creation does not support symlinks: {name}");
+    }
+    if metadata.is_dir() {
+        builder
+            .append_dir(archive_path, source)
+            .context("Could not write TAR directory")?;
+        *completed += 1;
+        progress(CreateArchiveProgress {
+            completed: *completed,
+            total,
+        });
+        let mut children = fs::read_dir(source)
+            .with_context(|| format!("Could not read {}", source.display()))?
+            .collect::<io::Result<Vec<_>>>()?;
+        children.sort_by_key(|entry| entry.file_name());
+        for child in children {
+            let child_name = child.file_name();
+            let child_archive_path = archive_path.join(child_name);
+            add_path_to_tar(
+                builder,
+                &child.path(),
+                &child_archive_path,
+                completed,
+                total,
+                progress,
+                cancelled,
+            )?;
+        }
+        return Ok(());
+    }
+    if metadata.is_file() {
+        let mut file =
+            File::open(source).with_context(|| format!("Could not open {}", source.display()))?;
+        builder
+            .append_file(archive_path, &mut file)
+            .context("Could not write TAR entry")?;
+        *completed += 1;
+        progress(CreateArchiveProgress {
+            completed: *completed,
+            total,
+        });
+        return Ok(());
+    }
+
+    let name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("item");
+    bail!("Cannot archive {name}");
 }
 
 #[derive(Clone, Copy)]
@@ -515,19 +725,34 @@ mod tests {
 
     #[test]
     fn normalizes_zip_names() {
-        assert_eq!(normalize_zip_output_name("backup").unwrap(), "backup.zip");
         assert_eq!(
-            normalize_zip_output_name("backup.zip").unwrap(),
-            "backup.zip"
+            normalize_archive_output_name("backup").unwrap(),
+            ("backup.zip".to_string(), CreateArchiveFormat::Zip)
         );
         assert_eq!(
-            normalize_zip_output_name("backup.7z")
+            normalize_archive_output_name("backup.zip").unwrap(),
+            ("backup.zip".to_string(), CreateArchiveFormat::Zip)
+        );
+        assert_eq!(
+            normalize_archive_output_name("backup.tar").unwrap(),
+            ("backup.tar".to_string(), CreateArchiveFormat::Tar)
+        );
+        assert_eq!(
+            normalize_archive_output_name("backup.tar.gz").unwrap(),
+            ("backup.tar.gz".to_string(), CreateArchiveFormat::TarGzip)
+        );
+        assert_eq!(
+            normalize_archive_output_name("backup.tgz").unwrap(),
+            ("backup.tgz".to_string(), CreateArchiveFormat::TarGzip)
+        );
+        assert_eq!(
+            normalize_archive_output_name("backup.7z")
                 .unwrap_err()
                 .to_string(),
-            "Archive creation supports ZIP"
+            "Archive creation supports ZIP, TAR, and TAR.GZ"
         );
         assert_eq!(
-            normalize_zip_output_name("../backup.zip")
+            normalize_archive_output_name("../backup.zip")
                 .unwrap_err()
                 .to_string(),
             "Use a filename, not a path"
@@ -567,6 +792,90 @@ mod tests {
             ]
         );
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn creates_tar_with_top_level_names() {
+        let root = temp_path("tar-top-level");
+        fs::create_dir_all(root.join("src/nested")).unwrap();
+        fs::write(root.join("src/lib.rs"), "lib").unwrap();
+        fs::write(root.join("src/nested/mod.rs"), "mod").unwrap();
+        fs::write(root.join("README.md"), "readme").unwrap();
+
+        let plan = plan_create_archive(
+            &root,
+            vec![root.join("README.md"), root.join("src")],
+            "archive.tar",
+            CreateArchiveOptions::default(),
+        )
+        .unwrap();
+        create_archive(&plan, |_| {}, || false).unwrap();
+
+        let file = File::open(root.join("archive.tar")).unwrap();
+        let mut archive = tar::Archive::new(file);
+        let mut names = archive
+            .entries()
+            .unwrap()
+            .map(|entry| entry.unwrap().path().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "README.md",
+                "src",
+                "src/lib.rs",
+                "src/nested",
+                "src/nested/mod.rs"
+            ]
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn creates_tar_gzip_archive() {
+        let root = temp_path("tar-gzip");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("README.md"), "readme").unwrap();
+
+        let plan = plan_create_archive(
+            &root,
+            vec![root.join("README.md")],
+            "archive.tgz",
+            CreateArchiveOptions::default(),
+        )
+        .unwrap();
+        create_archive(&plan, |_| {}, || false).unwrap();
+
+        let file = File::open(root.join("archive.tgz")).unwrap();
+        let decoder = flate2::read::GzDecoder::new(file);
+        let mut archive = tar::Archive::new(decoder);
+        let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
+        assert_eq!(entry.path().unwrap().to_string_lossy(), "README.md");
+        let mut contents = String::new();
+        use std::io::Read;
+        entry.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "readme");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rejects_tar_passwords() {
+        let root = temp_path("tar-password");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("README.md"), "readme").unwrap();
+        let error = plan_create_archive(
+            &root,
+            vec![root.join("README.md")],
+            "archive.tar",
+            CreateArchiveOptions {
+                format: CreateArchiveFormat::Zip,
+                encryption: ArchiveEncryption::Password(ArchivePassword::new("secret")),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "Password not supported for this format");
+        let _ = fs::remove_file(root.join("README.md"));
     }
 
     #[test]

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -3,8 +3,8 @@ mod extract;
 mod format;
 
 pub(crate) use self::create::{
-    ArchiveEncryption, CreateArchiveOptions, create_zip_archive, normalize_zip_output_name,
-    plan_create_archive,
+    ArchiveEncryption, CreateArchiveFormat, CreateArchiveOptions, create_archive,
+    normalize_archive_output_name, plan_create_archive,
 };
 pub(crate) use self::extract::{
     ArchivePassword, ExtractError, extract_archive_with_password, plan_extract,


### PR DESCRIPTION
## Summary

Add TAR, TAR.GZ, and TGZ output formats to archive creation.

Archive creation now chooses the output format from the filename extension while keeping ZIP as the default. Password protection remains ZIP-only, with the create overlay hiding password controls for unsupported formats and preserving existing passwords until the user switches format or removes them.

Refs #215.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed