### PR TITLE
feat(preview): add markdown frontmatter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added ZIP, 7Z, TAR, TAR.GZ/TGZ, TAR.XZ/TXZ, and TAR.BZ2/TBZ2/TBZ archive creation for the focused item or current selection, with editable archive names, background progress, cancellation, and a configurable `create_archive` (`C`) shortcut. ([#215])
-- Added password protection for ZIP and 7Z archive creation. ([#215])
-- Added safe symlink preservation for ZIP, 7Z, and TAR archive creation and extraction.
+- Added `.zip`, `.7z`, `.tar`, `.tar.gz`/`.tgz`, `.tar.xz`/`.txz`, and `.tar.bz2`/`.tbz2`/`.tbz` archive creation for the focused item or current selection, with editable archive names, background progress, cancellation, and a configurable `create_archive` (`C`) shortcut. ([#215])
+- Added password protection for `.zip` and `.7z` archive creation. ([#215])
+- Added safe symlink preservation for `.zip`, `.7z`, and `.tar` archive creation and extraction.
 - Added a show/hide control to encrypted archive password prompts.
+- Added YAML frontmatter rendering to Markdown previews and recognized Quarto `.qmd` files as Markdown. ([#223])
 
 ### Changed
 
@@ -273,6 +274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#223]: https://github.com/elio-fm/elio/issues/223
 [#215]: https://github.com/elio-fm/elio/issues/215
 [#201]: https://github.com/elio-fm/elio/issues/201
 [#199]: https://github.com/elio-fm/elio/issues/199

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -508,6 +508,11 @@ class = "document"
 icon = ""
 color = "#d3aa7c"
 
+[extensions.qmd]
+class = "document"
+icon = ""
+color = "#d3aa7c"
+
 [extensions.txt]
 class = "document"
 icon = ""

--- a/examples/themes/amber-dusk/theme.toml
+++ b/examples/themes/amber-dusk/theme.toml
@@ -405,6 +405,11 @@ class = "document"
 icon = ""
 color = "#c4a27a"
 
+[extensions.qmd]
+class = "document"
+icon = ""
+color = "#c4a27a"
+
 [extensions.pdf]
 class = "document"
 icon = "󰈙"

--- a/examples/themes/blush-light/theme.toml
+++ b/examples/themes/blush-light/theme.toml
@@ -327,6 +327,11 @@ class = "document"
 icon = ""
 color = "#bb907b"
 
+[extensions.qmd]
+class = "document"
+icon = ""
+color = "#bb907b"
+
 [extensions.txt]
 class = "document"
 icon = ""

--- a/examples/themes/catppuccin-mocha/theme.toml
+++ b/examples/themes/catppuccin-mocha/theme.toml
@@ -568,6 +568,11 @@ class = "document"
 icon = ""
 color = "#f9e2af"
 
+[extensions.qmd]
+class = "document"
+icon = ""
+color = "#f9e2af"
+
 [extensions.txt]
 class = "document"
 icon = ""

--- a/examples/themes/default-light/theme.toml
+++ b/examples/themes/default-light/theme.toml
@@ -568,6 +568,11 @@ class = "document"
 icon = ""
 color = "#ab977a"
 
+[extensions.qmd]
+class = "document"
+icon = ""
+color = "#ab977a"
+
 [extensions.txt]
 class = "document"
 icon = ""

--- a/examples/themes/tokyo-night/theme.toml
+++ b/examples/themes/tokyo-night/theme.toml
@@ -568,6 +568,11 @@ class = "document"
 icon = ""
 color = "#e0af68"
 
+[extensions.qmd]
+class = "document"
+icon = ""
+color = "#e0af68"
+
 [extensions.txt]
 class = "document"
 icon = ""

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -10,7 +10,7 @@ fn preview_for_extension(ext: &str) -> PreviewSpec {
 
 pub(super) fn inspect_extension(ext: &str) -> FileFacts {
     match ext {
-        "md" | "markdown" | "mdown" | "mkd" | "mdx" => FileFacts {
+        "md" | "markdown" | "mdown" | "mkd" | "mdx" | "qmd" => FileFacts {
             builtin_class: FileClass::Document,
             specific_type_label: None,
             preview: PreviewSpec::markdown(),

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -78,6 +78,14 @@ fn html_and_css_files_use_code_preview_support() {
 }
 
 #[test]
+fn quarto_markdown_files_use_markdown_preview_support() {
+    let facts = inspect_path(Path::new("analysis.qmd"), EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::Document);
+    assert_eq!(facts.preview.kind, PreviewKind::Markdown);
+}
+
+#[test]
 fn qml_files_use_code_preview_support() {
     let qml = inspect_path(Path::new("Main.qml"), EntryKind::File);
 

--- a/src/preview/markdown.rs
+++ b/src/preview/markdown.rs
@@ -93,6 +93,17 @@ struct MarkdownRenderer {
 
 pub(super) fn render_markdown_preview(text: &str) -> Vec<Line<'static>> {
     let mut renderer = MarkdownRenderer::new(theme::palette());
+    let text = if let Some((frontmatter, body)) = split_yaml_frontmatter(text) {
+        renderer.render_code_block(CodeBlockContext {
+            language: "yaml".to_string(),
+            text: frontmatter.to_string(),
+        });
+        renderer.push_blank_line();
+        body
+    } else {
+        text
+    };
+
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TASKLISTS);
@@ -818,6 +829,30 @@ impl MarkdownRenderer {
     }
 }
 
+fn split_yaml_frontmatter(text: &str) -> Option<(&str, &str)> {
+    let mut lines = text.split_inclusive('\n');
+    let first = lines.next()?;
+    if first.trim_end_matches(['\r', '\n']) != "---" {
+        return None;
+    }
+
+    let content_start = first.len();
+    let mut offset = content_start;
+
+    for line in lines {
+        let line_start = offset;
+        offset += line.len();
+
+        let marker = line.trim_end_matches(['\r', '\n']).trim();
+        if marker == "---" || marker == "..." {
+            let frontmatter = text[content_start..line_start].trim_end_matches(['\r', '\n']);
+            return Some((frontmatter, &text[offset..]));
+        }
+    }
+
+    None
+}
+
 fn heading_style(level: HeadingLevel, palette: theme::Palette) -> Style {
     let color = match level {
         HeadingLevel::H1 => palette.accent_text,
@@ -978,4 +1013,42 @@ fn chars_to_spans(chars: &[(char, Style)]) -> Vec<Span<'static>> {
         spans.push(Span::styled(text, style));
     }
     spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line_text(line: &Line<'static>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn renders_yaml_frontmatter_as_code_before_body() {
+        let lines = render_markdown_preview(
+            "---\ntitle: Daily note\ntags:\n  - obsidian\n---\n# Notes\nBody text",
+        );
+        let text: Vec<String> = lines.iter().map(line_text).collect();
+
+        assert!(text.iter().any(|line| line.contains("yaml")));
+        assert!(text.iter().any(|line| line.contains("title")));
+        assert!(text.iter().any(|line| line.contains("obsidian")));
+        assert!(text.iter().any(|line| line.contains("Notes")));
+        assert!(!text.iter().any(|line| line.contains("────────────────")));
+    }
+
+    #[test]
+    fn only_treats_opening_delimited_block_as_frontmatter() {
+        assert!(split_yaml_frontmatter("# Notes\n---\ntitle: no\n---\n").is_none());
+        assert!(split_yaml_frontmatter("---\ntitle: no closing\n# Notes\n").is_none());
+
+        let Some((frontmatter, body)) = split_yaml_frontmatter("---\ntitle: ok\n...\nBody") else {
+            panic!("expected frontmatter");
+        };
+        assert_eq!(frontmatter, "title: ok");
+        assert_eq!(body, "Body");
+    }
 }

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -131,6 +131,11 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
     assert_eq!(docs.icon, "󱧷");
     assert_eq!(docs.color, rgb(91, 168, 255));
 
+    let qmd = theme.resolve(Path::new("report.qmd"), EntryKind::File);
+    assert_eq!(qmd.class, FileClass::Document);
+    assert_eq!(qmd.icon, "");
+    assert_eq!(qmd.color, rgb(211, 170, 124));
+
     let bin = theme.resolve(Path::new("bin"), EntryKind::Directory);
     assert_eq!(bin.class, FileClass::Directory);
     assert_eq!(bin.icon, "󱁿");


### PR DESCRIPTION
## Summary

Add YAML frontmatter rendering to Markdown previews.

Markdown previews now render top-of-file YAML frontmatter as highlighted YAML before the document body, instead of treating the delimiters as horizontal rules and the metadata as normal Markdown. Quarto `.qmd` files are also recognized as Markdown and use the matching Markdown document icon/color in the bundled themes.

Closes #223.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed