### PR TITLE
feat(archive): safely preserve zip and tar symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added archive creation for the focused item or current selection, with editable archive names, background progress, cancellation, and a configurable `create_archive` (`C`) shortcut. ([#215])
 - Added ZIP password protection for archive creation. ([#215])
 - Added TAR, TAR.GZ, and TGZ output formats for archive creation. ([#215])
+- Added safe symlink preservation for ZIP/TAR archive creation and extraction.
 - Added a show/hide control to encrypted archive password prompts.
 
 ### Changed

--- a/src/app/jobs/tasks/archive_extract.rs
+++ b/src/app/jobs/tasks/archive_extract.rs
@@ -182,9 +182,17 @@ fn run_extract(
             } else {
                 "items"
             };
+            let link_note = match summary.skipped_links {
+                0 => String::new(),
+                1 => " — skipped 1 unsafe link".to_string(),
+                count => format!(" — skipped {count} unsafe links"),
+            };
             (
                 Some(summary.dest_dir),
-                format!("Extracted {} {noun} to \"{name}\"", summary.completed),
+                format!(
+                    "Extracted {} {noun} to \"{name}\"{link_note}",
+                    summary.completed
+                ),
             )
         }
         Err(ExtractError::PasswordRequired) => {

--- a/src/archive/create.rs
+++ b/src/archive/create.rs
@@ -270,8 +270,12 @@ where
         let root_name = archive_name(&source);
         add_path_to_zip(
             &mut writer,
-            &source,
-            Path::new(&root_name),
+            ZipEntryPaths {
+                source: &source,
+                archive_path: Path::new(&root_name),
+                root_source: &source,
+                root_archive_path: Path::new(&root_name),
+            },
             &mut completed,
             settings,
             progress,
@@ -372,62 +376,77 @@ where
     C: Fn() -> bool,
 {
     let mut builder = tar::Builder::new(writer);
-    let mut completed = 0usize;
+    let mut state = TarCreateState {
+        completed: 0,
+        total,
+        progress,
+        cancelled: &cancelled,
+        root_source: PathBuf::new(),
+        root_archive_path: PathBuf::new(),
+    };
     let mut sorted_sources = sources.to_vec();
     sorted_sources.sort_by_key(|source| archive_name(source));
 
     for source in sorted_sources {
         let root_name = archive_name(&source);
-        add_path_to_tar(
-            &mut builder,
-            &source,
-            Path::new(&root_name),
-            &mut completed,
-            total,
-            progress,
-            &cancelled,
-        )?;
+        state.root_source = source.clone();
+        state.root_archive_path = PathBuf::from(&root_name);
+        add_path_to_tar(&mut builder, &source, Path::new(&root_name), &mut state)?;
     }
 
     builder.finish().context("Could not finish TAR archive")?;
-    Ok(completed)
+    Ok(state.completed)
+}
+
+struct TarCreateState<'a, F, C> {
+    completed: usize,
+    total: usize,
+    progress: &'a mut F,
+    cancelled: &'a C,
+    root_source: PathBuf,
+    root_archive_path: PathBuf,
 }
 
 fn add_path_to_tar<W, F, C>(
     builder: &mut tar::Builder<W>,
     source: &Path,
     archive_path: &Path,
-    completed: &mut usize,
-    total: usize,
-    progress: &mut F,
-    cancelled: &C,
+    state: &mut TarCreateState<'_, F, C>,
 ) -> Result<()>
 where
     W: Write,
     F: FnMut(CreateArchiveProgress),
     C: Fn() -> bool,
 {
-    if cancelled() {
+    if (state.cancelled)() {
         bail!("Archive creation cancelled");
     }
 
     let metadata = fs::symlink_metadata(source)
         .with_context(|| format!("Could not inspect {}", source.display()))?;
     if metadata.file_type().is_symlink() {
-        let name = source
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("item");
-        bail!("TAR creation does not support symlinks: {name}");
+        add_symlink_to_tar(
+            builder,
+            source,
+            archive_path,
+            &state.root_source,
+            &state.root_archive_path,
+        )?;
+        state.completed += 1;
+        (state.progress)(CreateArchiveProgress {
+            completed: state.completed,
+            total: state.total,
+        });
+        return Ok(());
     }
     if metadata.is_dir() {
         builder
             .append_dir(archive_path, source)
             .context("Could not write TAR directory")?;
-        *completed += 1;
-        progress(CreateArchiveProgress {
-            completed: *completed,
-            total,
+        state.completed += 1;
+        (state.progress)(CreateArchiveProgress {
+            completed: state.completed,
+            total: state.total,
         });
         let mut children = fs::read_dir(source)
             .with_context(|| format!("Could not read {}", source.display()))?
@@ -436,15 +455,7 @@ where
         for child in children {
             let child_name = child.file_name();
             let child_archive_path = archive_path.join(child_name);
-            add_path_to_tar(
-                builder,
-                &child.path(),
-                &child_archive_path,
-                completed,
-                total,
-                progress,
-                cancelled,
-            )?;
+            add_path_to_tar(builder, &child.path(), &child_archive_path, state)?;
         }
         return Ok(());
     }
@@ -454,10 +465,10 @@ where
         builder
             .append_file(archive_path, &mut file)
             .context("Could not write TAR entry")?;
-        *completed += 1;
-        progress(CreateArchiveProgress {
-            completed: *completed,
-            total,
+        state.completed += 1;
+        (state.progress)(CreateArchiveProgress {
+            completed: state.completed,
+            total: state.total,
         });
         return Ok(());
     }
@@ -469,16 +480,93 @@ where
     bail!("Cannot archive {name}");
 }
 
+fn add_symlink_to_tar<W>(
+    builder: &mut tar::Builder<W>,
+    source: &Path,
+    archive_path: &Path,
+    root_source: &Path,
+    root_archive_path: &Path,
+) -> Result<()>
+where
+    W: Write,
+{
+    let target = fs::read_link(source)
+        .with_context(|| format!("Could not read symlink {}", source.display()))?;
+    let target = archived_symlink_target(archive_path, root_source, root_archive_path, &target);
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Symlink);
+    header.set_size(0);
+    builder
+        .append_link(&mut header, archive_path, &target)
+        .context("Could not write TAR symlink")?;
+    Ok(())
+}
+
+fn archived_symlink_target(
+    archive_path: &Path,
+    root_source: &Path,
+    root_archive_path: &Path,
+    target: &Path,
+) -> PathBuf {
+    if !target.is_absolute() {
+        return target.to_path_buf();
+    }
+    let Ok(internal_target) = target.strip_prefix(root_source) else {
+        return target.to_path_buf();
+    };
+    let archived_target = root_archive_path.join(internal_target);
+    let archive_parent = archive_path.parent().unwrap_or_else(|| Path::new(""));
+    relative_archive_path(archive_parent, &archived_target).unwrap_or_else(|| target.to_path_buf())
+}
+
+fn relative_archive_path(from_dir: &Path, to_path: &Path) -> Option<PathBuf> {
+    let from = from_dir.components().collect::<Vec<_>>();
+    let to = to_path.components().collect::<Vec<_>>();
+    if from
+        .iter()
+        .any(|component| !matches!(component, Component::Normal(_)))
+        || to
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+    let common = from
+        .iter()
+        .zip(&to)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = PathBuf::new();
+    for _ in common..from.len() {
+        relative.push("..");
+    }
+    for component in &to[common..] {
+        relative.push(component.as_os_str());
+    }
+    if relative.as_os_str().is_empty() {
+        Some(PathBuf::from("."))
+    } else {
+        Some(relative)
+    }
+}
+
 #[derive(Clone, Copy)]
 struct ZipCreateSettings<'a> {
     total: usize,
     password: Option<&'a ArchivePassword>,
 }
 
+#[derive(Clone, Copy)]
+struct ZipEntryPaths<'a> {
+    source: &'a Path,
+    archive_path: &'a Path,
+    root_source: &'a Path,
+    root_archive_path: &'a Path,
+}
+
 fn add_path_to_zip<F, C>(
     writer: &mut ZipWriter<File>,
-    source: &Path,
-    archive_path: &Path,
+    paths: ZipEntryPaths<'_>,
     completed: &mut usize,
     settings: ZipCreateSettings<'_>,
     progress: &mut F,
@@ -492,30 +580,35 @@ where
         bail!("Archive creation cancelled");
     }
 
-    let metadata = fs::symlink_metadata(source)
-        .with_context(|| format!("Could not inspect {}", source.display()))?;
+    let metadata = fs::symlink_metadata(paths.source)
+        .with_context(|| format!("Could not inspect {}", paths.source.display()))?;
     if metadata.file_type().is_symlink() {
-        add_symlink(writer, source, archive_path, completed, settings, progress)?;
+        add_symlink(writer, paths, completed, settings, progress)?;
         return Ok(());
     }
     if metadata.is_dir() {
-        add_directory(writer, archive_path, &metadata, settings.password)?;
+        add_directory(writer, paths.archive_path, &metadata, settings.password)?;
         *completed += 1;
         progress(CreateArchiveProgress {
             completed: *completed,
             total: settings.total,
         });
-        let mut children = fs::read_dir(source)
-            .with_context(|| format!("Could not read {}", source.display()))?
+        let mut children = fs::read_dir(paths.source)
+            .with_context(|| format!("Could not read {}", paths.source.display()))?
             .collect::<io::Result<Vec<_>>>()?;
         children.sort_by_key(|entry| entry.file_name());
         for child in children {
+            let child_path = child.path();
             let child_name = child.file_name();
-            let child_archive_path = archive_path.join(child_name);
+            let child_archive_path = paths.archive_path.join(child_name);
             add_path_to_zip(
                 writer,
-                &child.path(),
-                &child_archive_path,
+                ZipEntryPaths {
+                    source: &child_path,
+                    archive_path: &child_archive_path,
+                    root_source: paths.root_source,
+                    root_archive_path: paths.root_archive_path,
+                },
                 completed,
                 settings,
                 progress,
@@ -525,7 +618,13 @@ where
         return Ok(());
     }
     if metadata.is_file() {
-        add_file(writer, source, archive_path, &metadata, settings.password)?;
+        add_file(
+            writer,
+            paths.source,
+            paths.archive_path,
+            &metadata,
+            settings.password,
+        )?;
         *completed += 1;
         progress(CreateArchiveProgress {
             completed: *completed,
@@ -534,7 +633,8 @@ where
         return Ok(());
     }
 
-    let name = source
+    let name = paths
+        .source
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("item");
@@ -573,8 +673,7 @@ fn add_directory(
 
 fn add_symlink<F>(
     writer: &mut ZipWriter<File>,
-    source: &Path,
-    archive_path: &Path,
+    paths: ZipEntryPaths<'_>,
     completed: &mut usize,
     settings: ZipCreateSettings<'_>,
     progress: &mut F,
@@ -582,9 +681,15 @@ fn add_symlink<F>(
 where
     F: FnMut(CreateArchiveProgress),
 {
-    let target = fs::read_link(source)
-        .with_context(|| format!("Could not read symlink {}", source.display()))?;
-    let name = zip_entry_name(archive_path, false)?;
+    let target = fs::read_link(paths.source)
+        .with_context(|| format!("Could not read symlink {}", paths.source.display()))?;
+    let target = archived_symlink_target(
+        paths.archive_path,
+        paths.root_source,
+        paths.root_archive_path,
+        &target,
+    );
+    let name = zip_entry_name(paths.archive_path, false)?;
     let options = apply_zip_encryption(
         FileOptions::default()
             .compression_method(CompressionMethod::Stored)
@@ -592,10 +697,8 @@ where
         settings.password,
     );
     writer
-        .start_file(name, options)
+        .add_symlink(name, target.to_string_lossy(), options)
         .context("Could not write ZIP symlink")?;
-    let target = target.to_string_lossy();
-    io::copy(&mut target.as_bytes(), writer).context("Could not write ZIP symlink")?;
     *completed += 1;
     progress(CreateArchiveProgress {
         completed: *completed,
@@ -829,6 +932,124 @@ mod tests {
                 "src/nested/mod.rs"
             ]
         );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn creates_tar_with_symlink_entries() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("tar-symlink");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("target.txt"), "target").unwrap();
+        symlink("target.txt", root.join("link.txt")).unwrap();
+        symlink("missing.txt", root.join("broken.txt")).unwrap();
+
+        let plan = plan_create_archive(
+            &root,
+            vec![root.join("link.txt"), root.join("broken.txt")],
+            "archive.tar",
+            CreateArchiveOptions::default(),
+        )
+        .unwrap();
+        create_archive(&plan, |_| {}, || false).unwrap();
+
+        let file = File::open(root.join("archive.tar")).unwrap();
+        let mut archive = tar::Archive::new(file);
+        let mut entries = archive
+            .entries()
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                (
+                    entry.path().unwrap().to_string_lossy().to_string(),
+                    entry.header().entry_type(),
+                    entry
+                        .link_name()
+                        .unwrap()
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(
+            entries,
+            vec![
+                (
+                    "broken.txt".to_string(),
+                    tar::EntryType::Symlink,
+                    "missing.txt".to_string()
+                ),
+                (
+                    "link.txt".to_string(),
+                    tar::EntryType::Symlink,
+                    "target.txt".to_string()
+                )
+            ]
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn creates_tar_with_portable_internal_absolute_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("tar-absolute-internal-symlink");
+        let folder = root.join("folder");
+        fs::create_dir_all(folder.join("nested")).unwrap();
+        fs::write(folder.join("target.txt"), "target").unwrap();
+        symlink(folder.join("target.txt"), folder.join("nested/link.txt")).unwrap();
+
+        let plan = plan_create_archive(
+            &root,
+            vec![folder.clone()],
+            "archive.tar",
+            CreateArchiveOptions::default(),
+        )
+        .unwrap();
+        create_archive(&plan, |_| {}, || false).unwrap();
+
+        let file = File::open(root.join("archive.tar")).unwrap();
+        let mut archive = tar::Archive::new(file);
+        let link_target = archive
+            .entries()
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .find_map(|entry| {
+                (entry.path().unwrap().as_ref() == Path::new("folder/nested/link.txt"))
+                    .then(|| entry.link_name().unwrap().unwrap().into_owned())
+            })
+            .unwrap();
+        assert_eq!(link_target, Path::new("../target.txt"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn creates_zip_with_portable_internal_absolute_symlink() {
+        use std::io::Read;
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("zip-absolute-internal-symlink");
+        let folder = root.join("folder");
+        fs::create_dir_all(folder.join("nested")).unwrap();
+        fs::write(folder.join("target.txt"), "target").unwrap();
+        symlink(folder.join("target.txt"), folder.join("nested/link.txt")).unwrap();
+
+        let plan = plan_create_zip_archive(&root, vec![folder], "archive.zip").unwrap();
+        create_zip_archive(&plan, |_| {}, || false).unwrap();
+
+        let file = File::open(root.join("archive.zip")).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let mut entry = archive.by_name("folder/nested/link.txt").unwrap();
+        assert_eq!(entry.unix_mode().unwrap() & 0o170000, 0o120000);
+        let mut target = String::new();
+        entry.read_to_string(&mut target).unwrap();
+        assert_eq!(target, "../target.txt");
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -38,6 +38,7 @@ pub(crate) struct ExtractSummary {
     pub(crate) dest_dir: PathBuf,
     pub(crate) completed: usize,
     pub(crate) total: Option<usize>,
+    pub(crate) skipped_links: usize,
 }
 
 #[derive(Clone, Default, Eq, PartialEq)]
@@ -191,6 +192,7 @@ where
         dest_dir,
         completed: summary.completed,
         total: summary.total,
+        skipped_links: summary.skipped_links,
     })
 }
 
@@ -250,6 +252,8 @@ where
     let mut archive = zip::ZipArchive::new(file).context("Could not read ZIP archive")?;
     let total = archive.len();
     let mut completed = 0usize;
+    let mut skipped_links = 0usize;
+    let mut symlinks = Vec::new();
     progress(ExtractProgress {
         completed,
         total: Some(total),
@@ -268,6 +272,23 @@ where
         if entry.is_dir() {
             fs::create_dir_all(&out_path)
                 .with_context(|| format!("Could not create {}", out_path.display()))?;
+        } else if is_zip_symlink(&entry) {
+            let mut target = String::new();
+            if let Err(error) = entry.read_to_string(&mut target) {
+                if password.is_some() && encrypted && is_zip_bad_password_io(&error) {
+                    return Err(ExtractError::BadPassword);
+                }
+                return Err(error).context("Could not read ZIP symlink target")?;
+            }
+            let target = PathBuf::from(target);
+            if safe_relative_link_target(&plan.dest_dir, &out_path, &target) {
+                symlinks.push(DeferredSymlink {
+                    path: out_path,
+                    target,
+                });
+            } else {
+                skipped_links += 1;
+            }
         } else {
             if let Some(parent) = out_path.parent() {
                 fs::create_dir_all(parent)
@@ -295,12 +316,20 @@ where
             total: Some(total),
         });
     }
+    skipped_links += extract_deferred_symlinks(&plan.dest_dir, symlinks)?;
 
     Ok(ExtractSummary {
         dest_dir: plan.dest_dir.clone(),
         completed,
         total: Some(total),
+        skipped_links,
     })
+}
+
+fn is_zip_symlink<R: Read>(entry: &zip::read::ZipFile<'_, R>) -> bool {
+    entry
+        .unix_mode()
+        .is_some_and(|mode| mode & 0o170000 == 0o120000)
 }
 
 fn zip_entry_by_index<'a, R: Read + io::Seek>(
@@ -428,6 +457,7 @@ where
         dest_dir: plan.dest_dir.clone(),
         completed,
         total: Some(total),
+        skipped_links: 0,
     })
 }
 
@@ -566,6 +596,7 @@ where
             dest_dir: plan.dest_dir.clone(),
             completed: 0,
             total,
+            skipped_links: 0,
         });
     }
 
@@ -584,6 +615,7 @@ where
         dest_dir: plan.dest_dir.clone(),
         completed,
         total,
+        skipped_links: 0,
     })
 }
 
@@ -818,6 +850,8 @@ where
 {
     let mut archive = tar::Archive::new(reader);
     let mut completed = 0usize;
+    let mut skipped_links = 0usize;
+    let mut symlinks = Vec::new();
     progress(ExtractProgress { completed, total });
     for entry in archive.entries().context("Could not read TAR entries")? {
         if cancelled() {
@@ -825,14 +859,26 @@ where
         }
         let mut entry = entry.context("Could not read TAR entry")?;
         let entry_type = entry.header().entry_type();
-        if entry_type.is_symlink() || entry_type.is_hard_link() {
-            completed += 1;
-            progress(ExtractProgress { completed, total });
-            continue;
-        }
         let path = entry.path().context("Could not read TAR entry path")?;
         let out_path = checked_output_path(&plan.dest_dir, path.as_ref())?;
-        if entry_type.is_dir() {
+        if entry_type.is_symlink() {
+            match entry
+                .link_name()
+                .context("Could not read TAR symlink target")?
+            {
+                Some(target)
+                    if safe_relative_link_target(&plan.dest_dir, &out_path, target.as_ref()) =>
+                {
+                    symlinks.push(DeferredSymlink {
+                        path: out_path,
+                        target: target.into_owned(),
+                    });
+                }
+                _ => skipped_links += 1,
+            }
+        } else if entry_type.is_hard_link() {
+            skipped_links += 1;
+        } else if entry_type.is_dir() {
             fs::create_dir_all(&out_path)
                 .with_context(|| format!("Could not create {}", out_path.display()))?;
         } else if entry_type.is_file() {
@@ -847,11 +893,99 @@ where
         completed += 1;
         progress(ExtractProgress { completed, total });
     }
+    skipped_links += extract_deferred_symlinks(&plan.dest_dir, symlinks)?;
     Ok(ExtractSummary {
         dest_dir: plan.dest_dir.clone(),
         completed,
         total,
+        skipped_links,
     })
+}
+
+struct DeferredSymlink {
+    path: PathBuf,
+    target: PathBuf,
+}
+
+fn safe_relative_link_target(dest_dir: &Path, link_path: &Path, target: &Path) -> bool {
+    if target.is_absolute() {
+        return false;
+    }
+    let Some(parent) = link_path.parent() else {
+        return false;
+    };
+    let Ok(parent) = parent.strip_prefix(dest_dir) else {
+        return false;
+    };
+    let mut resolved = parent.to_path_buf();
+    for component in target.components() {
+        match component {
+            Component::Normal(part) => resolved.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !resolved.pop() {
+                    return false;
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => return false,
+        }
+    }
+    !resolved.as_os_str().is_empty()
+}
+
+fn extract_deferred_symlinks(dest_dir: &Path, symlinks: Vec<DeferredSymlink>) -> Result<usize> {
+    let mut skipped = 0usize;
+    for link in symlinks {
+        if create_safe_symlink(dest_dir, &link).is_err() {
+            skipped += 1;
+        }
+    }
+    Ok(skipped)
+}
+
+#[cfg(unix)]
+fn create_safe_symlink(dest_dir: &Path, link: &DeferredSymlink) -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let parent = link
+        .path
+        .parent()
+        .ok_or_else(|| anyhow!("Could not determine symlink parent"))?;
+    if parent_contains_symlink(dest_dir, parent)? || fs::symlink_metadata(&link.path).is_ok() {
+        bail!("Unsafe TAR symlink");
+    }
+    fs::create_dir_all(parent).with_context(|| format!("Could not create {}", parent.display()))?;
+    symlink(&link.target, &link.path)
+        .with_context(|| format!("Could not create symlink {}", link.path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_safe_symlink(_dest_dir: &Path, _link: &DeferredSymlink) -> Result<()> {
+    bail!("Archive symlinks are not supported on this platform")
+}
+
+fn parent_contains_symlink(dest_dir: &Path, parent: &Path) -> Result<bool> {
+    let relative = parent.strip_prefix(dest_dir).with_context(|| {
+        format!(
+            "Archive entry escapes the destination: {}",
+            parent.display()
+        )
+    })?;
+    let mut cursor = dest_dir.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(part) = component else {
+            continue;
+        };
+        cursor.push(part);
+        match fs::symlink_metadata(&cursor) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return Ok(true),
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(false)
 }
 
 fn checked_output_path(dest_dir: &Path, entry_path: &Path) -> Result<PathBuf> {
@@ -993,6 +1127,64 @@ Size = 5
     }
 
     #[test]
+    #[cfg(unix)]
+    fn extracts_safe_zip_symlink() {
+        let root = temp_path("zip-safe-link");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options = zip::write::SimpleFileOptions::default();
+            zip.start_file("target.txt", options).unwrap();
+            zip.write_all(b"hello").unwrap();
+            let link_options = options.unix_permissions(0o777);
+            zip.add_symlink("link.txt", "target.txt", link_options)
+                .unwrap();
+            zip.finish().unwrap();
+        }
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.skipped_links, 0);
+        let link_path = root.join("sample/link.txt");
+        assert!(
+            fs::symlink_metadata(&link_path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_link(link_path).unwrap(), Path::new("target.txt"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skips_unsafe_zip_symlinks() {
+        let root = temp_path("zip-unsafe-link");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.zip");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options = zip::write::SimpleFileOptions::default();
+            let link_options = options.unix_permissions(0o777);
+            zip.add_symlink("absolute", "/etc/passwd", link_options)
+                .unwrap();
+            zip.add_symlink("escape", "../escape", link_options)
+                .unwrap();
+            zip.finish().unwrap();
+        }
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.skipped_links, 2);
+        assert!(!root.join("sample/absolute").exists());
+        assert!(!root.join("sample/escape").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn corrupt_zip_does_not_request_password() {
         let root = temp_path("zip-corrupt");
         fs::create_dir_all(&root).unwrap();
@@ -1126,6 +1318,107 @@ Size = 5
             fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
             "hello"
         );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn extracts_safe_tar_symlink() {
+        let root = temp_path("tar-safe-link");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.tar");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut tar = tar::Builder::new(file);
+            fs::write(root.join("target.txt"), "hello").unwrap();
+            tar.append_path_with_name(root.join("target.txt"), "target.txt")
+                .unwrap();
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            tar.append_link(&mut header, "link.txt", "target.txt")
+                .unwrap();
+            tar.finish().unwrap();
+        }
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.skipped_links, 0);
+        assert_eq!(
+            fs::read_link(root.join("sample/link.txt")).unwrap(),
+            Path::new("target.txt")
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("sample/target.txt")).unwrap(),
+            "hello"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skips_unsafe_tar_symlinks() {
+        let root = temp_path("tar-unsafe-link");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.tar");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut tar = tar::Builder::new(file);
+            for (path, target) in [
+                ("absolute", "/tmp/outside"),
+                ("parent", "../outside"),
+                ("nested/parent", "../../outside"),
+            ] {
+                let mut header = tar::Header::new_gnu();
+                header.set_entry_type(tar::EntryType::Symlink);
+                header.set_size(0);
+                tar.append_link(&mut header, path, target).unwrap();
+            }
+            tar.finish().unwrap();
+        }
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
+
+        assert_eq!(summary.completed, 3);
+        assert_eq!(summary.skipped_links, 3);
+        assert!(!root.join("sample/absolute").exists());
+        assert!(!root.join("sample/parent").exists());
+        assert!(!root.join("sample/nested/parent").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tar_symlink_parent_does_not_redirect_later_entries() {
+        let root = temp_path("tar-link-parent");
+        fs::create_dir_all(&root).unwrap();
+        let archive_path = root.join("sample.tar");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut tar = tar::Builder::new(file);
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            tar.append_link(&mut header, "dir", "../outside").unwrap();
+            fs::write(root.join("file.txt"), "safe").unwrap();
+            tar.append_path_with_name(root.join("file.txt"), "dir/file.txt")
+                .unwrap();
+            tar.finish().unwrap();
+        }
+
+        let plan = plan_extract(&archive_path).unwrap();
+        let summary = extract_archive_with_password(&plan, None, |_| {}, || false).unwrap();
+
+        assert_eq!(summary.completed, 2);
+        assert_eq!(summary.skipped_links, 1);
+        assert_eq!(
+            fs::read_to_string(root.join("sample/dir/file.txt")).unwrap(),
+            "safe"
+        );
+        assert!(!root.join("outside/file.txt").exists());
         let _ = fs::remove_dir_all(root);
     }
 


### PR DESCRIPTION
## Summary

Preserve safe symlinks when creating and extracting ZIP and TAR archives.

ZIP and TAR archive creation now store symlinks as links instead of regular files, and internal absolute links are rewritten as portable relative archive targets. Extraction restores safe relative symlinks while skipping unsafe absolute or escaping links and reporting them in the completion status.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed