### PR TITLE
feat(preview): add Astro syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added safe symlink preservation for `.zip`, `.7z`, and `.tar` archive creation and extraction.
 - Added a show/hide control to encrypted archive password prompts.
 - Added YAML frontmatter rendering to Markdown previews and recognized Quarto `.qmd` files as Markdown. ([#223])
+- Added syntax-highlighted previews for Astro `.astro` files.
 - Added Kitty 0.47+ drag-and-drop support for dropping items into elio and dragging items out, with themed drag previews.
 
 ### Changed

--- a/assets/syntaxes/Astro.sublime-syntax
+++ b/assets/syntaxes/Astro.sublime-syntax
@@ -1,0 +1,106 @@
+%YAML 1.2
+---
+name: Astro
+file_extensions:
+  - astro
+scope: source.astro
+variables:
+  identifier: '[A-Za-z_$][A-Za-z0-9_$]*'
+contexts:
+  prototype:
+    - include: comments
+  main:
+    - match: '^---\s*$'
+      scope: punctuation.section.frontmatter.astro
+      push: frontmatter
+    - include: astro-expressions
+    - include: tags
+    - include: strings
+    - include: script
+  frontmatter:
+    - meta_scope: meta.frontmatter.astro source.ts
+    - match: '^---\s*$'
+      scope: punctuation.section.frontmatter.astro
+      pop: true
+    - include: script
+  astro-expressions:
+    - match: '\{'
+      scope: punctuation.section.embedded.begin.astro
+      push: expression
+  expression:
+    - meta_scope: meta.embedded.expression.astro source.ts
+    - match: '\}'
+      scope: punctuation.section.embedded.end.astro
+      pop: true
+    - include: script
+  tags:
+    - match: '<!--'
+      push: html-comment
+    - match: '(</?)([A-Za-z][A-Za-z0-9._:-]*)'
+      captures:
+        1: punctuation.definition.tag.astro
+        2: entity.name.tag.astro
+    - match: '(/?>)'
+      scope: punctuation.definition.tag.astro
+    - match: '\b([A-Za-z_:][-A-Za-z0-9_:.]*)(?=\s*(?:=|$))'
+      captures:
+        1: entity.other.attribute-name.astro
+  comments:
+    - match: '//.*$'
+      scope: comment.line.double-slash.astro
+    - match: '/\*'
+      push: block-comment
+  html-comment:
+    - meta_scope: comment.block.html.astro
+    - match: '-->'
+      pop: true
+  block-comment:
+    - meta_scope: comment.block.astro
+    - match: '/\*'
+      push: block-comment
+    - match: '\*/'
+      pop: true
+  strings:
+    - match: '"'
+      push: double-quoted-string
+    - match: "'"
+      push: single-quoted-string
+    - match: '`'
+      push: template-string
+  double-quoted-string:
+    - meta_scope: string.quoted.double.astro
+    - meta_include_prototype: false
+    - match: '\\.'
+      scope: constant.character.escape.astro
+    - match: '"'
+      pop: true
+  single-quoted-string:
+    - meta_scope: string.quoted.single.astro
+    - meta_include_prototype: false
+    - match: '\\.'
+      scope: constant.character.escape.astro
+    - match: "'"
+      pop: true
+  template-string:
+    - meta_scope: string.quoted.template.astro
+    - meta_include_prototype: false
+    - match: '\\.'
+      scope: constant.character.escape.astro
+    - match: '`'
+      pop: true
+  script:
+    - include: strings
+    - match: '\b(?:import|export|from|as|const|let|var|function|return|if|else|for|while|switch|case|break|continue|new|this|class|extends|async|await|try|catch|finally|throw|typeof|interface|type|enum)\b'
+      scope: keyword.control.astro
+    - match: '\b(?:string|number|boolean|unknown|never|void|object|symbol|bigint|any)\b'
+      scope: support.type.astro
+    - match: '\b[A-Z][A-Za-z0-9_]*\b'
+      scope: entity.name.type.astro
+    - match: '\b{{identifier}}(?=\s*(?:<[^>\n]+>\s*)?\()'
+      scope: entity.name.function.astro
+    - match: '\b(?:true|false|null|undefined)\b'
+      scope: constant.language.astro
+    - match: '\b(?:0x[0-9A-Fa-f_]+|\d[\d_]*(?:\.\d[\d_]*)?)\b'
+      scope: constant.numeric.astro
+    - match: '=>|[-+*/%=&|<>!?:]+'
+      scope: keyword.operator.astro

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -96,6 +96,11 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
             }),
             preview: preview_for_extension(ext),
         },
+        "astro" => FileFacts {
+            builtin_class: FileClass::Code,
+            specific_type_label: Some("Astro component"),
+            preview: preview_for_extension(ext),
+        },
         "sql" => FileFacts {
             builtin_class: FileClass::Code,
             specific_type_label: Some("SQL script"),

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -78,6 +78,16 @@ fn html_and_css_files_use_code_preview_support() {
 }
 
 #[test]
+fn astro_files_use_code_preview_support() {
+    let astro = inspect_path(Path::new("Card.astro"), EntryKind::File);
+
+    assert_eq!(astro.builtin_class, FileClass::Code);
+    assert_eq!(astro.specific_type_label, Some("Astro component"));
+    assert_eq!(astro.preview.language_hint, Some("astro"));
+    assert_code_spec(astro.preview, Some("astro"), CodeBackend::Syntect);
+}
+
+#[test]
 fn quarto_markdown_files_use_markdown_preview_support() {
     let facts = inspect_path(Path::new("analysis.qmd"), EntryKind::File);
 

--- a/src/preview/code/backends/syntect/tests.rs
+++ b/src/preview/code/backends/syntect/tests.rs
@@ -189,6 +189,10 @@ fn curated_bundle_supports_newly_vendored_languages() {
             "export function App() { return <button className=\"cta\">Hi</button>; }\n",
         ),
         (
+            "astro",
+            "---\nconst title: string = \"Elio\";\n---\n<Layout title={title}><h1>{title}</h1></Layout>\n",
+        ),
+        (
             "nix",
             "{ description = \"elio\"; outputs = { self }: { packages.default = self; }; }\n",
         ),

--- a/src/preview/code/registry/data/web.rs
+++ b/src/preview/code/registry/data/web.rs
@@ -83,6 +83,14 @@ pub(super) const LANGUAGES: &[RegistryEntry] = &[
         &["tsx"],
     ),
     entry(
+        language("astro", "Astro", CodeBackend::Syntect, None),
+        &["astro"],
+        &[],
+        &[],
+        &["astro"],
+        &["astro"],
+    ),
+    entry(
         language("qml", "QML", CodeBackend::Syntect, None),
         &["qml"],
         &[],

--- a/src/preview/code/registry/tests.rs
+++ b/src/preview/code/registry/tests.rs
@@ -69,6 +69,10 @@ fn extension_lookup_returns_canonical_language_ids() {
         Some("tsx")
     );
     assert_eq!(
+        language_for_extension("astro").map(|language| language.canonical_id),
+        Some("astro")
+    );
+    assert_eq!(
         language_for_extension("ps1").map(|language| language.canonical_id),
         Some("powershell")
     );
@@ -243,6 +247,10 @@ fn markdown_fence_lookup_supports_common_aliases() {
     assert_eq!(
         language_for_markdown_fence("qml").map(|language| language.canonical_id),
         Some("qml")
+    );
+    assert_eq!(
+        language_for_markdown_fence("astro").map(|language| language.canonical_id),
+        Some("astro")
     );
 }
 

--- a/src/preview/code/render/tests.rs
+++ b/src/preview/code/render/tests.rs
@@ -108,6 +108,10 @@ fn enabled_generic_source_preview_specs_use_syntect() {
         ("sass", "$fg: #fff\n.button\n  color: $fg\n"),
         ("less", "@fg: #fff;\n.button { color: @fg; }\n"),
         (
+            "astro",
+            "---\nconst title = \"Elio\";\n---\n<h1>{title}</h1>\n",
+        ),
+        (
             "nix",
             "{ description = \"elio\"; outputs = { self }: { packages.default = self; }; }\n",
         ),

--- a/src/preview/code/syntax_manifest.rs
+++ b/src/preview/code/syntax_manifest.rs
@@ -63,6 +63,11 @@ pub(crate) const CURATED_SYNTAXES: &[CuratedSyntax] = &[
         source: SyntaxSource::Vendored,
     },
     CuratedSyntax {
+        canonical_id: "astro",
+        lookup_token: "astro",
+        source: SyntaxSource::Vendored,
+    },
+    CuratedSyntax {
         canonical_id: "qml",
         lookup_token: "qml",
         source: SyntaxSource::Vendored,

--- a/src/preview/tests/code/syntect.rs
+++ b/src/preview/tests/code/syntect.rs
@@ -314,6 +314,48 @@ fn qml_preview_uses_curated_syntect_support() {
 }
 
 #[test]
+fn astro_preview_uses_curated_syntect_support() {
+    let root = temp_path("astro");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("Card.astro");
+    fs::write(
+        &path,
+        "---\nconst title: string = \"Elio\";\nconst count = 2;\n---\n<Layout title={title} client:load>\n  <h1>{title}</h1>\n  <span>{count}</span>\n</Layout>\n",
+    )
+    .expect("failed to write astro source");
+
+    let preview = build_preview(&file_entry(path));
+    let code_palette = theme::code_preview_palette();
+
+    assert_eq!(preview.kind, PreviewKind::Code);
+    assert!(
+        preview
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("Astro"))
+    );
+    assert_eq!(
+        span_color(&preview.lines[1], "const"),
+        Some(code_palette.keyword)
+    );
+    assert_eq!(
+        span_color(&preview.lines[1], "string"),
+        Some(code_palette.r#type)
+    );
+    assert_eq!(
+        span_color(&preview.lines[4], "Layout"),
+        Some(code_palette.tag)
+    );
+    assert_eq!(
+        span_color(&preview.lines[4], "title"),
+        Some(code_palette.parameter)
+    );
+    assert_eq!(span_color(&preview.lines[5], "h1"), Some(code_palette.tag));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn tsx_preview_uses_code_renderer() {
     let root = temp_path("tsx");
     fs::create_dir_all(&root).expect("failed to create temp root");


### PR DESCRIPTION
## Summary

Add syntax-highlighted previews for Astro `.astro` files.

Astro files are now recognized as code previews, use the Astro language in the syntax registry, and render through the curated Syntect syntax bundle.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo test --locked astro -- --nocapture`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed