### PR TITLE
feat(theme): add file type icons and search fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a show/hide control to encrypted archive password prompts.
 - Added YAML frontmatter rendering to Markdown previews and recognized Quarto `.qmd` files as Markdown. ([#223])
 - Added syntax-highlighted previews for Astro `.astro` files.
+- Added Jupyter notebook JSON previews and notebook icons.
+- Added default theme icons for Angular project files, CSV/TSV tables, object files, libraries, and WebAssembly modules.
 - Added Kitty 0.47+ drag-and-drop support for dropping items into elio and dragging items out, with themed drag previews.
 
 ### Changed
 
 - Made create and bulk rename overlays show more rows before scrolling, adapt better on short terminals, and use consistent scrollbar styling.
 - Dimmed help overlay key separators and removed the bottom close hint.
+
+### Fixed
+
+- Fixed Fuzzy Find result icons for nested files that use full-name rules, such as `LICENSE.md`.
 
 ## [1.10.0] - 2026-06-30
 

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -148,6 +148,36 @@ class = "file"
 icon = ""
 color = "#7aaeff"
 
+[extensions.a]
+class = "file"
+icon = ""
+color = "#d3aa7c"
+
+[extensions.lib]
+class = "file"
+icon = ""
+color = "#d3aa7c"
+
+[extensions.so]
+class = "file"
+icon = ""
+color = "#d3aa7c"
+
+[extensions.dylib]
+class = "file"
+icon = ""
+color = "#d3aa7c"
+
+[extensions.dll]
+class = "file"
+icon = ""
+color = "#d3aa7c"
+
+[extensions.wasm]
+class = "file"
+icon = ""
+color = "#b38cff"
+
 [extensions.desktop]
 class = "config"
 icon = "󰍹"

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -583,6 +583,16 @@ class = "config"
 icon = ""
 color = "#a884ff"
 
+[files."angular.json"]
+class = "config"
+icon = "󰚲"
+color = "#ef4444"
+
+[files."ng-package.json"]
+class = "config"
+icon = "󰚲"
+color = "#ef4444"
+
 [files."Dockerfile"]
 class = "config"
 icon = "󰡨"
@@ -1033,6 +1043,10 @@ color = "#5ba8ff"
 [directories.".astro"]
 icon = ""
 color = "#5ba8ff"
+
+[directories.".angular"]
+icon = "󰚲"
+color = "#ef4444"
 
 [directories."public"]
 icon = "󰉋"

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -138,6 +138,16 @@ class = "data"
 icon = "󱎏"
 color = "#4eb274"
 
+[extensions.o]
+class = "file"
+icon = ""
+color = "#7aaeff"
+
+[extensions.obj]
+class = "file"
+icon = ""
+color = "#7aaeff"
+
 [extensions.desktop]
 class = "config"
 icon = "󰍹"

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -138,6 +138,11 @@ class = "data"
 icon = "󱎏"
 color = "#4eb274"
 
+[extensions.ipynb]
+class = "document"
+icon = ""
+color = "#ffb86b"
+
 [extensions.o]
 class = "file"
 icon = ""

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -128,6 +128,16 @@ class = "config"
 icon = ""
 color = "#7db0ff"
 
+[extensions.csv]
+class = "data"
+icon = "󱎏"
+color = "#4eb274"
+
+[extensions.tsv]
+class = "data"
+icon = "󱎏"
+color = "#4eb274"
+
 [extensions.desktop]
 class = "config"
 icon = "󰍹"

--- a/src/app/search/overlay.rs
+++ b/src/app/search/overlay.rs
@@ -85,6 +85,7 @@ impl App {
                 let candidate = search.candidates.get(candidate_index)?;
                 Some(SearchRow {
                     index: visible_index,
+                    path: candidate.path.clone(),
                     name: candidate.name.clone(),
                     relative: candidate.relative.clone(),
                     is_dir: candidate.is_dir,

--- a/src/app/search/tests.rs
+++ b/src/app/search/tests.rs
@@ -143,6 +143,45 @@ fn opening_search_preserves_cached_limit_status() {
 }
 
 #[test]
+fn search_rows_keep_full_paths() {
+    let root = temp_path("row-full-path");
+    let license_path = root.join("nested/LICENSE.md");
+    fs::create_dir_all(license_path.parent().unwrap()).expect("failed to create temp tree");
+    fs::write(
+        &license_path,
+        "# SPDX-License-Identifier: Apache-2.0\n\nFixture license notes.\n",
+    )
+    .expect("failed to write license");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.jobs.search_cache = Some(SearchCache {
+        cwd: root.clone(),
+        scope: SearchScope::Files,
+        show_hidden: app.effective_show_hidden(),
+        fingerprint: app.navigation.directory_runtime.fingerprint,
+        candidates: Arc::new(vec![crate::fs::search::SearchCandidate {
+            path: license_path.clone(),
+            name: "LICENSE.md".to_string(),
+            name_key: "license.md".to_string(),
+            relative: "nested/LICENSE.md".to_string(),
+            relative_key: "nested/license.md".to_string(),
+            is_dir: false,
+            symlink: None,
+        }]),
+        stats: crate::fs::search::SearchIndexStats::default(),
+    });
+
+    app.open_fuzzy_finder(SearchScope::Files)
+        .expect("failed to open search");
+    let rows = app.search_rows(1);
+
+    assert_eq!(rows[0].path, license_path);
+    assert_eq!(rows[0].relative, "nested/LICENSE.md");
+
+    fs::remove_dir_all(root).expect("failed to remove temp tree");
+}
+
+#[test]
 fn search_progress_batch_updates_open_overlay_while_loading() {
     let root = temp_path("progress-batch");
     fs::create_dir_all(&root).expect("failed to create temp tree");

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -160,6 +160,7 @@ impl SearchScope {
 #[derive(Clone, Debug)]
 pub struct SearchRow {
     pub index: usize,
+    pub path: std::path::PathBuf,
     pub name: String,
     pub relative: String,
     pub is_dir: bool,

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -40,6 +40,11 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
             specific_type_label: Some("JSON5 file"),
             preview: preview_for_extension(ext),
         },
+        "ipynb" => FileFacts {
+            builtin_class: FileClass::Document,
+            specific_type_label: Some("Jupyter notebook"),
+            preview: preview_for_extension("json"),
+        },
         "toml" => FileFacts {
             builtin_class: FileClass::Config,
             specific_type_label: Some("TOML file"),

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -17,6 +17,23 @@ fn json5_gets_parser_backed_preview_support() {
 }
 
 #[test]
+fn jupyter_notebooks_use_json_preview_support() {
+    let facts = inspect_path(Path::new("analysis.ipynb"), EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::Document);
+    assert_eq!(facts.specific_type_label, Some("Jupyter notebook"));
+    assert_eq!(
+        facts.preview.structured_format,
+        Some(StructuredFormat::Json)
+    );
+    assert_code_spec(
+        facts.preview,
+        Some("json"),
+        CodeBackend::Custom(CustomCodeKind::Json),
+    );
+}
+
+#[test]
 fn supported_video_extensions_keep_specific_video_labels() {
     let cases = [
         ("clip.mp4", "MP4 video"),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,8 +36,6 @@ const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const ACTIVE_SCROLL_POLL_INTERVAL: Duration = Duration::from_millis(12);
 const WINDOWS_TERMINAL_ACTIVE_POLL_INTERVAL: Duration = Duration::from_millis(24);
 const RELATIVE_TIME_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
-const MAX_INPUT_EVENTS_PER_FRAME: usize = 64;
-const MAX_INPUT_BATCH_DURATION: Duration = Duration::from_millis(4);
 
 #[derive(Debug)]
 struct AppExit {
@@ -356,10 +354,7 @@ fn run_app(
             // terminals) arrive faster than the app can render: instead of one render per
             // event we accumulate all queued events first and render the final state once.
             let mut next_input = Some(first_input);
-            let batch_started_at = Instant::now();
-            let mut batched_events = 0usize;
             loop {
-                batched_events += 1;
                 let input = match next_input.take() {
                     Some(input) => input,
                     None => match try_read_runtime_input(&input_reader)? {
@@ -367,12 +362,7 @@ fn run_app(
                         None => break,
                     },
                 };
-                let input = coalesce_resize_inputs(
-                    &input_reader,
-                    input,
-                    &mut next_input,
-                    &mut batched_events,
-                )?;
+                let input = coalesce_resize_inputs(&input_reader, input, &mut next_input)?;
                 #[cfg(unix)]
                 let input_result = handle_runtime_input(
                     terminal,
@@ -433,12 +423,6 @@ fn run_app(
                     }
                 };
                 next_input = try_read_runtime_input(&input_reader)?;
-                if next_input.is_some()
-                    && (batched_events >= MAX_INPUT_EVENTS_PER_FRAME
-                        || batch_started_at.elapsed() >= MAX_INPUT_BATCH_DURATION)
-                {
-                    break;
-                }
             }
 
             if app.should_quit {
@@ -558,13 +542,11 @@ fn coalesce_resize_inputs(
     reader: &RuntimeInputReader,
     input: RuntimeInputEvent,
     next_input: &mut Option<RuntimeInputEvent>,
-    batched_events: &mut usize,
 ) -> Result<RuntimeInputEvent> {
     let RuntimeInputEvent::Terminal(Event::Resize(mut width, mut height)) = input else {
         return Ok(input);
     };
 
-    let started_at = Instant::now();
     loop {
         let candidate = if let Some(input) = next_input.take() {
             Some(input)
@@ -575,12 +557,6 @@ fn coalesce_resize_inputs(
             Some(RuntimeInputEvent::Terminal(Event::Resize(w, h))) => {
                 width = w;
                 height = h;
-                *batched_events += 1;
-                if *batched_events >= MAX_INPUT_EVENTS_PER_FRAME
-                    || started_at.elapsed() >= MAX_INPUT_BATCH_DURATION
-                {
-                    break;
-                }
             }
             Some(other) => {
                 *next_input = Some(other);

--- a/src/ui/overlay_manager/search.rs
+++ b/src/ui/overlay_manager/search.rs
@@ -197,10 +197,13 @@ pub(super) fn render_search_overlay(
                 );
             }
 
-            let row_path = std::path::Path::new(&row.relative);
-            let icon = theme::path_symbol_with_symlink(row_path, row.is_dir, row.symlink.as_ref());
-            let icon_color =
-                theme::path_color_with_symlink(row_path, row.is_dir, row.symlink.as_ref(), palette);
+            let icon = theme::path_symbol_with_symlink(&row.path, row.is_dir, row.symlink.as_ref());
+            let icon_color = theme::path_color_with_symlink(
+                &row.path,
+                row.is_dir,
+                row.symlink.as_ref(),
+                palette,
+            );
             let name_width = rect.width.saturating_sub(6) as usize;
             let path_width = rect.width.saturating_sub(4) as usize;
             frame.render_widget(

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -127,6 +127,13 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
         assert_eq!(table.color, rgb(78, 178, 116), "{path}");
     }
 
+    for path in ["main.o", "main.obj"] {
+        let object = theme.resolve(Path::new(path), EntryKind::File);
+        assert_eq!(object.class, FileClass::File, "{path}");
+        assert_eq!(object.icon, "", "{path}");
+        assert_eq!(object.color, rgb(122, 174, 255), "{path}");
+    }
+
     let package = theme.resolve(Path::new("package.json"), EntryKind::File);
     assert_eq!(package.icon, "󰏗");
 

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -120,6 +120,13 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
     assert_eq!(json.icon, "");
     assert_eq!(json.color, rgb(125, 176, 255));
 
+    for path in ["customers.csv", "orders.tsv"] {
+        let table = theme.resolve(Path::new(path), EntryKind::File);
+        assert_eq!(table.class, FileClass::Data, "{path}");
+        assert_eq!(table.icon, "󱎏", "{path}");
+        assert_eq!(table.color, rgb(78, 178, 116), "{path}");
+    }
+
     let package = theme.resolve(Path::new("package.json"), EntryKind::File);
     assert_eq!(package.icon, "󰏗");
 

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -123,8 +123,20 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
     let package = theme.resolve(Path::new("package.json"), EntryKind::File);
     assert_eq!(package.icon, "󰏗");
 
+    for path in ["angular.json", "ng-package.json"] {
+        let angular = theme.resolve(Path::new(path), EntryKind::File);
+        assert_eq!(angular.class, FileClass::Config, "{path}");
+        assert_eq!(angular.icon, "󰚲", "{path}");
+        assert_eq!(angular.color, rgb(239, 68, 68), "{path}");
+    }
+
     let modules = theme.resolve(Path::new("node_modules"), EntryKind::Directory);
     assert_eq!(modules.icon, "󰏗");
+
+    let angular_cache = theme.resolve(Path::new(".angular"), EntryKind::Directory);
+    assert_eq!(angular_cache.class, FileClass::Directory);
+    assert_eq!(angular_cache.icon, "󰚲");
+    assert_eq!(angular_cache.color, rgb(239, 68, 68));
 
     let docs = theme.resolve(Path::new("docs"), EntryKind::Directory);
     assert_eq!(docs.class, FileClass::Directory);

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -134,6 +134,24 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
         assert_eq!(object.color, rgb(122, 174, 255), "{path}");
     }
 
+    for path in [
+        "libapp.a",
+        "app.lib",
+        "libapp.so",
+        "libapp.dylib",
+        "app.dll",
+    ] {
+        let library = theme.resolve(Path::new(path), EntryKind::File);
+        assert_eq!(library.class, FileClass::File, "{path}");
+        assert_eq!(library.icon, "", "{path}");
+        assert_eq!(library.color, rgb(211, 170, 124), "{path}");
+    }
+
+    let wasm = theme.resolve(Path::new("module.wasm"), EntryKind::File);
+    assert_eq!(wasm.class, FileClass::File);
+    assert_eq!(wasm.icon, "");
+    assert_eq!(wasm.color, rgb(179, 140, 255));
+
     let package = theme.resolve(Path::new("package.json"), EntryKind::File);
     assert_eq!(package.icon, "󰏗");
 

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -127,6 +127,11 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
         assert_eq!(table.color, rgb(78, 178, 116), "{path}");
     }
 
+    let notebook = theme.resolve(Path::new("analysis.ipynb"), EntryKind::File);
+    assert_eq!(notebook.class, FileClass::Document);
+    assert_eq!(notebook.icon, "");
+    assert_eq!(notebook.color, rgb(255, 184, 107));
+
     for path in ["main.o", "main.obj"] {
         let object = theme.resolve(Path::new(path), EntryKind::File);
         assert_eq!(object.class, FileClass::File, "{path}");


### PR DESCRIPTION
## Summary

Add default theme icons for more project and binary file types, and improve search result behavior.

elio now recognizes Jupyter notebooks for JSON previews/icons, adds bundled icons for Angular project files, CSV/TSV tables, object files, libraries, and WebAssembly modules, and keeps Fuzzy Find result icons accurate for nested files that depend on full-name rules such as `LICENSE.md`. Fast typing in Fuzzy Find also drains queued input before redraws, so result updates no longer interrupt key bursts.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed