### PR TITLE
feat(dnd): add Kitty drag and drop support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added safe symlink preservation for `.zip`, `.7z`, and `.tar` archive creation and extraction.
 - Added a show/hide control to encrypted archive password prompts.
 - Added YAML frontmatter rendering to Markdown previews and recognized Quarto `.qmd` files as Markdown. ([#223])
+- Added Kitty 0.47+ drag-and-drop support for dropping items into elio and dragging items out, with themed drag previews.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "flate2",
+ "fontdue",
  "image",
  "json5",
  "libc",
@@ -585,9 +586,25 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontdue"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
+dependencies = [
+ "hashbrown 0.15.5",
+ "ttf-parser",
+]
 
 [[package]]
 name = "fsevent-sys"
@@ -679,13 +696,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -696,7 +724,7 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1947,6 +1975,12 @@ dependencies = [
  "urlencoding",
  "windows",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "typed-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ base64 = "0.22"
 cfb = "0.14"
 crossterm = "0.29"
 flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }
+fontdue = "0.9"
 image = { version = "0.25", default-features = false, features = ["gif", "ico", "jpeg", "png", "webp"] }
 notify = "8.2"
 json5 = "1.3"

--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -103,6 +103,7 @@ impl App {
         Ok(())
     }
 
+    #[cfg(any(unix, test))]
     pub(crate) fn drop_external_paths(&mut self, paths: Vec<PathBuf>, op: ClipOp) -> Result<bool> {
         let paths: Vec<PathBuf> = paths.into_iter().filter(|path| path.exists()).collect();
         if paths.is_empty() {

--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -103,22 +103,32 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn drop_external_paths(&mut self, paths: Vec<PathBuf>) -> Result<()> {
+    pub(crate) fn drop_external_paths(&mut self, paths: Vec<PathBuf>, op: ClipOp) -> Result<bool> {
         let paths: Vec<PathBuf> = paths.into_iter().filter(|path| path.exists()).collect();
         if paths.is_empty() {
             self.status = "Drop contains no local files".to_string();
-            return Ok(());
+            return Ok(false);
+        }
+        if op == ClipOp::Cut
+            && paths.iter().any(|path| {
+                path.file_name()
+                    .map(|file_name| self.navigation.cwd.join(file_name) == *path)
+                    .unwrap_or(false)
+            })
+        {
+            self.status = "Already here".to_string();
+            return Ok(false);
         }
 
         let request = QueuedPaste {
             dest_dir: self.navigation.cwd.clone(),
             paths,
-            op: ClipOp::Yank,
+            op,
             origin: PasteOrigin::Drop,
         };
         if paste_would_copy_directory_into_itself(&request) {
             self.status = "Cannot drop a folder into itself".to_string();
-            return Ok(());
+            return Ok(false);
         }
         if self.jobs.paste_progress.is_some() {
             self.jobs.queued_pastes.push_back(request);
@@ -132,7 +142,7 @@ impl App {
             self.start_paste_request(request);
             self.status = "Dropping files…".to_string();
         }
-        Ok(())
+        Ok(true)
     }
 
     pub(super) fn clear_queued_pastes(&mut self) -> usize {
@@ -178,7 +188,6 @@ impl App {
             dest_dir: request.dest_dir,
             paths: request.paths,
             op: request.op,
-            origin: request.origin,
         });
     }
 

--- a/src/app/clipboard/mod.rs
+++ b/src/app/clipboard/mod.rs
@@ -3,7 +3,7 @@ mod copy;
 use super::{
     App,
     jobs::PasteRequest,
-    state::{Clipboard, PasteProgress, QueuedPaste},
+    state::{Clipboard, PasteOrigin, PasteProgress, QueuedPaste},
     types::ClipOp,
 };
 use anyhow::Result;
@@ -103,6 +103,38 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn drop_external_paths(&mut self, paths: Vec<PathBuf>) -> Result<()> {
+        let paths: Vec<PathBuf> = paths.into_iter().filter(|path| path.exists()).collect();
+        if paths.is_empty() {
+            self.status = "Drop contains no local files".to_string();
+            return Ok(());
+        }
+
+        let request = QueuedPaste {
+            dest_dir: self.navigation.cwd.clone(),
+            paths,
+            op: ClipOp::Yank,
+            origin: PasteOrigin::Drop,
+        };
+        if paste_would_copy_directory_into_itself(&request) {
+            self.status = "Cannot drop a folder into itself".to_string();
+            return Ok(());
+        }
+        if self.jobs.paste_progress.is_some() {
+            self.jobs.queued_pastes.push_back(request);
+            let pending = self.jobs.queued_pastes.len();
+            self.status = if pending == 1 {
+                "Queued drop (1 pending)".to_string()
+            } else {
+                format!("Queued drop ({pending} pending)")
+            };
+        } else {
+            self.start_paste_request(request);
+            self.status = "Dropping files…".to_string();
+        }
+        Ok(())
+    }
+
     pub(super) fn clear_queued_pastes(&mut self) -> usize {
         let queued = self.jobs.queued_pastes.len();
         self.jobs.queued_pastes.clear();
@@ -126,6 +158,7 @@ impl App {
             dest_dir: self.navigation.cwd.clone(),
             paths: clipboard.paths,
             op: clipboard.op,
+            origin: PasteOrigin::Clipboard,
         })
     }
 
@@ -136,6 +169,7 @@ impl App {
             completed: 0,
             total: request.paths.len(),
             op: request.op,
+            origin: request.origin.clone(),
         });
         self.jobs.paste_dest_dir = Some(request.dest_dir.clone());
 
@@ -144,6 +178,7 @@ impl App {
             dest_dir: request.dest_dir,
             paths: request.paths,
             op: request.op,
+            origin: request.origin,
         });
     }
 

--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -209,6 +209,82 @@ fn yank_and_paste_copies_file_to_destination() {
     fs::remove_dir_all(&dst_dir).unwrap();
 }
 
+// ── external drop path ────────────────────────────────────────────────────────
+
+#[test]
+fn external_drop_copy_copies_file_to_current_directory() {
+    let src_dir = temp_path("drop-copy-src");
+    let dst_dir = temp_path("drop-copy-dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+    let source = src_dir.join("copy_me.txt");
+    fs::write(&source, "payload").unwrap();
+
+    let mut app = App::new_at(dst_dir.clone()).unwrap();
+    assert!(
+        app.drop_external_paths(vec![source.clone()], ClipOp::Yank)
+            .unwrap()
+    );
+    wait_for_paste_and_reload(&mut app);
+
+    assert_eq!(
+        fs::read_to_string(dst_dir.join("copy_me.txt")).unwrap(),
+        "payload"
+    );
+    assert!(source.exists(), "copy drop should keep the source file");
+    assert_eq!(app.status_message(), "Copied 1 item");
+
+    fs::remove_dir_all(&src_dir).unwrap();
+    fs::remove_dir_all(&dst_dir).unwrap();
+}
+
+#[test]
+fn external_drop_move_moves_file_to_current_directory() {
+    let src_dir = temp_path("drop-move-src");
+    let dst_dir = temp_path("drop-move-dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+    let source = src_dir.join("move_me.txt");
+    fs::write(&source, "payload").unwrap();
+
+    let mut app = App::new_at(dst_dir.clone()).unwrap();
+    assert!(
+        app.drop_external_paths(vec![source.clone()], ClipOp::Cut)
+            .unwrap()
+    );
+    wait_for_paste_and_reload(&mut app);
+
+    assert_eq!(
+        fs::read_to_string(dst_dir.join("move_me.txt")).unwrap(),
+        "payload"
+    );
+    assert!(!source.exists(), "move drop should remove the source file");
+    assert_eq!(app.status_message(), "Moved 1 item");
+
+    fs::remove_dir_all(&src_dir).unwrap();
+    fs::remove_dir_all(&dst_dir).unwrap();
+}
+
+#[test]
+fn external_drop_move_same_directory_is_clean_noop() {
+    let root = temp_path("drop-move-same-dir");
+    fs::create_dir_all(&root).unwrap();
+    let source = root.join("already_here.txt");
+    fs::write(&source, "payload").unwrap();
+
+    let mut app = App::new_at(root.clone()).unwrap();
+    assert!(
+        !app.drop_external_paths(vec![source.clone()], ClipOp::Cut)
+            .unwrap()
+    );
+
+    assert_eq!(fs::read_to_string(&source).unwrap(), "payload");
+    assert!(!root.join("already_here_1.txt").exists());
+    assert_eq!(app.status_message(), "Already here");
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
 // ── cut / move path ───────────────────────────────────────────────────────────
 
 #[test]

--- a/src/app/drag.rs
+++ b/src/app/drag.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::*;
 
 impl App {
@@ -48,14 +50,14 @@ impl App {
         self.drag_paths_for_candidate(&candidate)
     }
 
-    fn drag_paths_for_candidate(&self, candidate: &PathBuf) -> Vec<PathBuf> {
+    fn drag_paths_for_candidate(&self, candidate: &Path) -> Vec<PathBuf> {
         if !self.navigation.selected_paths.is_empty()
             && self.navigation.selected_paths.contains(candidate)
         {
             return self.selected_paths_sorted();
         }
 
-        vec![candidate.clone()]
+        vec![candidate.to_path_buf()]
     }
 
     fn entry_path_at(&self, column: u16, row: u16) -> Option<PathBuf> {

--- a/src/app/drag.rs
+++ b/src/app/drag.rs
@@ -10,6 +10,7 @@ impl App {
         }
     }
 
+    #[cfg(unix)]
     pub(crate) fn clear_drag_candidate(&mut self) {
         self.input.drag_candidate = None;
         self.input.drag_paths.clear();
@@ -27,6 +28,7 @@ impl App {
         self.input.drag_suppressed_until_up = true;
     }
 
+    #[cfg(any(unix, test))]
     pub(crate) fn take_drag_export_paths_at(&mut self, column: u16, row: u16) -> Vec<PathBuf> {
         if self.input.drag_suppressed_until_up {
             self.input.drag_candidate = None;
@@ -60,6 +62,7 @@ impl App {
         vec![candidate.to_path_buf()]
     }
 
+    #[cfg(any(unix, test))]
     fn entry_path_at(&self, column: u16, row: u16) -> Option<PathBuf> {
         self.input
             .frame_state

--- a/src/app/drag.rs
+++ b/src/app/drag.rs
@@ -1,0 +1,219 @@
+use super::*;
+
+impl App {
+    pub(in crate::app) fn remember_drag_candidate(&mut self, path: PathBuf) {
+        if !self.input.drag_suppressed_until_up {
+            self.input.drag_paths = self.drag_paths_for_candidate(&path);
+            self.input.drag_candidate = Some(path);
+        }
+    }
+
+    pub(crate) fn clear_drag_candidate(&mut self) {
+        self.input.drag_candidate = None;
+        self.input.drag_paths.clear();
+    }
+
+    pub(crate) fn clear_drag_state(&mut self) {
+        self.input.drag_candidate = None;
+        self.input.drag_paths.clear();
+        self.input.drag_suppressed_until_up = false;
+    }
+
+    pub(in crate::app) fn suppress_drag_until_button_up(&mut self) {
+        self.input.drag_candidate = None;
+        self.input.drag_paths.clear();
+        self.input.drag_suppressed_until_up = true;
+    }
+
+    pub(crate) fn take_drag_export_paths_at(&mut self, column: u16, row: u16) -> Vec<PathBuf> {
+        if self.input.drag_suppressed_until_up {
+            self.input.drag_candidate = None;
+            self.input.drag_paths.clear();
+            return Vec::new();
+        }
+
+        if let Some(candidate) = self.input.drag_candidate.take() {
+            let snapshot = std::mem::take(&mut self.input.drag_paths);
+            if !snapshot.is_empty() {
+                return snapshot;
+            }
+            return self.drag_paths_for_candidate(&candidate);
+        }
+
+        let candidate = self.entry_path_at(column, row);
+        let Some(candidate) = candidate else {
+            return Vec::new();
+        };
+
+        self.drag_paths_for_candidate(&candidate)
+    }
+
+    fn drag_paths_for_candidate(&self, candidate: &PathBuf) -> Vec<PathBuf> {
+        if !self.navigation.selected_paths.is_empty()
+            && self.navigation.selected_paths.contains(candidate)
+        {
+            return self.selected_paths_sorted();
+        }
+
+        vec![candidate.clone()]
+    }
+
+    fn entry_path_at(&self, column: u16, row: u16) -> Option<PathBuf> {
+        self.input
+            .frame_state
+            .entry_hits
+            .iter()
+            .find(|hit| rect_contains(hit.rect, column, row))
+            .and_then(|hit| self.navigation.entries.get(hit.index))
+            .map(|entry| entry.path.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn drag_export_paths(&self) -> Vec<PathBuf> {
+        if !self.navigation.selected_paths.is_empty() {
+            return self.selected_paths_sorted();
+        }
+        self.selected_entry()
+            .map(|entry| vec![entry.path.clone()])
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-drag-{label}-{unique}"))
+    }
+
+    fn make_app_with_entries() -> (App, PathBuf, PathBuf, PathBuf) {
+        let root = temp_path("export");
+        fs::create_dir_all(&root).expect("temp root");
+        let alpha = root.join("alpha.txt");
+        let beta = root.join("beta.txt");
+        let gamma = root.join("gamma.txt");
+        fs::write(&alpha, "a").expect("alpha");
+        fs::write(&beta, "b").expect("beta");
+        fs::write(&gamma, "g").expect("gamma");
+        let mut app = App::new_at(root).expect("app should initialize");
+        app.navigation.entries = vec![
+            Entry {
+                path: alpha.clone(),
+                name: "alpha.txt".to_string(),
+                name_key: "alpha.txt".to_string(),
+                ..Entry::default()
+            },
+            Entry {
+                path: beta.clone(),
+                name: "beta.txt".to_string(),
+                name_key: "beta.txt".to_string(),
+                ..Entry::default()
+            },
+            Entry {
+                path: gamma.clone(),
+                name: "gamma.txt".to_string(),
+                name_key: "gamma.txt".to_string(),
+                ..Entry::default()
+            },
+        ];
+        app.navigation.selected = 1;
+        (app, alpha, beta, gamma)
+    }
+
+    #[test]
+    fn drag_without_selection_exports_focused_entry() {
+        let (app, _alpha, beta, _gamma) = make_app_with_entries();
+
+        assert_eq!(app.drag_export_paths(), vec![beta]);
+    }
+
+    #[test]
+    fn drag_with_selection_exports_sorted_selection() {
+        let (mut app, alpha, _beta, gamma) = make_app_with_entries();
+        app.navigation.selected_paths.insert(gamma.clone());
+        app.navigation.selected_paths.insert(alpha.clone());
+
+        assert_eq!(app.drag_export_paths(), vec![alpha, gamma]);
+    }
+
+    #[test]
+    fn drag_with_no_entries_exports_nothing() {
+        let (mut app, _alpha, _beta, _gamma) = make_app_with_entries();
+        app.navigation.entries.clear();
+
+        assert!(app.drag_export_paths().is_empty());
+    }
+
+    #[test]
+    fn drag_offer_exports_clicked_entry_when_it_is_not_selected() {
+        let (mut app, _alpha, beta, _gamma) = make_app_with_entries();
+        app.remember_drag_candidate(beta.clone());
+
+        assert_eq!(app.take_drag_export_paths_at(0, 0), vec![beta]);
+    }
+
+    #[test]
+    fn drag_offer_exports_selection_when_clicked_entry_is_selected() {
+        let (mut app, alpha, _beta, gamma) = make_app_with_entries();
+        app.navigation.selected_paths.insert(gamma.clone());
+        app.navigation.selected_paths.insert(alpha.clone());
+        app.remember_drag_candidate(gamma.clone());
+
+        assert_eq!(app.take_drag_export_paths_at(0, 0), vec![alpha, gamma]);
+    }
+
+    #[test]
+    fn drag_offer_uses_mouse_down_selection_snapshot() {
+        let (mut app, alpha, _beta, gamma) = make_app_with_entries();
+        app.navigation.selected_paths.insert(gamma.clone());
+        app.navigation.selected_paths.insert(alpha.clone());
+        app.remember_drag_candidate(gamma.clone());
+        app.navigation.selected_paths.clear();
+
+        assert_eq!(app.take_drag_export_paths_at(0, 0), vec![alpha, gamma]);
+    }
+
+    #[test]
+    fn drag_offer_without_click_candidate_can_use_entry_hit() {
+        let (mut app, _alpha, _beta, _gamma) = make_app_with_entries();
+        app.set_frame_state(FrameState {
+            entry_hits: vec![EntryHit {
+                rect: Rect::new(2, 3, 12, 1),
+                index: 1,
+            }],
+            ..FrameState::default()
+        });
+
+        let expected = app.navigation.entries[1].path.clone();
+        assert_eq!(app.take_drag_export_paths_at(3, 3), vec![expected]);
+    }
+
+    #[test]
+    fn drag_offer_outside_entry_exports_nothing() {
+        let (mut app, _alpha, _beta, _gamma) = make_app_with_entries();
+
+        assert!(app.take_drag_export_paths_at(0, 0).is_empty());
+    }
+
+    #[test]
+    fn suppressed_drag_offer_exports_nothing_until_cleared() {
+        let (mut app, _alpha, beta, _gamma) = make_app_with_entries();
+        app.remember_drag_candidate(beta.clone());
+        app.suppress_drag_until_button_up();
+
+        assert!(app.take_drag_export_paths_at(0, 0).is_empty());
+
+        app.clear_drag_state();
+        app.remember_drag_candidate(beta.clone());
+        assert_eq!(app.take_drag_export_paths_at(0, 0), vec![beta]);
+    }
+}

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -67,6 +67,7 @@ impl App {
 
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                self.clear_drag_state();
                 self.update_wheel_target_from_position(mouse.column, mouse.row);
                 if let Some(rect) = self.input.frame_state.back_button
                     && rect_contains(rect, mouse.column, mouse.row)
@@ -123,6 +124,7 @@ impl App {
                     else {
                         return Ok(());
                     };
+                    self.remember_drag_candidate(path.clone());
                     self.select_index(hit.index);
                     if self.is_double_click(&path) {
                         if self.chooser_mode {
@@ -130,12 +132,16 @@ impl App {
                         } else {
                             self.open_entry_at_index(hit.index)?;
                         }
+                        self.suppress_drag_until_button_up();
                     }
                     self.input.last_click = Some(ClickState {
                         path,
                         at: Instant::now(),
                     });
                 }
+            }
+            MouseEventKind::Up(_) => {
+                self.clear_drag_state();
             }
             MouseEventKind::ScrollDown => {
                 self.handle_wheel_event(mouse, 1);

--- a/src/app/input/tests/mouse.rs
+++ b/src/app/input/tests/mouse.rs
@@ -13,6 +13,15 @@ fn left_click(column: u16, row: u16) -> Event {
     })
 }
 
+fn left_release(column: u16, row: u16) -> Event {
+    Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Up(MouseButton::Left),
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    })
+}
+
 fn entry_hit(index: usize, row: u16) -> EntryHit {
     EntryHit {
         rect: Rect {
@@ -64,6 +73,46 @@ fn double_click_opens_clicked_file_not_multi_selection() {
     let opened: Vec<_> = opened.lines().map(str::to_owned).collect();
     assert_eq!(opened, vec![beta.display().to_string()]);
     assert_eq!(app.status, "Opened beta.txt");
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn double_click_suppresses_drag_from_held_second_click() {
+    let root = temp_path("mouse-double-click-drag-suppression");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let beta = root.join("beta.txt");
+    fs::write(&beta, "beta").expect("failed to write beta");
+    let capture = root.join("capture.txt");
+    let _capture_guard = OpenInSystemCaptureGuard::install(capture);
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    let beta_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == beta)
+        .expect("beta should be visible");
+    app.set_frame_state(FrameState {
+        entry_hits: vec![entry_hit(beta_index, 1)],
+        ..FrameState::default()
+    });
+
+    app.handle_event(left_click(1, 1)).expect("first click");
+    app.handle_event(left_release(1, 1)).expect("first release");
+    app.handle_event(left_click(1, 1))
+        .expect("second click should open clicked file");
+
+    assert!(app.take_drag_export_paths_at(1, 1).is_empty());
+
+    app.handle_event(left_release(1, 1))
+        .expect("second release should clear suppression");
+    app.input.last_click = None;
+    app.handle_event(left_click(1, 1))
+        .expect("next click can start a new drag candidate");
+
+    assert_eq!(app.take_drag_export_paths_at(1, 1), vec![beta]);
 
     fs::remove_dir_all(root).ok();
 }

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -344,6 +344,8 @@ impl App {
                         continue;
                     }
                     if build.done {
+                        let paste_origin =
+                            self.jobs.paste_progress.as_ref().map(|p| p.origin.clone());
                         self.jobs.paste_progress = None;
                         let dest_dir = self
                             .jobs
@@ -372,13 +374,19 @@ impl App {
                             && (nav_target.is_none() || nav_to_dest)
                             && !defer_reload_for_same_dest
                         {
+                            let reselect_path =
+                                if paste_origin == Some(crate::app::state::PasteOrigin::Drop) {
+                                    build.destination_paths.first().cloned()
+                                } else {
+                                    None
+                                };
                             let _ = self.queue_directory_load(PendingDirectoryLoad {
                                 token: 0,
                                 target_cwd: dest_dir,
                                 previous_cwd: self.navigation.cwd.clone(),
                                 previous_selected_path: None,
                                 previous_selection_name: None,
-                                reselect_path: None,
+                                reselect_path,
                                 history_mode: DirectoryHistoryMode::None,
                                 refresh_search: false,
                                 completion: DirectoryLoadCompletion::Status(status),

--- a/src/app/jobs/tasks/paste.rs
+++ b/src/app/jobs/tasks/paste.rs
@@ -55,7 +55,7 @@ impl PastePool {
         let worker = thread::spawn(move || {
             while let Some(request) = PasteShared::pop(&shared_worker) {
                 PasteShared::set_active(&shared_worker, true);
-                let (completed, errors, stopped_early, destination_paths) = run_paste(
+                let (completed, already_here, errors, stopped_early, destination_paths) = run_paste(
                     &request,
                     &result_tx,
                     &shared_worker.cancelled,
@@ -63,12 +63,9 @@ impl PastePool {
                 );
                 PasteShared::set_active(&shared_worker, false);
 
-                let verb = match request.origin {
-                    crate::app::state::PasteOrigin::Drop => "Dropped",
-                    crate::app::state::PasteOrigin::Clipboard => match request.op {
-                        ClipOp::Yank => "Copied",
-                        ClipOp::Cut => "Moved",
-                    },
+                let verb = match request.op {
+                    ClipOp::Yank => "Copied",
+                    ClipOp::Cut => "Moved",
                 };
                 let status = if stopped_early {
                     match completed {
@@ -77,10 +74,16 @@ impl PastePool {
                         n => format!("Paste cancelled — {verb} {n} items"),
                     }
                 } else if errors.is_empty() {
-                    match completed {
-                        0 => "Nothing was pasted".to_string(),
-                        1 => format!("{verb} 1 item"),
-                        n => format!("{verb} {n} items"),
+                    match (completed, already_here) {
+                        (0, 0) => "Nothing was pasted".to_string(),
+                        (0, 1) => "Already here".to_string(),
+                        (0, n) => format!("{n} items already here"),
+                        (1, 0) => format!("{verb} 1 item"),
+                        (n, 0) => format!("{verb} {n} items"),
+                        (1, 1) => format!("{verb} 1 item; 1 already here"),
+                        (1, n) => format!("{verb} 1 item; {n} already here"),
+                        (n, 1) => format!("{verb} {n} items; 1 already here"),
+                        (n, skipped) => format!("{verb} {n} items; {skipped} already here"),
                     }
                 } else if completed == 0 {
                     if errors.len() == 1 {
@@ -175,7 +178,7 @@ impl PasteShared {
 
 /// Execute the paste operation, sending throttled intermediate progress
 /// results through `result_tx`. Returns completed count, errors, cancellation
-/// state, and destination paths actually written.
+/// state, skipped same-location moves, and destination paths actually written.
 ///
 /// `stopped_early` is `true` if the loop was cut short by a cancel flag rather
 /// than running to completion.
@@ -184,8 +187,9 @@ fn run_paste(
     result_tx: &mpsc::Sender<JobResult>,
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
-) -> (usize, Vec<String>, bool, Vec<PathBuf>) {
+) -> (usize, usize, Vec<String>, bool, Vec<PathBuf>) {
     let mut completed = 0usize;
+    let mut already_here = 0usize;
     let mut destination_paths = Vec::new();
     let mut errors: Vec<String> = Vec::new();
     let mut stopped_early = false;
@@ -216,12 +220,11 @@ fn run_paste(
             continue;
         }
 
-        // For cut: same-dir same-name is a no-op.
+        // For cut: same-dir same-name is a no-op, not a move.
         if request.op == ClipOp::Cut {
             let natural = request.dest_dir.join(file_name);
             if natural == *src {
-                completed += 1;
-                destination_paths.push(natural);
+                already_here += 1;
                 if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at)
                 {
                     break;
@@ -294,7 +297,13 @@ fn run_paste(
         }
     }
 
-    (completed, errors, stopped_early, destination_paths)
+    (
+        completed,
+        already_here,
+        errors,
+        stopped_early,
+        destination_paths,
+    )
 }
 
 /// Send a throttled intermediate progress result for the paste worker.

--- a/src/app/jobs/tasks/paste.rs
+++ b/src/app/jobs/tasks/paste.rs
@@ -55,7 +55,7 @@ impl PastePool {
         let worker = thread::spawn(move || {
             while let Some(request) = PasteShared::pop(&shared_worker) {
                 PasteShared::set_active(&shared_worker, true);
-                let (completed, errors, stopped_early) = run_paste(
+                let (completed, errors, stopped_early, destination_paths) = run_paste(
                     &request,
                     &result_tx,
                     &shared_worker.cancelled,
@@ -63,9 +63,12 @@ impl PastePool {
                 );
                 PasteShared::set_active(&shared_worker, false);
 
-                let verb = match request.op {
-                    ClipOp::Yank => "Copied",
-                    ClipOp::Cut => "Moved",
+                let verb = match request.origin {
+                    crate::app::state::PasteOrigin::Drop => "Dropped",
+                    crate::app::state::PasteOrigin::Clipboard => match request.op {
+                        ClipOp::Yank => "Copied",
+                        ClipOp::Cut => "Moved",
+                    },
                 };
                 let status = if stopped_early {
                     match completed {
@@ -99,6 +102,7 @@ impl PastePool {
                         completed,
                         done: true,
                         status: Some(status),
+                        destination_paths,
                     }))
                     .is_err()
                 {
@@ -170,7 +174,8 @@ impl PasteShared {
 }
 
 /// Execute the paste operation, sending throttled intermediate progress
-/// results through `result_tx`.  Returns `(completed, errors, stopped_early)`.
+/// results through `result_tx`. Returns completed count, errors, cancellation
+/// state, and destination paths actually written.
 ///
 /// `stopped_early` is `true` if the loop was cut short by a cancel flag rather
 /// than running to completion.
@@ -179,8 +184,9 @@ fn run_paste(
     result_tx: &mpsc::Sender<JobResult>,
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
-) -> (usize, Vec<String>, bool) {
+) -> (usize, Vec<String>, bool, Vec<PathBuf>) {
     let mut completed = 0usize;
+    let mut destination_paths = Vec::new();
     let mut errors: Vec<String> = Vec::new();
     let mut stopped_early = false;
     // Tracks when we last sent a progress result.  None = never sent, which
@@ -215,6 +221,7 @@ fn run_paste(
             let natural = request.dest_dir.join(file_name);
             if natural == *src {
                 completed += 1;
+                destination_paths.push(natural);
                 if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at)
                 {
                     break;
@@ -279,6 +286,7 @@ fn run_paste(
 
         if ok {
             completed += 1;
+            destination_paths.push(dest);
         }
 
         if !send_paste_progress(result_tx, request.token, completed, &mut last_progress_at) {
@@ -286,7 +294,7 @@ fn run_paste(
         }
     }
 
-    (completed, errors, stopped_early)
+    (completed, errors, stopped_early, destination_paths)
 }
 
 /// Send a throttled intermediate progress result for the paste worker.
@@ -307,6 +315,7 @@ fn send_paste_progress(
                 completed,
                 done: false,
                 status: None,
+                destination_paths: Vec::new(),
             }))
             .is_ok();
     }

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -312,7 +312,6 @@ pub(in crate::app) struct PasteRequest {
     pub(in crate::app) dest_dir: PathBuf,
     pub(in crate::app) paths: Vec<PathBuf>,
     pub(in crate::app) op: ClipOp,
-    pub(in crate::app) origin: crate::app::state::PasteOrigin,
 }
 
 #[derive(Debug)]

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -312,6 +312,7 @@ pub(in crate::app) struct PasteRequest {
     pub(in crate::app) dest_dir: PathBuf,
     pub(in crate::app) paths: Vec<PathBuf>,
     pub(in crate::app) op: ClipOp,
+    pub(in crate::app) origin: crate::app::state::PasteOrigin,
 }
 
 #[derive(Debug)]
@@ -322,6 +323,8 @@ pub(in crate::app) struct PasteBuild {
     pub(in crate::app) done: bool,
     /// Populated only when `done = true`.
     pub(in crate::app) status: Option<String>,
+    /// Destination paths actually written by the completed paste/drop.
+    pub(in crate::app) destination_paths: Vec<PathBuf>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ mod clipboard;
 mod constants;
 mod create;
 mod directory_counts;
+mod drag;
 mod git;
 mod input;
 mod jobs;

--- a/src/app/open_with/discovery/macos.rs
+++ b/src/app/open_with/discovery/macos.rs
@@ -39,6 +39,7 @@ type CFArrayRef = *const c_void;
 type CFStringRef = *const c_void;
 type CFIndex = isize;
 type CFStringEncoding = u32;
+type Boolean = u8;
 
 const LS_ROLES_ALL: u32 = 0xFFFF_FFFF;
 const LS_ROLES_VIEWER: u32 = 1 << 1;
@@ -87,7 +88,7 @@ unsafe extern "C" {
         buf: *mut i8,
         buf_size: CFIndex,
         enc: CFStringEncoding,
-    ) -> bool;
+    ) -> Boolean;
     fn CFRelease(cf: CFTypeRef);
 }
 
@@ -385,7 +386,7 @@ fn cf_url_to_path(url: CFURLRef) -> Option<String> {
     let ok =
         unsafe { CFStringGetCString(cf_str, buf.as_mut_ptr(), max_size, CF_STRING_ENCODING_UTF8) };
     unsafe { CFRelease(cf_str) };
-    if !ok {
+    if ok == 0 {
         return None;
     }
     unsafe { CStr::from_ptr(buf.as_ptr()) }
@@ -404,7 +405,7 @@ fn cf_string_to_string(value: CFStringRef) -> Option<String> {
     let mut buf: Vec<i8> = vec![0; max_size as usize];
     let ok =
         unsafe { CFStringGetCString(value, buf.as_mut_ptr(), max_size, CF_STRING_ENCODING_UTF8) };
-    if !ok {
+    if ok == 0 {
         return None;
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -101,6 +101,13 @@ pub(super) struct PasteProgress {
     pub(super) completed: usize,
     pub(super) total: usize,
     pub(super) op: ClipOp,
+    pub(super) origin: PasteOrigin,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum PasteOrigin {
+    Clipboard,
+    Drop,
 }
 
 #[derive(Clone, Debug)]
@@ -108,6 +115,7 @@ pub(super) struct QueuedPaste {
     pub(super) dest_dir: PathBuf,
     pub(super) paths: Vec<PathBuf>,
     pub(super) op: ClipOp,
+    pub(super) origin: PasteOrigin,
 }
 
 #[derive(Clone, Debug)]
@@ -715,6 +723,9 @@ pub(in crate::app) struct JobRuntime {
 pub(in crate::app) struct InputRuntime {
     pub(in crate::app) frame_state: FrameState,
     pub(in crate::app) last_click: Option<ClickState>,
+    pub(in crate::app) drag_candidate: Option<PathBuf>,
+    pub(in crate::app) drag_paths: Vec<PathBuf>,
+    pub(in crate::app) drag_suppressed_until_up: bool,
     pub(in crate::app) wheel_scroll: ScrollState,
     pub(in crate::app) wheel_profile: WheelProfile,
     pub(in crate::app) last_wheel_target: Option<WheelTarget>,
@@ -879,6 +890,9 @@ impl App {
             input: InputRuntime {
                 frame_state: FrameState::default(),
                 last_click: None,
+                drag_candidate: None,
+                drag_paths: Vec::new(),
+                drag_suppressed_until_up: false,
                 wheel_scroll: ScrollState {
                     horizontal: ScrollLane::new(),
                     vertical: ScrollLane::new(),

--- a/src/runtime/input/event.rs
+++ b/src/runtime/input/event.rs
@@ -1,9 +1,11 @@
 use crossterm::event::Event;
 
+#[cfg(unix)]
 use crate::runtime::kitty_dnd::KittyDndEvent;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(in crate::runtime) enum RuntimeInputEvent {
     Terminal(Event),
+    #[cfg(unix)]
     KittyDnd(KittyDndEvent),
 }

--- a/src/runtime/input/event.rs
+++ b/src/runtime/input/event.rs
@@ -1,0 +1,9 @@
+use crossterm::event::Event;
+
+use crate::runtime::kitty_dnd::KittyDndEvent;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::runtime) enum RuntimeInputEvent {
+    Terminal(Event),
+    KittyDnd(KittyDndEvent),
+}

--- a/src/runtime/input/mod.rs
+++ b/src/runtime/input/mod.rs
@@ -1,4 +1,5 @@
 mod event;
+#[cfg(unix)]
 mod parser;
 mod reader;
 

--- a/src/runtime/input/mod.rs
+++ b/src/runtime/input/mod.rs
@@ -1,0 +1,6 @@
+mod event;
+mod parser;
+mod reader;
+
+pub(in crate::runtime) use event::RuntimeInputEvent;
+pub(in crate::runtime) use reader::RuntimeInputReader;

--- a/src/runtime/input/parser/crossterm_compat.rs
+++ b/src/runtime/input/parser/crossterm_compat.rs
@@ -1,5 +1,6 @@
-// Vendored from crossterm 0.29 unix event parser, with imports adjusted so elio can intercept Kitty OSC 72 before normal event parsing.
-// Keep local changes minimal.
+// Adapted from crossterm 0.29's Unix event parser so elio can intercept Kitty
+// OSC 72 DND before normal event parsing. This is intentionally kept close to
+// upstream crossterm; when bumping crossterm, compare and port parser fixes.
 use std::io;
 
 use crossterm::event::{
@@ -28,7 +29,7 @@ pub(super) enum InternalEvent {
 //
 
 fn could_not_parse_event_error() -> io::Error {
-    io::Error::new(io::ErrorKind::Other, "Could not parse an event.")
+    io::Error::other("Could not parse an event.")
 }
 
 pub(super) fn parse_event(
@@ -604,15 +605,14 @@ fn parse_csi_u_encoded_key_code(buffer: &[u8]) -> io::Result<Option<InternalEven
     // and the terminal sends a keyboard event containing shift, the sequence will
     // contain an additional codepoint separated by a ':' character which contains
     // the shifted character according to the keyboard layout.
-    if modifiers.contains(KeyModifiers::SHIFT) {
-        if let Some(shifted_c) = codepoints
+    if modifiers.contains(KeyModifiers::SHIFT)
+        && let Some(shifted_c) = codepoints
             .next()
             .and_then(|codepoint| codepoint.parse::<u32>().ok())
             .and_then(char::from_u32)
-        {
-            keycode = KeyCode::Char(shifted_c);
-            modifiers.set(KeyModifiers::SHIFT, false);
-        }
+    {
+        keycode = KeyCode::Char(shifted_c);
+        modifiers.set(KeyModifiers::SHIFT, false);
     }
 
     let input_event = Event::Key(KeyEvent::new_with_kind_and_state(

--- a/src/runtime/input/parser/crossterm_compat.rs
+++ b/src/runtime/input/parser/crossterm_compat.rs
@@ -1,6 +1,7 @@
-// Adapted from crossterm 0.29's Unix event parser so elio can intercept Kitty
-// OSC 72 DND before normal event parsing. This is intentionally kept close to
-// upstream crossterm; when bumping crossterm, compare and port parser fixes.
+// Adapted from crossterm 0.29's MIT-licensed Unix event parser so elio can
+// intercept Kitty OSC 72 DND before normal event parsing. This is intentionally
+// kept close to upstream crossterm; when bumping crossterm, compare and port
+// parser fixes.
 use std::io;
 
 use crossterm::event::{

--- a/src/runtime/input/parser/crossterm_compat.rs
+++ b/src/runtime/input/parser/crossterm_compat.rs
@@ -1,0 +1,1512 @@
+// Vendored from crossterm 0.29 unix event parser, with imports adjusted so elio can intercept Kitty OSC 72 before normal event parsing.
+// Keep local changes minimal.
+use std::io;
+
+use crossterm::event::{
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, KeyboardEnhancementFlags,
+    MediaKeyCode, ModifierKeyCode, MouseButton, MouseEvent, MouseEventKind,
+};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) enum InternalEvent {
+    Event(Event),
+    CursorPosition(u16, u16),
+    KeyboardEnhancementFlags(KeyboardEnhancementFlags),
+    PrimaryDeviceAttributes,
+}
+
+// Event parsing
+//
+// This code (& previous one) are kind of ugly. We have to think about this,
+// because it's really not maintainable, no tests, etc.
+//
+// Every fn returns Result<Option<InputEvent>>
+//
+// Ok(None) -> wait for more bytes
+// Err(_) -> failed to parse event, clear the buffer
+// Ok(Some(event)) -> we have event, clear the buffer
+//
+
+fn could_not_parse_event_error() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "Could not parse an event.")
+}
+
+pub(super) fn parse_event(
+    buffer: &[u8],
+    input_available: bool,
+) -> io::Result<Option<InternalEvent>> {
+    if buffer.is_empty() {
+        return Ok(None);
+    }
+
+    match buffer[0] {
+        b'\x1B' => {
+            if buffer.len() == 1 {
+                if input_available {
+                    // Possible Esc sequence
+                    Ok(None)
+                } else {
+                    Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Esc.into()))))
+                }
+            } else {
+                match buffer[1] {
+                    b'O' => {
+                        if buffer.len() == 2 {
+                            Ok(None)
+                        } else {
+                            match buffer[2] {
+                                b'D' => {
+                                    Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Left.into()))))
+                                }
+                                b'C' => Ok(Some(InternalEvent::Event(Event::Key(
+                                    KeyCode::Right.into(),
+                                )))),
+                                b'A' => {
+                                    Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Up.into()))))
+                                }
+                                b'B' => {
+                                    Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Down.into()))))
+                                }
+                                b'H' => {
+                                    Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Home.into()))))
+                                }
+                                b'F' => {
+                                    Ok(Some(InternalEvent::Event(Event::Key(KeyCode::End.into()))))
+                                }
+                                // F1-F4
+                                val @ b'P'..=b'S' => Ok(Some(InternalEvent::Event(Event::Key(
+                                    KeyCode::F(1 + val - b'P').into(),
+                                )))),
+                                _ => Err(could_not_parse_event_error()),
+                            }
+                        }
+                    }
+                    b'[' => parse_csi(buffer),
+                    b'\x1B' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Esc.into())))),
+                    _ => parse_event(&buffer[1..], input_available).map(|event_option| {
+                        event_option.map(|event| {
+                            if let InternalEvent::Event(Event::Key(key_event)) = event {
+                                let mut alt_key_event = key_event;
+                                alt_key_event.modifiers |= KeyModifiers::ALT;
+                                InternalEvent::Event(Event::Key(alt_key_event))
+                            } else {
+                                event
+                            }
+                        })
+                    }),
+                }
+            }
+        }
+        b'\r' => Ok(Some(InternalEvent::Event(Event::Key(
+            KeyCode::Enter.into(),
+        )))),
+        // Issue #371: \n = 0xA, which is also the keycode for Ctrl+J. The only reason we get
+        // newlines as input is because the terminal converts \r into \n for us. When we
+        // enter raw mode, we disable that, so \n no longer has any meaning - it's better to
+        // use Ctrl+J. Waiting to handle it here means it gets picked up later
+        b'\n' if !crossterm::terminal::is_raw_mode_enabled().unwrap_or(false) => Ok(Some(
+            InternalEvent::Event(Event::Key(KeyCode::Enter.into())),
+        )),
+        b'\t' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Tab.into())))),
+        b'\x7F' => Ok(Some(InternalEvent::Event(Event::Key(
+            KeyCode::Backspace.into(),
+        )))),
+        c @ b'\x01'..=b'\x1A' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Char((c - 0x1 + b'a') as char),
+            KeyModifiers::CONTROL,
+        ))))),
+        c @ b'\x1C'..=b'\x1F' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Char((c - 0x1C + b'4') as char),
+            KeyModifiers::CONTROL,
+        ))))),
+        b'\0' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::CONTROL,
+        ))))),
+        _ => parse_utf8_char(buffer).map(|maybe_char| {
+            maybe_char
+                .map(KeyCode::Char)
+                .map(char_code_to_event)
+                .map(Event::Key)
+                .map(InternalEvent::Event)
+        }),
+    }
+}
+
+// converts KeyCode to KeyEvent (adds shift modifier in case of uppercase characters)
+fn char_code_to_event(code: KeyCode) -> KeyEvent {
+    let modifiers = match code {
+        KeyCode::Char(c) if c.is_uppercase() => KeyModifiers::SHIFT,
+        _ => KeyModifiers::empty(),
+    };
+    KeyEvent::new(code, modifiers)
+}
+
+fn parse_csi(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    assert!(buffer.starts_with(b"\x1B[")); // ESC [
+
+    if buffer.len() == 2 {
+        return Ok(None);
+    }
+
+    let input_event = match buffer[2] {
+        b'[' => {
+            if buffer.len() == 3 {
+                None
+            } else {
+                match buffer[3] {
+                    // NOTE (@imdaveho): cannot find when this occurs;
+                    // having another '[' after ESC[ not a likely scenario
+                    val @ b'A'..=b'E' => Some(Event::Key(KeyCode::F(1 + val - b'A').into())),
+                    _ => return Err(could_not_parse_event_error()),
+                }
+            }
+        }
+        b'D' => Some(Event::Key(KeyCode::Left.into())),
+        b'C' => Some(Event::Key(KeyCode::Right.into())),
+        b'A' => Some(Event::Key(KeyCode::Up.into())),
+        b'B' => Some(Event::Key(KeyCode::Down.into())),
+        b'H' => Some(Event::Key(KeyCode::Home.into())),
+        b'F' => Some(Event::Key(KeyCode::End.into())),
+        b'Z' => Some(Event::Key(KeyEvent::new_with_kind(
+            KeyCode::BackTab,
+            KeyModifiers::SHIFT,
+            KeyEventKind::Press,
+        ))),
+        b'M' => return parse_csi_normal_mouse(buffer),
+        b'<' => return parse_csi_sgr_mouse(buffer),
+        b'I' => Some(Event::FocusGained),
+        b'O' => Some(Event::FocusLost),
+        b';' => return parse_csi_modifier_key_code(buffer),
+        // P, Q, and S for compatibility with Kitty keyboard protocol,
+        // as the 1 in 'CSI 1 P' etc. must be omitted if there are no
+        // modifiers pressed:
+        // https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-functional-keys
+        b'P' => Some(Event::Key(KeyCode::F(1).into())),
+        b'Q' => Some(Event::Key(KeyCode::F(2).into())),
+        b'S' => Some(Event::Key(KeyCode::F(4).into())),
+        b'?' => match buffer[buffer.len() - 1] {
+            b'u' => return parse_csi_keyboard_enhancement_flags(buffer),
+            b'c' => return parse_csi_primary_device_attributes(buffer),
+            _ => None,
+        },
+        b'0'..=b'9' => {
+            // Numbered escape code.
+            if buffer.len() == 3 {
+                None
+            } else {
+                // The final byte of a CSI sequence can be in the range 64-126, so
+                // let's keep reading anything else.
+                let last_byte = buffer[buffer.len() - 1];
+                if !(64..=126).contains(&last_byte) {
+                    None
+                } else {
+                    if buffer.starts_with(b"\x1B[200~") {
+                        return parse_csi_bracketed_paste(buffer);
+                    }
+                    match last_byte {
+                        b'M' => return parse_csi_rxvt_mouse(buffer),
+                        b'~' => return parse_csi_special_key_code(buffer),
+                        b'u' => return parse_csi_u_encoded_key_code(buffer),
+                        b'R' => return parse_csi_cursor_position(buffer),
+                        _ => return parse_csi_modifier_key_code(buffer),
+                    }
+                }
+            }
+        }
+        _ => return Err(could_not_parse_event_error()),
+    };
+
+    Ok(input_event.map(InternalEvent::Event))
+}
+
+fn next_parsed<T>(iter: &mut dyn Iterator<Item = &str>) -> io::Result<T>
+where
+    T: std::str::FromStr,
+{
+    iter.next()
+        .ok_or_else(could_not_parse_event_error)?
+        .parse::<T>()
+        .map_err(|_| could_not_parse_event_error())
+}
+
+fn modifier_and_kind_parsed(iter: &mut dyn Iterator<Item = &str>) -> io::Result<(u8, u8)> {
+    let mut sub_split = iter
+        .next()
+        .ok_or_else(could_not_parse_event_error)?
+        .split(':');
+
+    let modifier_mask = next_parsed::<u8>(&mut sub_split)?;
+
+    if let Ok(kind_code) = next_parsed::<u8>(&mut sub_split) {
+        Ok((modifier_mask, kind_code))
+    } else {
+        Ok((modifier_mask, 1))
+    }
+}
+
+fn parse_csi_cursor_position(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // ESC [ Cy ; Cx R
+    //   Cy - cursor row number (starting from 1)
+    //   Cx - cursor column number (starting from 1)
+    assert!(buffer.starts_with(b"\x1B[")); // ESC [
+    assert!(buffer.ends_with(b"R"));
+
+    let s = std::str::from_utf8(&buffer[2..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+
+    let mut split = s.split(';');
+
+    let y = next_parsed::<u16>(&mut split)? - 1;
+    let x = next_parsed::<u16>(&mut split)? - 1;
+
+    Ok(Some(InternalEvent::CursorPosition(x, y)))
+}
+
+fn parse_csi_keyboard_enhancement_flags(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // ESC [ ? flags u
+    assert!(buffer.starts_with(b"\x1B[?")); // ESC [ ?
+    assert!(buffer.ends_with(b"u"));
+
+    if buffer.len() < 5 {
+        return Ok(None);
+    }
+
+    let bits = buffer[3];
+    let mut flags = KeyboardEnhancementFlags::empty();
+
+    if bits & 1 != 0 {
+        flags |= KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES;
+    }
+    if bits & 2 != 0 {
+        flags |= KeyboardEnhancementFlags::REPORT_EVENT_TYPES;
+    }
+    if bits & 4 != 0 {
+        flags |= KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS;
+    }
+    if bits & 8 != 0 {
+        flags |= KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
+    }
+    // *Note*: this is not yet supported by crossterm.
+    // if bits & 16 != 0 {
+    //     flags |= KeyboardEnhancementFlags::REPORT_ASSOCIATED_TEXT;
+    // }
+
+    Ok(Some(InternalEvent::KeyboardEnhancementFlags(flags)))
+}
+
+fn parse_csi_primary_device_attributes(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // ESC [ 64 ; attr1 ; attr2 ; ... ; attrn ; c
+    assert!(buffer.starts_with(b"\x1B[?"));
+    assert!(buffer.ends_with(b"c"));
+
+    // This is a stub for parsing the primary device attributes. This response is not
+    // exposed in the crossterm API so we don't need to parse the individual attributes yet.
+    // See <https://vt100.net/docs/vt510-rm/DA1.html>
+
+    Ok(Some(InternalEvent::PrimaryDeviceAttributes))
+}
+
+fn parse_modifiers(mask: u8) -> KeyModifiers {
+    let modifier_mask = mask.saturating_sub(1);
+    let mut modifiers = KeyModifiers::empty();
+    if modifier_mask & 1 != 0 {
+        modifiers |= KeyModifiers::SHIFT;
+    }
+    if modifier_mask & 2 != 0 {
+        modifiers |= KeyModifiers::ALT;
+    }
+    if modifier_mask & 4 != 0 {
+        modifiers |= KeyModifiers::CONTROL;
+    }
+    if modifier_mask & 8 != 0 {
+        modifiers |= KeyModifiers::SUPER;
+    }
+    if modifier_mask & 16 != 0 {
+        modifiers |= KeyModifiers::HYPER;
+    }
+    if modifier_mask & 32 != 0 {
+        modifiers |= KeyModifiers::META;
+    }
+    modifiers
+}
+
+fn parse_modifiers_to_state(mask: u8) -> KeyEventState {
+    let modifier_mask = mask.saturating_sub(1);
+    let mut state = KeyEventState::empty();
+    if modifier_mask & 64 != 0 {
+        state |= KeyEventState::CAPS_LOCK;
+    }
+    if modifier_mask & 128 != 0 {
+        state |= KeyEventState::NUM_LOCK;
+    }
+    state
+}
+
+fn parse_key_event_kind(kind: u8) -> KeyEventKind {
+    match kind {
+        1 => KeyEventKind::Press,
+        2 => KeyEventKind::Repeat,
+        3 => KeyEventKind::Release,
+        _ => KeyEventKind::Press,
+    }
+}
+
+fn parse_csi_modifier_key_code(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    assert!(buffer.starts_with(b"\x1B[")); // ESC [
+    //
+    let s = std::str::from_utf8(&buffer[2..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+    let mut split = s.split(';');
+
+    split.next();
+
+    let (modifiers, kind) =
+        if let Ok((modifier_mask, kind_code)) = modifier_and_kind_parsed(&mut split) {
+            (
+                parse_modifiers(modifier_mask),
+                parse_key_event_kind(kind_code),
+            )
+        } else if buffer.len() > 3 {
+            (
+                parse_modifiers(
+                    (buffer[buffer.len() - 2] as char)
+                        .to_digit(10)
+                        .ok_or_else(could_not_parse_event_error)? as u8,
+                ),
+                KeyEventKind::Press,
+            )
+        } else {
+            (KeyModifiers::NONE, KeyEventKind::Press)
+        };
+    let key = buffer[buffer.len() - 1];
+
+    let keycode = match key {
+        b'A' => KeyCode::Up,
+        b'B' => KeyCode::Down,
+        b'C' => KeyCode::Right,
+        b'D' => KeyCode::Left,
+        b'F' => KeyCode::End,
+        b'H' => KeyCode::Home,
+        b'P' => KeyCode::F(1),
+        b'Q' => KeyCode::F(2),
+        b'R' => KeyCode::F(3),
+        b'S' => KeyCode::F(4),
+        _ => return Err(could_not_parse_event_error()),
+    };
+
+    let input_event = Event::Key(KeyEvent::new_with_kind(keycode, modifiers, kind));
+
+    Ok(Some(InternalEvent::Event(input_event)))
+}
+
+fn translate_functional_key_code(codepoint: u32) -> Option<(KeyCode, KeyEventState)> {
+    if let Some(keycode) = match codepoint {
+        57399 => Some(KeyCode::Char('0')),
+        57400 => Some(KeyCode::Char('1')),
+        57401 => Some(KeyCode::Char('2')),
+        57402 => Some(KeyCode::Char('3')),
+        57403 => Some(KeyCode::Char('4')),
+        57404 => Some(KeyCode::Char('5')),
+        57405 => Some(KeyCode::Char('6')),
+        57406 => Some(KeyCode::Char('7')),
+        57407 => Some(KeyCode::Char('8')),
+        57408 => Some(KeyCode::Char('9')),
+        57409 => Some(KeyCode::Char('.')),
+        57410 => Some(KeyCode::Char('/')),
+        57411 => Some(KeyCode::Char('*')),
+        57412 => Some(KeyCode::Char('-')),
+        57413 => Some(KeyCode::Char('+')),
+        57414 => Some(KeyCode::Enter),
+        57415 => Some(KeyCode::Char('=')),
+        57416 => Some(KeyCode::Char(',')),
+        57417 => Some(KeyCode::Left),
+        57418 => Some(KeyCode::Right),
+        57419 => Some(KeyCode::Up),
+        57420 => Some(KeyCode::Down),
+        57421 => Some(KeyCode::PageUp),
+        57422 => Some(KeyCode::PageDown),
+        57423 => Some(KeyCode::Home),
+        57424 => Some(KeyCode::End),
+        57425 => Some(KeyCode::Insert),
+        57426 => Some(KeyCode::Delete),
+        57427 => Some(KeyCode::KeypadBegin),
+        _ => None,
+    } {
+        return Some((keycode, KeyEventState::KEYPAD));
+    }
+
+    if let Some(keycode) = match codepoint {
+        57358 => Some(KeyCode::CapsLock),
+        57359 => Some(KeyCode::ScrollLock),
+        57360 => Some(KeyCode::NumLock),
+        57361 => Some(KeyCode::PrintScreen),
+        57362 => Some(KeyCode::Pause),
+        57363 => Some(KeyCode::Menu),
+        57376 => Some(KeyCode::F(13)),
+        57377 => Some(KeyCode::F(14)),
+        57378 => Some(KeyCode::F(15)),
+        57379 => Some(KeyCode::F(16)),
+        57380 => Some(KeyCode::F(17)),
+        57381 => Some(KeyCode::F(18)),
+        57382 => Some(KeyCode::F(19)),
+        57383 => Some(KeyCode::F(20)),
+        57384 => Some(KeyCode::F(21)),
+        57385 => Some(KeyCode::F(22)),
+        57386 => Some(KeyCode::F(23)),
+        57387 => Some(KeyCode::F(24)),
+        57388 => Some(KeyCode::F(25)),
+        57389 => Some(KeyCode::F(26)),
+        57390 => Some(KeyCode::F(27)),
+        57391 => Some(KeyCode::F(28)),
+        57392 => Some(KeyCode::F(29)),
+        57393 => Some(KeyCode::F(30)),
+        57394 => Some(KeyCode::F(31)),
+        57395 => Some(KeyCode::F(32)),
+        57396 => Some(KeyCode::F(33)),
+        57397 => Some(KeyCode::F(34)),
+        57398 => Some(KeyCode::F(35)),
+        57428 => Some(KeyCode::Media(MediaKeyCode::Play)),
+        57429 => Some(KeyCode::Media(MediaKeyCode::Pause)),
+        57430 => Some(KeyCode::Media(MediaKeyCode::PlayPause)),
+        57431 => Some(KeyCode::Media(MediaKeyCode::Reverse)),
+        57432 => Some(KeyCode::Media(MediaKeyCode::Stop)),
+        57433 => Some(KeyCode::Media(MediaKeyCode::FastForward)),
+        57434 => Some(KeyCode::Media(MediaKeyCode::Rewind)),
+        57435 => Some(KeyCode::Media(MediaKeyCode::TrackNext)),
+        57436 => Some(KeyCode::Media(MediaKeyCode::TrackPrevious)),
+        57437 => Some(KeyCode::Media(MediaKeyCode::Record)),
+        57438 => Some(KeyCode::Media(MediaKeyCode::LowerVolume)),
+        57439 => Some(KeyCode::Media(MediaKeyCode::RaiseVolume)),
+        57440 => Some(KeyCode::Media(MediaKeyCode::MuteVolume)),
+        57441 => Some(KeyCode::Modifier(ModifierKeyCode::LeftShift)),
+        57442 => Some(KeyCode::Modifier(ModifierKeyCode::LeftControl)),
+        57443 => Some(KeyCode::Modifier(ModifierKeyCode::LeftAlt)),
+        57444 => Some(KeyCode::Modifier(ModifierKeyCode::LeftSuper)),
+        57445 => Some(KeyCode::Modifier(ModifierKeyCode::LeftHyper)),
+        57446 => Some(KeyCode::Modifier(ModifierKeyCode::LeftMeta)),
+        57447 => Some(KeyCode::Modifier(ModifierKeyCode::RightShift)),
+        57448 => Some(KeyCode::Modifier(ModifierKeyCode::RightControl)),
+        57449 => Some(KeyCode::Modifier(ModifierKeyCode::RightAlt)),
+        57450 => Some(KeyCode::Modifier(ModifierKeyCode::RightSuper)),
+        57451 => Some(KeyCode::Modifier(ModifierKeyCode::RightHyper)),
+        57452 => Some(KeyCode::Modifier(ModifierKeyCode::RightMeta)),
+        57453 => Some(KeyCode::Modifier(ModifierKeyCode::IsoLevel3Shift)),
+        57454 => Some(KeyCode::Modifier(ModifierKeyCode::IsoLevel5Shift)),
+        _ => None,
+    } {
+        return Some((keycode, KeyEventState::empty()));
+    }
+
+    None
+}
+
+fn parse_csi_u_encoded_key_code(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    assert!(buffer.starts_with(b"\x1B[")); // ESC [
+    assert!(buffer.ends_with(b"u"));
+
+    // This function parses `CSI … u` sequences. These are sequences defined in either
+    // the `CSI u` (a.k.a. "Fix Keyboard Input on Terminals - Please", https://www.leonerd.org.uk/hacks/fixterms/)
+    // or Kitty Keyboard Protocol (https://sw.kovidgoyal.net/kitty/keyboard-protocol/) specifications.
+    // This CSI sequence is a tuple of semicolon-separated numbers.
+    let s = std::str::from_utf8(&buffer[2..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+    let mut split = s.split(';');
+
+    // In `CSI u`, this is parsed as:
+    //
+    //     CSI codepoint ; modifiers u
+    //     codepoint: ASCII Dec value
+    //
+    // The Kitty Keyboard Protocol extends this with optional components that can be
+    // enabled progressively. The full sequence is parsed as:
+    //
+    //     CSI unicode-key-code:alternate-key-codes ; modifiers:event-type ; text-as-codepoints u
+    let mut codepoints = split
+        .next()
+        .ok_or_else(could_not_parse_event_error)?
+        .split(':');
+
+    let codepoint = codepoints
+        .next()
+        .ok_or_else(could_not_parse_event_error)?
+        .parse::<u32>()
+        .map_err(|_| could_not_parse_event_error())?;
+
+    let (mut modifiers, kind, state_from_modifiers) =
+        if let Ok((modifier_mask, kind_code)) = modifier_and_kind_parsed(&mut split) {
+            (
+                parse_modifiers(modifier_mask),
+                parse_key_event_kind(kind_code),
+                parse_modifiers_to_state(modifier_mask),
+            )
+        } else {
+            (KeyModifiers::NONE, KeyEventKind::Press, KeyEventState::NONE)
+        };
+
+    let (mut keycode, state_from_keycode) = {
+        if let Some((special_key_code, state)) = translate_functional_key_code(codepoint) {
+            (special_key_code, state)
+        } else if let Some(c) = char::from_u32(codepoint) {
+            (
+                match c {
+                    '\x1B' => KeyCode::Esc,
+                    '\r' => KeyCode::Enter,
+                    // Issue #371: \n = 0xA, which is also the keycode for Ctrl+J. The only reason we get
+                    // newlines as input is because the terminal converts \r into \n for us. When we
+                    // enter raw mode, we disable that, so \n no longer has any meaning - it's better to
+                    // use Ctrl+J. Waiting to handle it here means it gets picked up later
+                    '\n' if !crossterm::terminal::is_raw_mode_enabled().unwrap_or(false) => {
+                        KeyCode::Enter
+                    }
+                    '\t' => {
+                        if modifiers.contains(KeyModifiers::SHIFT) {
+                            KeyCode::BackTab
+                        } else {
+                            KeyCode::Tab
+                        }
+                    }
+                    '\x7F' => KeyCode::Backspace,
+                    _ => KeyCode::Char(c),
+                },
+                KeyEventState::empty(),
+            )
+        } else {
+            return Err(could_not_parse_event_error());
+        }
+    };
+
+    if let KeyCode::Modifier(modifier_keycode) = keycode {
+        match modifier_keycode {
+            ModifierKeyCode::LeftAlt | ModifierKeyCode::RightAlt => {
+                modifiers.set(KeyModifiers::ALT, true)
+            }
+            ModifierKeyCode::LeftControl | ModifierKeyCode::RightControl => {
+                modifiers.set(KeyModifiers::CONTROL, true)
+            }
+            ModifierKeyCode::LeftShift | ModifierKeyCode::RightShift => {
+                modifiers.set(KeyModifiers::SHIFT, true)
+            }
+            ModifierKeyCode::LeftSuper | ModifierKeyCode::RightSuper => {
+                modifiers.set(KeyModifiers::SUPER, true)
+            }
+            ModifierKeyCode::LeftHyper | ModifierKeyCode::RightHyper => {
+                modifiers.set(KeyModifiers::HYPER, true)
+            }
+            ModifierKeyCode::LeftMeta | ModifierKeyCode::RightMeta => {
+                modifiers.set(KeyModifiers::META, true)
+            }
+            _ => {}
+        }
+    }
+
+    // When the "report alternate keys" flag is enabled in the Kitty Keyboard Protocol
+    // and the terminal sends a keyboard event containing shift, the sequence will
+    // contain an additional codepoint separated by a ':' character which contains
+    // the shifted character according to the keyboard layout.
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        if let Some(shifted_c) = codepoints
+            .next()
+            .and_then(|codepoint| codepoint.parse::<u32>().ok())
+            .and_then(char::from_u32)
+        {
+            keycode = KeyCode::Char(shifted_c);
+            modifiers.set(KeyModifiers::SHIFT, false);
+        }
+    }
+
+    let input_event = Event::Key(KeyEvent::new_with_kind_and_state(
+        keycode,
+        modifiers,
+        kind,
+        state_from_keycode | state_from_modifiers,
+    ));
+
+    Ok(Some(InternalEvent::Event(input_event)))
+}
+
+fn parse_csi_special_key_code(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    assert!(buffer.starts_with(b"\x1B[")); // ESC [
+    assert!(buffer.ends_with(b"~"));
+
+    let s = std::str::from_utf8(&buffer[2..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+    let mut split = s.split(';');
+
+    // This CSI sequence can be a list of semicolon-separated numbers.
+    let first = next_parsed::<u8>(&mut split)?;
+
+    let (modifiers, kind, state) =
+        if let Ok((modifier_mask, kind_code)) = modifier_and_kind_parsed(&mut split) {
+            (
+                parse_modifiers(modifier_mask),
+                parse_key_event_kind(kind_code),
+                parse_modifiers_to_state(modifier_mask),
+            )
+        } else {
+            (KeyModifiers::NONE, KeyEventKind::Press, KeyEventState::NONE)
+        };
+
+    let keycode = match first {
+        1 | 7 => KeyCode::Home,
+        2 => KeyCode::Insert,
+        3 => KeyCode::Delete,
+        4 | 8 => KeyCode::End,
+        5 => KeyCode::PageUp,
+        6 => KeyCode::PageDown,
+        v @ 11..=15 => KeyCode::F(v - 10),
+        v @ 17..=21 => KeyCode::F(v - 11),
+        v @ 23..=26 => KeyCode::F(v - 12),
+        v @ 28..=29 => KeyCode::F(v - 15),
+        v @ 31..=34 => KeyCode::F(v - 17),
+        _ => return Err(could_not_parse_event_error()),
+    };
+
+    let input_event = Event::Key(KeyEvent::new_with_kind_and_state(
+        keycode, modifiers, kind, state,
+    ));
+
+    Ok(Some(InternalEvent::Event(input_event)))
+}
+
+fn parse_csi_rxvt_mouse(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // rxvt mouse encoding:
+    // ESC [ Cb ; Cx ; Cy ; M
+
+    assert!(buffer.starts_with(b"\x1B[")); // ESC [
+    assert!(buffer.ends_with(b"M"));
+
+    let s = std::str::from_utf8(&buffer[2..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+    let mut split = s.split(';');
+
+    let cb = next_parsed::<u8>(&mut split)?
+        .checked_sub(32)
+        .ok_or_else(could_not_parse_event_error)?;
+    let (kind, modifiers) = parse_cb(cb)?;
+
+    let cx = next_parsed::<u16>(&mut split)? - 1;
+    let cy = next_parsed::<u16>(&mut split)? - 1;
+
+    Ok(Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+        kind,
+        column: cx,
+        row: cy,
+        modifiers,
+    }))))
+}
+
+fn parse_csi_normal_mouse(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // Normal mouse encoding: ESC [ M CB Cx Cy (6 characters only).
+
+    assert!(buffer.starts_with(b"\x1B[M")); // ESC [ M
+
+    if buffer.len() < 6 {
+        return Ok(None);
+    }
+
+    let cb = buffer[3]
+        .checked_sub(32)
+        .ok_or_else(could_not_parse_event_error)?;
+    let (kind, modifiers) = parse_cb(cb)?;
+
+    // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
+    // The upper left character position on the terminal is denoted as 1,1.
+    // Subtract 1 to keep it synced with cursor
+    let cx = u16::from(buffer[4].saturating_sub(32)) - 1;
+    let cy = u16::from(buffer[5].saturating_sub(32)) - 1;
+
+    Ok(Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+        kind,
+        column: cx,
+        row: cy,
+        modifiers,
+    }))))
+}
+
+fn parse_csi_sgr_mouse(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // ESC [ < Cb ; Cx ; Cy (;) (M or m)
+
+    assert!(buffer.starts_with(b"\x1B[<")); // ESC [ <
+
+    if !buffer.ends_with(b"m") && !buffer.ends_with(b"M") {
+        return Ok(None);
+    }
+
+    let s = std::str::from_utf8(&buffer[3..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+    let mut split = s.split(';');
+
+    let cb = next_parsed::<u8>(&mut split)?;
+    let (kind, modifiers) = parse_cb(cb)?;
+
+    // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
+    // The upper left character position on the terminal is denoted as 1,1.
+    // Subtract 1 to keep it synced with cursor
+    let cx = next_parsed::<u16>(&mut split)? - 1;
+    let cy = next_parsed::<u16>(&mut split)? - 1;
+
+    // When button 3 in Cb is used to represent mouse release, you can't tell which button was
+    // released. SGR mode solves this by having the sequence end with a lowercase m if it's a
+    // button release and an uppercase M if it's a button press.
+    //
+    // We've already checked that the last character is a lowercase or uppercase M at the start of
+    // this function, so we just need one if.
+    let kind = if buffer.last() == Some(&b'm') {
+        match kind {
+            MouseEventKind::Down(button) => MouseEventKind::Up(button),
+            other => other,
+        }
+    } else {
+        kind
+    };
+
+    Ok(Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+        kind,
+        column: cx,
+        row: cy,
+        modifiers,
+    }))))
+}
+
+/// Cb is the byte of a mouse input that contains the button being used, the key modifiers being
+/// held and whether the mouse is dragging or not.
+///
+/// Bit layout of cb, from low to high:
+///
+/// - button number
+/// - button number
+/// - shift
+/// - meta (alt)
+/// - control
+/// - mouse is dragging
+/// - button number
+/// - button number
+fn parse_cb(cb: u8) -> io::Result<(MouseEventKind, KeyModifiers)> {
+    let button_number = (cb & 0b0000_0011) | ((cb & 0b1100_0000) >> 4);
+    let dragging = cb & 0b0010_0000 == 0b0010_0000;
+
+    let kind = match (button_number, dragging) {
+        (0, false) => MouseEventKind::Down(MouseButton::Left),
+        (1, false) => MouseEventKind::Down(MouseButton::Middle),
+        (2, false) => MouseEventKind::Down(MouseButton::Right),
+        (0, true) => MouseEventKind::Drag(MouseButton::Left),
+        (1, true) => MouseEventKind::Drag(MouseButton::Middle),
+        (2, true) => MouseEventKind::Drag(MouseButton::Right),
+        (3, false) => MouseEventKind::Up(MouseButton::Left),
+        (3, true) | (4, true) | (5, true) => MouseEventKind::Moved,
+        (4, false) => MouseEventKind::ScrollUp,
+        (5, false) => MouseEventKind::ScrollDown,
+        (6, false) => MouseEventKind::ScrollLeft,
+        (7, false) => MouseEventKind::ScrollRight,
+        // We do not support other buttons.
+        _ => return Err(could_not_parse_event_error()),
+    };
+
+    let mut modifiers = KeyModifiers::empty();
+
+    if cb & 0b0000_0100 == 0b0000_0100 {
+        modifiers |= KeyModifiers::SHIFT;
+    }
+    if cb & 0b0000_1000 == 0b0000_1000 {
+        modifiers |= KeyModifiers::ALT;
+    }
+    if cb & 0b0001_0000 == 0b0001_0000 {
+        modifiers |= KeyModifiers::CONTROL;
+    }
+
+    Ok((kind, modifiers))
+}
+
+fn parse_csi_bracketed_paste(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // ESC [ 2 0 0 ~ pasted text ESC 2 0 1 ~
+    assert!(buffer.starts_with(b"\x1B[200~"));
+
+    if !buffer.ends_with(b"\x1b[201~") {
+        Ok(None)
+    } else {
+        let paste = String::from_utf8_lossy(&buffer[6..buffer.len() - 6]).to_string();
+        Ok(Some(InternalEvent::Event(Event::Paste(paste))))
+    }
+}
+
+fn parse_utf8_char(buffer: &[u8]) -> io::Result<Option<char>> {
+    match std::str::from_utf8(buffer) {
+        Ok(s) => {
+            let ch = s.chars().next().ok_or_else(could_not_parse_event_error)?;
+
+            Ok(Some(ch))
+        }
+        Err(_) => {
+            // from_utf8 failed, but we have to check if we need more bytes for code point
+            // and if all the bytes we have no are valid
+
+            let required_bytes = match buffer[0] {
+                // https://en.wikipedia.org/wiki/UTF-8#Description
+                (0x00..=0x7F) => 1, // 0xxxxxxx
+                (0xC0..=0xDF) => 2, // 110xxxxx 10xxxxxx
+                (0xE0..=0xEF) => 3, // 1110xxxx 10xxxxxx 10xxxxxx
+                (0xF0..=0xF7) => 4, // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                (0x80..=0xBF) | (0xF8..=0xFF) => return Err(could_not_parse_event_error()),
+            };
+
+            // More than 1 byte, check them for 10xxxxxx pattern
+            if required_bytes > 1 && buffer.len() > 1 {
+                for byte in &buffer[1..] {
+                    if byte & !0b0011_1111 != 0b1000_0000 {
+                        return Err(could_not_parse_event_error());
+                    }
+                }
+            }
+
+            if buffer.len() < required_bytes {
+                // All bytes looks good so far, but we need more of them
+                Ok(None)
+            } else {
+                Err(could_not_parse_event_error())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyEventState, KeyModifiers, MouseButton, MouseEvent};
+
+    use super::*;
+
+    #[test]
+    fn test_esc_key() {
+        assert_eq!(
+            parse_event(b"\x1B", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyCode::Esc.into()))),
+        );
+    }
+
+    #[test]
+    fn test_possible_esc_sequence() {
+        assert_eq!(parse_event(b"\x1B", true).unwrap(), None,);
+    }
+
+    #[test]
+    fn test_alt_key() {
+        assert_eq!(
+            parse_event(b"\x1Bc", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::ALT
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_alt_shift() {
+        assert_eq!(
+            parse_event(b"\x1BH", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('H'),
+                KeyModifiers::ALT | KeyModifiers::SHIFT
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_alt_ctrl() {
+        assert_eq!(
+            parse_event(b"\x1B\x14", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('t'),
+                KeyModifiers::ALT | KeyModifiers::CONTROL
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_event_subsequent_calls() {
+        // The main purpose of this test is to check if we're passing
+        // correct slice to other parse_ functions.
+
+        // parse_csi_cursor_position
+        assert_eq!(
+            parse_event(b"\x1B[20;10R", false).unwrap(),
+            Some(InternalEvent::CursorPosition(9, 19))
+        );
+
+        // parse_csi
+        assert_eq!(
+            parse_event(b"\x1B[D", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyCode::Left.into()))),
+        );
+
+        // parse_csi_modifier_key_code
+        assert_eq!(
+            parse_event(b"\x1B[2D", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Left,
+                KeyModifiers::SHIFT
+            ))))
+        );
+
+        // parse_csi_special_key_code
+        assert_eq!(
+            parse_event(b"\x1B[3~", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyCode::Delete.into()))),
+        );
+
+        // parse_csi_bracketed_paste
+        assert_eq!(
+            parse_event(b"\x1B[200~on and on and on\x1B[201~", false).unwrap(),
+            Some(InternalEvent::Event(Event::Paste(
+                "on and on and on".to_string()
+            ))),
+        );
+
+        // parse_csi_rxvt_mouse
+        assert_eq!(
+            parse_event(b"\x1B[32;30;40;M", false).unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 29,
+                row: 39,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+
+        // parse_csi_normal_mouse
+        assert_eq!(
+            parse_event(b"\x1B[M0\x60\x70", false).unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 63,
+                row: 79,
+                modifiers: KeyModifiers::CONTROL,
+            })))
+        );
+
+        // parse_csi_sgr_mouse
+        assert_eq!(
+            parse_event(b"\x1B[<0;20;10;M", false).unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 19,
+                row: 9,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+
+        // parse_utf8_char
+        assert_eq!(
+            parse_event("Ž".as_bytes(), false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('Ž'),
+                KeyModifiers::SHIFT
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_event() {
+        assert_eq!(
+            parse_event(b"\t", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyCode::Tab.into()))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_cursor_position() {
+        assert_eq!(
+            parse_csi_cursor_position(b"\x1B[20;10R").unwrap(),
+            Some(InternalEvent::CursorPosition(9, 19))
+        );
+    }
+
+    #[test]
+    fn test_parse_csi() {
+        assert_eq!(
+            parse_csi(b"\x1B[D").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyCode::Left.into()))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_modifier_key_code() {
+        assert_eq!(
+            parse_csi_modifier_key_code(b"\x1B[2D").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Left,
+                KeyModifiers::SHIFT
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_special_key_code() {
+        assert_eq!(
+            parse_csi_special_key_code(b"\x1B[3~").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyCode::Delete.into()))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_special_key_code_multiple_values_not_supported() {
+        assert_eq!(
+            parse_csi_special_key_code(b"\x1B[3;2~").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Delete,
+                KeyModifiers::SHIFT
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_bracketed_paste() {
+        //
+        assert_eq!(
+            parse_event(b"\x1B[200~o", false).unwrap(),
+            None,
+            "A partial bracketed paste isn't parsed"
+        );
+        assert_eq!(
+            parse_event(b"\x1B[200~o\x1B[2D", false).unwrap(),
+            None,
+            "A partial bracketed paste containing another escape code isn't parsed"
+        );
+        assert_eq!(
+            parse_event(b"\x1B[200~o\x1B[2D\x1B[201~", false).unwrap(),
+            Some(InternalEvent::Event(Event::Paste("o\x1B[2D".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_focus() {
+        assert_eq!(
+            parse_csi(b"\x1B[O").unwrap(),
+            Some(InternalEvent::Event(Event::FocusLost))
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_rxvt_mouse() {
+        assert_eq!(
+            parse_csi_rxvt_mouse(b"\x1B[32;30;40;M").unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 29,
+                row: 39,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_normal_mouse() {
+        assert_eq!(
+            parse_csi_normal_mouse(b"\x1B[M0\x60\x70").unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 63,
+                row: 79,
+                modifiers: KeyModifiers::CONTROL,
+            })))
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_sgr_mouse() {
+        assert_eq!(
+            parse_csi_sgr_mouse(b"\x1B[<0;20;10;M").unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 19,
+                row: 9,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+        assert_eq!(
+            parse_csi_sgr_mouse(b"\x1B[<0;20;10M").unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 19,
+                row: 9,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+        assert_eq!(
+            parse_csi_sgr_mouse(b"\x1B[<0;20;10;m").unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Left),
+                column: 19,
+                row: 9,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+        assert_eq!(
+            parse_csi_sgr_mouse(b"\x1B[<0;20;10m").unwrap(),
+            Some(InternalEvent::Event(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Left),
+                column: 19,
+                row: 9,
+                modifiers: KeyModifiers::empty(),
+            })))
+        );
+    }
+
+    #[test]
+    fn test_utf8() {
+        // https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php#54805
+
+        // 'Valid ASCII' => "a",
+        assert_eq!(parse_utf8_char(b"a").unwrap(), Some('a'),);
+
+        // 'Valid 2 Octet Sequence' => "\xc3\xb1",
+        assert_eq!(parse_utf8_char(&[0xC3, 0xB1]).unwrap(), Some('ñ'),);
+
+        // 'Invalid 2 Octet Sequence' => "\xc3\x28",
+        assert!(parse_utf8_char(&[0xC3, 0x28]).is_err());
+
+        // 'Invalid Sequence Identifier' => "\xa0\xa1",
+        assert!(parse_utf8_char(&[0xA0, 0xA1]).is_err());
+
+        // 'Valid 3 Octet Sequence' => "\xe2\x82\xa1",
+        assert_eq!(
+            parse_utf8_char(&[0xE2, 0x81, 0xA1]).unwrap(),
+            Some('\u{2061}'),
+        );
+
+        // 'Invalid 3 Octet Sequence (in 2nd Octet)' => "\xe2\x28\xa1",
+        assert!(parse_utf8_char(&[0xE2, 0x28, 0xA1]).is_err());
+
+        // 'Invalid 3 Octet Sequence (in 3rd Octet)' => "\xe2\x82\x28",
+        assert!(parse_utf8_char(&[0xE2, 0x82, 0x28]).is_err());
+
+        // 'Valid 4 Octet Sequence' => "\xf0\x90\x8c\xbc",
+        assert_eq!(
+            parse_utf8_char(&[0xF0, 0x90, 0x8C, 0xBC]).unwrap(),
+            Some('𐌼'),
+        );
+
+        // 'Invalid 4 Octet Sequence (in 2nd Octet)' => "\xf0\x28\x8c\xbc",
+        assert!(parse_utf8_char(&[0xF0, 0x28, 0x8C, 0xBC]).is_err());
+
+        // 'Invalid 4 Octet Sequence (in 3rd Octet)' => "\xf0\x90\x28\xbc",
+        assert!(parse_utf8_char(&[0xF0, 0x90, 0x28, 0xBC]).is_err());
+
+        // 'Invalid 4 Octet Sequence (in 4th Octet)' => "\xf0\x28\x8c\x28",
+        assert!(parse_utf8_char(&[0xF0, 0x28, 0x8C, 0x28]).is_err());
+    }
+
+    #[test]
+    fn test_parse_char_event_lowercase() {
+        assert_eq!(
+            parse_event(b"c", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::empty()
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_char_event_uppercase() {
+        assert_eq!(
+            parse_event(b"C", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('C'),
+                KeyModifiers::SHIFT
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_basic_csi_u_encoded_key_code() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;2u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('A'),
+                KeyModifiers::SHIFT
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;7u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::ALT | KeyModifiers::CONTROL
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_basic_csi_u_encoded_key_code_special_keys() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[13u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Enter,
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[27u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Esc,
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57358u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::CapsLock,
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57376u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::F(13),
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57428u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Media(MediaKeyCode::Play),
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57441u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Modifier(ModifierKeyCode::LeftShift),
+                KeyModifiers::SHIFT,
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_u_encoded_keypad_code() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57399u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(
+                KeyEvent::new_with_kind_and_state(
+                    KeyCode::Char('0'),
+                    KeyModifiers::empty(),
+                    KeyEventKind::Press,
+                    KeyEventState::KEYPAD,
+                )
+            ))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57419u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(
+                KeyEvent::new_with_kind_and_state(
+                    KeyCode::Up,
+                    KeyModifiers::empty(),
+                    KeyEventKind::Press,
+                    KeyEventState::KEYPAD,
+                )
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_u_encoded_key_code_with_types() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;1u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('a'),
+                KeyModifiers::empty(),
+                KeyEventKind::Press,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;1:1u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('a'),
+                KeyModifiers::empty(),
+                KeyEventKind::Press,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;5:1u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('a'),
+                KeyModifiers::CONTROL,
+                KeyEventKind::Press,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;1:2u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('a'),
+                KeyModifiers::empty(),
+                KeyEventKind::Repeat,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;1:3u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('a'),
+                KeyModifiers::empty(),
+                KeyEventKind::Release,
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_u_encoded_key_code_has_modifier_on_modifier_press() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57449u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Modifier(ModifierKeyCode::RightAlt),
+                KeyModifiers::ALT,
+                KeyEventKind::Press,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57449;3:3u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Modifier(ModifierKeyCode::RightAlt),
+                KeyModifiers::ALT,
+                KeyEventKind::Release,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57450u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Modifier(ModifierKeyCode::RightSuper),
+                KeyModifiers::SUPER,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57451u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Modifier(ModifierKeyCode::RightHyper),
+                KeyModifiers::HYPER,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57452u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Modifier(ModifierKeyCode::RightMeta),
+                KeyModifiers::META,
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_u_encoded_key_code_with_extra_modifiers() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;9u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::SUPER
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;17u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::HYPER,
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;33u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::META,
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_u_encoded_key_code_with_extra_state() {
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[97;65u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(
+                KeyEvent::new_with_kind_and_state(
+                    KeyCode::Char('a'),
+                    KeyModifiers::empty(),
+                    KeyEventKind::Press,
+                    KeyEventState::CAPS_LOCK,
+                )
+            ))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[49;129u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(
+                KeyEvent::new_with_kind_and_state(
+                    KeyCode::Char('1'),
+                    KeyModifiers::empty(),
+                    KeyEventKind::Press,
+                    KeyEventState::NUM_LOCK,
+                )
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_u_with_shifted_keycode() {
+        assert_eq!(
+            // A-S-9 is equivalent to A-(
+            parse_event(b"\x1B[57:40;4u", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('('),
+                KeyModifiers::ALT,
+            )))),
+        );
+        assert_eq!(
+            // A-S-minus is equivalent to A-_
+            parse_event(b"\x1B[45:95;4u", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Char('_'),
+                KeyModifiers::ALT,
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_special_key_code_with_types() {
+        assert_eq!(
+            parse_event(b"\x1B[;1:3B", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Down,
+                KeyModifiers::empty(),
+                KeyEventKind::Release,
+            )))),
+        );
+        assert_eq!(
+            parse_event(b"\x1B[1;1:3B", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Down,
+                KeyModifiers::empty(),
+                KeyEventKind::Release,
+            )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_numbered_escape_code_with_types() {
+        assert_eq!(
+            parse_event(b"\x1B[5;1:3~", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::PageUp,
+                KeyModifiers::empty(),
+                KeyEventKind::Release,
+            )))),
+        );
+        assert_eq!(
+            parse_event(b"\x1B[6;5:3~", false).unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::PageDown,
+                KeyModifiers::CONTROL,
+                KeyEventKind::Release,
+            )))),
+        );
+    }
+}

--- a/src/runtime/input/parser/kitty_dnd.rs
+++ b/src/runtime/input/parser/kitty_dnd.rs
@@ -1,0 +1,19 @@
+use crate::runtime::kitty_dnd::{self, KittyDndEvent};
+
+use super::osc;
+
+#[derive(Default)]
+pub(super) struct Parser {
+    state: kitty_dnd::Osc72State,
+}
+
+impl Parser {
+    pub(super) fn parse(&mut self, buffer: &mut Vec<u8>) -> Option<KittyDndEvent> {
+        if !buffer.starts_with(b"\x1b]72;") {
+            return None;
+        }
+        let end = osc::end(buffer)?;
+        let sequence: Vec<u8> = buffer.drain(..end).collect();
+        kitty_dnd::parse_osc72_with_state(&sequence, &mut self.state)
+    }
+}

--- a/src/runtime/input/parser/mod.rs
+++ b/src/runtime/input/parser/mod.rs
@@ -42,17 +42,18 @@ pub(super) fn parse_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::kitty_dnd::KittyDndEvent;
+    use crate::runtime::kitty_dnd::{DndOperation, KittyDndEvent};
 
     #[test]
     fn routes_kitty_dnd_osc72_before_crossterm_compat() {
         let mut parser = Parser::default();
-        let mut buffer = b"\x1b]72;t=M:x=1:y=2;text/uri-list\x1b\\".to_vec();
+        let mut buffer = b"\x1b]72;t=M:x=1:y=2:o=1;text/uri-list\x1b\\".to_vec();
 
         assert_eq!(
             parse_event(&mut parser, &mut buffer, false).unwrap(),
             Some(RuntimeInputEvent::KittyDnd(KittyDndEvent::DropOffer {
                 mime_index: 1,
+                operation: DndOperation::Copy,
                 final_drop: true,
             }))
         );
@@ -85,6 +86,7 @@ mod tests {
             Some(RuntimeInputEvent::KittyDnd(KittyDndEvent::DropData {
                 mime_index: 1,
                 paths: vec![std::path::PathBuf::from("/tmp/a.txt")],
+                unsupported_schemes: Vec::new(),
             }))
         );
     }

--- a/src/runtime/input/parser/mod.rs
+++ b/src/runtime/input/parser/mod.rs
@@ -1,0 +1,106 @@
+pub(super) mod crossterm_compat;
+mod kitty_dnd;
+mod osc;
+
+use std::io;
+
+use crate::runtime::input::RuntimeInputEvent;
+
+#[derive(Default)]
+pub(super) struct Parser {
+    kitty_dnd: kitty_dnd::Parser,
+}
+
+pub(super) fn parse_event(
+    parser: &mut Parser,
+    buffer: &mut Vec<u8>,
+    input_available: bool,
+) -> io::Result<Option<RuntimeInputEvent>> {
+    let len_before_dnd = buffer.len();
+    if let Some(event) = parser.kitty_dnd.parse(buffer) {
+        return Ok(Some(RuntimeInputEvent::KittyDnd(event)));
+    }
+    if buffer.len() != len_before_dnd {
+        return Ok(None);
+    }
+    if buffer.is_empty() {
+        return Ok(None);
+    }
+    if osc::starts_with_osc(buffer) && osc::end(buffer).is_none() {
+        return Ok(None);
+    }
+    match crossterm_compat::parse_event(buffer, input_available) {
+        Ok(Some(crossterm_compat::InternalEvent::Event(event))) => {
+            Ok(Some(RuntimeInputEvent::Terminal(event)))
+        }
+        Ok(Some(_)) => Ok(None),
+        Ok(None) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::kitty_dnd::KittyDndEvent;
+
+    #[test]
+    fn routes_kitty_dnd_osc72_before_crossterm_compat() {
+        let mut parser = Parser::default();
+        let mut buffer = b"\x1b]72;t=M:x=1:y=2;text/uri-list\x1b\\".to_vec();
+
+        assert_eq!(
+            parse_event(&mut parser, &mut buffer, false).unwrap(),
+            Some(RuntimeInputEvent::KittyDnd(KittyDndEvent::DropOffer {
+                mime_index: 1,
+                final_drop: true,
+            }))
+        );
+    }
+
+    #[test]
+    fn waits_for_complete_osc_sequence() {
+        let mut parser = Parser::default();
+        let mut buffer = b"\x1b]72;t=M:x=1:y=2;text/uri-list".to_vec();
+
+        assert_eq!(parse_event(&mut parser, &mut buffer, true).unwrap(), None);
+        assert!(!buffer.is_empty());
+    }
+
+    #[test]
+    fn keeps_kitty_dnd_chunks_until_end_marker() {
+        let mut parser = Parser::default();
+        let mut buffer = b"\x1b]72;t=r:x=1:m=1;ZmlsZTov\x1b\\".to_vec();
+
+        assert_eq!(parse_event(&mut parser, &mut buffer, false).unwrap(), None);
+        assert!(buffer.is_empty());
+
+        let mut buffer = b"\x1b]72;m=1;Ly90bXAvYS50eHQ\x1b\\".to_vec();
+        assert_eq!(parse_event(&mut parser, &mut buffer, false).unwrap(), None);
+        assert!(buffer.is_empty());
+
+        let mut buffer = b"\x1b]72;t=r:x=1:m=0;\x1b\\".to_vec();
+        assert_eq!(
+            parse_event(&mut parser, &mut buffer, false).unwrap(),
+            Some(RuntimeInputEvent::KittyDnd(KittyDndEvent::DropData {
+                mime_index: 1,
+                paths: vec![std::path::PathBuf::from("/tmp/a.txt")],
+            }))
+        );
+    }
+
+    #[test]
+    fn preserves_following_bytes_after_kitty_dnd_sequence() {
+        let mut parser = Parser::default();
+        let mut buffer = b"\x1b]72;t=o:x=1:y=2\x1b\\\x1b]72;t=e:x=4:y=1\x1b\\".to_vec();
+
+        assert_eq!(
+            parse_event(&mut parser, &mut buffer, false).unwrap(),
+            Some(RuntimeInputEvent::KittyDnd(KittyDndEvent::DragOffer {
+                x: 1,
+                y: 2,
+            }))
+        );
+        assert_eq!(buffer, b"\x1b]72;t=e:x=4:y=1\x1b\\");
+    }
+}

--- a/src/runtime/input/parser/osc.rs
+++ b/src/runtime/input/parser/osc.rs
@@ -1,0 +1,17 @@
+pub(super) fn starts_with_osc(buffer: &[u8]) -> bool {
+    buffer.starts_with(b"\x1b]")
+}
+
+pub(super) fn end(buffer: &[u8]) -> Option<usize> {
+    let mut index = 0;
+    while index < buffer.len() {
+        if buffer[index] == b'\x07' {
+            return Some(index + 1);
+        }
+        if buffer[index] == b'\x1b' && buffer.get(index + 1) == Some(&b'\\') {
+            return Some(index + 2);
+        }
+        index += 1;
+    }
+    None
+}

--- a/src/runtime/input/reader.rs
+++ b/src/runtime/input/reader.rs
@@ -1,42 +1,63 @@
+use std::io;
+
+#[cfg(unix)]
+use std::sync::mpsc;
+
+#[cfg(unix)]
+use std::time::Duration;
+
+#[cfg(unix)]
 use std::{
     fs::OpenOptions,
-    io::{self, Read},
+    io::Read,
     os::fd::AsRawFd,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
-        mpsc::{self, Receiver, TryRecvError},
+        mpsc::{Receiver, TryRecvError},
     },
     thread,
-    time::Duration,
 };
 
+#[cfg(unix)]
 use crossterm::{event::Event, terminal};
 
+#[cfg(unix)]
 use super::{RuntimeInputEvent, parser};
 
+#[cfg(unix)]
 const RESIZE_POLL_INTERVAL: Duration = Duration::from_millis(16);
 
 pub(in crate::runtime) enum RuntimeInputReader {
     Crossterm,
+    #[cfg(unix)]
     Custom(CustomInputReader),
 }
 
 impl RuntimeInputReader {
     pub(in crate::runtime) fn new(use_custom_reader: bool) -> io::Result<Self> {
         if use_custom_reader {
-            CustomInputReader::spawn().map(Self::Custom)
+            #[cfg(unix)]
+            {
+                CustomInputReader::spawn().map(Self::Custom)
+            }
+            #[cfg(not(unix))]
+            {
+                Ok(Self::Crossterm)
+            }
         } else {
             Ok(Self::Crossterm)
         }
     }
 }
 
+#[cfg(unix)]
 pub(in crate::runtime) struct CustomInputReader {
     receiver: Receiver<io::Result<RuntimeInputEvent>>,
     paused: Arc<AtomicBool>,
 }
 
+#[cfg(unix)]
 impl CustomInputReader {
     fn spawn() -> io::Result<Self> {
         let tty = OpenOptions::new().read(true).open("/dev/tty")?;
@@ -87,10 +108,12 @@ impl CustomInputReader {
     }
 }
 
+#[cfg(unix)]
 fn current_terminal_size() -> Option<(u16, u16)> {
     terminal::size().ok()
 }
 
+#[cfg(unix)]
 fn read_loop(
     mut tty: std::fs::File,
     sender: mpsc::Sender<io::Result<RuntimeInputEvent>>,
@@ -122,6 +145,7 @@ fn read_loop(
     }
 }
 
+#[cfg(unix)]
 fn resize_loop(sender: mpsc::Sender<io::Result<RuntimeInputEvent>>, paused: Arc<AtomicBool>) {
     let mut last_size = current_terminal_size();
     loop {
@@ -148,6 +172,7 @@ fn resize_loop(sender: mpsc::Sender<io::Result<RuntimeInputEvent>>, paused: Arc<
     }
 }
 
+#[cfg(unix)]
 fn parse_buffer(
     parser_state: &mut parser::Parser,
     buffer: &mut Vec<u8>,
@@ -182,10 +207,12 @@ fn parse_buffer(
     }
 }
 
+#[cfg(unix)]
 fn is_unsupported_input_sequence(error: &io::Error) -> bool {
     error.kind() == io::ErrorKind::Other && error.to_string() == "Could not parse an event."
 }
 
+#[cfg(unix)]
 fn set_nonblocking(fd: i32) -> io::Result<()> {
     // SAFETY: fcntl is called with a live /dev/tty fd and does not retain pointers.
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
@@ -199,7 +226,7 @@ fn set_nonblocking(fd: i32) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/src/runtime/input/reader.rs
+++ b/src/runtime/input/reader.rs
@@ -1,0 +1,248 @@
+use std::{
+    fs::OpenOptions,
+    io::{self, Read},
+    os::fd::AsRawFd,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, TryRecvError},
+    },
+    thread,
+    time::Duration,
+};
+
+use crossterm::{event::Event, terminal};
+
+use super::{RuntimeInputEvent, parser};
+
+const RESIZE_POLL_INTERVAL: Duration = Duration::from_millis(16);
+
+pub(in crate::runtime) enum RuntimeInputReader {
+    Crossterm,
+    Custom(CustomInputReader),
+}
+
+impl RuntimeInputReader {
+    pub(in crate::runtime) fn new(use_custom_reader: bool) -> io::Result<Self> {
+        if use_custom_reader {
+            CustomInputReader::spawn().map(Self::Custom)
+        } else {
+            Ok(Self::Crossterm)
+        }
+    }
+}
+
+pub(in crate::runtime) struct CustomInputReader {
+    receiver: Receiver<io::Result<RuntimeInputEvent>>,
+    paused: Arc<AtomicBool>,
+}
+
+impl CustomInputReader {
+    fn spawn() -> io::Result<Self> {
+        let tty = OpenOptions::new().read(true).open("/dev/tty")?;
+        set_nonblocking(tty.as_raw_fd())?;
+        let (sender, receiver) = mpsc::channel();
+        let paused = Arc::new(AtomicBool::new(false));
+        let thread_paused = Arc::clone(&paused);
+        let resize_paused = Arc::clone(&paused);
+        let resize_sender = sender.clone();
+        thread::Builder::new()
+            .name("elio-runtime-input".to_string())
+            .spawn(move || read_loop(tty, sender, thread_paused))
+            .map_err(io::Error::other)?;
+        thread::Builder::new()
+            .name("elio-runtime-resize".to_string())
+            .spawn(move || resize_loop(resize_sender, resize_paused))
+            .map_err(io::Error::other)?;
+        Ok(Self { receiver, paused })
+    }
+
+    pub(in crate::runtime) fn set_paused(&self, paused: bool) {
+        self.paused.store(paused, Ordering::Relaxed);
+    }
+
+    pub(in crate::runtime) fn recv_timeout(
+        &self,
+        timeout: Duration,
+    ) -> io::Result<Option<RuntimeInputEvent>> {
+        match self.receiver.recv_timeout(timeout) {
+            Ok(event) => event.map(Some),
+            Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "input reader stopped",
+            )),
+        }
+    }
+
+    pub(in crate::runtime) fn try_recv(&self) -> io::Result<Option<RuntimeInputEvent>> {
+        match self.receiver.try_recv() {
+            Ok(event) => event.map(Some),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "input reader stopped",
+            )),
+        }
+    }
+}
+
+fn current_terminal_size() -> Option<(u16, u16)> {
+    terminal::size().ok()
+}
+
+fn read_loop(
+    mut tty: std::fs::File,
+    sender: mpsc::Sender<io::Result<RuntimeInputEvent>>,
+    paused: Arc<AtomicBool>,
+) {
+    let mut buffer = Vec::<u8>::new();
+    let mut parser = parser::Parser::default();
+    let mut byte = [0u8; 1];
+    loop {
+        if paused.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_millis(10));
+            continue;
+        }
+        match tty.read(&mut byte) {
+            Ok(0) => thread::sleep(Duration::from_millis(2)),
+            Ok(_) => {
+                buffer.push(byte[0]);
+                parse_buffer(&mut parser, &mut buffer, &sender, true);
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                parse_buffer(&mut parser, &mut buffer, &sender, false);
+                thread::sleep(Duration::from_millis(2));
+            }
+            Err(error) => {
+                let _ = sender.send(Err(error));
+                break;
+            }
+        }
+    }
+}
+
+fn resize_loop(sender: mpsc::Sender<io::Result<RuntimeInputEvent>>, paused: Arc<AtomicBool>) {
+    let mut last_size = current_terminal_size();
+    loop {
+        thread::sleep(RESIZE_POLL_INTERVAL);
+        if paused.load(Ordering::Relaxed) {
+            last_size = current_terminal_size();
+            continue;
+        }
+        let Some(size) = current_terminal_size() else {
+            continue;
+        };
+        if last_size == Some(size) {
+            continue;
+        }
+        last_size = Some(size);
+        if sender
+            .send(Ok(RuntimeInputEvent::Terminal(Event::Resize(
+                size.0, size.1,
+            ))))
+            .is_err()
+        {
+            break;
+        }
+    }
+}
+
+fn parse_buffer(
+    parser_state: &mut parser::Parser,
+    buffer: &mut Vec<u8>,
+    sender: &mpsc::Sender<io::Result<RuntimeInputEvent>>,
+    input_available: bool,
+) {
+    loop {
+        if buffer.is_empty() {
+            return;
+        }
+        let len_before = buffer.len();
+        match parser::parse_event(parser_state, buffer, input_available) {
+            Ok(Some(event)) => {
+                if buffer.len() == len_before {
+                    buffer.clear();
+                }
+                let _ = sender.send(Ok(event));
+            }
+            Ok(None) => {
+                if buffer.len() != len_before && !buffer.is_empty() {
+                    continue;
+                }
+                return;
+            }
+            Err(error) => {
+                buffer.clear();
+                if !is_unsupported_input_sequence(&error) {
+                    let _ = sender.send(Err(error));
+                }
+            }
+        }
+    }
+}
+
+fn is_unsupported_input_sequence(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::Other && error.to_string() == "Could not parse an event."
+}
+
+fn set_nonblocking(fd: i32) -> io::Result<()> {
+    // SAFETY: fcntl is called with a live /dev/tty fd and does not retain pointers.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: same fd; OR-ing O_NONBLOCK preserves existing flags.
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_mouse_button_sequence_is_ignored() {
+        let (sender, receiver) = mpsc::channel();
+        let mut parser = parser::Parser::default();
+        let mut buffer = b"\x1b[<128;10;5M".to_vec();
+
+        parse_buffer(&mut parser, &mut buffer, &sender, false);
+
+        assert!(buffer.is_empty());
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn parse_errors_from_real_io_are_still_errors() {
+        let error = io::Error::other("different failure");
+        assert!(!is_unsupported_input_sequence(&error));
+    }
+
+    #[test]
+    fn parse_buffer_keeps_concatenated_kitty_dnd_events() {
+        let (sender, receiver) = mpsc::channel();
+        let mut parser = parser::Parser::default();
+        let mut buffer = b"\x1b]72;t=o:x=1:y=2\x1b\\\x1b]72;t=e:x=4:y=1\x1b\\".to_vec();
+
+        parse_buffer(&mut parser, &mut buffer, &sender, false);
+
+        assert!(buffer.is_empty());
+        assert_eq!(
+            receiver.try_recv().unwrap().unwrap(),
+            RuntimeInputEvent::KittyDnd(crate::runtime::kitty_dnd::KittyDndEvent::DragOffer {
+                x: 1,
+                y: 2,
+            })
+        );
+        assert_eq!(
+            receiver.try_recv().unwrap().unwrap(),
+            RuntimeInputEvent::KittyDnd(crate::runtime::kitty_dnd::KittyDndEvent::DragEnded {
+                cancelled: true,
+            })
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+}

--- a/src/runtime/kitty_dnd/capability.rs
+++ b/src/runtime/kitty_dnd/capability.rs
@@ -1,0 +1,273 @@
+use std::{env, process::Command};
+
+const MIN_KITTY_DND_VERSION: KittyVersion = KittyVersion {
+    major: 0,
+    minor: 47,
+    patch: 0,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::runtime) struct KittyDndRuntime {
+    enabled: bool,
+    machine_id: Option<String>,
+}
+
+impl KittyDndRuntime {
+    pub(super) const fn disabled() -> Self {
+        Self {
+            enabled: false,
+            machine_id: None,
+        }
+    }
+
+    pub(super) fn enabled(machine_id: Option<String>) -> Self {
+        Self {
+            enabled: true,
+            machine_id,
+        }
+    }
+
+    pub(in crate::runtime) const fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub(in crate::runtime) fn drag_machine_id(&self) -> Option<&str> {
+        self.machine_id.as_deref()
+    }
+}
+
+pub(in crate::runtime) fn detect_kitty_dnd_runtime() -> KittyDndRuntime {
+    let env = RuntimeEnv::read();
+    detect_from_env(&env, query_kitty_version, local_machine_id)
+}
+
+#[derive(Debug, Default)]
+struct RuntimeEnv {
+    term: Option<String>,
+    term_program: Option<String>,
+    kitty_window_id: bool,
+    tmux: bool,
+    zellij: bool,
+    ssh_connection: bool,
+    ssh_tty: bool,
+}
+
+impl RuntimeEnv {
+    fn read() -> Self {
+        Self {
+            term: env::var("TERM").ok(),
+            term_program: env::var("TERM_PROGRAM").ok(),
+            kitty_window_id: env::var_os("KITTY_WINDOW_ID").is_some(),
+            tmux: env::var_os("TMUX").is_some(),
+            zellij: env::var_os("ZELLIJ").is_some(),
+            ssh_connection: env::var_os("SSH_CONNECTION").is_some(),
+            ssh_tty: env::var_os("SSH_TTY").is_some(),
+        }
+    }
+}
+
+fn detect_from_env(
+    env: &RuntimeEnv,
+    query_version: impl FnOnce() -> Option<KittyVersion>,
+    _read_machine_id: impl FnOnce() -> Option<String>,
+) -> KittyDndRuntime {
+    if !is_kitty_env(env) || env.tmux || env.zellij || env.ssh_connection || env.ssh_tty {
+        return KittyDndRuntime::disabled();
+    }
+
+    match query_version() {
+        Some(version) if version >= MIN_KITTY_DND_VERSION => KittyDndRuntime::enabled(None),
+        _ => KittyDndRuntime::disabled(),
+    }
+}
+
+fn is_kitty_env(env: &RuntimeEnv) -> bool {
+    env.term
+        .as_deref()
+        .is_some_and(|term| term.to_ascii_lowercase().contains("xterm-kitty"))
+        || env
+            .term_program
+            .as_deref()
+            .is_some_and(|program| program.eq_ignore_ascii_case("kitty"))
+        || env.kitty_window_id
+}
+
+fn query_kitty_version() -> Option<KittyVersion> {
+    let output = Command::new("kitty").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_kitty_version(&String::from_utf8_lossy(&output.stdout))
+        .or_else(|| parse_kitty_version(&String::from_utf8_lossy(&output.stderr)))
+}
+
+fn local_machine_id() -> Option<String> {
+    None
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct KittyVersion {
+    major: u16,
+    minor: u16,
+    patch: u16,
+}
+
+fn parse_kitty_version(output: &str) -> Option<KittyVersion> {
+    let version = output
+        .split_whitespace()
+        .find(|part| part.chars().next().is_some_and(|c| c.is_ascii_digit()))?;
+    let mut parts = version.split('.');
+    Some(KittyVersion {
+        major: parts.next()?.parse().ok()?,
+        minor: parts.next()?.parse().ok()?,
+        patch: parts
+            .next()
+            .and_then(|patch| {
+                patch
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect::<String>()
+                    .parse()
+                    .ok()
+            })
+            .unwrap_or(0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kitty_env() -> RuntimeEnv {
+        RuntimeEnv {
+            term: Some("xterm-kitty".to_string()),
+            ..RuntimeEnv::default()
+        }
+    }
+
+    #[test]
+    fn gates_to_kitty_047_or_newer() {
+        assert!(
+            detect_from_env(
+                &kitty_env(),
+                || parse_kitty_version("kitty 0.47.0"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+        assert!(
+            detect_from_env(
+                &kitty_env(),
+                || parse_kitty_version("kitty 0.47.4"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+        assert!(
+            !detect_from_env(
+                &kitty_env(),
+                || parse_kitty_version("kitty 0.46.2"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+    }
+
+    #[test]
+    fn uses_empty_machine_id_for_local_drag_out() {
+        let runtime = detect_from_env(
+            &kitty_env(),
+            || parse_kitty_version("kitty 0.47.4"),
+            || Some("host;bad\x1b\\".to_string()),
+        );
+        assert_eq!(runtime.drag_machine_id(), None);
+    }
+
+    #[test]
+    fn disables_without_queryable_version() {
+        assert!(!detect_from_env(&kitty_env(), || None, || Some("local".to_string())).is_enabled());
+    }
+
+    #[test]
+    fn disables_inside_mux_or_ssh() {
+        let mut env = kitty_env();
+        env.tmux = true;
+        assert!(
+            !detect_from_env(
+                &env,
+                || parse_kitty_version("kitty 0.47.4"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+
+        let mut env = kitty_env();
+        env.zellij = true;
+        assert!(
+            !detect_from_env(
+                &env,
+                || parse_kitty_version("kitty 0.47.4"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+
+        let mut env = kitty_env();
+        env.ssh_connection = true;
+        assert!(
+            !detect_from_env(
+                &env,
+                || parse_kitty_version("kitty 0.47.4"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+
+        let mut env = kitty_env();
+        env.ssh_tty = true;
+        assert!(
+            !detect_from_env(
+                &env,
+                || parse_kitty_version("kitty 0.47.4"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+    }
+
+    #[test]
+    fn disables_non_kitty_terminals() {
+        let env = RuntimeEnv {
+            term: Some("xterm-ghostty".to_string()),
+            ..RuntimeEnv::default()
+        };
+        assert!(
+            !detect_from_env(
+                &env,
+                || parse_kitty_version("kitty 0.47.4"),
+                || Some("local".to_string())
+            )
+            .is_enabled()
+        );
+    }
+
+    #[test]
+    fn parses_common_version_outputs() {
+        assert_eq!(
+            parse_kitty_version("kitty 0.47.4 created by Kovid Goyal"),
+            Some(KittyVersion {
+                major: 0,
+                minor: 47,
+                patch: 4
+            })
+        );
+        assert_eq!(
+            parse_kitty_version("kitty 0.48.0-alpha"),
+            Some(KittyVersion {
+                major: 0,
+                minor: 48,
+                patch: 0
+            })
+        );
+    }
+}

--- a/src/runtime/kitty_dnd/drag_image.rs
+++ b/src/runtime/kitty_dnd/drag_image.rs
@@ -1,0 +1,633 @@
+use std::{
+    collections::{HashMap, HashSet},
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{Arc, Mutex, OnceLock},
+    thread,
+};
+
+use fontdue::{Font, FontSettings};
+use image::{ImageEncoder, codecs::png::PngEncoder};
+use ratatui::style::Color;
+
+const FONT_SIZE: f32 = 28.0;
+const ICON_SIZE: f32 = 30.0;
+const ICON_SLOT_WIDTH: u32 = 32;
+const PADDING_X: u32 = 18;
+const ICON_TEXT_GAP: u32 = 9;
+const WIDE_ICON_TEXT_GAP: u32 = 12;
+const RADIUS: f32 = 13.0;
+const MAX_TEXT_CHARS: usize = 30;
+const PREWARM_DRAG_ICONS: &str = "󰉋󰌺󰆍󰒓󰈙󰿃󰋩󰎆󰀼󰛖󰆼󰈔󰉓";
+
+pub(in crate::runtime) struct DragImage {
+    pub(in crate::runtime) png: Vec<u8>,
+    pub(in crate::runtime) width: u32,
+    pub(in crate::runtime) height: u32,
+}
+
+struct Canvas<'a> {
+    pixels: &'a mut [u8],
+    width: u32,
+    height: u32,
+}
+
+#[derive(Clone, Copy)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[derive(Clone, Copy)]
+struct Rect {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+}
+
+pub(in crate::runtime) fn prewarm_drag_image_renderer() {
+    let _ = thread::Builder::new()
+        .name("elio-drag-image-prewarm".to_string())
+        .spawn(|| {
+            if let Some(fonts) = font_cache().get_or_init(load_font_from_disk).as_ref() {
+                let _ = load_glyph_fallbacks_for_text(fonts, PREWARM_DRAG_ICONS);
+            }
+        });
+}
+
+pub(in crate::runtime) fn render_drag_image(
+    icon: &str,
+    text: &str,
+    icon_color: Color,
+    card_color: Color,
+    text_color: Color,
+) -> Option<DragImage> {
+    let base_fonts = loaded_fonts()?;
+    let fonts = RenderFontSet {
+        base: base_fonts,
+        glyph_fallbacks: load_glyph_fallbacks_for_text(base_fonts, icon),
+    };
+    if !can_render_text(&fonts, icon) {
+        return None;
+    }
+
+    let style = resolve_card_style(card_color, text_color);
+    let text = truncate_text(text, MAX_TEXT_CHARS);
+    let icon_width = measure_text(&fonts, icon, ICON_SIZE).ceil() as u32;
+    let icon_slot_width = icon_slot_width(icon_width);
+    let text_width = measure_text(&fonts, &text, FONT_SIZE).ceil() as u32;
+    let icon_text_gap = icon_text_gap(icon_slot_width);
+    let width = PADDING_X * 2 + icon_slot_width + icon_text_gap + text_width;
+    let height = 48;
+    let mut pixels = vec![0u8; width as usize * height as usize * 4];
+
+    let mut canvas = Canvas {
+        pixels: &mut pixels,
+        width,
+        height,
+    };
+
+    draw_rounded_rect(
+        &mut canvas,
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: width as f32,
+            height: height as f32,
+        },
+        RADIUS,
+        style.bg,
+    );
+
+    let baseline = 32.0;
+    draw_text(
+        &mut canvas,
+        &fonts,
+        icon,
+        ICON_SIZE,
+        Point {
+            x: (PADDING_X + icon_x_offset(icon_width, icon_slot_width)) as f32,
+            y: baseline + 1.0,
+        },
+        color_rgba(icon_color, 255),
+    );
+    draw_text(
+        &mut canvas,
+        &fonts,
+        &text,
+        FONT_SIZE,
+        Point {
+            x: (PADDING_X + icon_slot_width + icon_text_gap) as f32,
+            y: baseline,
+        },
+        style.text,
+    );
+
+    let mut png = Vec::new();
+    PngEncoder::new(&mut png)
+        .write_image(&pixels, width, height, image::ExtendedColorType::Rgba8)
+        .ok()?;
+    Some(DragImage { png, width, height })
+}
+
+struct CardStyle {
+    bg: [u8; 4],
+    text: [u8; 4],
+}
+
+fn resolve_card_style(card_color: Color, text_color: Color) -> CardStyle {
+    const DARK_BG: [u8; 4] = [0, 0, 0, 232];
+    const LIGHT_TEXT: [u8; 4] = [231, 237, 245, 255];
+    const DARK_TEXT: [u8; 4] = [38, 28, 35, 255];
+
+    let bg_rgb = color_rgb(card_color).unwrap_or([DARK_BG[0], DARK_BG[1], DARK_BG[2]]);
+    let bg = [bg_rgb[0], bg_rgb[1], bg_rgb[2], 232];
+
+    CardStyle {
+        bg,
+        text: readable_text_for(bg, color_rgb(text_color), LIGHT_TEXT, DARK_TEXT),
+    }
+}
+
+fn readable_text_for(
+    bg: [u8; 4],
+    preferred: Option<[u8; 3]>,
+    light: [u8; 4],
+    dark: [u8; 4],
+) -> [u8; 4] {
+    if let Some([r, g, b]) =
+        preferred.filter(|rgb| contrast_ratio(*rgb, [bg[0], bg[1], bg[2]]) >= 4.5)
+    {
+        return [r, g, b, 255];
+    }
+
+    if contrast_ratio([light[0], light[1], light[2]], [bg[0], bg[1], bg[2]])
+        >= contrast_ratio([dark[0], dark[1], dark[2]], [bg[0], bg[1], bg[2]])
+    {
+        light
+    } else {
+        dark
+    }
+}
+
+fn contrast_ratio(fg: [u8; 3], bg: [u8; 3]) -> f32 {
+    let fg = relative_luminance(fg);
+    let bg = relative_luminance(bg);
+    let (light, dark) = if fg >= bg { (fg, bg) } else { (bg, fg) };
+    (light + 0.05) / (dark + 0.05)
+}
+
+fn relative_luminance([r, g, b]: [u8; 3]) -> f32 {
+    fn channel(value: u8) -> f32 {
+        let value = value as f32 / 255.0;
+        if value <= 0.03928 {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).powf(2.4)
+        }
+    }
+
+    0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+fn font_cache() -> &'static OnceLock<Option<FontSet>> {
+    static FONTS: OnceLock<Option<FontSet>> = OnceLock::new();
+    &FONTS
+}
+
+fn loaded_fonts() -> Option<&'static FontSet> {
+    font_cache().get_or_init(load_font_from_disk).as_ref()
+}
+
+fn icon_text_gap(icon_width: u32) -> u32 {
+    if icon_width >= 30 {
+        WIDE_ICON_TEXT_GAP
+    } else {
+        ICON_TEXT_GAP
+    }
+}
+
+fn icon_slot_width(icon_width: u32) -> u32 {
+    icon_width.max(ICON_SLOT_WIDTH)
+}
+
+fn icon_x_offset(icon_width: u32, icon_slot_width: u32) -> u32 {
+    icon_slot_width.saturating_sub(icon_width) / 2
+}
+
+struct FontSet {
+    primary: Font,
+    fallbacks: Vec<Font>,
+}
+
+struct RenderFontSet<'a> {
+    base: &'a FontSet,
+    glyph_fallbacks: Vec<Arc<Font>>,
+}
+
+fn load_font_from_disk() -> Option<FontSet> {
+    let primary_path = kitty_font_family()
+        .as_deref()
+        .and_then(resolve_fontconfig_family)
+        .or_else(|| resolve_fontconfig_family("monospace"))
+        .or_else(known_font_fallback)?;
+    let primary = load_font(&primary_path)?;
+
+    let fallbacks = ["Symbols Nerd Font Mono", "Symbols Nerd Font"]
+        .into_iter()
+        .filter_map(resolve_matching_fontconfig_family)
+        .filter(|path| path != &primary_path)
+        .filter_map(|path| load_font(&path))
+        .collect();
+
+    Some(FontSet { primary, fallbacks })
+}
+
+fn load_glyph_fallbacks_for_text(fonts: &FontSet, text: &str) -> Vec<Arc<Font>> {
+    let mut seen_chars = HashSet::new();
+    let mut fallbacks = Vec::new();
+
+    for ch in text.chars() {
+        if !seen_chars.insert(ch)
+            || font_set_has_char(fonts, ch)
+            || arc_fonts_have_char(&fallbacks, ch)
+        {
+            continue;
+        }
+
+        if let Some(font) = cached_glyph_fallback(ch) {
+            fallbacks.push(font);
+        }
+    }
+
+    fallbacks
+}
+
+fn glyph_fallback_cache() -> &'static Mutex<HashMap<char, Option<Arc<Font>>>> {
+    static CACHE: OnceLock<Mutex<HashMap<char, Option<Arc<Font>>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_glyph_fallback(ch: char) -> Option<Arc<Font>> {
+    {
+        let mut cache = glyph_fallback_cache()
+            .lock()
+            .expect("glyph fallback cache lock");
+        if let Some(cached) = cache.get(&ch).cloned() {
+            return cached;
+        }
+        if let Some(font) = cache
+            .values()
+            .filter_map(Option::as_ref)
+            .find(|font| font.lookup_glyph_index(ch) != 0)
+            .cloned()
+        {
+            cache.insert(ch, Some(Arc::clone(&font)));
+            return Some(font);
+        }
+    }
+
+    let resolved = load_glyph_fallback(ch);
+    glyph_fallback_cache()
+        .lock()
+        .expect("glyph fallback cache lock")
+        .insert(ch, resolved.clone());
+    resolved
+}
+
+fn load_glyph_fallback(ch: char) -> Option<Arc<Font>> {
+    let path = resolve_fontconfig_char(ch)?;
+    let font = load_font(&path)?;
+    (font.lookup_glyph_index(ch) != 0).then(|| Arc::new(font))
+}
+
+fn resolve_fontconfig_char(ch: char) -> Option<PathBuf> {
+    let query = fontconfig_charset_query(ch);
+    let output = Command::new("fc-match")
+        .arg("-f")
+        .arg("%{file}\n")
+        .arg(query)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let output = String::from_utf8_lossy(&output.stdout);
+    let path = PathBuf::from(output.lines().next()?.trim());
+    path.exists().then_some(path)
+}
+
+fn fontconfig_charset_query(ch: char) -> String {
+    format!(":charset={:x}", ch as u32)
+}
+
+fn load_font(path: &Path) -> Option<Font> {
+    let bytes = fs::read(path).ok()?;
+    Font::from_bytes(bytes, FontSettings::default()).ok()
+}
+
+fn kitty_font_family() -> Option<String> {
+    let mut visited = Vec::new();
+    for path in kitty_config_candidates() {
+        if let Some(font) = kitty_font_family_from_config(&path, &mut visited, 0) {
+            return Some(font);
+        }
+    }
+    None
+}
+
+fn kitty_config_candidates() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
+        paths.push(PathBuf::from(config_home).join("kitty/kitty.conf"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".config/kitty/kitty.conf"));
+    }
+    if let Some(config_dir) = dirs::config_dir() {
+        paths.push(config_dir.join("kitty/kitty.conf"));
+    }
+    paths
+}
+
+fn kitty_font_family_from_config(
+    path: &Path,
+    visited: &mut Vec<PathBuf>,
+    depth: usize,
+) -> Option<String> {
+    if depth > 8 || visited.iter().any(|visited| visited == path) {
+        return None;
+    }
+    visited.push(path.to_path_buf());
+
+    let content = fs::read_to_string(path).ok()?;
+    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    for line in content.lines() {
+        let line = line.split_once('#').map_or(line, |(line, _)| line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(value) = kitty_setting_value(line, "font_family") {
+            if !value.eq_ignore_ascii_case("auto") {
+                return Some(value.to_string());
+            }
+        } else if let Some(include) = kitty_setting_value(line, "include") {
+            let include = PathBuf::from(include);
+            let include = if include.is_absolute() {
+                include
+            } else {
+                base_dir.join(include)
+            };
+            if let Some(font) = kitty_font_family_from_config(&include, visited, depth + 1) {
+                return Some(font);
+            }
+        }
+    }
+    None
+}
+
+fn kitty_setting_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let value = line.strip_prefix(key)?;
+    if !value.starts_with(char::is_whitespace) {
+        return None;
+    }
+    clean_kitty_value(value)
+}
+
+fn clean_kitty_value(value: &str) -> Option<&str> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.trim_matches(['\'', '"']))
+}
+
+fn resolve_fontconfig_family(family: &str) -> Option<PathBuf> {
+    resolve_fontconfig_family_output(family).map(|(_, path)| path)
+}
+
+fn resolve_matching_fontconfig_family(family: &str) -> Option<PathBuf> {
+    let (matched_family, path) = resolve_fontconfig_family_output(family)?;
+    matched_family
+        .to_ascii_lowercase()
+        .contains(&family.to_ascii_lowercase())
+        .then_some(path)
+}
+
+fn resolve_fontconfig_family_output(family: &str) -> Option<(String, PathBuf)> {
+    let output = Command::new("fc-match")
+        .args(["-f", "%{family}\n%{file}\n", family])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let output = String::from_utf8_lossy(&output.stdout);
+    let mut lines = output.lines();
+    let matched_family = lines.next()?.trim().to_string();
+    let path = PathBuf::from(lines.next()?.trim());
+    path.exists().then_some((matched_family, path))
+}
+
+fn known_font_fallback() -> Option<PathBuf> {
+    [
+        "/usr/share/fonts/TTF/MesloLGMNerdFont-Regular.ttf",
+        "/usr/share/fonts/TTF/MesloLGLNerdFont-Regular.ttf",
+        "/usr/share/fonts/TTF/FantasqueSansMNerdFont-Regular.ttf",
+        "/usr/share/fonts/TTF/vscode.ttf",
+        "/usr/share/fonts/noto/NotoSans-Regular.ttf",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .find(|path| path.exists())
+}
+
+fn truncate_text(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut truncated: String = text.chars().take(max_chars.saturating_sub(3)).collect();
+    truncated.push_str("...");
+    truncated
+}
+
+fn measure_text(fonts: &RenderFontSet<'_>, text: &str, size: f32) -> f32 {
+    text.chars()
+        .map(|ch| {
+            font_for_char_or_primary(fonts, ch)
+                .metrics(ch, size)
+                .advance_width
+                .max(0.0)
+        })
+        .sum()
+}
+
+fn can_render_text(fonts: &RenderFontSet<'_>, text: &str) -> bool {
+    text.chars().all(|ch| font_for_char(fonts, ch).is_some())
+}
+
+fn font_set_has_char(fonts: &FontSet, ch: char) -> bool {
+    fonts.primary.lookup_glyph_index(ch) != 0 || fonts_have_char(&fonts.fallbacks, ch)
+}
+
+fn fonts_have_char(fonts: &[Font], ch: char) -> bool {
+    fonts.iter().any(|font| font.lookup_glyph_index(ch) != 0)
+}
+
+fn arc_fonts_have_char(fonts: &[Arc<Font>], ch: char) -> bool {
+    fonts.iter().any(|font| font.lookup_glyph_index(ch) != 0)
+}
+
+fn font_for_char_or_primary<'a>(fonts: &'a RenderFontSet<'_>, ch: char) -> &'a Font {
+    font_for_char(fonts, ch).unwrap_or(&fonts.base.primary)
+}
+
+fn font_for_char<'a>(fonts: &'a RenderFontSet<'_>, ch: char) -> Option<&'a Font> {
+    if fonts.base.primary.lookup_glyph_index(ch) != 0 {
+        return Some(&fonts.base.primary);
+    }
+    fonts
+        .base
+        .fallbacks
+        .iter()
+        .find(|font| font.lookup_glyph_index(ch) != 0)
+        .or_else(|| {
+            fonts
+                .glyph_fallbacks
+                .iter()
+                .find(|font| font.lookup_glyph_index(ch) != 0)
+                .map(Arc::as_ref)
+        })
+}
+
+fn draw_text(
+    canvas: &mut Canvas<'_>,
+    fonts: &RenderFontSet<'_>,
+    text: &str,
+    size: f32,
+    origin: Point,
+    rgba: [u8; 4],
+) {
+    let mut cursor = origin.x;
+    for ch in text.chars() {
+        let font = font_for_char_or_primary(fonts, ch);
+        let (metrics, bitmap) = font.rasterize(ch, size);
+        let glyph_x = cursor + metrics.xmin as f32;
+        let glyph_y = origin.y - metrics.ymin as f32 - metrics.height as f32;
+        for row in 0..metrics.height {
+            for col in 0..metrics.width {
+                let alpha = bitmap[row * metrics.width + col];
+                if alpha == 0 {
+                    continue;
+                }
+                blend_pixel(
+                    canvas,
+                    glyph_x + col as f32,
+                    glyph_y + row as f32,
+                    [
+                        rgba[0],
+                        rgba[1],
+                        rgba[2],
+                        ((alpha as u16 * rgba[3] as u16) / 255) as u8,
+                    ],
+                );
+            }
+        }
+        cursor += metrics.advance_width;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fontconfig_charset_query_uses_lowercase_hex_codepoint() {
+        assert_eq!(fontconfig_charset_query('󰉋'), ":charset=f024b");
+        assert_eq!(fontconfig_charset_query('A'), ":charset=41");
+    }
+}
+
+fn draw_rounded_rect(canvas: &mut Canvas<'_>, rect: Rect, radius: f32, rgba: [u8; 4]) {
+    let left = rect.x.floor().max(0.0) as u32;
+    let top = rect.y.floor().max(0.0) as u32;
+    let right = (rect.x + rect.width).ceil().min(canvas.width as f32) as u32;
+    let bottom = (rect.y + rect.height).ceil().min(canvas.height as f32) as u32;
+    for py in top..bottom {
+        for px in left..right {
+            let alpha = rounded_rect_coverage(px as f32 + 0.5, py as f32 + 0.5, rect, radius);
+            if alpha > 0.0 {
+                let mut c = rgba;
+                c[3] = (rgba[3] as f32 * alpha).round() as u8;
+                blend_pixel(canvas, px as f32, py as f32, c);
+            }
+        }
+    }
+}
+
+fn rounded_rect_coverage(px: f32, py: f32, rect: Rect, radius: f32) -> f32 {
+    let cx = px.clamp(rect.x + radius, rect.x + rect.width - radius);
+    let cy = py.clamp(rect.y + radius, rect.y + rect.height - radius);
+    let dx = px - cx;
+    let dy = py - cy;
+    let dist = (dx * dx + dy * dy).sqrt();
+    (radius + 0.5 - dist).clamp(0.0, 1.0)
+}
+
+fn blend_pixel(canvas: &mut Canvas<'_>, x: f32, y: f32, src: [u8; 4]) {
+    let x = x.round() as i32;
+    let y = y.round() as i32;
+    if x < 0 || y < 0 || x >= canvas.width as i32 || y >= canvas.height as i32 || src[3] == 0 {
+        return;
+    }
+    let idx = (y as u32 * canvas.width + x as u32) as usize * 4;
+    let sa = src[3] as f32 / 255.0;
+    let da = canvas.pixels[idx + 3] as f32 / 255.0;
+    let out_a = sa + da * (1.0 - sa);
+    if out_a <= f32::EPSILON {
+        return;
+    }
+    for (channel, src_channel) in src.iter().copied().enumerate().take(3) {
+        let sc = src_channel as f32 / 255.0;
+        let dc = canvas.pixels[idx + channel] as f32 / 255.0;
+        canvas.pixels[idx + channel] =
+            (((sc * sa + dc * da * (1.0 - sa)) / out_a) * 255.0).round() as u8;
+    }
+    canvas.pixels[idx + 3] = (out_a * 255.0).round() as u8;
+}
+
+fn color_rgba(color: Color, alpha: u8) -> [u8; 4] {
+    let [r, g, b] = color_rgb(color).unwrap_or([231, 237, 245]);
+    [r, g, b, alpha]
+}
+
+fn color_rgb(color: Color) -> Option<[u8; 3]> {
+    Some(match color {
+        Color::Rgb(r, g, b) => [r, g, b],
+        Color::Black => [0, 0, 0],
+        Color::Red => [220, 76, 76],
+        Color::Green => [87, 201, 87],
+        Color::Yellow => [245, 216, 91],
+        Color::Blue => [91, 168, 255],
+        Color::Magenta => [255, 134, 216],
+        Color::Cyan => [36, 217, 184],
+        Color::Gray => [140, 151, 168],
+        Color::DarkGray => [48, 48, 48],
+        Color::LightRed => [255, 107, 107],
+        Color::LightGreen => [141, 223, 109],
+        Color::LightYellow => [255, 216, 102],
+        Color::LightBlue => [156, 188, 255],
+        Color::LightMagenta => [215, 142, 255],
+        Color::LightCyan => [138, 231, 255],
+        Color::White => [231, 237, 245],
+        Color::Indexed(_) | Color::Reset => return None,
+    })
+}

--- a/src/runtime/kitty_dnd/drag_image.rs
+++ b/src/runtime/kitty_dnd/drag_image.rs
@@ -2,7 +2,6 @@ use std::{
     collections::{HashMap, HashSet},
     env, fs,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
     sync::{Arc, Mutex, OnceLock},
     thread,
 };
@@ -230,14 +229,14 @@ struct RenderFontSet<'a> {
 fn load_font_from_disk() -> Option<FontSet> {
     let primary_path = kitty_font_family()
         .as_deref()
-        .and_then(resolve_fontconfig_family)
-        .or_else(|| resolve_fontconfig_family("monospace"))
+        .and_then(platform_fonts::resolve_family)
+        .or_else(platform_fonts::resolve_monospace)
         .or_else(known_font_fallback)?;
     let primary = load_font(&primary_path)?;
 
     let fallbacks = ["Symbols Nerd Font Mono", "Symbols Nerd Font"]
         .into_iter()
-        .filter_map(resolve_matching_fontconfig_family)
+        .filter_map(platform_fonts::resolve_matching_family)
         .filter(|path| path != &primary_path)
         .filter_map(|path| load_font(&path))
         .collect();
@@ -298,32 +297,9 @@ fn cached_glyph_fallback(ch: char) -> Option<Arc<Font>> {
 }
 
 fn load_glyph_fallback(ch: char) -> Option<Arc<Font>> {
-    let path = resolve_fontconfig_char(ch)?;
+    let path = platform_fonts::resolve_char(ch)?;
     let font = load_font(&path)?;
     (font.lookup_glyph_index(ch) != 0).then(|| Arc::new(font))
-}
-
-fn resolve_fontconfig_char(ch: char) -> Option<PathBuf> {
-    let query = fontconfig_charset_query(ch);
-    let output = Command::new("fc-match")
-        .arg("-f")
-        .arg("%{file}\n")
-        .arg(query)
-        .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let output = String::from_utf8_lossy(&output.stdout);
-    let path = PathBuf::from(output.lines().next()?.trim());
-    path.exists().then_some(path)
-}
-
-fn fontconfig_charset_query(ch: char) -> String {
-    format!(":charset={:x}", ch as u32)
 }
 
 fn load_font(path: &Path) -> Option<Font> {
@@ -408,33 +384,295 @@ fn clean_kitty_value(value: &str) -> Option<&str> {
     Some(value.trim_matches(['\'', '"']))
 }
 
-fn resolve_fontconfig_family(family: &str) -> Option<PathBuf> {
-    resolve_fontconfig_family_output(family).map(|(_, path)| path)
-}
+#[cfg(not(target_os = "macos"))]
+mod platform_fonts {
+    use std::{
+        path::PathBuf,
+        process::{Command, Stdio},
+    };
 
-fn resolve_matching_fontconfig_family(family: &str) -> Option<PathBuf> {
-    let (matched_family, path) = resolve_fontconfig_family_output(family)?;
-    matched_family
-        .to_ascii_lowercase()
-        .contains(&family.to_ascii_lowercase())
-        .then_some(path)
-}
-
-fn resolve_fontconfig_family_output(family: &str) -> Option<(String, PathBuf)> {
-    let output = Command::new("fc-match")
-        .args(["-f", "%{family}\n%{file}\n", family])
-        .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    pub(super) fn resolve_family(family: &str) -> Option<PathBuf> {
+        resolve_family_output(family).map(|(_, path)| path)
     }
-    let output = String::from_utf8_lossy(&output.stdout);
-    let mut lines = output.lines();
-    let matched_family = lines.next()?.trim().to_string();
-    let path = PathBuf::from(lines.next()?.trim());
-    path.exists().then_some((matched_family, path))
+
+    pub(super) fn resolve_monospace() -> Option<PathBuf> {
+        resolve_family("monospace")
+    }
+
+    pub(super) fn resolve_matching_family(family: &str) -> Option<PathBuf> {
+        let (matched_family, path) = resolve_family_output(family)?;
+        matched_family
+            .to_ascii_lowercase()
+            .contains(&family.to_ascii_lowercase())
+            .then_some(path)
+    }
+
+    pub(super) fn resolve_char(ch: char) -> Option<PathBuf> {
+        let query = fontconfig_charset_query(ch);
+        let output = Command::new("fc-match")
+            .arg("-f")
+            .arg("%{file}\n")
+            .arg(query)
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let output = String::from_utf8_lossy(&output.stdout);
+        let path = PathBuf::from(output.lines().next()?.trim());
+        path.exists().then_some(path)
+    }
+
+    pub(super) fn fontconfig_charset_query(ch: char) -> String {
+        format!(":charset={:x}", ch as u32)
+    }
+
+    fn resolve_family_output(family: &str) -> Option<(String, PathBuf)> {
+        let output = Command::new("fc-match")
+            .args(["-f", "%{family}\n%{file}\n", family])
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let output = String::from_utf8_lossy(&output.stdout);
+        let mut lines = output.lines();
+        let matched_family = lines.next()?.trim().to_string();
+        let path = PathBuf::from(lines.next()?.trim());
+        path.exists().then_some((matched_family, path))
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform_fonts {
+    use std::{ffi::c_void, path::PathBuf, ptr};
+
+    type Boolean = u8;
+    type CFIndex = isize;
+    type CFStringEncoding = u32;
+    type CFTypeRef = *const c_void;
+    type CFStringRef = *const c_void;
+    type CFURLRef = *const c_void;
+    type CTFontRef = *const c_void;
+    type CTFontDescriptorRef = *const c_void;
+    type CGFloat = f64;
+
+    const K_CF_STRING_ENCODING_UTF8: CFStringEncoding = 0x0800_0100;
+    const K_CFURL_POSIX_PATH_STYLE: CFIndex = 0;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CFRange {
+        location: CFIndex,
+        length: CFIndex,
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFRelease(cf: CFTypeRef);
+        fn CFStringCreateWithBytes(
+            alloc: *const c_void,
+            bytes: *const u8,
+            num_bytes: CFIndex,
+            encoding: CFStringEncoding,
+            is_external_representation: Boolean,
+        ) -> CFStringRef;
+        fn CFStringGetCString(
+            string: CFStringRef,
+            buffer: *mut i8,
+            buffer_size: CFIndex,
+            encoding: CFStringEncoding,
+        ) -> Boolean;
+        fn CFStringGetLength(string: CFStringRef) -> CFIndex;
+        fn CFStringGetMaximumSizeForEncoding(
+            length: CFIndex,
+            encoding: CFStringEncoding,
+        ) -> CFIndex;
+        fn CFURLCopyFileSystemPath(url: CFURLRef, path_style: CFIndex) -> CFStringRef;
+    }
+
+    #[link(name = "CoreText", kind = "framework")]
+    unsafe extern "C" {
+        static kCTFontURLAttribute: CFStringRef;
+
+        fn CTFontCreateWithName(
+            name: CFStringRef,
+            size: CGFloat,
+            matrix: *const c_void,
+        ) -> CTFontRef;
+        fn CTFontCreateForString(
+            current_font: CTFontRef,
+            string: CFStringRef,
+            range: CFRange,
+        ) -> CTFontRef;
+        fn CTFontCopyFamilyName(font: CTFontRef) -> CFStringRef;
+        fn CTFontCopyFontDescriptor(font: CTFontRef) -> CTFontDescriptorRef;
+        fn CTFontDescriptorCopyAttribute(
+            descriptor: CTFontDescriptorRef,
+            attribute: CFStringRef,
+        ) -> CFTypeRef;
+    }
+
+    pub(super) fn resolve_family(family: &str) -> Option<PathBuf> {
+        font_path_for_family(family).map(|resolved| resolved.path)
+    }
+
+    pub(super) fn resolve_monospace() -> Option<PathBuf> {
+        ["Menlo", "Monaco"]
+            .into_iter()
+            .find_map(|family| font_path_for_family(family).map(|resolved| resolved.path))
+    }
+
+    pub(super) fn resolve_matching_family(family: &str) -> Option<PathBuf> {
+        let resolved = font_path_for_family(family)?;
+        resolved
+            .family
+            .to_ascii_lowercase()
+            .contains(&family.to_ascii_lowercase())
+            .then_some(resolved.path)
+    }
+
+    pub(super) fn resolve_char(ch: char) -> Option<PathBuf> {
+        let base_font =
+            create_font_for_family("Menlo").or_else(|| create_font_for_family("Monaco"))?;
+        let Some(text) = cf_string_from_str(&ch.to_string()) else {
+            release_if_present(base_font);
+            return None;
+        };
+        let length = unsafe { CFStringGetLength(text) };
+        let fallback = unsafe {
+            CTFontCreateForString(
+                base_font,
+                text,
+                CFRange {
+                    location: 0,
+                    length,
+                },
+            )
+        };
+
+        let path = font_path_for_font(fallback).map(|resolved| resolved.path);
+        release_if_present(fallback);
+        release_if_present(text);
+        release_if_present(base_font);
+        path
+    }
+
+    struct ResolvedFont {
+        path: PathBuf,
+        family: String,
+    }
+
+    fn font_path_for_family(family: &str) -> Option<ResolvedFont> {
+        let font = create_font_for_family(family)?;
+        let resolved = font_path_for_font(font);
+        release_if_present(font);
+        resolved
+    }
+
+    fn create_font_for_family(family: &str) -> Option<CTFontRef> {
+        let name = cf_string_from_str(family)?;
+        let font = unsafe { CTFontCreateWithName(name, 12.0, ptr::null()) };
+        release_if_present(name);
+        (!font.is_null()).then_some(font)
+    }
+
+    fn font_path_for_font(font: CTFontRef) -> Option<ResolvedFont> {
+        if font.is_null() {
+            return None;
+        }
+
+        let descriptor = unsafe { CTFontCopyFontDescriptor(font) };
+        if descriptor.is_null() {
+            return None;
+        }
+
+        let url = unsafe { CTFontDescriptorCopyAttribute(descriptor, kCTFontURLAttribute) };
+        let family = copy_font_family(font);
+        let path = font_url_to_path(url as CFURLRef);
+
+        release_if_present(url);
+        release_if_present(descriptor);
+
+        Some(ResolvedFont {
+            path: path?,
+            family: family?,
+        })
+    }
+
+    fn font_url_to_path(url: CFURLRef) -> Option<PathBuf> {
+        if url.is_null() {
+            return None;
+        }
+
+        let path_string = unsafe { CFURLCopyFileSystemPath(url, K_CFURL_POSIX_PATH_STYLE) };
+        let path = cf_string_to_string(path_string).map(PathBuf::from);
+        release_if_present(path_string);
+        path.filter(|path| path.exists())
+    }
+
+    fn copy_font_family(font: CTFontRef) -> Option<String> {
+        let family = unsafe { CTFontCopyFamilyName(font) };
+        let value = cf_string_to_string(family);
+        release_if_present(family);
+        value
+    }
+
+    fn cf_string_from_str(value: &str) -> Option<CFStringRef> {
+        let string = unsafe {
+            CFStringCreateWithBytes(
+                ptr::null(),
+                value.as_ptr(),
+                value.len() as CFIndex,
+                K_CF_STRING_ENCODING_UTF8,
+                0,
+            )
+        };
+        (!string.is_null()).then_some(string)
+    }
+
+    fn cf_string_to_string(value: CFStringRef) -> Option<String> {
+        if value.is_null() {
+            return None;
+        }
+
+        let length = unsafe { CFStringGetLength(value) };
+        let capacity =
+            unsafe { CFStringGetMaximumSizeForEncoding(length, K_CF_STRING_ENCODING_UTF8) } + 1;
+        let mut bytes = vec![0i8; capacity as usize];
+        let ok = unsafe {
+            CFStringGetCString(
+                value,
+                bytes.as_mut_ptr(),
+                capacity,
+                K_CF_STRING_ENCODING_UTF8,
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+
+        let nul = bytes
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(bytes.len());
+        let bytes = bytes[..nul]
+            .iter()
+            .map(|byte| *byte as u8)
+            .collect::<Vec<_>>();
+        String::from_utf8(bytes).ok()
+    }
+
+    fn release_if_present(value: CFTypeRef) {
+        if !value.is_null() {
+            unsafe { CFRelease(value) };
+        }
+    }
 }
 
 fn known_font_fallback() -> Option<PathBuf> {
@@ -545,17 +783,6 @@ fn draw_text(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fontconfig_charset_query_uses_lowercase_hex_codepoint() {
-        assert_eq!(fontconfig_charset_query('󰉋'), ":charset=f024b");
-        assert_eq!(fontconfig_charset_query('A'), ":charset=41");
-    }
-}
-
 fn draw_rounded_rect(canvas: &mut Canvas<'_>, rect: Rect, radius: f32, rgba: [u8; 4]) {
     let left = rect.x.floor().max(0.0) as u32;
     let top = rect.y.floor().max(0.0) as u32;
@@ -630,4 +857,20 @@ fn color_rgb(color: Color) -> Option<[u8; 3]> {
         Color::White => [231, 237, 245],
         Color::Indexed(_) | Color::Reset => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn fontconfig_charset_query_uses_lowercase_hex_codepoint() {
+        assert_eq!(
+            super::platform_fonts::fontconfig_charset_query('󰉋'),
+            ":charset=f024b"
+        );
+        assert_eq!(
+            super::platform_fonts::fontconfig_charset_query('A'),
+            ":charset=41"
+        );
+    }
 }

--- a/src/runtime/kitty_dnd/event.rs
+++ b/src/runtime/kitty_dnd/event.rs
@@ -5,18 +5,20 @@ use base64::{
     engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
 };
 
-use super::protocol::URI_LIST_MIME;
+use super::protocol::{DndOperation, URI_LIST_MIME};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(in crate::runtime) enum KittyDndEvent {
     DropOffer {
         mime_index: u8,
+        operation: DndOperation,
         final_drop: bool,
     },
     DropLeave,
     DropData {
         mime_index: u8,
         paths: Vec<PathBuf>,
+        unsupported_schemes: Vec<String>,
     },
     DropDataError {
         mime_index: Option<u8>,
@@ -34,7 +36,7 @@ pub(in crate::runtime) enum KittyDndEvent {
         mime_index: u8,
     },
     DragActionChanged {
-        operation: u8,
+        operation: DndOperation,
     },
     DragDropped,
     DragDataRequested {
@@ -113,33 +115,21 @@ fn event_from_parts(fields: DndFields, payload: &[u8]) -> Option<KittyDndEvent> 
             if fields.x == Some(-1) && fields.y == Some(-1) {
                 return Some(KittyDndEvent::DropLeave);
             }
-            offered_uri_list(payload).map_or(
-                Some(KittyDndEvent::DropUnsupported { final_drop: false }),
-                |mime_index| {
-                    Some(KittyDndEvent::DropOffer {
-                        mime_index,
-                        final_drop: false,
-                    })
-                },
-            )
+            drop_offer_from_parts(fields.op, payload, false)
         }
-        b'M' => offered_uri_list(payload).map_or(
-            Some(KittyDndEvent::DropUnsupported { final_drop: true }),
-            |mime_index| {
-                Some(KittyDndEvent::DropOffer {
-                    mime_index,
-                    final_drop: true,
-                })
-            },
-        ),
+        b'M' => drop_offer_from_parts(fields.op, payload, true),
         b'r' => {
             let mime_index = fields.x.and_then(|x| u8::try_from(x).ok())?;
             if payload.is_empty() && fields.more == Some(false) {
                 return None;
             }
             let data = decode_base64(payload)?;
-            let paths = parse_uri_list(&String::from_utf8(data).ok()?);
-            Some(KittyDndEvent::DropData { mime_index, paths })
+            let payload = parse_uri_list(&String::from_utf8(data).ok()?);
+            Some(KittyDndEvent::DropData {
+                mime_index,
+                paths: payload.paths,
+                unsupported_schemes: payload.unsupported_schemes,
+            })
         }
         b'R' => Some(KittyDndEvent::DropDataError {
             mime_index: fields.x.and_then(|x| u8::try_from(x).ok()),
@@ -153,7 +143,7 @@ fn event_from_parts(fields: DndFields, payload: &[u8]) -> Option<KittyDndEvent> 
             mime_index: fields.y.and_then(|y| u8::try_from(y).ok())?,
         }),
         b'e' if fields.x == Some(2) => Some(KittyDndEvent::DragActionChanged {
-            operation: fields.op.and_then(|op| u8::try_from(op).ok())?,
+            operation: fields.op.and_then(DndOperation::from_protocol)?,
         }),
         b'e' if fields.x == Some(3) => Some(KittyDndEvent::DragDropped),
         b'e' if fields.x == Some(4) => Some(KittyDndEvent::DragEnded {
@@ -183,6 +173,24 @@ fn decode_base64(payload: &[u8]) -> Option<Vec<u8>> {
         .ok()
 }
 
+fn drop_offer_from_parts(
+    operation: Option<i32>,
+    payload: &[u8],
+    final_drop: bool,
+) -> Option<KittyDndEvent> {
+    let operation = operation.and_then(DndOperation::from_protocol)?;
+    offered_uri_list(payload).map_or(
+        Some(KittyDndEvent::DropUnsupported { final_drop }),
+        |mime_index| {
+            Some(KittyDndEvent::DropOffer {
+                mime_index,
+                operation,
+                final_drop,
+            })
+        },
+    )
+}
+
 fn offered_uri_list(payload: &[u8]) -> Option<u8> {
     let text = std::str::from_utf8(payload).ok()?;
     text.split_whitespace()
@@ -191,12 +199,37 @@ fn offered_uri_list(payload: &[u8]) -> Option<u8> {
         .and_then(|idx| u8::try_from(idx + 1).ok())
 }
 
-fn parse_uri_list(text: &str) -> Vec<PathBuf> {
-    text.lines()
+#[derive(Debug, Default, Eq, PartialEq)]
+struct ParsedUriList {
+    paths: Vec<PathBuf>,
+    unsupported_schemes: Vec<String>,
+}
+
+fn parse_uri_list(text: &str) -> ParsedUriList {
+    let mut parsed = ParsedUriList::default();
+    for uri in text
+        .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .filter_map(file_uri_to_path)
-        .collect()
+    {
+        if let Some(path) = file_uri_to_path(uri) {
+            parsed.paths.push(path);
+            continue;
+        }
+        let scheme = uri
+            .split_once(':')
+            .map(|(scheme, _)| scheme)
+            .filter(|scheme| !scheme.is_empty())
+            .unwrap_or("unknown");
+        if !parsed
+            .unsupported_schemes
+            .iter()
+            .any(|known| known == scheme)
+        {
+            parsed.unsupported_schemes.push(scheme.to_string());
+        }
+    }
+    parsed
 }
 
 fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
@@ -292,6 +325,7 @@ mod tests {
             parse_osc72(b"\x1b]72;t=M:x=12:y=5:o=1;text/plain text/uri-list\x1b\\"),
             Some(KittyDndEvent::DropOffer {
                 mime_index: 2,
+                operation: DndOperation::Copy,
                 final_drop: true,
             })
         );
@@ -300,12 +334,65 @@ mod tests {
     #[test]
     fn parses_unsupported_drop_offer_with_phase() {
         assert_eq!(
-            parse_osc72(b"\x1b]72;t=m:x=12:y=5;text/plain\x1b\\"),
+            parse_osc72(b"\x1b]72;t=m:x=12:y=5:o=1;text/plain\x1b\\"),
             Some(KittyDndEvent::DropUnsupported { final_drop: false })
         );
         assert_eq!(
-            parse_osc72(b"\x1b]72;t=M:x=12:y=5;text/plain\x1b\\"),
+            parse_osc72(b"\x1b]72;t=M:x=12:y=5:o=2;text/plain\x1b\\"),
             Some(KittyDndEvent::DropUnsupported { final_drop: true })
+        );
+    }
+
+    #[test]
+    fn parses_drop_offer_operation() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=m:x=12:y=5:o=2;text/uri-list\x1b\\"),
+            Some(KittyDndEvent::DropOffer {
+                mime_index: 1,
+                operation: DndOperation::Move,
+                final_drop: false,
+            })
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=m:x=12:y=5:o=3;text/uri-list\x1b\\"),
+            Some(KittyDndEvent::DropOffer {
+                mime_index: 1,
+                operation: DndOperation::Either,
+                final_drop: false,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_drop_offer_without_valid_operation() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=m:x=12:y=5;text/uri-list\x1b\\"),
+            None
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=m:x=12:y=5:o=9;text/uri-list\x1b\\"),
+            None
+        );
+    }
+
+    #[test]
+    fn reports_unsupported_uri_schemes_in_drop_data() {
+        let data =
+            STANDARD_NO_PAD.encode("trash:///foo\nsmb://server/share/file\nfile:///tmp/a.txt");
+        let sequence = format!("\x1b]72;t=r:x=1;{data}\x1b\\");
+        let mut state = Osc72State::default();
+        assert_eq!(
+            parse_osc72_with_state(sequence.as_bytes(), &mut state),
+            None
+        );
+
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;t=r:x=1:m=0;\x1b\\", &mut state),
+            Some(KittyDndEvent::DropData {
+                mime_index: 1,
+                paths: vec![PathBuf::from("/tmp/a.txt")],
+                unsupported_schemes: vec!["trash".to_string(), "smb".to_string()],
+            })
         );
     }
 
@@ -335,6 +422,7 @@ mod tests {
             Some(KittyDndEvent::DropData {
                 mime_index: 1,
                 paths: vec![PathBuf::from("/tmp/a b.txt")],
+                unsupported_schemes: vec!["file".to_string()],
             })
         );
     }
@@ -355,7 +443,9 @@ mod tests {
         );
         assert_eq!(
             parse_osc72(b"\x1b]72;t=e:x=2:o=1\x1b\\"),
-            Some(KittyDndEvent::DragActionChanged { operation: 1 })
+            Some(KittyDndEvent::DragActionChanged {
+                operation: DndOperation::Copy,
+            })
         );
         assert_eq!(
             parse_osc72(b"\x1b]72;t=e:x=3\x1b\\"),
@@ -404,6 +494,7 @@ mod tests {
             Some(KittyDndEvent::DropData {
                 mime_index: 1,
                 paths: vec![PathBuf::from("/tmp/a.txt")],
+                unsupported_schemes: Vec::new(),
             })
         );
     }
@@ -428,6 +519,7 @@ mod tests {
             Some(KittyDndEvent::DropData {
                 mime_index: 1,
                 paths: vec![PathBuf::from("/tmp/a.txt")],
+                unsupported_schemes: Vec::new(),
             })
         );
     }

--- a/src/runtime/kitty_dnd/event.rs
+++ b/src/runtime/kitty_dnd/event.rs
@@ -1,0 +1,434 @@
+use std::path::PathBuf;
+
+use base64::{
+    Engine,
+    engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
+};
+
+use super::protocol::URI_LIST_MIME;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::runtime) enum KittyDndEvent {
+    DropOffer {
+        mime_index: u8,
+        final_drop: bool,
+    },
+    DropLeave,
+    DropData {
+        mime_index: u8,
+        paths: Vec<PathBuf>,
+    },
+    DropDataError {
+        mime_index: Option<u8>,
+        message: String,
+    },
+    DropUnsupported {
+        final_drop: bool,
+    },
+    DragOffer {
+        x: u16,
+        y: u16,
+    },
+    DragStarted,
+    DragAccepted {
+        mime_index: u8,
+    },
+    DragActionChanged {
+        operation: u8,
+    },
+    DragDropped,
+    DragDataRequested {
+        mime_index: u8,
+    },
+    DragEnded {
+        cancelled: bool,
+    },
+    DragError {
+        message: String,
+    },
+}
+
+#[derive(Default)]
+pub(in crate::runtime) struct Osc72State {
+    fields: DndFields,
+    payload: Vec<u8>,
+    active: bool,
+}
+
+impl Osc72State {
+    fn reset(&mut self) {
+        self.fields = DndFields::default();
+        self.payload.clear();
+        self.active = false;
+    }
+}
+
+#[cfg(test)]
+pub(in crate::runtime) fn parse_osc72(sequence: &[u8]) -> Option<KittyDndEvent> {
+    let mut state = Osc72State::default();
+    parse_osc72_with_state(sequence, &mut state)
+}
+
+pub(in crate::runtime) fn parse_osc72_with_state(
+    sequence: &[u8],
+    state: &mut Osc72State,
+) -> Option<KittyDndEvent> {
+    let body = strip_osc72(sequence)?;
+    let (metadata, payload) =
+        SplitOnceByte::split_once(body, |byte| *byte == b';').unwrap_or((body, &[]));
+    let fields = DndFields::parse(metadata);
+    let payload_for_event;
+    let fields_for_event;
+    let ty = if state.active {
+        state.fields.ty
+    } else {
+        fields.ty
+    };
+    let has_more = fields.more == Some(true) || ty == Some(b'r') && !payload.is_empty();
+
+    if state.active {
+        state.payload.extend_from_slice(payload);
+        if has_more {
+            return None;
+        }
+        fields_for_event = state.fields.clone();
+        payload_for_event = std::mem::take(&mut state.payload);
+        state.reset();
+        return event_from_parts(fields_for_event, &payload_for_event);
+    }
+
+    if has_more {
+        state.fields = fields;
+        state.payload.extend_from_slice(payload);
+        state.active = true;
+        return None;
+    }
+
+    event_from_parts(fields, payload)
+}
+
+fn event_from_parts(fields: DndFields, payload: &[u8]) -> Option<KittyDndEvent> {
+    match fields.ty? {
+        b'm' => {
+            if fields.x == Some(-1) && fields.y == Some(-1) {
+                return Some(KittyDndEvent::DropLeave);
+            }
+            offered_uri_list(payload).map_or(
+                Some(KittyDndEvent::DropUnsupported { final_drop: false }),
+                |mime_index| {
+                    Some(KittyDndEvent::DropOffer {
+                        mime_index,
+                        final_drop: false,
+                    })
+                },
+            )
+        }
+        b'M' => offered_uri_list(payload).map_or(
+            Some(KittyDndEvent::DropUnsupported { final_drop: true }),
+            |mime_index| {
+                Some(KittyDndEvent::DropOffer {
+                    mime_index,
+                    final_drop: true,
+                })
+            },
+        ),
+        b'r' => {
+            let mime_index = fields.x.and_then(|x| u8::try_from(x).ok())?;
+            if payload.is_empty() && fields.more == Some(false) {
+                return None;
+            }
+            let data = decode_base64(payload)?;
+            let paths = parse_uri_list(&String::from_utf8(data).ok()?);
+            Some(KittyDndEvent::DropData { mime_index, paths })
+        }
+        b'R' => Some(KittyDndEvent::DropDataError {
+            mime_index: fields.x.and_then(|x| u8::try_from(x).ok()),
+            message: String::from_utf8_lossy(payload).into_owned(),
+        }),
+        b'o' => Some(KittyDndEvent::DragOffer {
+            x: fields.x.and_then(|x| u16::try_from(x).ok())?,
+            y: fields.y.and_then(|y| u16::try_from(y).ok())?,
+        }),
+        b'e' if fields.x == Some(1) => Some(KittyDndEvent::DragAccepted {
+            mime_index: fields.y.and_then(|y| u8::try_from(y).ok())?,
+        }),
+        b'e' if fields.x == Some(2) => Some(KittyDndEvent::DragActionChanged {
+            operation: fields.op.and_then(|op| u8::try_from(op).ok())?,
+        }),
+        b'e' if fields.x == Some(3) => Some(KittyDndEvent::DragDropped),
+        b'e' if fields.x == Some(4) => Some(KittyDndEvent::DragEnded {
+            cancelled: fields.y.unwrap_or(0) != 0,
+        }),
+        b'e' if fields.x == Some(5) => Some(KittyDndEvent::DragDataRequested {
+            mime_index: fields.y.and_then(|y| u8::try_from(y).ok())?,
+        }),
+        b'E' if payload == b"OK" => Some(KittyDndEvent::DragStarted),
+        b'E' => Some(KittyDndEvent::DragError {
+            message: String::from_utf8_lossy(payload).into_owned(),
+        }),
+        _ => None,
+    }
+}
+
+fn strip_osc72(sequence: &[u8]) -> Option<&[u8]> {
+    let body = sequence.strip_prefix(b"\x1b]72;")?;
+    body.strip_suffix(b"\x1b\\")
+        .or_else(|| body.strip_suffix(b"\x07"))
+}
+
+fn decode_base64(payload: &[u8]) -> Option<Vec<u8>> {
+    STANDARD
+        .decode(payload)
+        .or_else(|_| STANDARD_NO_PAD.decode(payload))
+        .ok()
+}
+
+fn offered_uri_list(payload: &[u8]) -> Option<u8> {
+    let text = std::str::from_utf8(payload).ok()?;
+    text.split_whitespace()
+        .position(|mime| mime == URI_LIST_MIME)
+        // Kitty's data request index is 1-based, not Rust's 0-based `position()`.
+        .and_then(|idx| u8::try_from(idx + 1).ok())
+}
+
+fn parse_uri_list(text: &str) -> Vec<PathBuf> {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(file_uri_to_path)
+        .collect()
+}
+
+fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    let path = if let Some(local) = rest.strip_prefix("localhost/") {
+        format!("/{local}")
+    } else if rest.starts_with('/') {
+        rest.to_string()
+    } else {
+        return None;
+    };
+    Some(PathBuf::from(percent_decode(&path)?))
+}
+
+fn percent_decode(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let high = bytes.get(index + 1).copied().and_then(hex_value)?;
+            let low = bytes.get(index + 2).copied().and_then(hex_value)?;
+            out.push((high << 4) | low);
+            index += 3;
+        } else {
+            out.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Default)]
+struct DndFields {
+    ty: Option<u8>,
+    x: Option<i32>,
+    y: Option<i32>,
+    op: Option<i32>,
+    more: Option<bool>,
+}
+
+impl DndFields {
+    fn parse(metadata: &[u8]) -> Self {
+        let mut fields = Self::default();
+        for field in metadata.split(|byte| *byte == b':') {
+            let Some((key, value)) = SplitOnceByte::split_once(field, |byte| *byte == b'=') else {
+                continue;
+            };
+            match key {
+                b"t" => fields.ty = value.first().copied(),
+                b"x" => fields.x = parse_i32(value),
+                b"y" => fields.y = parse_i32(value),
+                b"o" => fields.op = parse_i32(value),
+                b"m" => fields.more = parse_i32(value).map(|value| value != 0),
+                _ => {}
+            }
+        }
+        fields
+    }
+}
+
+fn parse_i32(value: &[u8]) -> Option<i32> {
+    std::str::from_utf8(value).ok()?.parse().ok()
+}
+
+trait SplitOnceByte {
+    fn split_once(&self, predicate: impl FnMut(&u8) -> bool) -> Option<(&[u8], &[u8])>;
+}
+
+impl SplitOnceByte for [u8] {
+    fn split_once(&self, mut predicate: impl FnMut(&u8) -> bool) -> Option<(&[u8], &[u8])> {
+        let index = self.iter().position(&mut predicate)?;
+        Some((&self[..index], &self[index + 1..]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_drop_offer_for_uri_list() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=M:x=12:y=5:o=1;text/plain text/uri-list\x1b\\"),
+            Some(KittyDndEvent::DropOffer {
+                mime_index: 2,
+                final_drop: true,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_unsupported_drop_offer_with_phase() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=m:x=12:y=5;text/plain\x1b\\"),
+            Some(KittyDndEvent::DropUnsupported { final_drop: false })
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=M:x=12:y=5;text/plain\x1b\\"),
+            Some(KittyDndEvent::DropUnsupported { final_drop: true })
+        );
+    }
+
+    #[test]
+    fn parses_drop_data_error() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=R:x=1;EPERM:cannot drop into self window\x1b\\"),
+            Some(KittyDndEvent::DropDataError {
+                mime_index: Some(1),
+                message: "EPERM:cannot drop into self window".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn decodes_local_file_uri_list() {
+        let payload =
+            STANDARD.encode("file:///tmp/a%20b.txt\r\n# comment\r\nfile://remote/tmp/no\r\n");
+        let sequence = format!("\x1b]72;t=r:x=1;{payload}\x1b\\");
+        let mut state = Osc72State::default();
+        assert_eq!(
+            parse_osc72_with_state(sequence.as_bytes(), &mut state),
+            None
+        );
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;t=r:x=1:m=0;\x1b\\", &mut state),
+            Some(KittyDndEvent::DropData {
+                mime_index: 1,
+                paths: vec![PathBuf::from("/tmp/a b.txt")],
+            })
+        );
+    }
+
+    #[test]
+    fn parses_drag_offer() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=o:x=12:y=5\x1b\\"),
+            Some(KittyDndEvent::DragOffer { x: 12, y: 5 })
+        );
+    }
+
+    #[test]
+    fn parses_drag_data_request_and_end() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=e:x=1:y=0\x1b\\"),
+            Some(KittyDndEvent::DragAccepted { mime_index: 0 })
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=e:x=2:o=1\x1b\\"),
+            Some(KittyDndEvent::DragActionChanged { operation: 1 })
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=e:x=3\x1b\\"),
+            Some(KittyDndEvent::DragDropped)
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=e:x=5:y=0\x1b\\"),
+            Some(KittyDndEvent::DragDataRequested { mime_index: 0 })
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=e:x=4:y=1\x1b\\"),
+            Some(KittyDndEvent::DragEnded { cancelled: true })
+        );
+    }
+
+    #[test]
+    fn parses_drag_start_acknowledgement() {
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=E;OK\x1b\\"),
+            Some(KittyDndEvent::DragStarted)
+        );
+        assert_eq!(
+            parse_osc72(b"\x1b]72;t=E;EPERM\x1b\\"),
+            Some(KittyDndEvent::DragError {
+                message: "EPERM".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_empty_end_of_data_marker() {
+        assert_eq!(parse_osc72(b"\x1b]72;t=r:x=1:m=0;\x1b\\"), None);
+    }
+
+    #[test]
+    fn decodes_unpadded_base64_uri_list() {
+        let payload = STANDARD_NO_PAD.encode("file:///tmp/a.txt");
+        let sequence = format!("\x1b]72;t=r:x=1;{payload}\x1b\\");
+        let mut state = Osc72State::default();
+        assert_eq!(
+            parse_osc72_with_state(sequence.as_bytes(), &mut state),
+            None
+        );
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;t=r:x=1:m=0;\x1b\\", &mut state),
+            Some(KittyDndEvent::DropData {
+                mime_index: 1,
+                paths: vec![PathBuf::from("/tmp/a.txt")],
+            })
+        );
+    }
+
+    #[test]
+    fn assembles_chunked_drop_data() {
+        let mut state = Osc72State::default();
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;t=r:x=1:m=1;ZmlsZTov\x1b\\", &mut state),
+            None
+        );
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;m=1;Ly90bXAv\x1b\\", &mut state),
+            None
+        );
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;m=1;YS50eHQ\x1b\\", &mut state),
+            None
+        );
+        assert_eq!(
+            parse_osc72_with_state(b"\x1b]72;t=r:x=1:m=0;\x1b\\", &mut state),
+            Some(KittyDndEvent::DropData {
+                mime_index: 1,
+                paths: vec![PathBuf::from("/tmp/a.txt")],
+            })
+        );
+    }
+}

--- a/src/runtime/kitty_dnd/mod.rs
+++ b/src/runtime/kitty_dnd/mod.rs
@@ -5,8 +5,8 @@ mod protocol;
 pub(super) use capability::{KittyDndRuntime, detect_kitty_dnd_runtime};
 pub(in crate::runtime) use event::{KittyDndEvent, Osc72State, parse_osc72_with_state};
 pub(super) use protocol::{
-    accept_drop_sequence, agree_drag_either_sequence, cancel_drag_sequence, disable_sequence,
-    drag_data_error_sequence, finish_drop_sequence, present_drag_data_sequence,
+    DndOperation, DropFinish, accept_drop_sequence, agree_drag_sequence, cancel_drag_sequence,
+    disable_sequence, drag_data_error_sequence, finish_drop_sequence, present_drag_data_sequence,
     present_drag_icon_sequence, reject_drop_sequence, request_drop_data_sequence,
     send_drag_data_sequence, start_drag_sequence, startup_sequence, uri_list_payload,
 };

--- a/src/runtime/kitty_dnd/mod.rs
+++ b/src/runtime/kitty_dnd/mod.rs
@@ -1,11 +1,19 @@
+#[cfg(unix)]
 mod capability;
+#[cfg(unix)]
 mod drag_image;
+#[cfg(unix)]
 mod event;
+#[cfg(unix)]
 mod protocol;
 
+#[cfg(unix)]
 pub(super) use capability::{KittyDndRuntime, detect_kitty_dnd_runtime};
+#[cfg(unix)]
 pub(in crate::runtime) use drag_image::{prewarm_drag_image_renderer, render_drag_image};
+#[cfg(unix)]
 pub(in crate::runtime) use event::{KittyDndEvent, Osc72State, parse_osc72_with_state};
+#[cfg(unix)]
 pub(super) use protocol::{
     DndOperation, DropFinish, accept_drop_sequence, agree_drag_sequence, cancel_drag_sequence,
     disable_sequence, drag_data_error_sequence, finish_drop_sequence, present_drag_data_sequence,
@@ -13,3 +21,33 @@ pub(super) use protocol::{
     request_drop_data_sequence, send_drag_data_sequence, start_drag_sequence, startup_sequence,
     uri_list_payload,
 };
+
+#[cfg(not(unix))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::runtime) struct KittyDndRuntime;
+
+#[cfg(not(unix))]
+impl KittyDndRuntime {
+    pub(in crate::runtime) const fn is_enabled(&self) -> bool {
+        false
+    }
+
+    pub(in crate::runtime) const fn drag_machine_id(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[cfg(not(unix))]
+pub(in crate::runtime) const fn detect_kitty_dnd_runtime() -> KittyDndRuntime {
+    KittyDndRuntime
+}
+
+#[cfg(not(unix))]
+pub(in crate::runtime) const fn disable_sequence() -> &'static str {
+    ""
+}
+
+#[cfg(not(unix))]
+pub(in crate::runtime) const fn startup_sequence(_machine_id: Option<&str>) -> &'static str {
+    ""
+}

--- a/src/runtime/kitty_dnd/mod.rs
+++ b/src/runtime/kitty_dnd/mod.rs
@@ -1,12 +1,15 @@
 mod capability;
+mod drag_image;
 mod event;
 mod protocol;
 
 pub(super) use capability::{KittyDndRuntime, detect_kitty_dnd_runtime};
+pub(in crate::runtime) use drag_image::{prewarm_drag_image_renderer, render_drag_image};
 pub(in crate::runtime) use event::{KittyDndEvent, Osc72State, parse_osc72_with_state};
 pub(super) use protocol::{
     DndOperation, DropFinish, accept_drop_sequence, agree_drag_sequence, cancel_drag_sequence,
     disable_sequence, drag_data_error_sequence, finish_drop_sequence, present_drag_data_sequence,
-    present_drag_icon_sequence, reject_drop_sequence, request_drop_data_sequence,
-    send_drag_data_sequence, start_drag_sequence, startup_sequence, uri_list_payload,
+    present_drag_icon_png_sequence, present_drag_icon_sequence, reject_drop_sequence,
+    request_drop_data_sequence, send_drag_data_sequence, start_drag_sequence, startup_sequence,
+    uri_list_payload,
 };

--- a/src/runtime/kitty_dnd/mod.rs
+++ b/src/runtime/kitty_dnd/mod.rs
@@ -1,0 +1,12 @@
+mod capability;
+mod event;
+mod protocol;
+
+pub(super) use capability::{KittyDndRuntime, detect_kitty_dnd_runtime};
+pub(in crate::runtime) use event::{KittyDndEvent, Osc72State, parse_osc72_with_state};
+pub(super) use protocol::{
+    accept_drop_sequence, agree_drag_either_sequence, cancel_drag_sequence, disable_sequence,
+    drag_data_error_sequence, finish_drop_sequence, present_drag_data_sequence,
+    present_drag_icon_sequence, reject_drop_sequence, request_drop_data_sequence,
+    send_drag_data_sequence, start_drag_sequence, startup_sequence, uri_list_payload,
+};

--- a/src/runtime/kitty_dnd/protocol.rs
+++ b/src/runtime/kitty_dnd/protocol.rs
@@ -5,6 +5,39 @@ use base64::{Engine, engine::general_purpose::STANDARD_NO_PAD};
 pub(super) const URI_LIST_MIME: &str = "text/uri-list";
 const DRAG_PAYLOAD_CHUNK_SIZE: usize = 4096;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::runtime) enum DndOperation {
+    Copy,
+    Move,
+    Either,
+}
+
+impl DndOperation {
+    pub(super) fn from_protocol(value: i32) -> Option<Self> {
+        match value {
+            1 => Some(Self::Copy),
+            2 => Some(Self::Move),
+            3 => Some(Self::Either),
+            _ => None,
+        }
+    }
+
+    fn protocol_value(self) -> u8 {
+        match self {
+            Self::Copy => 1,
+            Self::Move => 2,
+            Self::Either => 3,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::runtime) enum DropFinish {
+    Copy,
+    Move,
+    Reject,
+}
+
 /// Enable the local Kitty DND slice elio currently supports: accepting file URI
 /// drops and offering local file URI drags.
 pub(in crate::runtime) fn startup_sequence(machine_id: Option<&str>) -> String {
@@ -28,8 +61,15 @@ fn enable_drag_sequence(machine_id: &str) -> String {
     format!("\x1b]72;t=o:x=1;{machine_id}\x1b\\")
 }
 
-pub(in crate::runtime) fn accept_drop_sequence() -> String {
-    format!("\x1b]72;t=m:o=1;{URI_LIST_MIME}\x1b\\")
+pub(in crate::runtime) fn accept_drop_sequence(operation: DndOperation) -> String {
+    let operation = match operation {
+        DndOperation::Copy | DndOperation::Either => DndOperation::Copy,
+        DndOperation::Move => DndOperation::Move,
+    };
+    format!(
+        "\x1b]72;t=m:o={};{URI_LIST_MIME}\x1b\\",
+        operation.protocol_value()
+    )
 }
 
 pub(in crate::runtime) fn reject_drop_sequence() -> &'static str {
@@ -40,16 +80,19 @@ pub(in crate::runtime) fn request_drop_data_sequence(mime_index: u8) -> String {
     format!("\x1b]72;t=r:x={mime_index}\x1b\\")
 }
 
-pub(in crate::runtime) fn finish_drop_sequence(success: bool) -> &'static str {
-    if success {
-        "\x1b]72;t=r:o=1\x1b\\"
-    } else {
-        "\x1b]72;t=r:o=0\x1b\\"
+pub(in crate::runtime) fn finish_drop_sequence(finish: DropFinish) -> &'static str {
+    match finish {
+        DropFinish::Copy => "\x1b]72;t=r:o=1\x1b\\",
+        DropFinish::Move => "\x1b]72;t=r:o=2\x1b\\",
+        DropFinish::Reject => "\x1b]72;t=r:o=0\x1b\\",
     }
 }
 
-pub(in crate::runtime) fn agree_drag_either_sequence() -> String {
-    format!("\x1b]72;t=o:o=3;{URI_LIST_MIME}\x1b\\")
+pub(in crate::runtime) fn agree_drag_sequence(operation: DndOperation) -> String {
+    format!(
+        "\x1b]72;t=o:o={};{URI_LIST_MIME}\x1b\\",
+        operation.protocol_value()
+    )
 }
 
 pub(in crate::runtime) fn start_drag_sequence() -> &'static str {
@@ -73,8 +116,7 @@ pub(in crate::runtime) fn cancel_drag_sequence() -> &'static str {
 }
 
 pub(in crate::runtime) fn present_drag_icon_sequence(label: &str) -> String {
-    // Match Yazi's simple text icon payload: no image format, tiny logical size,
-    // transparent icon payload accepted by Kitty's DND protocol.
+    // Present a compact text icon payload accepted by Kitty's DND protocol.
     present_drag_payload_sequence("t=p:x=-1:y=0:X=6:Y=4:o=0", label.as_bytes(), false)
 }
 
@@ -162,19 +204,45 @@ mod tests {
     #[test]
     fn drop_reply_sequences_match_protocol_shape() {
         assert_eq!(
-            accept_drop_sequence(),
+            accept_drop_sequence(DndOperation::Copy),
+            "\x1b]72;t=m:o=1;text/uri-list\x1b\\"
+        );
+        assert_eq!(
+            accept_drop_sequence(DndOperation::Move),
+            "\x1b]72;t=m:o=2;text/uri-list\x1b\\"
+        );
+        assert_eq!(
+            accept_drop_sequence(DndOperation::Either),
             "\x1b]72;t=m:o=1;text/uri-list\x1b\\"
         );
         assert_eq!(reject_drop_sequence(), "\x1b]72;t=m:o=0\x1b\\");
         assert_eq!(request_drop_data_sequence(2), "\x1b]72;t=r:x=2\x1b\\");
-        assert_eq!(finish_drop_sequence(true), "\x1b]72;t=r:o=1\x1b\\");
-        assert_eq!(finish_drop_sequence(false), "\x1b]72;t=r:o=0\x1b\\");
+        assert_eq!(
+            finish_drop_sequence(DropFinish::Copy),
+            "\x1b]72;t=r:o=1\x1b\\"
+        );
+        assert_eq!(
+            finish_drop_sequence(DropFinish::Move),
+            "\x1b]72;t=r:o=2\x1b\\"
+        );
+        assert_eq!(
+            finish_drop_sequence(DropFinish::Reject),
+            "\x1b]72;t=r:o=0\x1b\\"
+        );
     }
 
     #[test]
-    fn drag_reply_sequences_match_yazi_shape() {
+    fn drag_reply_sequences_match_protocol_shape() {
         assert_eq!(
-            agree_drag_either_sequence(),
+            agree_drag_sequence(DndOperation::Copy),
+            "\x1b]72;t=o:o=1;text/uri-list\x1b\\"
+        );
+        assert_eq!(
+            agree_drag_sequence(DndOperation::Move),
+            "\x1b]72;t=o:o=2;text/uri-list\x1b\\"
+        );
+        assert_eq!(
+            agree_drag_sequence(DndOperation::Either),
             "\x1b]72;t=o:o=3;text/uri-list\x1b\\"
         );
         assert_eq!(start_drag_sequence(), "\x1b]72;t=P:x=-1\x1b\\");
@@ -222,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn present_drag_icon_matches_yazi_text_icon_shape_without_finish_marker() {
+    fn present_drag_icon_uses_text_payload_without_finish_marker() {
         assert_eq!(
             present_drag_icon_sequence("1 selected file(s)"),
             "\x1b]72;t=p:x=-1:y=0:X=6:Y=4:o=0:m=0;MSBzZWxlY3RlZCBmaWxlKHMp\x1b\\"

--- a/src/runtime/kitty_dnd/protocol.rs
+++ b/src/runtime/kitty_dnd/protocol.rs
@@ -117,7 +117,15 @@ pub(in crate::runtime) fn cancel_drag_sequence() -> &'static str {
 
 pub(in crate::runtime) fn present_drag_icon_sequence(label: &str) -> String {
     // Present a compact text icon payload accepted by Kitty's DND protocol.
-    present_drag_payload_sequence("t=p:x=-1:y=0:X=6:Y=4:o=0", label.as_bytes(), false)
+    present_drag_payload_sequence("t=p:x=-1:y=0:X=6:Y=4:o=1024", label.as_bytes(), false)
+}
+
+pub(in crate::runtime) fn present_drag_icon_png_sequence(
+    width: u32,
+    height: u32,
+    png: &[u8],
+) -> String {
+    present_drag_payload_sequence(&format!("t=p:x=-1:y=100:X={width}:Y={height}"), png, false)
 }
 
 fn present_drag_payload_sequence(metadata: &str, data: &[u8], finish: bool) -> String {
@@ -293,7 +301,7 @@ mod tests {
     fn present_drag_icon_uses_text_payload_without_finish_marker() {
         assert_eq!(
             present_drag_icon_sequence("1 selected file(s)"),
-            "\x1b]72;t=p:x=-1:y=0:X=6:Y=4:o=0:m=0;MSBzZWxlY3RlZCBmaWxlKHMp\x1b\\"
+            "\x1b]72;t=p:x=-1:y=0:X=6:Y=4:o=1024:m=0;MSBzZWxlY3RlZCBmaWxlKHMp\x1b\\"
         );
     }
 

--- a/src/runtime/kitty_dnd/protocol.rs
+++ b/src/runtime/kitty_dnd/protocol.rs
@@ -1,0 +1,249 @@
+use std::path::{Path, PathBuf};
+
+use base64::{Engine, engine::general_purpose::STANDARD_NO_PAD};
+
+pub(super) const URI_LIST_MIME: &str = "text/uri-list";
+const DRAG_PAYLOAD_CHUNK_SIZE: usize = 4096;
+
+/// Enable the local Kitty DND slice elio currently supports: accepting file URI
+/// drops and offering local file URI drags.
+pub(in crate::runtime) fn startup_sequence(machine_id: Option<&str>) -> String {
+    format!(
+        "{}{}",
+        enable_drop_sequence(),
+        enable_drag_sequence(machine_id.unwrap_or(""))
+    )
+}
+
+/// Disable both halves before suspending or restoring the terminal.
+pub(in crate::runtime) fn disable_sequence() -> &'static str {
+    "\x1b]72;t=A\x1b\\\x1b]72;t=o:x=2\x1b\\"
+}
+
+fn enable_drop_sequence() -> String {
+    format!("\x1b]72;t=a;{URI_LIST_MIME}\x1b\\")
+}
+
+fn enable_drag_sequence(machine_id: &str) -> String {
+    format!("\x1b]72;t=o:x=1;{machine_id}\x1b\\")
+}
+
+pub(in crate::runtime) fn accept_drop_sequence() -> String {
+    format!("\x1b]72;t=m:o=1;{URI_LIST_MIME}\x1b\\")
+}
+
+pub(in crate::runtime) fn reject_drop_sequence() -> &'static str {
+    "\x1b]72;t=m:o=0\x1b\\"
+}
+
+pub(in crate::runtime) fn request_drop_data_sequence(mime_index: u8) -> String {
+    format!("\x1b]72;t=r:x={mime_index}\x1b\\")
+}
+
+pub(in crate::runtime) fn finish_drop_sequence(success: bool) -> &'static str {
+    if success {
+        "\x1b]72;t=r:o=1\x1b\\"
+    } else {
+        "\x1b]72;t=r:o=0\x1b\\"
+    }
+}
+
+pub(in crate::runtime) fn agree_drag_either_sequence() -> String {
+    format!("\x1b]72;t=o:o=3;{URI_LIST_MIME}\x1b\\")
+}
+
+pub(in crate::runtime) fn start_drag_sequence() -> &'static str {
+    "\x1b]72;t=P:x=-1\x1b\\"
+}
+
+pub(in crate::runtime) fn present_drag_data_sequence(mime_index: i8, data: &[u8]) -> String {
+    present_drag_payload_sequence(&format!("t=p:x={mime_index}"), data, true)
+}
+
+pub(in crate::runtime) fn send_drag_data_sequence(mime_index: u8, data: &[u8]) -> String {
+    present_drag_payload_sequence(&format!("t=e:y={mime_index}"), data, true)
+}
+
+pub(in crate::runtime) fn drag_data_error_sequence(mime_index: u8, error: &str) -> String {
+    format!("\x1b]72;t=E:y={mime_index};{error}\x1b\\")
+}
+
+pub(in crate::runtime) fn cancel_drag_sequence() -> &'static str {
+    "\x1b]72;t=E:y=-1\x1b\\"
+}
+
+pub(in crate::runtime) fn present_drag_icon_sequence(label: &str) -> String {
+    // Match Yazi's simple text icon payload: no image format, tiny logical size,
+    // transparent icon payload accepted by Kitty's DND protocol.
+    present_drag_payload_sequence("t=p:x=-1:y=0:X=6:Y=4:o=0", label.as_bytes(), false)
+}
+
+fn present_drag_payload_sequence(metadata: &str, data: &[u8], finish: bool) -> String {
+    let encoded = STANDARD_NO_PAD.encode(data);
+    let mut sequence = String::new();
+    let chunks = encoded.as_bytes().chunks(DRAG_PAYLOAD_CHUNK_SIZE).count();
+    for (index, chunk) in encoded
+        .as_bytes()
+        .chunks(DRAG_PAYLOAD_CHUNK_SIZE)
+        .enumerate()
+    {
+        let more = usize::from(index + 1 < chunks);
+        let chunk = std::str::from_utf8(chunk).expect("base64 output is valid UTF-8");
+        if index == 0 {
+            sequence.push_str(&format!("\x1b]72;{metadata}:m={more};{chunk}\x1b\\"));
+        } else {
+            sequence.push_str(&format!("\x1b]72;m={more};{chunk}\x1b\\"));
+        }
+    }
+    if finish {
+        sequence.push_str(&format!("\x1b]72;{metadata}:m=0;\x1b\\"));
+    }
+    sequence
+}
+
+pub(in crate::runtime) fn uri_list_payload(paths: &[PathBuf]) -> Vec<u8> {
+    paths
+        .iter()
+        .filter(|path| path.is_absolute())
+        .map(|path| {
+            let mut encoded = percent_encode_path(path);
+            if path.is_dir() && !encoded.ends_with('/') {
+                encoded.push('/');
+            }
+            format!("file://{encoded}")
+        })
+        .collect::<Vec<_>>()
+        .join("\r\n")
+        .into_bytes()
+}
+
+fn percent_encode_path(path: &Path) -> String {
+    let mut encoded = String::new();
+    for byte in path.to_string_lossy().as_bytes() {
+        encoded.push_str(&percent_encode_byte(*byte));
+    }
+    encoded
+}
+
+fn percent_encode_byte(byte: u8) -> String {
+    match byte {
+        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+            char::from(byte).to_string()
+        }
+        _ => format!("%{byte:02X}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_enables_drop_and_drag_without_machine_id() {
+        assert_eq!(
+            startup_sequence(None),
+            "\x1b]72;t=a;text/uri-list\x1b\\\x1b]72;t=o:x=1;\x1b\\"
+        );
+    }
+
+    #[test]
+    fn startup_enables_drop_and_drag_with_machine_id() {
+        assert_eq!(
+            startup_sequence(Some("host")),
+            "\x1b]72;t=a;text/uri-list\x1b\\\x1b]72;t=o:x=1;host\x1b\\"
+        );
+    }
+
+    #[test]
+    fn disable_turns_off_drop_and_drag() {
+        assert_eq!(disable_sequence(), "\x1b]72;t=A\x1b\\\x1b]72;t=o:x=2\x1b\\");
+    }
+
+    #[test]
+    fn drop_reply_sequences_match_protocol_shape() {
+        assert_eq!(
+            accept_drop_sequence(),
+            "\x1b]72;t=m:o=1;text/uri-list\x1b\\"
+        );
+        assert_eq!(reject_drop_sequence(), "\x1b]72;t=m:o=0\x1b\\");
+        assert_eq!(request_drop_data_sequence(2), "\x1b]72;t=r:x=2\x1b\\");
+        assert_eq!(finish_drop_sequence(true), "\x1b]72;t=r:o=1\x1b\\");
+        assert_eq!(finish_drop_sequence(false), "\x1b]72;t=r:o=0\x1b\\");
+    }
+
+    #[test]
+    fn drag_reply_sequences_match_yazi_shape() {
+        assert_eq!(
+            agree_drag_either_sequence(),
+            "\x1b]72;t=o:o=3;text/uri-list\x1b\\"
+        );
+        assert_eq!(start_drag_sequence(), "\x1b]72;t=P:x=-1\x1b\\");
+    }
+
+    #[test]
+    fn uri_list_payload_encodes_absolute_local_paths_without_trailing_crlf() {
+        assert_eq!(
+            uri_list_payload(&[
+                PathBuf::from("/tmp/a b.txt"),
+                PathBuf::from("relative"),
+                PathBuf::from("/tmp/é.txt"),
+            ]),
+            b"file:///tmp/a%20b.txt\r\nfile:///tmp/%C3%A9.txt".to_vec()
+        );
+    }
+
+    #[test]
+    fn present_drag_data_encodes_and_finishes_payload() {
+        assert_eq!(
+            present_drag_data_sequence(0, b"file:///tmp/a.txt"),
+            "\x1b]72;t=p:x=0:m=0;ZmlsZTovLy90bXAvYS50eHQ\x1b\\\x1b]72;t=p:x=0:m=0;\x1b\\"
+        );
+    }
+
+    #[test]
+    fn send_drag_data_responds_to_terminal_request_without_restarting_drag() {
+        assert_eq!(
+            send_drag_data_sequence(0, b"file:///tmp/a.txt"),
+            "\x1b]72;t=e:y=0:m=0;ZmlsZTovLy90bXAvYS50eHQ\x1b\\\x1b]72;t=e:y=0:m=0;\x1b\\"
+        );
+    }
+
+    #[test]
+    fn drag_data_error_reports_requested_index() {
+        assert_eq!(
+            drag_data_error_sequence(2, "ENOENT"),
+            "\x1b]72;t=E:y=2;ENOENT\x1b\\"
+        );
+    }
+
+    #[test]
+    fn cancel_drag_aborts_the_pending_source_drag() {
+        assert_eq!(cancel_drag_sequence(), "\x1b]72;t=E:y=-1\x1b\\");
+    }
+
+    #[test]
+    fn present_drag_icon_matches_yazi_text_icon_shape_without_finish_marker() {
+        assert_eq!(
+            present_drag_icon_sequence("1 selected file(s)"),
+            "\x1b]72;t=p:x=-1:y=0:X=6:Y=4:o=0:m=0;MSBzZWxlY3RlZCBmaWxlKHMp\x1b\\"
+        );
+    }
+
+    #[test]
+    fn uri_list_payload_appends_slash_for_directories() {
+        let root = std::env::temp_dir().join(format!(
+            "elio-dnd-dir-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+
+        let payload = uri_list_payload(std::slice::from_ref(&root));
+        let text = String::from_utf8(payload).unwrap();
+        assert!(text.ends_with('/'));
+
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -14,11 +14,11 @@ use self::{
 };
 use crate::{
     RunOptions, RunOutcome,
-    app::{App, ChooserExit, ClipOp, PendingTerminalTask},
-    config,
-    core::EntryKind,
-    path_display, shell, ui, zoxide,
+    app::{App, ChooserExit, PendingTerminalTask},
+    config, path_display, shell, ui, zoxide,
 };
+#[cfg(unix)]
+use crate::{app::ClipOp, core::EntryKind};
 use anyhow::Result;
 use crossterm::{
     cursor::SetCursorStyle,
@@ -46,11 +46,13 @@ struct AppExit {
 }
 
 #[derive(Debug, Default)]
+#[cfg(unix)]
 struct PendingDragOut {
     active: bool,
     uri_list: Vec<u8>,
 }
 
+#[cfg(unix)]
 impl PendingDragOut {
     fn reset(&mut self) {
         self.active = false;
@@ -59,16 +61,19 @@ impl PendingDragOut {
 }
 
 #[derive(Debug, Default)]
+#[cfg(unix)]
 struct PendingDropIn {
     op: Option<ClipOp>,
 }
 
+#[cfg(unix)]
 struct DragIconLabel {
     icon: String,
     text: String,
     icon_color: ratatui::style::Color,
 }
 
+#[cfg(unix)]
 impl PendingDropIn {
     fn set(&mut self, op: ClipOp) {
         self.op = Some(op);
@@ -165,6 +170,7 @@ fn run_app(
     reveal_hidden_start_focus: bool,
     chooser_enabled: bool,
 ) -> Result<AppExit> {
+    #[cfg(unix)]
     if kitty_dnd.is_enabled() {
         kitty_dnd::prewarm_drag_image_renderer();
     }
@@ -203,7 +209,9 @@ fn run_app(
     let mut search_cursor_active = false;
     let mut terminal_focused = true;
     let mut last_relative_time_refresh_at = Instant::now();
+    #[cfg(unix)]
     let mut pending_drag_out = PendingDragOut::default();
+    #[cfg(unix)]
     let mut pending_drop_in = PendingDropIn::default();
 
     loop {
@@ -365,14 +373,17 @@ fn run_app(
                     &mut next_input,
                     &mut batched_events,
                 )?;
-                let Some(event) = handle_runtime_input(
+                #[cfg(unix)]
+                let input_result = handle_runtime_input(
                     terminal,
                     &mut app,
                     input,
                     &mut pending_drag_out,
                     &mut pending_drop_in,
-                )?
-                else {
+                )?;
+                #[cfg(not(unix))]
+                let input_result = handle_runtime_input(input)?;
+                let Some(event) = input_result else {
                     dirty = true;
                     next_input = try_read_runtime_input(&input_reader)?;
                     continue;
@@ -515,6 +526,7 @@ fn read_runtime_input(
                 Ok(None)
             }
         }
+        #[cfg(unix)]
         RuntimeInputReader::Custom(reader) => Ok(reader.recv_timeout(timeout)?),
     }
 }
@@ -528,14 +540,18 @@ fn try_read_runtime_input(reader: &RuntimeInputReader) -> Result<Option<RuntimeI
                 Ok(None)
             }
         }
+        #[cfg(unix)]
         RuntimeInputReader::Custom(reader) => Ok(reader.try_recv()?),
     }
 }
 
 fn pause_runtime_input(reader: &RuntimeInputReader, paused: bool) {
+    #[cfg(unix)]
     if let RuntimeInputReader::Custom(reader) = reader {
         reader.set_paused(paused);
     }
+    #[cfg(not(unix))]
+    let _ = (reader, paused);
 }
 
 fn coalesce_resize_inputs(
@@ -577,6 +593,7 @@ fn coalesce_resize_inputs(
     Ok(RuntimeInputEvent::Terminal(Event::Resize(width, height)))
 }
 
+#[cfg(unix)]
 fn handle_runtime_input(
     terminal: &mut AppTerminal,
     app: &mut App,
@@ -593,6 +610,14 @@ fn handle_runtime_input(
     }
 }
 
+#[cfg(not(unix))]
+fn handle_runtime_input(input: RuntimeInputEvent) -> Result<Option<Event>> {
+    match input {
+        RuntimeInputEvent::Terminal(event) => Ok(Some(event)),
+    }
+}
+
+#[cfg(unix)]
 fn handle_kitty_dnd_event(
     terminal: &mut AppTerminal,
     app: &mut App,
@@ -747,6 +772,7 @@ fn handle_kitty_dnd_event(
     Ok(())
 }
 
+#[cfg(unix)]
 fn unsupported_drop_scheme_status(schemes: &[String]) -> String {
     match schemes {
         [] => "Drop contains no local files".to_string(),
@@ -755,6 +781,7 @@ fn unsupported_drop_scheme_status(schemes: &[String]) -> String {
     }
 }
 
+#[cfg(unix)]
 fn choose_drop_op(operation: kitty_dnd::DndOperation) -> ClipOp {
     match operation {
         kitty_dnd::DndOperation::Copy => ClipOp::Yank,
@@ -762,6 +789,7 @@ fn choose_drop_op(operation: kitty_dnd::DndOperation) -> ClipOp {
     }
 }
 
+#[cfg(unix)]
 fn drop_op_to_dnd_operation(op: ClipOp) -> kitty_dnd::DndOperation {
     match op {
         ClipOp::Yank => kitty_dnd::DndOperation::Copy,
@@ -769,6 +797,7 @@ fn drop_op_to_dnd_operation(op: ClipOp) -> kitty_dnd::DndOperation {
     }
 }
 
+#[cfg(unix)]
 fn clip_op_to_drop_finish(op: ClipOp) -> kitty_dnd::DropFinish {
     match op {
         ClipOp::Yank => kitty_dnd::DropFinish::Copy,
@@ -776,6 +805,7 @@ fn clip_op_to_drop_finish(op: ClipOp) -> kitty_dnd::DropFinish {
     }
 }
 
+#[cfg(unix)]
 fn drag_icon_sequence(label: &DragIconLabel) -> String {
     let palette = ui::theme::palette();
     if let Some(image) = kitty_dnd::render_drag_image(
@@ -791,16 +821,19 @@ fn drag_icon_sequence(label: &DragIconLabel) -> String {
     kitty_dnd::present_drag_icon_sequence(&label.as_text())
 }
 
+#[cfg(unix)]
 impl DragIconLabel {
     fn as_text(&self) -> String {
         format!("{} {}", self.icon, self.text)
     }
 }
 
+#[cfg(unix)]
 fn drag_icon_label(app: &App, paths: &[PathBuf]) -> DragIconLabel {
     drag_icon_label_with(paths, |path| drag_icon_for_path(app, path))
 }
 
+#[cfg(unix)]
 fn drag_icon_label_with<F>(paths: &[PathBuf], mut icon_for_path: F) -> DragIconLabel
 where
     F: FnMut(&Path) -> (String, ratatui::style::Color),
@@ -834,6 +867,7 @@ where
     }
 }
 
+#[cfg(unix)]
 fn drag_icon_for_path(app: &App, path: &Path) -> (String, ratatui::style::Color) {
     if let Some(entry) = app
         .navigation
@@ -849,6 +883,7 @@ fn drag_icon_for_path(app: &App, path: &Path) -> (String, ratatui::style::Color)
     (appearance.icon.to_string(), appearance.color)
 }
 
+#[cfg(unix)]
 fn drag_entry_kind(path: &Path) -> EntryKind {
     match std::fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_dir() => EntryKind::Directory,
@@ -856,6 +891,7 @@ fn drag_entry_kind(path: &Path) -> EntryKind {
     }
 }
 
+#[cfg(unix)]
 fn drag_icon_for_many<F>(
     paths: &[PathBuf],
     icon_for_path: &mut F,
@@ -894,6 +930,7 @@ where
     }
 }
 
+#[cfg(unix)]
 fn truncate_drag_label_text(label: &str, max_chars: usize) -> String {
     if label.chars().count() <= max_chars {
         return label.to_string();
@@ -930,14 +967,18 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, drag_icon_label_with,
-        event_implies_terminal_focus, event_poll_interval, unsupported_drop_scheme_status,
+        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, event_implies_terminal_focus,
+        event_poll_interval,
     };
+    #[cfg(unix)]
+    use super::{drag_icon_label_with, unsupported_drop_scheme_status};
     use crossterm::event::Event;
+    use std::time::Duration;
+    #[cfg(unix)]
     use std::{
         fs,
         path::PathBuf,
-        time::{Duration, SystemTime, UNIX_EPOCH},
+        time::{SystemTime, UNIX_EPOCH},
     };
 
     #[test]
@@ -997,6 +1038,7 @@ mod tests {
         assert!(!event_implies_terminal_focus(&Event::Resize(80, 24)));
     }
 
+    #[cfg(unix)]
     #[test]
     fn unsupported_drop_scheme_status_names_one_or_many_schemes() {
         assert_eq!(
@@ -1009,6 +1051,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn drag_icon_label_uses_name_for_single_item_and_count_for_many() {
         assert_eq!(
@@ -1029,6 +1072,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn drag_icon_label_uses_multi_item_icon_for_mixed_selection() {
         let paths = [PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")];
@@ -1043,6 +1087,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn drag_icon_label_uses_multi_folder_icon_for_different_folder_icons() {
         let root = std::env::temp_dir().join(format!(
@@ -1071,6 +1116,7 @@ mod tests {
         assert_eq!(label, "󰉓 2 items");
     }
 
+    #[cfg(unix)]
     #[test]
     fn drag_icon_label_truncates_long_names() {
         assert_eq!(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -14,7 +14,7 @@ use self::{
 };
 use crate::{
     RunOptions, RunOutcome,
-    app::{App, ChooserExit, PendingTerminalTask},
+    app::{App, ChooserExit, ClipOp, PendingTerminalTask},
     config, path_display, shell, ui, zoxide,
 };
 use anyhow::Result;
@@ -53,6 +53,25 @@ impl PendingDragOut {
     fn reset(&mut self) {
         self.active = false;
         self.uri_list.clear();
+    }
+}
+
+#[derive(Debug, Default)]
+struct PendingDropIn {
+    op: Option<ClipOp>,
+}
+
+impl PendingDropIn {
+    fn set(&mut self, op: ClipOp) {
+        self.op = Some(op);
+    }
+
+    fn take(&mut self) -> Option<ClipOp> {
+        self.op.take()
+    }
+
+    fn reset(&mut self) {
+        self.op = None;
     }
 }
 
@@ -173,6 +192,7 @@ fn run_app(
     let mut terminal_focused = true;
     let mut last_relative_time_refresh_at = Instant::now();
     let mut pending_drag_out = PendingDragOut::default();
+    let mut pending_drop_in = PendingDropIn::default();
 
     loop {
         if app.should_quit {
@@ -333,8 +353,13 @@ fn run_app(
                     &mut next_input,
                     &mut batched_events,
                 )?;
-                let Some(event) =
-                    handle_runtime_input(terminal, &mut app, input, &mut pending_drag_out)?
+                let Some(event) = handle_runtime_input(
+                    terminal,
+                    &mut app,
+                    input,
+                    &mut pending_drag_out,
+                    &mut pending_drop_in,
+                )?
                 else {
                     dirty = true;
                     next_input = try_read_runtime_input(&input_reader)?;
@@ -545,11 +570,12 @@ fn handle_runtime_input(
     app: &mut App,
     input: RuntimeInputEvent,
     pending_drag_out: &mut PendingDragOut,
+    pending_drop_in: &mut PendingDropIn,
 ) -> Result<Option<Event>> {
     match input {
         RuntimeInputEvent::Terminal(event) => Ok(Some(event)),
         RuntimeInputEvent::KittyDnd(event) => {
-            handle_kitty_dnd_event(terminal, app, event, pending_drag_out)?;
+            handle_kitty_dnd_event(terminal, app, event, pending_drag_out, pending_drop_in)?;
             Ok(None)
         }
     }
@@ -560,44 +586,60 @@ fn handle_kitty_dnd_event(
     app: &mut App,
     event: kitty_dnd::KittyDndEvent,
     pending_drag_out: &mut PendingDragOut,
+    pending_drop_in: &mut PendingDropIn,
 ) -> Result<()> {
     match event {
         kitty_dnd::KittyDndEvent::DropOffer {
             mime_index,
+            operation,
             final_drop,
         } => {
+            let chosen_op = choose_drop_op(operation);
             let sequence = if pending_drag_out.active && final_drop {
                 pending_drag_out.reset();
+                pending_drop_in.reset();
                 app.clear_drag_state();
                 format!(
                     "{}{}",
-                    kitty_dnd::finish_drop_sequence(false),
+                    kitty_dnd::finish_drop_sequence(kitty_dnd::DropFinish::Reject),
                     kitty_dnd::cancel_drag_sequence()
                 )
             } else if pending_drag_out.active {
+                pending_drop_in.reset();
                 kitty_dnd::reject_drop_sequence().to_string()
             } else if final_drop {
+                pending_drop_in.set(chosen_op);
                 kitty_dnd::request_drop_data_sequence(mime_index)
             } else {
-                kitty_dnd::accept_drop_sequence()
+                pending_drop_in.set(chosen_op);
+                kitty_dnd::accept_drop_sequence(drop_op_to_dnd_operation(chosen_op))
             };
             terminal.backend_mut().write_all(sequence.as_bytes())?;
             terminal.backend_mut().flush()?;
         }
-        kitty_dnd::KittyDndEvent::DropData { paths, .. } => {
+        kitty_dnd::KittyDndEvent::DropData {
+            paths,
+            unsupported_schemes,
+            ..
+        } => {
             let was_own_drag = pending_drag_out.active;
-            let success = !was_own_drag && !paths.is_empty();
-            if success {
-                app.drop_external_paths(paths)?;
-            } else if was_own_drag {
+            let op = pending_drop_in.take();
+            let mut finish = kitty_dnd::DropFinish::Reject;
+            if was_own_drag {
                 pending_drag_out.reset();
                 app.clear_drag_state();
+            } else if !unsupported_schemes.is_empty() {
+                app.set_status_message(unsupported_drop_scheme_status(&unsupported_schemes));
+            } else if let Some(op) = op {
+                if app.drop_external_paths(paths, op)? {
+                    finish = clip_op_to_drop_finish(op);
+                }
             } else {
-                app.set_status_message("Drop contains no local files");
+                app.set_status_message("Drop was not negotiated");
             }
             terminal
                 .backend_mut()
-                .write_all(kitty_dnd::finish_drop_sequence(success).as_bytes())?;
+                .write_all(kitty_dnd::finish_drop_sequence(finish).as_bytes())?;
             if was_own_drag {
                 terminal
                     .backend_mut()
@@ -615,9 +657,9 @@ fn handle_kitty_dnd_event(
                 pending_drag_out.reset();
                 app.clear_drag_state();
             }
-            terminal
-                .backend_mut()
-                .write_all(kitty_dnd::finish_drop_sequence(false).as_bytes())?;
+            terminal.backend_mut().write_all(
+                kitty_dnd::finish_drop_sequence(kitty_dnd::DropFinish::Reject).as_bytes(),
+            )?;
             if was_own_drag {
                 terminal
                     .backend_mut()
@@ -629,8 +671,9 @@ fn handle_kitty_dnd_event(
             terminal.backend_mut().flush()?;
         }
         kitty_dnd::KittyDndEvent::DropUnsupported { final_drop } => {
+            pending_drop_in.reset();
             let sequence = if final_drop {
-                kitty_dnd::finish_drop_sequence(false)
+                kitty_dnd::finish_drop_sequence(kitty_dnd::DropFinish::Reject)
             } else {
                 kitty_dnd::reject_drop_sequence()
             };
@@ -654,7 +697,7 @@ fn handle_kitty_dnd_event(
             }
 
             let label = drag_icon_label(&paths);
-            let mut sequence = kitty_dnd::agree_drag_either_sequence();
+            let mut sequence = kitty_dnd::agree_drag_sequence(kitty_dnd::DndOperation::Either);
             sequence.push_str(&kitty_dnd::present_drag_data_sequence(0, &uri_list));
             sequence.push_str(&kitty_dnd::present_drag_icon_sequence(&label));
             sequence.push_str(kitty_dnd::start_drag_sequence());
@@ -690,6 +733,35 @@ fn handle_kitty_dnd_event(
         }
     }
     Ok(())
+}
+
+fn unsupported_drop_scheme_status(schemes: &[String]) -> String {
+    match schemes {
+        [] => "Drop contains no local files".to_string(),
+        [scheme] => format!("Unsupported drop URI scheme: {scheme}"),
+        schemes => format!("Unsupported drop URI schemes: {}", schemes.join(", ")),
+    }
+}
+
+fn choose_drop_op(operation: kitty_dnd::DndOperation) -> ClipOp {
+    match operation {
+        kitty_dnd::DndOperation::Copy => ClipOp::Yank,
+        kitty_dnd::DndOperation::Move | kitty_dnd::DndOperation::Either => ClipOp::Cut,
+    }
+}
+
+fn drop_op_to_dnd_operation(op: ClipOp) -> kitty_dnd::DndOperation {
+    match op {
+        ClipOp::Yank => kitty_dnd::DndOperation::Copy,
+        ClipOp::Cut => kitty_dnd::DndOperation::Move,
+    }
+}
+
+fn clip_op_to_drop_finish(op: ClipOp) -> kitty_dnd::DropFinish {
+    match op {
+        ClipOp::Yank => kitty_dnd::DropFinish::Copy,
+        ClipOp::Cut => kitty_dnd::DropFinish::Move,
+    }
 }
 
 fn drag_icon_label(paths: &[PathBuf]) -> String {
@@ -737,7 +809,7 @@ where
 mod tests {
     use super::{
         ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, drag_icon_label,
-        event_implies_terminal_focus, event_poll_interval,
+        event_implies_terminal_focus, event_poll_interval, unsupported_drop_scheme_status,
     };
     use crossterm::event::Event;
     use std::{path::PathBuf, time::Duration};
@@ -797,6 +869,18 @@ mod tests {
         assert!(!event_implies_terminal_focus(&Event::FocusLost));
         assert!(!event_implies_terminal_focus(&Event::FocusGained));
         assert!(!event_implies_terminal_focus(&Event::Resize(80, 24)));
+    }
+
+    #[test]
+    fn unsupported_drop_scheme_status_names_one_or_many_schemes() {
+        assert_eq!(
+            unsupported_drop_scheme_status(&["trash".to_string()]),
+            "Unsupported drop URI scheme: trash"
+        );
+        assert_eq!(
+            unsupported_drop_scheme_status(&["trash".to_string(), "smb".to_string()]),
+            "Unsupported drop URI schemes: trash, smb"
+        );
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -15,7 +15,9 @@ use self::{
 use crate::{
     RunOptions, RunOutcome,
     app::{App, ChooserExit, ClipOp, PendingTerminalTask},
-    config, path_display, shell, ui, zoxide,
+    config,
+    core::EntryKind,
+    path_display, shell, ui, zoxide,
 };
 use anyhow::Result;
 use crossterm::{
@@ -59,6 +61,12 @@ impl PendingDragOut {
 #[derive(Debug, Default)]
 struct PendingDropIn {
     op: Option<ClipOp>,
+}
+
+struct DragIconLabel {
+    icon: String,
+    text: String,
+    icon_color: ratatui::style::Color,
 }
 
 impl PendingDropIn {
@@ -157,6 +165,10 @@ fn run_app(
     reveal_hidden_start_focus: bool,
     chooser_enabled: bool,
 ) -> Result<AppExit> {
+    if kitty_dnd.is_enabled() {
+        kitty_dnd::prewarm_drag_image_renderer();
+    }
+
     let mut app = match cwd {
         Some(cwd) => App::new_at_startup(cwd, start_focus, reveal_hidden_start_focus)?,
         None => App::new()?,
@@ -696,10 +708,10 @@ fn handle_kitty_dnd_event(
                 return Ok(());
             }
 
-            let label = drag_icon_label(&paths);
+            let label = drag_icon_label(app, &paths);
             let mut sequence = kitty_dnd::agree_drag_sequence(kitty_dnd::DndOperation::Either);
             sequence.push_str(&kitty_dnd::present_drag_data_sequence(0, &uri_list));
-            sequence.push_str(&kitty_dnd::present_drag_icon_sequence(&label));
+            sequence.push_str(&drag_icon_sequence(&label));
             sequence.push_str(kitty_dnd::start_drag_sequence());
             terminal.backend_mut().write_all(sequence.as_bytes())?;
             terminal.backend_mut().flush()?;
@@ -764,23 +776,133 @@ fn clip_op_to_drop_finish(op: ClipOp) -> kitty_dnd::DropFinish {
     }
 }
 
-fn drag_icon_label(paths: &[PathBuf]) -> String {
-    const MAX_LABEL_CHARS: usize = 32;
-
-    let label = match paths {
-        [path] => path
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .filter(|name| !name.is_empty())
-            .unwrap_or_else(|| "1 item".to_string()),
-        paths => format!("{} items", paths.len()),
-    };
-
-    if label.chars().count() <= MAX_LABEL_CHARS {
-        return label;
+fn drag_icon_sequence(label: &DragIconLabel) -> String {
+    let palette = ui::theme::palette();
+    if let Some(image) = kitty_dnd::render_drag_image(
+        &label.icon,
+        &label.text,
+        label.icon_color,
+        palette.elevated,
+        palette.text,
+    ) {
+        return kitty_dnd::present_drag_icon_png_sequence(image.width, image.height, &image.png);
     }
 
-    let mut truncated: String = label.chars().take(MAX_LABEL_CHARS - 3).collect();
+    kitty_dnd::present_drag_icon_sequence(&label.as_text())
+}
+
+impl DragIconLabel {
+    fn as_text(&self) -> String {
+        format!("{} {}", self.icon, self.text)
+    }
+}
+
+fn drag_icon_label(app: &App, paths: &[PathBuf]) -> DragIconLabel {
+    drag_icon_label_with(paths, |path| drag_icon_for_path(app, path))
+}
+
+fn drag_icon_label_with<F>(paths: &[PathBuf], mut icon_for_path: F) -> DragIconLabel
+where
+    F: FnMut(&Path) -> (String, ratatui::style::Color),
+{
+    const MAX_LABEL_CHARS: usize = 32;
+
+    let (icon, text) = match paths {
+        [path] => {
+            let (icon, icon_color) = icon_for_path(path);
+            let text = path
+                .file_name()
+                .map(|name| crate::app::sanitize_terminal_text(&name.to_string_lossy()))
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| "1 item".to_string());
+            return DragIconLabel {
+                icon,
+                text: truncate_drag_label_text(&text, MAX_LABEL_CHARS),
+                icon_color,
+            };
+        }
+        paths => (
+            drag_icon_for_many(paths, &mut icon_for_path),
+            format!("{} items", paths.len()),
+        ),
+    };
+    let text = truncate_drag_label_text(&text, MAX_LABEL_CHARS);
+    DragIconLabel {
+        icon: icon.0,
+        text,
+        icon_color: icon.1,
+    }
+}
+
+fn drag_icon_for_path(app: &App, path: &Path) -> (String, ratatui::style::Color) {
+    if let Some(entry) = app
+        .navigation
+        .entries
+        .iter()
+        .find(|entry| entry.path == path)
+    {
+        let appearance = ui::theme::resolve_browser_entry(entry);
+        return (appearance.icon.to_string(), appearance.color);
+    }
+
+    let appearance = ui::theme::resolve_path(path, drag_entry_kind(path));
+    (appearance.icon.to_string(), appearance.color)
+}
+
+fn drag_entry_kind(path: &Path) -> EntryKind {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => EntryKind::Directory,
+        _ => EntryKind::File,
+    }
+}
+
+fn drag_icon_for_many<F>(
+    paths: &[PathBuf],
+    icon_for_path: &mut F,
+) -> (String, ratatui::style::Color)
+where
+    F: FnMut(&Path) -> (String, ratatui::style::Color),
+{
+    const MULTIPLE_FOLDERS_ICON: &str = "󰉓";
+    const MULTIPLE_FILES_ICON: &str = "";
+
+    let Some((first, rest)) = paths.split_first() else {
+        let appearance = ui::theme::resolve_path(Path::new("item"), EntryKind::File);
+        return (MULTIPLE_FILES_ICON.to_string(), appearance.color);
+    };
+
+    let first_kind = drag_entry_kind(first);
+    let (first_icon, first_color) = icon_for_path(first);
+    let mut all_same_icon = true;
+    let mut all_directories = first_kind == EntryKind::Directory;
+
+    for path in rest {
+        let kind = drag_entry_kind(path);
+        let (icon, _) = icon_for_path(path);
+        all_same_icon &= icon == first_icon;
+        all_directories &= kind == EntryKind::Directory;
+    }
+
+    if all_same_icon {
+        (first_icon, first_color)
+    } else if all_directories {
+        let appearance = ui::theme::resolve_path(Path::new("folder"), EntryKind::Directory);
+        (MULTIPLE_FOLDERS_ICON.to_string(), appearance.color)
+    } else {
+        let appearance = ui::theme::resolve_path(Path::new("item"), EntryKind::File);
+        (MULTIPLE_FILES_ICON.to_string(), appearance.color)
+    }
+}
+
+fn truncate_drag_label_text(label: &str, max_chars: usize) -> String {
+    if label.chars().count() <= max_chars {
+        return label.to_string();
+    }
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+
+    let mut truncated: String = label.chars().take(max_chars - 3).collect();
     truncated.push_str("...");
     truncated
 }
@@ -808,11 +930,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, drag_icon_label,
+        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, drag_icon_label_with,
         event_implies_terminal_focus, event_poll_interval, unsupported_drop_scheme_status,
     };
     use crossterm::event::Event;
-    use std::{path::PathBuf, time::Duration};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn event_poll_interval_stays_idle_while_terminal_is_unfocused() {
@@ -886,22 +1012,76 @@ mod tests {
     #[test]
     fn drag_icon_label_uses_name_for_single_item_and_count_for_many() {
         assert_eq!(
-            drag_icon_label(&[PathBuf::from("/tmp/report.pdf")]),
-            "report.pdf"
+            drag_icon_label_with(&[PathBuf::from("/tmp/report.pdf")], |_| (
+                "󰈙".to_string(),
+                ratatui::style::Color::White,
+            ))
+            .as_text(),
+            "󰈙 report.pdf"
         );
         assert_eq!(
-            drag_icon_label(&[PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")]),
-            "2 items"
+            drag_icon_label_with(&[PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")], |_| (
+                "󰈔".to_string(),
+                ratatui::style::Color::White,
+            ))
+            .as_text(),
+            "󰈔 2 items"
         );
+    }
+
+    #[test]
+    fn drag_icon_label_uses_multi_item_icon_for_mixed_selection() {
+        let paths = [PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")];
+
+        assert_eq!(
+            drag_icon_label_with(&paths, |path| (
+                if path.ends_with("a") { "󰉋" } else { "󰈔" }.to_string(),
+                ratatui::style::Color::White,
+            ))
+            .as_text(),
+            " 2 items"
+        );
+    }
+
+    #[test]
+    fn drag_icon_label_uses_multi_folder_icon_for_different_folder_icons() {
+        let root = std::env::temp_dir().join(format!(
+            "elio-drag-icons-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let first = root.join("src");
+        let second = root.join("docs");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+
+        let label = drag_icon_label_with(&[first, second], |path| {
+            let icon = if path.ends_with("src") {
+                "󰉋"
+            } else {
+                "󰉓"
+            };
+            (icon.to_string(), ratatui::style::Color::White)
+        })
+        .as_text();
+        fs::remove_dir_all(root).unwrap();
+
+        assert_eq!(label, "󰉓 2 items");
     }
 
     #[test]
     fn drag_icon_label_truncates_long_names() {
         assert_eq!(
-            drag_icon_label(&[PathBuf::from(
-                "/tmp/abcdefghijklmnopqrstuvwxyz0123456789.txt"
-            )]),
-            "abcdefghijklmnopqrstuvwxyz012..."
+            drag_icon_label_with(
+                &[PathBuf::from(
+                    "/tmp/abcdefghijklmnopqrstuvwxyz0123456789.txt"
+                )],
+                |_| ("󰈔".to_string(), ratatui::style::Color::White)
+            )
+            .as_text(),
+            "󰈔 abcdefghijklmnopqrstuvwxyz012..."
         );
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,9 +1,12 @@
 mod draw;
+mod input;
+mod kitty_dnd;
 mod session_files;
 mod terminal;
 
 use self::{
     draw::draw_terminal_frame,
+    input::{RuntimeInputEvent, RuntimeInputReader},
     session_files::{write_chooser_file_if_requested, write_cwd_file_if_requested},
     terminal::{
         AppTerminal, Drainer, init_terminal, restore_terminal, resume_terminal, suspend_terminal,
@@ -31,11 +34,26 @@ const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const ACTIVE_SCROLL_POLL_INTERVAL: Duration = Duration::from_millis(12);
 const WINDOWS_TERMINAL_ACTIVE_POLL_INTERVAL: Duration = Duration::from_millis(24);
 const RELATIVE_TIME_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_INPUT_EVENTS_PER_FRAME: usize = 64;
+const MAX_INPUT_BATCH_DURATION: Duration = Duration::from_millis(4);
 
 #[derive(Debug)]
 struct AppExit {
     final_cwd: Option<PathBuf>,
     chooser: Option<ChooserExit>,
+}
+
+#[derive(Debug, Default)]
+struct PendingDragOut {
+    active: bool,
+    uri_list: Vec<u8>,
+}
+
+impl PendingDragOut {
+    fn reset(&mut self) {
+        self.active = false;
+        self.uri_list.clear();
+    }
 }
 
 pub(crate) fn run_with_startup_state(
@@ -50,16 +68,17 @@ pub(crate) fn run_with_startup_state(
     } = options;
     config::initialize();
     ui::theme::initialize();
-    let (mut terminal, drainer) = init_terminal()?;
+    let (mut terminal, drainer, kitty_dnd) = init_terminal()?;
     let result = run_app(
         &mut terminal,
         &drainer,
+        &kitty_dnd,
         start_dir,
         start_focus,
         reveal_hidden_start_focus,
         chooser_file.is_some(),
     );
-    restore_terminal(&mut terminal, &drainer)?;
+    restore_terminal(&mut terminal, &drainer, &kitty_dnd)?;
     let app_exit = result?;
     if let Some(final_cwd) = app_exit.final_cwd {
         write_cwd_file_if_requested(cwd_file.as_deref(), &final_cwd)?;
@@ -113,6 +132,7 @@ fn apply_zoxide_query_result(app: &mut App, result: zoxide::QueryResult) {
 fn run_app(
     terminal: &mut AppTerminal,
     drainer: &Drainer,
+    kitty_dnd: &kitty_dnd::KittyDndRuntime,
     cwd: Option<PathBuf>,
     start_focus: Option<PathBuf>,
     reveal_hidden_start_focus: bool,
@@ -135,10 +155,24 @@ fn run_app(
     // crossterm and cannot corrupt mouse reporting.
     app.enable_terminal_image_previews();
 
+    let input_reader = match RuntimeInputReader::new(kitty_dnd.is_enabled()) {
+        Ok(reader) => reader,
+        Err(error) => {
+            if kitty_dnd.is_enabled() {
+                terminal
+                    .backend_mut()
+                    .write_all(kitty_dnd::disable_sequence().as_bytes())?;
+                terminal.backend_mut().flush()?;
+                app.set_status_message(format!("Kitty DND disabled: {error}"));
+            }
+            RuntimeInputReader::Crossterm
+        }
+    };
     let mut dirty = true;
     let mut search_cursor_active = false;
     let mut terminal_focused = true;
     let mut last_relative_time_refresh_at = Instant::now();
+    let mut pending_drag_out = PendingDragOut::default();
 
     loop {
         if app.should_quit {
@@ -276,13 +310,36 @@ fn run_app(
             ],
         );
 
-        if event::poll(poll_interval)? {
+        if let Some(first_input) = read_runtime_input(&input_reader, poll_interval)? {
             // Batch all immediately-available events into one render cycle.
             // This prevents lag when events (especially scroll events from high-frequency
             // terminals) arrive faster than the app can render: instead of one render per
             // event we accumulate all queued events first and render the final state once.
+            let mut next_input = Some(first_input);
+            let batch_started_at = Instant::now();
+            let mut batched_events = 0usize;
             loop {
-                let event = event::read()?;
+                batched_events += 1;
+                let input = match next_input.take() {
+                    Some(input) => input,
+                    None => match try_read_runtime_input(&input_reader)? {
+                        Some(input) => input,
+                        None => break,
+                    },
+                };
+                let input = coalesce_resize_inputs(
+                    &input_reader,
+                    input,
+                    &mut next_input,
+                    &mut batched_events,
+                )?;
+                let Some(event) =
+                    handle_runtime_input(terminal, &mut app, input, &mut pending_drag_out)?
+                else {
+                    dirty = true;
+                    next_input = try_read_runtime_input(&input_reader)?;
+                    continue;
+                };
                 if std::env::var_os("ELIO_LOG_MOUSE").is_some()
                     && let Event::Mouse(m) = &event
                 {
@@ -326,9 +383,12 @@ fn run_app(
                     if needs_render && terminal_focused {
                         dirty = true;
                     }
-                }
-                // Stop batching once there are no more immediately available events.
-                if !event::poll(Duration::ZERO)? {
+                };
+                next_input = try_read_runtime_input(&input_reader)?;
+                if next_input.is_some()
+                    && (batched_events >= MAX_INPUT_EVENTS_PER_FRAME
+                        || batch_started_at.elapsed() >= MAX_INPUT_BATCH_DURATION)
+                {
                     break;
                 }
             }
@@ -342,15 +402,19 @@ fn run_app(
             if let Some(task) = app.pending_terminal_task.take() {
                 let zoxide_result = match task {
                     PendingTerminalTask::Command { program, args } => {
-                        suspend_terminal(terminal, drainer, true)?;
+                        pause_runtime_input(&input_reader, true);
+                        suspend_terminal(terminal, drainer, true, kitty_dnd)?;
                         run_blocking_in_terminal(&program, &args);
-                        resume_terminal(terminal, drainer)?;
+                        resume_terminal(terminal, drainer, kitty_dnd)?;
+                        pause_runtime_input(&input_reader, false);
                         None
                     }
                     PendingTerminalTask::Shell { cwd } => {
-                        suspend_terminal(terminal, drainer, true)?;
+                        pause_runtime_input(&input_reader, true);
+                        suspend_terminal(terminal, drainer, true, kitty_dnd)?;
                         let shell_result = shell::run_in_current_terminal(&cwd);
-                        resume_terminal(terminal, drainer)?;
+                        resume_terminal(terminal, drainer, kitty_dnd)?;
+                        pause_runtime_input(&input_reader, false);
                         match shell_result {
                             Ok(()) => refresh_after_shell(&mut app, &cwd),
                             Err(error) => app.set_status_message(error),
@@ -362,9 +426,11 @@ fn run_app(
                         if let Some(result) = zoxide::preflight(&cwd) {
                             Some(result)
                         } else {
-                            suspend_terminal(terminal, drainer, false)?;
+                            pause_runtime_input(&input_reader, true);
+                            suspend_terminal(terminal, drainer, false, kitty_dnd)?;
                             let result = zoxide::run_query_in_terminal(&cwd);
-                            resume_terminal(terminal, drainer)?;
+                            resume_terminal(terminal, drainer, kitty_dnd)?;
+                            pause_runtime_input(&input_reader, false);
                             Some(result)
                         }
                     }
@@ -400,6 +466,253 @@ fn event_implies_terminal_focus(event: &Event) -> bool {
     matches!(event, Event::Key(_) | Event::Mouse(_) | Event::Paste(_))
 }
 
+fn read_runtime_input(
+    reader: &RuntimeInputReader,
+    timeout: Duration,
+) -> Result<Option<RuntimeInputEvent>> {
+    match reader {
+        RuntimeInputReader::Crossterm => {
+            if event::poll(timeout)? {
+                Ok(Some(RuntimeInputEvent::Terminal(event::read()?)))
+            } else {
+                Ok(None)
+            }
+        }
+        RuntimeInputReader::Custom(reader) => Ok(reader.recv_timeout(timeout)?),
+    }
+}
+
+fn try_read_runtime_input(reader: &RuntimeInputReader) -> Result<Option<RuntimeInputEvent>> {
+    match reader {
+        RuntimeInputReader::Crossterm => {
+            if event::poll(Duration::ZERO)? {
+                Ok(Some(RuntimeInputEvent::Terminal(event::read()?)))
+            } else {
+                Ok(None)
+            }
+        }
+        RuntimeInputReader::Custom(reader) => Ok(reader.try_recv()?),
+    }
+}
+
+fn pause_runtime_input(reader: &RuntimeInputReader, paused: bool) {
+    if let RuntimeInputReader::Custom(reader) = reader {
+        reader.set_paused(paused);
+    }
+}
+
+fn coalesce_resize_inputs(
+    reader: &RuntimeInputReader,
+    input: RuntimeInputEvent,
+    next_input: &mut Option<RuntimeInputEvent>,
+    batched_events: &mut usize,
+) -> Result<RuntimeInputEvent> {
+    let RuntimeInputEvent::Terminal(Event::Resize(mut width, mut height)) = input else {
+        return Ok(input);
+    };
+
+    let started_at = Instant::now();
+    loop {
+        let candidate = if let Some(input) = next_input.take() {
+            Some(input)
+        } else {
+            try_read_runtime_input(reader)?
+        };
+        match candidate {
+            Some(RuntimeInputEvent::Terminal(Event::Resize(w, h))) => {
+                width = w;
+                height = h;
+                *batched_events += 1;
+                if *batched_events >= MAX_INPUT_EVENTS_PER_FRAME
+                    || started_at.elapsed() >= MAX_INPUT_BATCH_DURATION
+                {
+                    break;
+                }
+            }
+            Some(other) => {
+                *next_input = Some(other);
+                break;
+            }
+            None => break,
+        }
+    }
+
+    Ok(RuntimeInputEvent::Terminal(Event::Resize(width, height)))
+}
+
+fn handle_runtime_input(
+    terminal: &mut AppTerminal,
+    app: &mut App,
+    input: RuntimeInputEvent,
+    pending_drag_out: &mut PendingDragOut,
+) -> Result<Option<Event>> {
+    match input {
+        RuntimeInputEvent::Terminal(event) => Ok(Some(event)),
+        RuntimeInputEvent::KittyDnd(event) => {
+            handle_kitty_dnd_event(terminal, app, event, pending_drag_out)?;
+            Ok(None)
+        }
+    }
+}
+
+fn handle_kitty_dnd_event(
+    terminal: &mut AppTerminal,
+    app: &mut App,
+    event: kitty_dnd::KittyDndEvent,
+    pending_drag_out: &mut PendingDragOut,
+) -> Result<()> {
+    match event {
+        kitty_dnd::KittyDndEvent::DropOffer {
+            mime_index,
+            final_drop,
+        } => {
+            let sequence = if pending_drag_out.active && final_drop {
+                pending_drag_out.reset();
+                app.clear_drag_state();
+                format!(
+                    "{}{}",
+                    kitty_dnd::finish_drop_sequence(false),
+                    kitty_dnd::cancel_drag_sequence()
+                )
+            } else if pending_drag_out.active {
+                kitty_dnd::reject_drop_sequence().to_string()
+            } else if final_drop {
+                kitty_dnd::request_drop_data_sequence(mime_index)
+            } else {
+                kitty_dnd::accept_drop_sequence()
+            };
+            terminal.backend_mut().write_all(sequence.as_bytes())?;
+            terminal.backend_mut().flush()?;
+        }
+        kitty_dnd::KittyDndEvent::DropData { paths, .. } => {
+            let was_own_drag = pending_drag_out.active;
+            let success = !was_own_drag && !paths.is_empty();
+            if success {
+                app.drop_external_paths(paths)?;
+            } else if was_own_drag {
+                pending_drag_out.reset();
+                app.clear_drag_state();
+            } else {
+                app.set_status_message("Drop contains no local files");
+            }
+            terminal
+                .backend_mut()
+                .write_all(kitty_dnd::finish_drop_sequence(success).as_bytes())?;
+            if was_own_drag {
+                terminal
+                    .backend_mut()
+                    .write_all(kitty_dnd::cancel_drag_sequence().as_bytes())?;
+            }
+            terminal.backend_mut().flush()?;
+        }
+        kitty_dnd::KittyDndEvent::DropLeave => {}
+        kitty_dnd::KittyDndEvent::DropDataError {
+            mime_index: _,
+            message,
+        } => {
+            let was_own_drag = pending_drag_out.active;
+            if pending_drag_out.active {
+                pending_drag_out.reset();
+                app.clear_drag_state();
+            }
+            terminal
+                .backend_mut()
+                .write_all(kitty_dnd::finish_drop_sequence(false).as_bytes())?;
+            if was_own_drag {
+                terminal
+                    .backend_mut()
+                    .write_all(kitty_dnd::cancel_drag_sequence().as_bytes())?;
+            }
+            if !message.is_empty() {
+                app.set_status_message(format!("Drop failed: {message}"));
+            }
+            terminal.backend_mut().flush()?;
+        }
+        kitty_dnd::KittyDndEvent::DropUnsupported { final_drop } => {
+            let sequence = if final_drop {
+                kitty_dnd::finish_drop_sequence(false)
+            } else {
+                kitty_dnd::reject_drop_sequence()
+            };
+            terminal.backend_mut().write_all(sequence.as_bytes())?;
+            terminal.backend_mut().flush()?;
+        }
+        kitty_dnd::KittyDndEvent::DragOffer { x, y } => {
+            if pending_drag_out.active {
+                return Ok(());
+            }
+            let paths = app.take_drag_export_paths_at(x, y);
+            let uri_list = kitty_dnd::uri_list_payload(&paths);
+            if uri_list.is_empty() {
+                pending_drag_out.reset();
+                app.clear_drag_candidate();
+                terminal
+                    .backend_mut()
+                    .write_all(kitty_dnd::cancel_drag_sequence().as_bytes())?;
+                terminal.backend_mut().flush()?;
+                return Ok(());
+            }
+
+            let label = drag_icon_label(&paths);
+            let mut sequence = kitty_dnd::agree_drag_either_sequence();
+            sequence.push_str(&kitty_dnd::present_drag_data_sequence(0, &uri_list));
+            sequence.push_str(&kitty_dnd::present_drag_icon_sequence(&label));
+            sequence.push_str(kitty_dnd::start_drag_sequence());
+            terminal.backend_mut().write_all(sequence.as_bytes())?;
+            terminal.backend_mut().flush()?;
+
+            pending_drag_out.active = true;
+            pending_drag_out.uri_list = uri_list;
+        }
+        kitty_dnd::KittyDndEvent::DragDataRequested { mime_index } => {
+            let sequence = if pending_drag_out.active && mime_index == 0 {
+                kitty_dnd::send_drag_data_sequence(mime_index, &pending_drag_out.uri_list)
+            } else {
+                kitty_dnd::drag_data_error_sequence(mime_index, "ENOENT")
+            };
+            terminal.backend_mut().write_all(sequence.as_bytes())?;
+            terminal.backend_mut().flush()?;
+        }
+        kitty_dnd::KittyDndEvent::DragStarted
+        | kitty_dnd::KittyDndEvent::DragAccepted { mime_index: _ }
+        | kitty_dnd::KittyDndEvent::DragActionChanged { operation: _ }
+        | kitty_dnd::KittyDndEvent::DragDropped => {}
+        kitty_dnd::KittyDndEvent::DragEnded { cancelled: _ } => {
+            pending_drag_out.reset();
+            app.clear_drag_state();
+        }
+        kitty_dnd::KittyDndEvent::DragError { message } => {
+            pending_drag_out.reset();
+            app.clear_drag_state();
+            if !message.is_empty() {
+                app.set_status_message(format!("Kitty DND drag failed: {message}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn drag_icon_label(paths: &[PathBuf]) -> String {
+    const MAX_LABEL_CHARS: usize = 32;
+
+    let label = match paths {
+        [path] => path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| "1 item".to_string()),
+        paths => format!("{} items", paths.len()),
+    };
+
+    if label.chars().count() <= MAX_LABEL_CHARS {
+        return label;
+    }
+
+    let mut truncated: String = label.chars().take(MAX_LABEL_CHARS - 3).collect();
+    truncated.push_str("...");
+    truncated
+}
+
 fn event_poll_interval<I>(
     base_poll_interval: Duration,
     terminal_focused: bool,
@@ -423,11 +736,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, event_implies_terminal_focus,
-        event_poll_interval,
+        ACTIVE_SCROLL_POLL_INTERVAL, IDLE_POLL_INTERVAL, drag_icon_label,
+        event_implies_terminal_focus, event_poll_interval,
     };
     use crossterm::event::Event;
-    use std::time::Duration;
+    use std::{path::PathBuf, time::Duration};
 
     #[test]
     fn event_poll_interval_stays_idle_while_terminal_is_unfocused() {
@@ -484,5 +797,27 @@ mod tests {
         assert!(!event_implies_terminal_focus(&Event::FocusLost));
         assert!(!event_implies_terminal_focus(&Event::FocusGained));
         assert!(!event_implies_terminal_focus(&Event::Resize(80, 24)));
+    }
+
+    #[test]
+    fn drag_icon_label_uses_name_for_single_item_and_count_for_many() {
+        assert_eq!(
+            drag_icon_label(&[PathBuf::from("/tmp/report.pdf")]),
+            "report.pdf"
+        );
+        assert_eq!(
+            drag_icon_label(&[PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")]),
+            "2 items"
+        );
+    }
+
+    #[test]
+    fn drag_icon_label_truncates_long_names() {
+        assert_eq!(
+            drag_icon_label(&[PathBuf::from(
+                "/tmp/abcdefghijklmnopqrstuvwxyz0123456789.txt"
+            )]),
+            "abcdefghijklmnopqrstuvwxyz012..."
+        );
     }
 }

--- a/src/runtime/terminal.rs
+++ b/src/runtime/terminal.rs
@@ -1,3 +1,7 @@
+use super::kitty_dnd::{
+    KittyDndRuntime, detect_kitty_dnd_runtime, disable_sequence as disable_kitty_dnd_sequence,
+    startup_sequence as kitty_dnd_startup_sequence,
+};
 use anyhow::Result;
 use crossterm::{
     cursor::SetCursorStyle,
@@ -188,7 +192,7 @@ impl Drop for ThreadedWriter {
     }
 }
 
-pub(super) fn init_terminal() -> Result<(AppTerminal, Drainer)> {
+pub(super) fn init_terminal() -> Result<(AppTerminal, Drainer, KittyDndRuntime)> {
     match try_init_terminal() {
         Ok(pair) => Ok(pair),
         Err(error) => {
@@ -198,9 +202,10 @@ pub(super) fn init_terminal() -> Result<(AppTerminal, Drainer)> {
     }
 }
 
-fn try_init_terminal() -> Result<(AppTerminal, Drainer)> {
+fn try_init_terminal() -> Result<(AppTerminal, Drainer, KittyDndRuntime)> {
     enable_raw_mode()?;
     let (mut terminal_output, frame_output) = terminal_output_handles()?;
+    let kitty_dnd = detect_kitty_dnd_runtime();
     execute!(
         terminal_output,
         EnterAlternateScreen,
@@ -225,6 +230,14 @@ fn try_init_terminal() -> Result<(AppTerminal, Drainer)> {
     // Terminals that don't support it ignore this silently.
     write!(terminal_output, "\x1b[>4;1m")?;
 
+    if kitty_dnd.is_enabled() {
+        write!(
+            terminal_output,
+            "{}",
+            kitty_dnd_startup_sequence(kitty_dnd.drag_machine_id())
+        )?;
+    }
+
     terminal_output.flush()?;
     push_keyboard_enhancement_if_supported(&mut terminal_output)?;
 
@@ -236,7 +249,7 @@ fn try_init_terminal() -> Result<(AppTerminal, Drainer)> {
     let mut terminal = Terminal::new(backend)?;
     clear_for_full_repaint(&mut terminal)?;
     terminal.hide_cursor()?;
-    Ok((terminal, drainer))
+    Ok((terminal, drainer, kitty_dnd))
 }
 
 #[cfg(unix)]
@@ -271,8 +284,12 @@ pub(super) fn suspend_terminal(
     terminal: &mut AppTerminal,
     drainer: &Drainer,
     leave_alternate: bool,
+    kitty_dnd: &KittyDndRuntime,
 ) -> Result<()> {
     let backend = terminal.backend_mut();
+    if kitty_dnd.is_enabled() {
+        write!(backend, "{}", disable_kitty_dnd_sequence())?;
+    }
     write!(backend, "\x1b[>4;0m")?;
     write!(backend, "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l")?;
     backend.flush()?;
@@ -299,7 +316,11 @@ pub(super) fn suspend_terminal(
 
 /// Restores the TUI after [`suspend_terminal`].  Forces a full redraw on the
 /// next render cycle so no stale content is left on screen.
-pub(super) fn resume_terminal(terminal: &mut AppTerminal, drainer: &Drainer) -> Result<()> {
+pub(super) fn resume_terminal(
+    terminal: &mut AppTerminal,
+    drainer: &Drainer,
+    kitty_dnd: &KittyDndRuntime,
+) -> Result<()> {
     enable_raw_mode()?;
     {
         // Route restore escapes through the backend so they stay ordered with
@@ -315,6 +336,13 @@ pub(super) fn resume_terminal(terminal: &mut AppTerminal, drainer: &Drainer) -> 
         )?;
         write!(backend, "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h")?;
         write!(backend, "\x1b[>4;1m")?;
+        if kitty_dnd.is_enabled() {
+            write!(
+                backend,
+                "{}",
+                kitty_dnd_startup_sequence(kitty_dnd.drag_machine_id())
+            )?;
+        }
         backend.flush()?;
     }
     drainer.drain();
@@ -324,10 +352,17 @@ pub(super) fn resume_terminal(terminal: &mut AppTerminal, drainer: &Drainer) -> 
     Ok(())
 }
 
-pub(super) fn restore_terminal(terminal: &mut AppTerminal, drainer: &Drainer) -> Result<()> {
+pub(super) fn restore_terminal(
+    terminal: &mut AppTerminal,
+    drainer: &Drainer,
+    kitty_dnd: &KittyDndRuntime,
+) -> Result<()> {
     // Disable in reverse order and do it before leaving the alternate screen so the
     // terminal processes the escape sequences while still in the right mode.
     let backend = terminal.backend_mut();
+    if kitty_dnd.is_enabled() {
+        write!(backend, "{}", disable_kitty_dnd_sequence())?;
+    }
     write!(backend, "\x1b[>4;0m")?; // reset XTSHIFTESCAPE
     write!(backend, "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l")?; // disable mouse modes
     backend.flush()?;
@@ -349,6 +384,7 @@ pub(super) fn restore_terminal(terminal: &mut AppTerminal, drainer: &Drainer) ->
 fn cleanup_terminal_state() -> io::Result<()> {
     if let Ok((mut terminal_output, _)) = terminal_output_handles() {
         let _ = write!(terminal_output, "\x1b[>4;0m");
+        let _ = write!(terminal_output, "{}", disable_kitty_dnd_sequence());
         let _ = write!(
             terminal_output,
             "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l"


### PR DESCRIPTION
## Summary

Add native drag and drop support for local Kitty 0.47+ sessions.

elio can now drag local files out to other apps and accept local file drops into the current directory when running in Kitty outside tmux, Zellij, or SSH. Drag previews use the active theme for their background and file/folder icons, with safe text fallbacks, and unsupported terminals continue using the normal input path.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested on Linux and FreeBSD with Kitty 0.47+

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed